### PR TITLE
Vagov 933 migrate promos

### DIFF
--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.landing_page.field_intro_text
     - field.field.node.landing_page.field_meta_tags
     - field.field.node.landing_page.field_plainlanguage_date
+    - field.field.node.landing_page.field_promo
     - field.field.node.landing_page.field_related_links
     - field.field.node.landing_page.field_spokes
     - node.type.landing_page
@@ -36,6 +37,18 @@ third_party_settings:
         weight: '-10'
       label: Governance
       region: content
+    group_right_rail:
+      children:
+        - field_promo
+      parent_name: ''
+      weight: 7
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Right Rail'
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page
@@ -87,6 +100,12 @@ content:
     third_party_settings: {  }
     type: datetime_default
     region: content
+  field_promo:
+    weight: 18
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_related_links:
     weight: 5
     settings:
@@ -127,7 +146,7 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 13
+    weight: 14
     settings: {  }
     region: content
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.landing_page.field_intro_text
     - field.field.node.landing_page.field_meta_tags
     - field.field.node.landing_page.field_plainlanguage_date
+    - field.field.node.landing_page.field_promo
     - field.field.node.landing_page.field_related_links
     - field.field.node.landing_page.field_spokes
     - node.type.landing_page
@@ -68,6 +69,14 @@ content:
       timezone_override: ''
     third_party_settings: {  }
     type: datetime_default
+    region: content
+  field_promo:
+    weight: 110
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_related_links:
     weight: 104

--- a/config/sync/field.field.node.landing_page.field_promo.yml
+++ b/config/sync/field.field.node.landing_page.field_promo.yml
@@ -1,0 +1,29 @@
+uuid: 2ad4d376-5787-49cb-a910-742aeef6da0b
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.promo
+    - field.storage.node.field_promo
+    - node.type.landing_page
+id: node.landing_page.field_promo
+field_name: field_promo
+entity_type: node
+bundle: landing_page
+label: Promo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:block_content'
+  handler_settings:
+    target_bundles:
+      promo: promo
+    sort:
+      field: info
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_promo.yml
+++ b/config/sync/field.storage.node.field_promo.yml
@@ -1,0 +1,20 @@
+uuid: 6a7e6b60-7701-47c8-98c4-50d3d1166d64
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - node
+id: node.field_promo
+field_name: field_promo
+entity_type: node
+type: entity_reference
+settings:
+  target_type: block_content
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: aa0997ad-0a7c-423f-b873-456b92183bc6
+uuid: eb59bae4-181e-4ae0-a366-c9c44887c6ca
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_healthcare.yml
+++ b/config/sync/migrate_plus.migration.va_healthcare.yml
@@ -1,4 +1,4 @@
-uuid: 1e7dbda9-d523-4629-a2ab-4cc9ff982e37
+uuid: 82f80c09-4e29-47e9-aaf5-510f335039b9
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: 0c186725-cdc5-4b47-85a1-39cca77f059a
+uuid: 4260a9a7-1aa2-4880-b06d-73d92e5791e2
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: 7xJV8aF80kpGoGU4wAuNmYSGH31pcFR0skggiCKyf7A
+  default_config_hash: qVQdxrM--cuMak_tE3vPoLBP3AJQ4waA3QqEKgIZTaE
 id: va_hub
 class: null
 field_plugin_method: null
@@ -152,6 +152,10 @@ process:
   revision_timestamp: lastupdate
   field_intro_text: intro_text
   field_description: description
+  field_promo:
+    plugin: migration_lookup
+    migration: va_promo
+    source: url
   field_plainlanguage_date:
     plugin: format_date
     from_format: n/j/y
@@ -162,4 +166,6 @@ process:
     default_value: landing_page
 destination:
   plugin: 'entity:node'
