### PR TITLE
Vagov 934 migrate alert blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "drupal/social_media_links": "^2.6",
         "weitzman/drupal-test-traits": "dev-master",
         "phpunit/phpunit": "^6",
-        "drupal/redirect": "^1.3"
+        "drupal/redirect": "^1.3",
+        "michelf/php-markdown": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13b0b41afbc917384a9e9e79cb8ed740",
+    "content-hash": "5a9422adee453e8febed0689f3f33e4a",
     "packages": [
         {
             "name": "acquia/headless_lightning",
-            "version": "1.4.0-beta2",
+            "version": "1.4.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/headless-lightning.git",
-                "reference": "d504b8ced5b39d094b2b4e3ed7e5cb5016329a1e"
+                "reference": "99a306e47540b0eafaa118c7ae22cad1830e5e02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/headless-lightning/zipball/d504b8ced5b39d094b2b4e3ed7e5cb5016329a1e",
-                "reference": "d504b8ced5b39d094b2b4e3ed7e5cb5016329a1e",
+                "url": "https://api.github.com/repos/acquia/headless-lightning/zipball/99a306e47540b0eafaa118c7ae22cad1830e5e02",
+                "reference": "99a306e47540b0eafaa118c7ae22cad1830e5e02",
                 "shasum": ""
             },
             "require": {
-                "acquia/lightning": "3.2.2",
+                "acquia/lightning": "3.2.3",
                 "cweagans/composer-patches": "^1.6.4",
                 "drupal-composer/drupal-scaffold": "^2.0.0"
             },
@@ -29,6 +29,7 @@
                 "acquia/lightning_dev": "dev-8.x-1.x",
                 "drupal/console": "^1.0.0",
                 "drupal/devel": "^1.0",
+                "drupal/facets": "^1.2",
                 "drupal/schema_metatag": "^1.3"
             },
             "type": "drupal-profile",
@@ -69,30 +70,30 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal Lightning as a backend for fully decoupled applications.",
-            "time": "2018-11-05T16:52:25+00:00"
+            "time": "2019-01-11T13:54:44+00:00"
         },
         {
             "name": "acquia/lightning",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/lightning.git",
-                "reference": "0dc7bfbf047ad843aee4e8791640ed5392d80c33"
+                "reference": "03cb47633e770d6aada29cbcd58894cab41dd4c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/lightning/zipball/0dc7bfbf047ad843aee4e8791640ed5392d80c33",
-                "reference": "0dc7bfbf047ad843aee4e8791640ed5392d80c33",
+                "url": "https://api.github.com/repos/acquia/lightning/zipball/03cb47633e770d6aada29cbcd58894cab41dd4c9",
+                "reference": "03cb47633e770d6aada29cbcd58894cab41dd4c9",
                 "shasum": ""
             },
             "require": {
                 "cweagans/composer-patches": "^1.6.4",
                 "drupal-composer/drupal-scaffold": "^2.0.0",
-                "drupal/lightning_api": "^2.7",
-                "drupal/lightning_core": "^3.2",
-                "drupal/lightning_layout": "^1.4",
-                "drupal/lightning_media": "^3.1",
-                "drupal/lightning_workflow": "^3.1",
+                "drupal/lightning_api": "^3.1",
+                "drupal/lightning_core": "^3.4",
+                "drupal/lightning_layout": "^1.5",
+                "drupal/lightning_media": "^3.4",
+                "drupal/lightning_workflow": "^3.2",
                 "oomphinc/composer-installers-extender": "^1.1"
             },
             "require-dev": {
@@ -144,7 +145,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "The best of Drupal, curated by Acquia",
-            "time": "2018-10-18T00:13:32+00:00"
+            "time": "2018-12-20T13:34:53+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -3853,20 +3854,20 @@
         },
         {
             "name": "drupal/jsonapi",
-            "version": "1.24.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/jsonapi",
-                "reference": "8.x-1.24"
+                "reference": "8.x-2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/jsonapi-8.x-1.24.zip",
-                "reference": "8.x-1.24",
-                "shasum": "61ff3254b228d41c6a37d3b6e37f30120c0729b7"
+                "url": "https://ftp.drupal.org/files/projects/jsonapi-8.x-2.0.zip",
+                "reference": "8.x-2.0",
+                "shasum": "223dfe947f61503c759e5aca68ab73fe1a04716f"
             },
             "require": {
-                "drupal/core": "^8.4.3"
+                "drupal/core": "^8.5.4"
             },
             "require-dev": {
                 "drupal/schemata": "1.x-dev#8325d172e1d6880aa24073f8f751ef089282cf9a",
@@ -3876,11 +3877,11 @@
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.24",
-                    "datestamp": "1545243863",
+                    "version": "8.x-2.0",
+                    "datestamp": "1546977002",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3978,23 +3979,23 @@
         },
         {
             "name": "drupal/lightning_api",
-            "version": "2.8.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/lightning_api",
-                "reference": "8.x-2.8"
+                "reference": "8.x-3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/lightning_api-8.x-2.8.zip",
-                "reference": "8.x-2.8",
-                "shasum": "437fa63f7e82e0b1fa8c25828624c3a80744563a"
+                "url": "https://ftp.drupal.org/files/projects/lightning_api-8.x-3.1.zip",
+                "reference": "8.x-3.1",
+                "shasum": "921e00c08f9ac6582988b40a5205434b5e5da06e"
             },
             "require": {
                 "cweagans/composer-patches": "^1.6.4",
                 "drupal-composer/drupal-scaffold": "^2.0.0",
                 "drupal/core": "~8.0",
-                "drupal/jsonapi": "^1.24.0",
+                "drupal/jsonapi": "^2.0.0-rc4",
                 "drupal/lightning_core": "^2.11 || ^3.4",
                 "drupal/openapi": "^1.0-beta2",
                 "drupal/openapi_ui_redoc": "^1.0",
@@ -4011,11 +4012,12 @@
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-2.x": "2.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-8.x-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.8",
-                    "datestamp": "1545249181",
+                    "version": "8.x-3.1",
+                    "datestamp": "1545253380",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4031,6 +4033,10 @@
                         "type:bower-asset",
                         "type:npm-asset"
                     ],
