### PR TITLE
VAGOV-000: Re-exported landing page teaser display config.

### DIFF
--- a/config/sync/core.entity_view_display.node.landing_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.teaser.yml
@@ -27,4 +27,6 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  content_moderation_control: true
+  field_meta_tags: true


### PR DESCRIPTION
This fixes a minor glitch that left config/sync/core.entity_view_display.node.landing_page.teaser.yml in an 'update' state even after it was successfully imported using drush cim. To see the problem, run drush cim. It will import successfully. But when you run drush cim again, core.entity_view_display.node.landing_page.teaser.yml still shows up as needing to update.

This patch shouldn't change the landing page teaser at all (not that that matters). It just makes cim recognize that it's in sync.