-migration_dependencies: {  }
+migration_dependencies:
+  required:
+    - va_promo

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,0 +1,88 @@
+uuid: 5e95f747-3b8c-4306-bfec-3d2855fcd0a3
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate
+_core:
+  default_config_hash: sj9js-mXrjCaK5dDzRPKM79wrbjV9zsEtCpO7dqhbq0
+id: va_promo
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: va_gov
+label: 'Import promo blocks from va.gov'
+source:
+  plugin: url_list
+  urls:
+    - 'https://www.va.gov/health-care/'
+    - 'https://www.va.gov/disability/'
+    - 'https://www.va.gov/education/'
+    - 'https://www.va.gov/careers-employment/'
+    - 'https://www.va.gov/pension/'
+    - 'https://www.va.gov/housing-assistance/'
+    - 'https://www.va.gov/life-insurance/'
+    - 'https://www.va.gov/burials-memorials/'
+    - 'https://www.va.gov/records/'
+  migration_tools:
+    -
+      source: url
+      source_type: url
+      source_operations:
+        -
+          operation: modifier
+          modifier: basicCleanup
+      fields:
+        title:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: addSearch
+              method: findSelector
+              arguments:
+                - '.hub-promo-text h4.heading a'
+        image:
+          obtainer: ObtainImage
+          jobs:
+            -
+              job: addSearch
+              method: pluckImages
+              arguments:
+                - .hub-promo
+        body:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: addSearch
+              method: pluckSelector
+              arguments:
+                - .hub-promo-text
+                - '1'
+                - HTML
+      dom_operations:
+        -
+          operation: get_field
+          field: title
+        -
+          operation: get_field
+          field: image
+        -
+          operation: get_field
+          field: body
+process:
+  info: title
+  field_image:
+    -
+      plugin: migration_lookup
+      migration: va_promo_media
+      source: url
+  type:
+    plugin: default_value
+    default_value: promo
+destination:
+  plugin: 'entity:block_content'
+migration_dependencies:
+  required:
+    - va_promo_media

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,0 +1,80 @@
+uuid: cde4e0ef-f25d-484a-8791-97b1772fd0db
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate
+_core:
+  default_config_hash: jxRe89M3EEXRmkyLp1wVEEo_E85WsuOE9PxdGKqn6BA
+id: va_promo_images
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: va_gov
+label: 'Import promo block images from va.gov'
+source:
+  plugin: url_list
+  urls:
+    - 'https://www.va.gov/health-care/'
+    - 'https://www.va.gov/disability/'
+    - 'https://www.va.gov/education/'
+    - 'https://www.va.gov/careers-employment/'
+    - 'https://www.va.gov/pension/'
+    - 'https://www.va.gov/housing-assistance/'
+    - 'https://www.va.gov/life-insurance/'
+    - 'https://www.va.gov/burials-memorials/'
+    - 'https://www.va.gov/records/'
+  migration_tools:
+    -
+      source: url
+      source_type: url
+      source_operations:
+        -
+          operation: modifier
+          modifier: basicCleanup
+      fields:
+        image:
+          obtainer: ObtainImage
+          jobs:
+            -
+              job: addSearch
+              method: pluckImages
+              arguments:
+                - .hub-promo
+      dom_operations:
+        -
+          operation: get_field
+          field: image
+  constants:
+    file_dest_uri: 'public://hub_promos'
+process:
+  src_url:
+    plugin: extract
+    source: image
+    index:
+      - 0
+      - src
+  image_file:
+    -
+      plugin: explode
+      source: '@src_url'
+      delimiter: /
+    -
+      plugin: array_pop
+  file_dest:
+    plugin: concat
+    delimiter: /
+    source:
+      - constants/file_dest_uri
+      - '@image_file'
+  filename: '@image_file'
+  uri:
+    plugin: download
+    source:
+      - '@src_url'
+      - '@file_dest'
+destination:
+  plugin: 'entity:file'
+migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,0 +1,51 @@
+uuid: 17237a78-467a-43a7-9bf0-ff042d947882
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate
+_core:
+  default_config_hash: VcNYMhzvNWztPzAvrJtCIQGwi_OpT4xAthYcUpnKEJ8
+id: va_promo_media
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: va_gov
+label: 'Create media entities from promo block images.'
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      url: 'https://www.va.gov/health-care/'
+    -
+      url: 'https://www.va.gov/disability/'
+    -
+      url: 'https://www.va.gov/education/'
+    -
+      url: 'https://www.va.gov/careers-employment/'
+    -
+      url: 'https://www.va.gov/pension/'
+    -
+      url: 'https://www.va.gov/housing-assistance/'
+    -
+      url: 'https://www.va.gov/life-insurance/'
+    -
+      url: 'https://www.va.gov/burials-memorials/'
+    -
+      url: 'https://www.va.gov/records/'
+  ids:
+    url:
+      type: string
+process:
+  image/target_id:
+    plugin: migration_lookup
+    migration: va_promo_images
+    source: url
+destination:
+  plugin: 'entity:media'
+  default_bundle: image
+migration_dependencies:
+  required:
+    - va_promo_images

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: 258333f8-613e-4027-acaf-43a6f770a80b
+uuid: b686919a-3cb3-44c0-bc3a-b38a6ce4489b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_work_areas.yml
+++ b/config/sync/migrate_plus.migration.va_work_areas.yml
@@ -1,4 +1,4 @@
-uuid: c0ab007c-c92a-46bc-bd76-9bd2cf39fb25
+uuid: 5be8cb36-4789-4fb8-a355-0ea551acfb72
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: f89a2dc4-b513-4e94-90dc-584bf1127ed0
+uuid: 6f327d9a-2164-46bc-938b-14dd511e2375
 langcode: en
 status: true
 dependencies:

--- a/config/sync/views.view.va_blocks_admin.yml
+++ b/config/sync/views.view.va_blocks_admin.yml
@@ -6,13 +6,11 @@ dependencies:
     - block_content.type.alert
     - block_content.type.promo
     - field.storage.block_content.field_image
-    - field.storage.block_content.field_promo_link
     - image.style.2_1_medium_thumbnail
     - user.role.authenticated
   module:
     - block_content
     - content_moderation
-    - entity_reference_revisions
     - media
     - user
 id: va_blocks_admin
@@ -152,10 +150,10 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        field_promo_link:
-          id: field_promo_link
-          table: block_content__field_promo_link
-          field: field_promo_link
+        info:
+          id: info
+          table: block_content_field_data
+          field: info
           relationship: none
           group_type: group
           admin_label: ''
@@ -188,7 +186,7 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: ''
+          element_type: strong
           element_class: ''
           element_label_type: ''
           element_label_class: ''
@@ -200,11 +198,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_revisions_entity_view
+          click_sort_column: value
+          type: string
           settings:
-            view_mode: default
-          group_column: ''
+            link_to_entity: false
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -214,6 +212,8 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: block_content
+          entity_field: info
           plugin_id: field
         edit_block_content:
           id: edit_block_content
@@ -429,7 +429,6 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.block_content.field_image'
-        - 'config:field.storage.block_content.field_promo_link'
   page_1:
     display_plugin: page
     id: page_1
@@ -457,7 +456,6 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.block_content.field_image'
-        - 'config:field.storage.block_content.field_promo_link'
   page_2:
     display_plugin: page
     id: page_2
@@ -565,7 +563,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: 'You can <a href="/block/add/alert?destination=/admin/content/alerts">create an alert</a> to highlight time-sensitive content, usually at the top of a page.  Alerts can be created and then added to an existing page, or can be added directly from certain types of content.'
+          content: '<p>You can <a href="/block/add/alert?destination=/admin/content/alerts">create an alert</a> to highlight time-sensitive content, usually at the top of a page.  Alerts can be created and then added to an existing page, or can be added directly from certain types of content.</p>'
           plugin_id: text_custom
       display_description: ''
     cache_metadata:
@@ -577,4 +575,3 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.block_content.field_image'
-        - 'config:field.storage.block_content.field_promo_link'

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
@@ -153,6 +153,10 @@ process:  # assign the fields we collected above to Drupal fields.
   revision_timestamp: lastupdate
   field_intro_text: intro_text
   field_description: description
+  field_promo:
+    plugin: migration_lookup
+    migration: va_promo
+    source: url
   field_plainlanguage_date:
     plugin: format_date
     from_format: 'n/j/y'
@@ -165,8 +169,9 @@ process:  # assign the fields we collected above to Drupal fields.
 destination:
   plugin: 'entity:node'
 
-migration_dependencies: {} # Remove the {} before adding dependencies below.
-  # If there are migrations that should run before this one (e.g. for an entity that this node references), put them here.
+migration_dependencies:
+  required:
+    - va_promo
 
 # This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_promo.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_promo.yml