+                    "docroot/modules/contrib/acquia/{$name}": [
+                        "drupal/lightning_core",
+                        "drupal/lightning_api"
+                    ],
                     "docroot/modules/contrib/{$name}": [
                         "type:drupal-module"
                     ],
@@ -4045,6 +4051,11 @@
                     "bower-asset",
                     "npm-asset"
                 ]
+            },
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\Tests\\lightning_api\\": "tests/src"
+                }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "scripts": {
@@ -11488,20 +11499,20 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.36.0",
+            "version": "v1.37.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "730c9c4471b5152d23061feb02b03382264c8a15"
+                "reference": "66be9366c76cbf23e82e7171d47cbfa54a057a62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/730c9c4471b5152d23061feb02b03382264c8a15",
-                "reference": "730c9c4471b5152d23061feb02b03382264c8a15",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/66be9366c76cbf23e82e7171d47cbfa54a057a62",
+                "reference": "66be9366c76cbf23e82e7171d47cbfa54a057a62",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=5.4.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
@@ -11512,7 +11523,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.36-dev"
+                    "dev-master": "1.37-dev"
                 }
             },
             "autoload": {
@@ -11550,7 +11561,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2018-12-16T10:34:11+00:00"
+            "time": "2019-01-14T14:59:29+00:00"
         },
         {
             "name": "vardot/blazy",
@@ -14177,16 +14188,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.1.1",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "8aae5b59b83bb4d0dbf07b0a835f2680a658f610"
+                "reference": "594bcae1fc0bccd3993d2f0d61a018e26ac2865a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8aae5b59b83bb4d0dbf07b0a835f2680a658f610",
-                "reference": "8aae5b59b83bb4d0dbf07b0a835f2680a658f610",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/594bcae1fc0bccd3993d2f0d61a018e26ac2865a",
+                "reference": "594bcae1fc0bccd3993d2f0d61a018e26ac2865a",
                 "shasum": ""
             },
             "require": {
@@ -14202,7 +14213,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -14224,7 +14235,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-12-26T11:32:39+00:00"
+            "time": "2019-01-12T16:31:37+00:00"
         },
         {
             "name": "psy/psysh",

--- a/composer.lock
+++ b/composer.lock
@@ -8006,6 +8006,52 @@
             "time": "2018-12-27T22:03:43+00:00"
         },
         {
+            "name": "michelf/php-markdown",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/michelf/php-markdown.git",
+                "reference": "01ab082b355bf188d907b9929cd99b2923053495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/michelf/php-markdown/zipball/01ab082b355bf188d907b9929cd99b2923053495",
+                "reference": "01ab082b355bf188d907b9929cd99b2923053495",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Michelf\\": "Michelf/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Michel Fortin",
+                    "email": "michel.fortin@michelf.ca",
+                    "homepage": "https://michelf.ca/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "John Gruber",
+                    "homepage": "https://daringfireball.net/"
+                }
+            ],
+            "description": "PHP Markdown",
+            "homepage": "https://michelf.ca/projects/php-markdown/",
+            "keywords": [
+                "markdown"
+            ],
+            "time": "2018-01-15T00:49:33+00:00"
+        },
+        {
             "name": "mkalkbrenner/php-htmldiff-advanced",
             "version": "0.0.8",
             "source": {

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_alert_block.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_alert_block.yml
@@ -1,0 +1,30 @@
+id: va_alert_block
+label: Migrate alert blocks from va.gov
+migration_group: va_gov
+
+source:
+  plugin: alert_block
+  urls:
+    - "https://github.com/department-of-veterans-affairs/vagov-content/tree/master/pages/health-care"
+  fields:
+    - alert_type
+    - alert_title
+
+process:
+  info: alert_title
+  field_alert_title: alert_title
+  field_alert_type: alert_type
+  type:
+    plugin: default_value
+    default_value: alert
+
+destination:
+  plugin: 'entity:block_content'
+
+migration_dependencies: {}
+
+# This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_healthcare.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_healthcare.yml
@@ -53,6 +53,14 @@ source:
             - '.feature'
             - '1'
             - innerHTML
+      alert_title:
+        obtainer: ObtainHtml
+        jobs:
+        -
+          job: 'addSearch'
+          method: 'pluckSelector'
+          arguments:
+            - '.usa-alert-heading'
       related_links:
         obtainer: ObtainHtml
         jobs:
@@ -104,6 +112,15 @@ source:
       operation: get_field
       field: featured_content
     -
+      # Remove expander trigger before getting alert title
+      operation: modifier
+      modifier: removeSelectorAll
+      arguments:
+        - '#crisis-expander-link'
+    -
+      operation: get_field
+      field: alert_title
+    -
       operation: get_field
       field: related_links
     -
@@ -119,6 +136,12 @@ source:
       modifier: removeSelectorAll
       arguments:
         - 'script'
+    -
+      # Remove any alert boxes (they'll be attached via 'alert title', above).
+      operation: modifier
+      modifier: removeSelectorAll
+      arguments:
+        - '.usa-alert'
     -
       # Replace any React forms with a placeholder (this will be dropped soon)
       operation: modifier
@@ -145,6 +168,10 @@ process:  # assign the fields we collected above to Drupal fields.
     from_format: 'n/j/y'
     to_format: 'Y-m-d'
     source: plainlanguage_date
+  field_alert:
+    plugin: migration_lookup
+    migration: va_alert_block
+    source: alert_title
   type:
     plugin: default_value   # We want to asign the 'type' field a static value.
     default_value: page # The value is 'page'.
@@ -152,8 +179,10 @@ process:  # assign the fields we collected above to Drupal fields.
 destination:
   plugin: 'entity:node'
 
-migration_dependencies: {} # Remove the {} before adding dependencies below.
-  # If there are migrations that should run before this one (e.g. for an entity that this node references), put them here.
+# This migration depends on the va_alert_block migration to generate any alert blocks the nodes reference.
+migration_dependencies:
+  required:
+  - va_alert_block
 
 # This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
+++ b/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
@@ -41,13 +41,14 @@ class PostRowSave implements EventSubscriberInterface {
       case 'va_healthcare':
         $this->convertIntroTextToPlainText($event->getDestinationIdValues()[0]);
         $migrator->process('related_links', 'field_related_links');
+        $migrator->process('featured_content', 'field_featured_content');
         $migrator->process('body', 'field_content_block');
         break;
 
-        case 'va_alert_block':
+      case 'va_alert_block':
         $migrator->process('alert_body', 'field_alert_content');
         break;
-        
+
       case 'va_hub':
         $this->convertIntroTextToPlainText($event->getDestinationIdValues()[0]);
         $migrator->process('related_links', 'field_related_links');

--- a/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
+++ b/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
@@ -44,6 +44,10 @@ class PostRowSave implements EventSubscriberInterface {
         $migrator->process('body', 'field_content_block');
         break;
 
+        case 'va_alert_block':
+        $migrator->process('alert_body', 'field_alert_content');
+        break;
+        
       case 'va_hub':
         $this->convertIntroTextToPlainText($event->getDestinationIdValues()[0]);
         $migrator->process('related_links', 'field_related_links');

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/ExpandableText.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/ExpandableText.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\va_gov_migrate\Paragraph;
 
+use Drupal\migration_tools\Message;
 use Drupal\va_gov_migrate\ParagraphType;
 use QueryPath\DOMQuery;
 
@@ -23,18 +24,34 @@ class ExpandableText extends ParagraphType {
    * {@inheritdoc}
    */
   protected function isParagraph(DOMQuery $query_path) {
-    return $query_path->hasClass('additional-info-container');
+    return $query_path->hasClass('expander-content');
   }
 
   /**
    * {@inheritdoc}
    */
   protected function getFieldValues(DOMQuery $query_path) {
+    if ($query_path->prev()->attr('id') == 'crisis-expander-link') {
+      $expander = $query_path->prev()->text();
+    }
+    else {
+      Message::make('Expanding block missing trigger text: @html',
+        ['@html' => $this::$migrator->row->getSourceProperty('alert_title')],
+        Message::ERROR);
+      $expander = "Show more";
+    }
     return
       [
-        'field_text_expander' => $query_path->find('.additional-info-title')->text(),
-        'field_wysiwyg' => $query_path->find('.additional-info-content')->innerHTML(),
+        'field_text_expander' => $expander,
+        'field_wysiwyg' => $query_path->find('.expander-content-inner')->innerHTML(),
       ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function isExternalContent(DOMQuery $query_path) {
+    return $query_path->attr('id') == 'crisis-expander-link';
   }
 
 }

--- a/docroot/modules/custom/va_gov_migrate/src/ParagraphMigrator.php
+++ b/docroot/modules/custom/va_gov_migrate/src/ParagraphMigrator.php
@@ -188,17 +188,24 @@ class ParagraphMigrator {
             }
             continue;
           }
-          // If the element does contain unwrapped text, that text will be lost.
-          if (str_replace(' ', '', $element->text()) !=
-              str_replace(' ', '', $element->childrenText())) {
-            Message::make('Lost text, in @file', ['@file' => $parent_entity->url()], Message::ERROR);
-          }
           // Add the opening tag.
           $attr = '';
           foreach ($element->attr() as $name => $value) {
             $attr .= $name . '="' . $value . '" ';
           }
           $this->wysiwyg .= "<{$element->tag()} $attr>";
+
+          // If the element does contain unwrapped text, that text will be lost.
+          if (str_replace(' ', '', $element->text()) !=
+            str_replace(' ', '', $element->childrenText())) {
+            Message::make('Lost text in @file from @element',
+              [
+                '@file' => $parent_entity->url(),
+                '@element' => "<{$element->tag()} $attr>",
+              ],
+              Message::ERROR);
+          }
+
           // Look for paragraphs in the children.
           $this->addParagraphs($element->children(), $parent_entity, $parent_field);
           $this->wysiwyg .= "</{$element->tag()}>";

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/AlertBlockSource.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/AlertBlockSource.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Plugin\migrate\source;
+
+use Drupal\migration_tools\Message;
+use QueryPath\DOMQuery;
+use Drupal\va_gov_migrate\ParagraphMigrator;
+use Drupal\migration_tools\StringTools;
+use Michelf\MarkdownExtra;
+
+/**
+ * Gets blocks from pages referenced by metalsmith files.
+ *
+ * This source requires a list of urls that are either metalsmith files
+ * or a github directory listing of metalsmith files.
+ *
+ * @MigrateSource(
+ *  id = "alert_block"
+ * )
+ */
+class AlertBlockSource extends MetalsmithSource {
+
+  /**
+   * Remove rows with duplicate alert titles and make sure they're identical.
+   */
+  protected function validateRows() {
+    $unique_rows = [];
+
+    foreach ($this->rows as $row) {
+      $alert_title = $row['alert_title'];
+
+      // If we've already got that title, make sure the blocks are identical.
+      if (in_array($alert_title, array_column($unique_rows, 'alert_title'))) {
+        $key = array_search($alert_title, array_column($unique_rows, 'alert_title'));
+        if (Stringtools::superTrim($row['alert_body']) != Stringtools::superTrim($unique_rows[$key]['alert_body'])) {
+          Message::make('Alert boxes with the same title, but different bodies on @url1 and @url2',
+            [
+              '@url1' => $unique_rows[$key]['url'],
+              '@url2' => $row['url'],
+            ],
+            Message::ERROR);
+        }
+        elseif ($row['alert_type'] != $unique_rows[$key]['alert_type']) {
+          Message::make('Alert boxes with the same title and body, but different type: @type1 on @url1 and @type2 on @url2',
+            [
+              '@url1' => $unique_rows[$key]['url'],
+              '@url2' => $row['url'],
+              '@type1' => $unique_rows[$key]['alert_type'],
+              '@type2' => $row['alert_type'],
+            ],
+            Message::ERROR);
+        }
+      }
+      // Otherwise, just add this one to the list.
+      else {
+        $unique_rows[] = $row;
+      }
+    }
+
+    $this->rows = $unique_rows;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function addRow($url) {
+    $page_content = '';
+    if (!($row = self::readMetalsmithFile($url, $page_content)) || empty($page_content)) {
+      return;
+    }
+
+    $row = [];
+
+    $query_path = ParagraphMigrator::createQueryPath($page_content);
+    $alerts = $query_path->find('.usa-alert');
+    /** @var \QueryPath\DOMQuery $alert */
+    foreach ($alerts as $alert) {
+      $row['alert_type'] = $this->getAlertType($alert);
+
+      // Sometimes expander trigger is nested inside heading.
+      $title_path = $alert->find('.usa-alert-heading');
+      $trigger_path = $title_path->find('#crisis-expander-link')->remove();
+      $row['alert_title'] = $title_path->text();
+      // The heading is nested within the body, so remove it.
+      $alert->find('.usa-alert-heading')->remove();
+
+      // If we found a trigger path add it to the body.
+      if ($trigger_path->count()) {
+        $trigger_path->insertBefore($alert->find('.expander-content'));
+      }
+
+      $body = MarkdownExtra::defaultTransform($alert->find('.usa-alert-body')->innerHTML());
+      // Markdown extra encodes html and wraps it in code and pre tags.
+      $body = str_replace(['<code>', '</code>', '<pre>', '</pre>'], '', $body);
+      $row['alert_body'] = html_entity_decode($body);
+
+      $row['url'] = self::getPageUrl($url, $row);
+
+      $this->rows[] = $row;
+
+    }
+  }
+
+  /**
+   * Get the drupal alert type from the html class.
+   *
+   * @param \QueryPath\DOMQuery $alert
+   *   The query path for the alert.
+   *
+   * @return mixed|string
+   *   The drupal list key for the alert type.
+   */
+  public function getAlertType(DOMQuery $alert) {
+    // Classes mapped to CMS list keys.
+    $types = [
+      'usa-alert-success' => 'success',
+      'usa-alert-warning' => 'warning',
+      'usa-alert-error' => 'error',
+      'usa-alert-info' => 'information',
+      'usa-alert-continue' => 'continue',
+    ];
+
+    foreach ($types as $class => $type) {
+      if ($alert->hasClass($class)) {
+        return $type;
+      }
+    }
+
+    \Drupal::logger('va_gov_migrate')->error('No alert type found for alert, @heading',
+      [
+        '@heading' => $alert->find('.usa-alert-heading')->text(),
+      ]
+    );
+
+    // Let's make success the default.
+    return 'success';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids['alert_title']['type'] = 'string';
+    return $ids;
+  }
+
+}


### PR DESCRIPTION
To test:
1. Run composer install
2. Run drush cr 
2. Uninstall and reinstall va_gov_migrate module
3. From UI run 'Migrate alert blocks from va.gov'. Then run 'Import healthcare pages and paragraphs from va.gov'. OR From command line, run lando drush mim va_healthcare --update
4. That should generate 4 alert blocks and attach them to appropriate basic pages, e.g. 'Depression Treatment For Veterans', 'Order Hearing Aid Batteries And Prosthetic Socks From VA', 'Posttraumatic Stress Disorder (PTSD)', 'Get Your VA Medical Records Online'.

@andyhawks the latest composer update hosed drupal for me until I ran drush cr. When this gets merged, could you warn everyone about that if I forget to?