### PR TITLE
VAGOV-942: Added support services migration.

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_support_service.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_support_service.yml
@@ -1,0 +1,35 @@
+id: va_support_service
+label: Import support services from va.gov
+migration_group: va_gov
+
+source:
+  plugin: support_service
+  urls:     # This can be a list urls to crawl or .md files to read.
+    - "https://github.com/department-of-veterans-affairs/vagov-content/blob/master/pages/pension/index.md"
+    - "https://github.com/department-of-veterans-affairs/vagov-content/blob/master/pages/burials-memorials/index.md"
+    - "https://github.com/department-of-veterans-affairs/vagov-content/blob/master/pages/health-care/index.md"
+    - "https://github.com/department-of-veterans-affairs/vagov-content/blob/master/pages/records/index.md"
+  fields:  # List any frontmatter fields you want to migrate.
+    - service_name
+    - service_number
+    - service_url
+
+process:  # assign the fields we collected above to Drupal fields.
+  title: service_name
+  field_link: service_url
+  field_phone_number: service_number
+  type:
+    plugin: default_value   # We want to assign the 'type' field a static value.
+    default_value: support_service # The value is 'support_service'.
+
+destination:
+  plugin: 'entity:node'
+
+migration_dependencies: {} # Remove the {} before adding dependencies below.
+  # If there are migrations that should run before this one (e.g. for an entity that this node references), put them here.
+
+# This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
+dependencies:
+  enforced:
+    module:
+    - va_gov_migrate  # The module this migration script belongs to.

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/SupportService.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/SupportService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Plugin\migrate\source;
+
+use Drupal\migration_tools\Message;
+
+/**
+ * Gets support service info from metalsmith files.
+ *
+ * This source requires a list of urls that are either metalsmith files
+ * or a github directory listing of metalsmith files.
+ *
+ * @MigrateSource(
+ *  id = "support_service"
+ * )
+ */
+class SupportService extends MetalsmithSource {
+
+  /**
+   * An array of associative arrays to populate Support Service nodes.
+   *
+   * @var array
+   */
+  protected $serviceRows;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function validateRows() {
+    // Get all the support service rows.
+    foreach ($this->rows as $row) {
+      if (!isset($row['social'])) {
+        continue;
+      }
+
+      foreach ($row['social'][0]['subsections'] as $subsection) {
+        foreach ($subsection['links'] as $service) {
+          $this->serviceRows[] = [
+            'service_name' => isset($service['label']) ? $service['label'] : $service['title'],
+            'service_url' => $service['url'],
+            'service_number' => isset($service['number']) ? $service['number'] : '',
+            'url' => $row['url'],
+          ];
+        }
+      }
+    }
+
+    // Remove duplicates.
+    $unique_rows = [];
+    foreach ($this->serviceRows as $service_row) {
+      if (($key = array_search($service_row['service_name'], array_column($unique_rows, 'service_name'))) === FALSE) {
+        $unique_rows[] = $service_row;
+      }
+      else {
+        if ($service_row['service_url'] != $unique_rows[$key]['service_url']) {
+          Message::make('Support Service, "@name", links to @link1 on @url1 and @link2 on @url2',
+            [
+              '@name' => $service_row['service_name'],
+              '@link1' => $service_row['service_url'],
+              '@url1' => $service_row['url'],
+              '@link2' => $unique_rows[$key]['service_url'],
+              '@url2' => $unique_rows[$key]['url'],
+            ], Message::ERROR);
+        }
+      }
+    }
+    $this->rows = $unique_rows;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids['service_name']['type'] = 'string';
+    return $ids;
+  }
+
+}


### PR DESCRIPTION
To test:

1. Uninstall and reinstall va_gov_migrate module.
2 Run migration, "Import support services from va.gov" (va_support_service).
3. Verify that 10 nodes of type, 'Support Service', were created. 
4. Verify that links in the "Ask Questions" block on the right rail of https://www.va.gov/health-care/ have corresponding Support Service nodes.