@@ -1,0 +1,90 @@
+id: va_promo
+label: Import promo blocks from va.gov
+migration_group: va_gov
+source:
+  plugin: url_list
+  urls:     # For url_list, this is a list of web pages to read
+    - "https://www.va.gov/health-care/"
+    - "https://www.va.gov/disability/"
+    - "https://www.va.gov/education/"
+    - "https://www.va.gov/careers-employment/"
+    - "https://www.va.gov/pension/"
+    - "https://www.va.gov/housing-assistance/"
+    - "https://www.va.gov/life-insurance/"
+    - "https://www.va.gov/burials-memorials/"
+    - "https://www.va.gov/records/"
+
+  migration_tools:
+  -
+    # Just leave this as is, if using metalsmith_source or url_list source.
+    source: url # The field we're passing to migration_tools is called 'url'.
+    source_type: url  # Source type can be either 'url' or 'html'.
+
+    source_operations:
+    -
+      operation: modifier
+      modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
+    fields:
+      title:
+        obtainer: ObtainHtml
+        jobs:
+        -
+          job: addSearch  # Run a job to search the DOM and assign the results to this field.
+          method: findSelector # Don't remove it from the DOM (the paragraph will need it).
+          arguments:
+          - '.hub-promo-text h4.heading a'
+      image:
+        obtainer: ObtainImage
+        jobs:
+        -
+          job: 'addSearch'
+          method: 'pluckImages'
+          arguments:
+            - '.hub-promo'
+      body:
+        obtainer: ObtainHtml
+        jobs:
+        -
+          job: 'addSearch'
+          method: 'pluckSelector'
+          arguments:
+            - '.hub-promo-text'
+            - '1'
+            - HTML
+    dom_operations:
+    -
+      # This runs first.
+      operation: get_field
+      field: title  # Use the 'title' recipe from above to create the field.
+    -
+      # This runs next.
+      operation: get_field
+      field: image
+    -
+      operation: get_field
+      field: body
+
+process:  # assign the fields we collected above to Drupal fields.
+  info: title
+  field_image:
+    -
+      plugin: migration_lookup  # Get value from previous migration
+      migration: va_promo_media # The migration to use
+      source: url # The source field in this migration that corresponds to the source id of the previous migration
+
+  type:
+    plugin: default_value
+    default_value: promo
+
+destination:
+  plugin: 'entity:block_content'
+
+migration_dependencies:
+  required:
+    - va_promo_media
+
+# This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
+dependencies:
+  enforced:
+    module:
+    - va_gov_migrate  # The module this migration script belongs to.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_promo_images.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_promo_images.yml
@@ -1,0 +1,83 @@
+id: va_promo_images
+label: Import promo block images from va.gov
+migration_group: va_gov
+source:
+  plugin: url_list
+  urls:     # For url_list, this is a list of web pages to read
+    - "https://www.va.gov/health-care/"
+    - "https://www.va.gov/disability/"
+    - "https://www.va.gov/education/"
+    - "https://www.va.gov/careers-employment/"
+    - "https://www.va.gov/pension/"
+    - "https://www.va.gov/housing-assistance/"
+    - "https://www.va.gov/life-insurance/"
+    - "https://www.va.gov/burials-memorials/"
+    - "https://www.va.gov/records/"
+
+  migration_tools:
+  -
+    # Just leave this as is, if using metalsmith_source or url_list source.
+    source: url # The field we're passing to migration_tools is called 'url'.
+    source_type: url  # Source type can be either 'url' or 'html'.
+
+    source_operations:
+    -
+      operation: modifier
+      modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
+    fields:
+      image:
+        obtainer: ObtainImage
+        jobs:
+        -
+          job: 'addSearch'
+          method: 'pluckImages'
+          arguments:
+            - '.hub-promo'
+    dom_operations:
+    -
+      operation: get_field
+      field: image
+
+  constants:
+    file_dest_uri: 'public://hub_promos'
+
+process:  # assign the fields we collected above to Drupal fields.
+  src_url:
+    plugin: extract
+    source: image
+    index:
+      - 0
+      - src
+  image_file:
+    -
+      plugin: explode
+      source: '@src_url'
+      delimiter: /
+    -
+      plugin: array_pop
+
+  file_dest:
+      plugin: concat
+      delimiter: /
+      source:
+        - constants/file_dest_uri
+        - '@image_file'
+
+  filename: '@image_file'
+  uri:
+    plugin: download
+    source:
+      - '@src_url'
+      - '@file_dest'
+
+destination:
+  plugin: entity:file
+
+migration_dependencies: {} # Remove the {} before adding dependencies below.
+  # If there are migrations that should run before this one (e.g. for an entity that this node references), put them here.
+
+# This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
+dependencies:
+  enforced:
+    module:
+    - va_gov_migrate  # The module this migration script belongs to.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_promo_media.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_promo_media.yml
@@ -1,0 +1,48 @@
+id: va_promo_media
+label: Create media entities from promo block images.
+migration_group: va_gov
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      url: "https://www.va.gov/health-care/"
+    -
+      url: "https://www.va.gov/disability/"
+    -
+      url: "https://www.va.gov/education/"
+    -
+      url: "https://www.va.gov/careers-employment/"
+    -
+      url: "https://www.va.gov/pension/"
+    -
+      url: "https://www.va.gov/housing-assistance/"
+    -
+      url: "https://www.va.gov/life-insurance/"
+    -
+      url: "https://www.va.gov/burials-memorials/"
+    -
+      url: "https://www.va.gov/records/"
+  ids:
+    url:
+      type: string
+
+
+process:  # assign the fields we collected above to Drupal fields.
+  image/target_id:
+    plugin: migration_lookup
+    migration: va_promo_images
+    source: url
+
+destination:
+  plugin: entity:media
+  default_bundle: image
+
+migration_dependencies:
+  required:
+    - va_promo_images
+
+# This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
+dependencies:
+  enforced:
+    module:
+    - va_gov_migrate  # The module this migration script belongs to.

