### PR TITLE
VAGOV-1313 add support services to hubs

### DIFF
--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_form_mode.node.inline_entity_form
     - field.field.node.landing_page.field_administration
     - field.field.node.landing_page.field_alert
     - field.field.node.landing_page.field_description
@@ -12,11 +13,13 @@ dependencies:
     - field.field.node.landing_page.field_promo
     - field.field.node.landing_page.field_related_links
     - field.field.node.landing_page.field_spokes
+    - field.field.node.landing_page.field_support_services
     - node.type.landing_page
   module:
     - content_moderation
     - datetime
     - field_group
+    - inline_entity_form
     - metatag
     - paragraphs
     - path
@@ -27,7 +30,7 @@ third_party_settings:
         - field_administration
         - field_plainlanguage_date
       parent_name: ''
-      weight: 14
+      weight: 15
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -40,8 +43,9 @@ third_party_settings:
     group_right_rail:
       children:
         - field_promo
+        - field_support_services
       parent_name: ''
-      weight: 7
+      weight: 6
       format_type: fieldset
       format_settings:
         id: ''
@@ -49,6 +53,7 @@ third_party_settings:
         description: ''
         required_fields: true
       label: 'Right Rail'
+      region: content
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page
@@ -56,7 +61,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -89,7 +94,7 @@ content:
     type: string_textarea
     region: content
   field_meta_tags:
-    weight: 12
+    weight: 13
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
@@ -144,6 +149,22 @@ content:
     third_party_settings: {  }
     type: paragraphs
     region: content
+  field_support_services:
+    weight: 19
+    settings:
+      form_mode: inline_entity_form
+      label_singular: ''
+      label_plural: ''
+      collapsed: true
+      allow_new: true
+      allow_existing: true
+      match_operator: CONTAINS
+      override_labels: false
+      collapsible: false
+      allow_duplicate: false
+    third_party_settings: {  }
+    type: inline_entity_form_complex
+    region: content
   moderation_state:
     type: moderation_state_default
     weight: 14
@@ -152,7 +173,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -160,21 +181,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 12
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   title:
@@ -187,7 +208,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -195,7 +216,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.landing_page.field_promo
     - field.field.node.landing_page.field_related_links
     - field.field.node.landing_page.field_spokes
+    - field.field.node.landing_page.field_support_services
     - node.type.landing_page
   module:
     - datetime
@@ -95,6 +96,14 @@ content:
       link: ''
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
+    region: content
+  field_support_services:
+    weight: 111
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   links:
     weight: 100

--- a/config/sync/field.field.node.landing_page.field_support_services.yml
+++ b/config/sync/field.field.node.landing_page.field_support_services.yml
@@ -1,0 +1,29 @@
+uuid: 53c127fb-fc45-419e-8c23-2a424792e3ed
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_support_services
+    - node.type.landing_page
+    - node.type.support_service
+id: node.landing_page.field_support_services
+field_name: field_support_services
+entity_type: node
+bundle: landing_page
+label: 'Support Services'
+description: '[Help text goes here]'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      support_service: support_service
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_support_services.yml
+++ b/config/sync/field.storage.node.field_support_services.yml
@@ -1,0 +1,19 @@
+uuid: b923097f-ba92-4faf-be8b-1c1d4d9d789e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_support_services
+field_name: field_support_services
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: eb59bae4-181e-4ae0-a366-c9c44887c6ca
+uuid: 3c558060-6525-4530-9c21-995d1650290a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_healthcare.yml
+++ b/config/sync/migrate_plus.migration.va_healthcare.yml
@@ -1,4 +1,4 @@
-uuid: 82f80c09-4e29-47e9-aaf5-510f335039b9
+uuid: 6bc8b321-fe66-467f-a3df-caf3ccfa3ab1
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: 4260a9a7-1aa2-4880-b06d-73d92e5791e2
+uuid: 5a3bdc32-0cc6-4519-9553-555971edbf5e
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: qVQdxrM--cuMak_tE3vPoLBP3AJQ4waA3QqEKgIZTaE
+  default_config_hash: '-7M292HkeE5Hdj8CqoJAOqgRqpu-_14zFKj1J9k5blA'
 id: va_hub
 class: null
 field_plugin_method: null
@@ -32,6 +32,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - social
   migration_tools:
     -
       source: url
@@ -161,6 +162,25 @@ process:
     from_format: n/j/y
     to_format: Y-m-d
     source: plainlanguage_date
+  field_support_services:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: social
+    -
+      plugin: extract
+      index:
+        - 0
+        - subsections
+        - 1
+        - links
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: migration_lookup
+          migration: va_support_service
+          source: title
   type:
     plugin: default_value
     default_value: landing_page
@@ -169,3 +189,4 @@ destination:
 migration_dependencies:
   required:
     - va_promo
+    - va_support_service

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: 5e95f747-3b8c-4306-bfec-3d2855fcd0a3
+uuid: 7a414538-7de9-4856-aafa-86a3797adadb
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: cde4e0ef-f25d-484a-8791-97b1772fd0db
+uuid: 0adc6e7a-d3d3-4742-87de-dc033c40e6f7
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: 17237a78-467a-43a7-9bf0-ff042d947882
+uuid: 8b8fff71-5075-447b-970a-5fa4a5978e70
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: b686919a-3cb3-44c0-bc3a-b38a6ce4489b
+uuid: 2800e063-47db-4d72-8ca1-1ded821997ae
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_work_areas.yml
+++ b/config/sync/migrate_plus.migration.va_work_areas.yml
@@ -1,4 +1,4 @@
-uuid: 5be8cb36-4789-4fb8-a355-0ea551acfb72
+uuid: 6e65ab4b-f4db-423e-af46-f37d92ebc90a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: 6f327d9a-2164-46bc-938b-14dd511e2375
+uuid: f9e2064e-276d-46a7-b07e-695bad805698
 langcode: en
 status: true
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
@@ -19,6 +19,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - social
 
   migration_tools:
   -
@@ -162,6 +163,25 @@ process:  # assign the fields we collected above to Drupal fields.
     from_format: 'n/j/y'
     to_format: 'Y-m-d'
     source: plainlanguage_date
+  field_support_services:
+    -
+      plugin: skip_on_empty # if source is empty, skip it
+      method: process # don't process this field (but do process the rest of the row)
+      source: social  # the field to check and to pass to the next step
+    -
+      plugin: extract # extract values from array - this returns the contents of social[0]['subsections']
+      index:
+        - 0 # heading: Ask Questions
+        - subsections
+        - 1
+        - links
+    -
+      plugin: sub_process # run for each subsection in array that we extracted above
+      process:
+        target_id:
+          plugin: migration_lookup
+          migration: va_support_service
+          source: title
   type:
     plugin: default_value   # We want to asign the 'type' field a static value.
     default_value: landing_page # The value is 'landing_page'.
@@ -172,6 +192,7 @@ destination:
 migration_dependencies:
   required:
     - va_promo
+    - va_support_service
 
 # This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
 dependencies:


### PR DESCRIPTION
To test:
1. Sync config (drush cim)
2. Run "Import hub pages and paragraphs from va.gov" migration with 'update' checked (drush mim --update --execute-dependencies
3. Verify that hub pages have a 'Support Services' field and it's populated.

Note:
I used Inline Entity Form for Support Services field. Not sure how that will or should affect editing permissions for Support Service nodes.