### PR TITLE
VAGOV-000: Add scheme to internal uri's and format to rich text fields

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/ExpandableText.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/ExpandableText.php
@@ -36,14 +36,14 @@ class ExpandableText extends ParagraphType {
     }
     else {
       Message::make('Expanding block missing trigger text: @html',
-        ['@html' => $this::$migrator->row->getSourceProperty('alert_title')],
+        ['@html' => self::$migrator->row->getSourceProperty('alert_title')],
         Message::ERROR);
       $expander = "Show more";
     }
     return
       [
         'field_text_expander' => $expander,
-        'field_wysiwyg' => $query_path->find('.expander-content-inner')->innerHTML(),
+        'field_wysiwyg' => self::toRichText($query_path->find('.expander-content-inner')->innerHTML()),
       ];
   }
 

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/LinksListItem.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/LinksListItem.php
@@ -74,7 +74,7 @@ class LinksListItem extends ParagraphType {
 
     return [
       'field_link' => [
-        'uri' => $url,
+        'uri' => self::toUri($url),
         'title' => $title,
       ],
       'field_link_summary' => $summary,

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/NumberCallout.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/NumberCallout.php
@@ -36,7 +36,7 @@ class NumberCallout extends ParagraphType {
   protected function getFieldValues(DOMQuery $query_path) {
     return [
       'field_short_phrase_with_a_number' => $query_path->children('.number')->text(),
-      'field_wysiwyg' => $query_path->children('.description')->innerHTML(),
+      'field_wysiwyg' => self::toRichText($query_path->children('.description')->innerHTML()),
     ];
   }
 

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/QaSection.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/QaSection.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_migrate\Paragraph;
 
 use Drupal\migration_tools\Obtainer\ObtainHtml;
+use Drupal\migration_tools\StringTools;
 use Drupal\va_gov_migrate\ParagraphType;
 use QueryPath\DOMQuery;
 
@@ -76,7 +77,7 @@ class QaSection extends ParagraphType {
           $is_accordion = TRUE;
         }
       }
-      elseif ($qp->text() != 'Jump to a section:') {
+      elseif (StringTools::superTrim($qp->text()) != 'Jump to a section:') {
         // If it survived all the tests, it's intro text.
         if (!empty($intro_text)) {
           // Add line breaks between elements.

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/ReactWidget.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/ReactWidget.php
@@ -66,7 +66,7 @@ class ReactWidget extends ParagraphType {
     return [
       'field_cta_widget' => $cta,
       'field_default_link' => [
-        'uri' => $link_url,
+        'uri' => self::toUri($link_url),
         'title' => $link_text,
       ],
       'field_button_format' => $link_button,

--- a/docroot/modules/custom/va_gov_migrate/src/ParagraphType.php
+++ b/docroot/modules/custom/va_gov_migrate/src/ParagraphType.php
@@ -219,4 +219,38 @@ abstract class ParagraphType {
     }
   }
 
+  /**
+   * Adds 'internal' scheme to root-relative urls.
+   *
+   * @param string $url
+   *   The url to process.
+   *
+   * @return string
+   *   The uri.
+   */
+  public static function toUri($url) {
+    if (substr($url, 0, 1) == '/' && substr($url, 0, 2) != '//') {
+      $url = 'internal:' . $url;
+    }
+    return $url;
+  }
+
+  /**
+   * Returns an array with 'value' and 'format' to assign to a rich text field.
+   *
+   * We may want to add to this to sanitize the html.
+   *
+   * @param string $text
+   *   The html save to the field.
+   *
+   * @return array
+   *   An array that can be assigned to a rich text field.
+   */
+  public static function toRichText($text) {
+    return [
+      "value" => $text,
+      "format" => "rich_text",
+    ];
+  }
+
 }


### PR DESCRIPTION
This fixes the problem with internal urls on the site. They still won't link to anything yet, but they won't break the page now. Also fixed a couple of places where the text format wasn't set to rich text. It looked fine in drupal, but graphql was encoding the html.