--- a/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
+++ b/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
@@ -54,6 +54,10 @@ class PostRowSave implements EventSubscriberInterface {
         $migrator->process('related_links', 'field_related_links');
         $migrator->process('hub_links', 'field_spokes');
         break;
+
+      case 'va_promo':
+        $migrator->process('body', 'field_promo_link');
+        break;
     }
   }
 

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/LinksListItem.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/LinksListItem.php
@@ -29,6 +29,9 @@ class LinksListItem extends ParagraphType {
     elseif ($query_path->parent()->hasClass('hub-page-link-list')) {
       return 'li' == $query_path->tag() && $query_path->parent()->hasClass('hub-page-link-list');
     }
+    else {
+      return 'section' == $query_path->tag() && $query_path->hasClass('hub-promo-text');
+    }
 
   }
 
@@ -36,14 +39,34 @@ class LinksListItem extends ParagraphType {
    * {@inheritdoc}
    */
   protected function getFieldValues(DOMQuery $query_path) {
-    $title_raw = !empty($query_path->children('a')->children('.va-nav-linkslist-title')->text()) ?
-    $query_path->children('a')->children('.va-nav-linkslist-title')->text() : $query_path->children('a')->children('.hub-page-link-list__header')->text();
+    if ($query_path->parent()->hasClass('va-nav-linkslist-list') || $query_path->parent()->hasClass('hub-page-link-list')) {
+      $title_raw = !empty($query_path->children('a')
+        ->children('.va-nav-linkslist-title')
+        ->text()) ?
+        $query_path->children('a')
+          ->children('.va-nav-linkslist-title')
+          ->text() : $query_path->children('a')
+          ->children('.hub-page-link-list__header')
+          ->text();
 
-    $summary_raw = !empty($query_path->children('a')->children('.va-nav-linkslist-description')->text()) ?
-      $query_path->children('a')->children('.va-nav-linkslist-description')->text() : $query_path->children('a')->children('.hub-page-link-list__description')->text();
+      $summary_raw = !empty($query_path->children('a')
+        ->children('.va-nav-linkslist-description')
+        ->text()) ?
+        $query_path->children('a')
+          ->children('.va-nav-linkslist-description')
+          ->text() : $query_path->children('a')
+          ->children('.hub-page-link-list__description')
+          ->text();
 
-    if (empty($title_raw)) {
-      $title_raw = $query_path->children('a')->children('b')->text();
+      if (empty($title_raw)) {
+        $title_raw = $query_path->children('a')->children('b')->text();
+      }
+      $url = $query_path->children('a')->attr('href');
+    }
+    else {
+      $title_raw = $query_path->children('h4')->text();
+      $summary_raw = $query_path->children('p')->text();
+      $url = $query_path->children('h4')->children('a')->attr('href');
     }
 
     $title = trim($title_raw);
@@ -51,7 +74,7 @@ class LinksListItem extends ParagraphType {
 
     return [
       'field_link' => [
-        'uri' => $query_path->children('a')->attr('href'),
+        'uri' => $url,
         'title' => $title,
       ],
       'field_link_summary' => $summary,


### PR DESCRIPTION
To test:
1. Import config (drush cim). 
2. Run hub migration ('Import hub pages and paragraphs from va.gov' from ui or 'drush mim va_hub --execute-dependencies --update' from command line).
3. Verify that there are now 9 promo blocks with images (/admin/content/promos).
4. Verify that hub pages now have links to promo blocks (near bottom of edit page, in 'Right Rail' section.

(Note that this pr also contains rebased branches VAGOV-1309-et and VAGOV-000-update-migrate-config)