### PR TITLE
Vagov 1568 migrate sidebar nav

### DIFF
--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: 3ce5e5aa-5cf5-4f49-982f-079783ec36e1
+uuid: 62532edd-50c6-4d85-93c5-9caf9ef23bf4
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_menu.yml
@@ -1,0 +1,48 @@
+uuid: a22a0024-e6fb-44f3-a7a5-075b71873da3
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate
+_core:
+  default_config_hash: a-7I903J_qYf3mqFod4-P7sMbL3-DU7Y7YXTByziRLI
+id: va_benefits_menu
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: va_gov
+label: 'Import menu links for health care benefits main menus'
+source:
+  plugin: va_benefits_menu_source
+  sections:
+    - 'Health Care'
+  constants:
+    bundle: menu_link_content
+    zero: 0
+    one: 1
+process:
+  bundle: constants/bundle
+  title: title
+  menu_name: menu
+  link/uri:
+    plugin: link_uri
+    source:
+      - href
+    validate_route: false
+  route:
+    plugin: route
+    source: href
+  route_name: '@route/route_name'
+  route_parameters: '@route/route_parameters'
+  url: '@route/url'
+  options: '@route/options'
+  external: external
+  weight: weight
+  expanded: constants/zero
+  enabled: constants/one
+destination:
+  plugin: 'entity:menu_link_content'
+  no_stub: true
+migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.va_healthcare.yml
+++ b/config/sync/migrate_plus.migration.va_healthcare.yml
@@ -1,4 +1,4 @@
-uuid: afedb685-ec36-4351-b88f-c90514e02a20
+uuid: 7a66e788-5e5e-4c4a-a93d-b2e58f61289d
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: b2a80253-80f8-44fe-8ba8-ef63a939f99a
+uuid: 9214d793-4c08-42da-9826-a45164af2549
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach.yml
+++ b/config/sync/migrate_plus.migration.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: 1af03bf6-960d-483f-ac57-cd0cb370d1ab
+uuid: 072d8ed7-c947-4fc1-ba41-12b7b5b75725
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
@@ -1,4 +1,4 @@
-uuid: 48e139ef-9185-41f9-bf27-ee5b7e40407d
+uuid: d1df7e5a-bdeb-4953-87b6-8416233d6337
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
@@ -1,4 +1,4 @@
-uuid: 86dd9654-f755-4c1d-bbcc-4df21bd3163e
+uuid: bd58e04f-0c52-4532-a75d-53edb8998b54
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_files.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_files.yml
@@ -1,4 +1,4 @@
-uuid: 73a59e5e-7a37-41f2-9c1c-83b82b8dd1c3
+uuid: c726121a-a3a5-4fde-a9c4-d678ff61dab3
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_image_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_image_media.yml
@@ -1,4 +1,4 @@
-uuid: cdf437bd-9852-4557-8860-2c13125fb1d0
+uuid: 96b0716d-31bc-4ae8-a1fb-667d33ef9acd
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_video.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_video.yml
@@ -1,4 +1,4 @@
-uuid: 261db393-9770-4963-8db9-4b6c93663d2b
+uuid: fd322e35-3df5-4fb6-b75e-2060c546ed21
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: f673e92d-6416-4af9-8cae-67ad990e6e9e
+uuid: 3e108262-4886-45f3-8afd-aa097aae6fb1
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: 90bbedf7-24a6-42c2-b06b-443e8af1d0f4
+uuid: d43040e9-d6b4-4c75-8548-c083bb031752
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: 348d03ad-1043-43be-9d0e-ff73bd1d6fe1
+uuid: 816cd603-0b76-4de5-bafb-40c46b7b54d1
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: 0bb9aef2-bb64-4bf2-a021-bf029be3a6c0
+uuid: 81e68992-9c42-492d-8130-3e040c2bda0b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_work_areas.yml
+++ b/config/sync/migrate_plus.migration.va_work_areas.yml
@@ -1,4 +1,4 @@
-uuid: bd774c07-f63b-48d3-8d3c-8b5287e6f0ed
+uuid: da0dac3d-ccaf-41af-8d12-9ec7c4db57ac
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: 43a5c609-4433-458c-a192-f7f2ef20b237
+uuid: 9382ac10-47ab-4d36-8eed-34c44fd52013
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_outreach.yml
+++ b/config/sync/migrate_plus.migration_group.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: 62c96ba9-16cc-4eb2-abf2-50798dd1f0ac
+uuid: f6cf5696-f1a4-4d44-bae8-67a4e8933660
 langcode: en
 status: true
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_menu.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_menu.yml
@@ -1,0 +1,43 @@
+id: va_benefits_menu
+label: Import menu links for health care benefits main menus
+migration_group: va_gov
+
+source:
+  plugin: va_benefits_menu_source
+  sections:
+    - "Health Care"
+  constants:
+    bundle: menu_link_content
+    zero: 0
+    one: 1
+
+process:
+  bundle: 'constants/bundle'
+  title: title
+  menu_name: menu
+  'link/uri':
+    plugin: link_uri
+    source:
+      - href
+    validate_route: false
+  route:
+    plugin: route
+    source: href
+  route_name: '@route/route_name'
+  route_parameters: '@route/route_parameters'
+  url: '@route/url'
+  options: '@route/options'
+  external: external
+  weight: weight
+  expanded: 'constants/zero'
+  enabled: 'constants/one'
+
+destination:
+  plugin: entity:menu_link_content
+  no_stub: true
+
+migration_dependencies: {}
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate

--- a/docroot/modules/custom/va_gov_migrate/data/sidebar.json
+++ b/docroot/modules/custom/va_gov_migrate/data/sidebar.json
@@ -1,0 +1,17166 @@
+[
+  {
+    "fileName": "veterans-portrait-project/index.html",
+    "sidebarTitle": "",
+    "backLink": null,
+    "items": [],
+    "menus": []
+  },
+  {
+    "fileName": "welcome-kit/index.html",
+    "sidebarTitle": "",
+    "backLink": null,
+    "items": [],
+    "menus": []
+  },
+  {
+    "fileName": "discharge-upgrade-instructions/index.html",
+    "sidebarTitle": "Records",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Records",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get VA Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Types of Veteran ID Cards",
+            "href": "/records/get-veteran-id-cards",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Learn How to Apply for a Home Loan COE",
+            "href": "/housing-assistance/home-loans/how-to-apply/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Discharge Upgrade",
+            "href": "/discharge-upgrade-instructions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/aid-attendance-housebound/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/eligibility/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/how-to-apply/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": [
+              {
+                "title": "Fully Developed Claim Program",
+                "href": "/pension/how-to-apply/fully-developed-claim"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/pension-management-centers/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/survivors-pension/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/survivors-pension-rates/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/veterans-pension-rates/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/how-to-apply/fully-developed-claim/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": {
+      "title": "How to Apply",
+      "href": "/pension/how-to-apply"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Fully Developed Claim Program",
+        "href": "/pension/how-to-apply/fully-developed-claim",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "records/download-va-letters/index.html",
+    "sidebarTitle": "Records",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Records",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get VA Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Types of Veteran ID Cards",
+            "href": "/records/get-veteran-id-cards",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Learn How to Apply for a Home Loan COE",
+            "href": "/housing-assistance/home-loans/how-to-apply/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Discharge Upgrade",
+            "href": "/discharge-upgrade-instructions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "records/get-military-service-records/index.html",
+    "sidebarTitle": "Records",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Records",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get VA Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Types of Veteran ID Cards",
+            "href": "/records/get-veteran-id-cards",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Learn How to Apply for a Home Loan COE",
+            "href": "/housing-assistance/home-loans/how-to-apply/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Discharge Upgrade",
+            "href": "/discharge-upgrade-instructions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "records/get-veteran-id-cards/index.html",
+    "sidebarTitle": "Records",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Records",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get VA Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Types of Veteran ID Cards",
+            "href": "/records/get-veteran-id-cards",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Learn How to Apply for a Home Loan COE",
+            "href": "/housing-assistance/home-loans/how-to-apply/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Discharge Upgrade",
+            "href": "/discharge-upgrade-instructions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "records/get-veteran-id-cards/vic/index.html",
+    "sidebarTitle": "Records",
+    "backLink": {
+      "title": "Types of Veteran ID Cards",
+      "href": "/records/get-veteran-id-cards"
+    },
+    "items": [],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/careerscope-skills-assessment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/dependent-benefits/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/education-and-career-counseling/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/family-resources/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/veteran-owned-business-support/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/veteran-resources/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/vetsuccess-on-campus/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": [
+              {
+                "title": "Programs",
+                "href": "/careers-employment/vocational-rehabilitation/programs"
+              },
+              {
+                "title": "Eligibility",
+                "href": "/careers-employment/vocational-rehabilitation/eligibility"
+              },
+              {
+                "title": "How to Apply",
+                "href": "/careers-employment/vocational-rehabilitation/how-to-apply"
+              },
+              {
+                "title": "Accessing VR&E Through IDES",
+                "href": "/careers-employment/vocational-rehabilitation/ides"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/eligibility/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/how-to-apply/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/ides/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": [
+          {
+            "title": "Reemployment",
+            "href": "/careers-employment/vocational-rehabilitation/programs/reemployment"
+          },
+          {
+            "title": "Rapid Access to Employment",
+            "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment"
+          },
+          {
+            "title": "Self-Employment",
+            "href": "/careers-employment/vocational-rehabilitation/programs/self-employment"
+          },
+          {
+            "title": "Long-Term Services",
+            "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services"
+          },
+          {
+            "title": "Independent Living",
+            "href": "/careers-employment/vocational-rehabilitation/programs/independent-living"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/independent-living/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/long-term-services/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/reemployment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/self-employment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "burials-memorials/bereavement-counseling/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/dependency-indemnity-compensation/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/eligibility/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": [
+              {
+                "title": "Burial in a Private Cemetery",
+                "href": "https://www.cem.va.gov/cem/burial_benefits/private_cemetery.asp"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/memorial-items/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": [
+              {
+                "title": "Headstones, Markers or Medallions",
+                "href": "/burials-memorials/memorial-items/headstones-markers-medallions"
+              },
+              {
+                "title": "Burial Flags",
+                "href": "/burials-memorials/memorial-items/burial-flags"
+              },
+              {
+                "title": "Presidential Memorial Certificates",
+                "href": "/burials-memorials/memorial-items/presidential-memorial-certificates"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/plan-a-burial/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": [
+              {
+                "title": "Military Funeral Honors",
+                "href": "https://www.cem.va.gov/CEM/military_funeral_honors.asp"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/pre-need-eligibility/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": [
+              {
+                "title": "Apply Now",
+                "href": "/burials-and-memorials/pre-need/form-10007-apply-for-eligibility/"
+              },
+              {
+                "title": "FAQs",
+                "href": "http://www.cem.va.gov/CEM/pre-need/FAQ/"
+              },
+              {
+                "title": "After You Apply",
+                "href": "/burials-memorials/pre-need-eligibility/after-you-apply"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/veterans-burial-allowance/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": [
+              {
+                "title": "Apply Now",
+                "href": "/burials-and-memorials/application/530"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/what-to-expect-at-military-funeral/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/burials-memorials/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pre-need Burial Eligibility Determination",
+            "href": "/burials-memorials/pre-need-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Allowance",
+            "href": "/burials-memorials/veterans-burial-allowance",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Memorial Items",
+            "href": "/burials-memorials/memorial-items",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Bereavement Counseling",
+            "href": "/burials-memorials/bereavement-counseling",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Plan a Burial",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Plan a Burial",
+            "href": "/burials-memorials/plan-a-burial",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule a Burial",
+            "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Cemetery",
+            "href": "https://www.cem.va.gov/cems/listcem.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Daily Burial Schedule",
+            "href": "https://www.cem.va.gov/cem/dailyburialschedule/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor DIC Rates",
+            "href": "https://www.benefits.va.gov/Compensation/current_rates_dic.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Parents DIC Rates",
+            "href": "https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Replace Medals, Awards, and Decorations",
+            "href": "https://www.archives.gov/veterans/replace-medals",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/veterans",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Grave Locator",
+            "href": "https://m.va.gov/gravelocator/index.cfm",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Burial Benefits FAQs",
+            "href": "https://www.cem.va.gov/cem/faq.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "What to Expect at a Military Funeral",
+            "href": "/burials-memorials/what-to-expect-at-military-funeral",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "burials-memorials/pre-need-eligibility/after-you-apply/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": {
+      "title": "Pre-need Burial Eligibility Determination",
+      "href": "/burials-memorials/pre-need-eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Apply Now",
+        "href": "/burials-and-memorials/pre-need/form-10007-apply-for-eligibility/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "FAQs",
+        "href": "http://www.cem.va.gov/CEM/pre-need/FAQ/",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "After You Apply",
+        "href": "/burials-memorials/pre-need-eligibility/after-you-apply",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "burials-memorials/memorial-items/burial-flags/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": {
+      "title": "Memorial Items",
+      "href": "/burials-memorials/memorial-items"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Headstones, Markers or Medallions",
+        "href": "/burials-memorials/memorial-items/headstones-markers-medallions",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Burial Flags",
+        "href": "/burials-memorials/memorial-items/burial-flags",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Presidential Memorial Certificates",
+        "href": "/burials-memorials/memorial-items/presidential-memorial-certificates",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "burials-memorials/memorial-items/headstones-markers-medallions/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": {
+      "title": "Memorial Items",
+      "href": "/burials-memorials/memorial-items"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Headstones, Markers or Medallions",
+        "href": "/burials-memorials/memorial-items/headstones-markers-medallions",
+        "items": [
+          {
+            "title": "Types",
+            "href": "https://www.cem.va.gov/cem/hmm/types.asp"
+          },
+          {
+            "title": "Replacements",
+            "href": "https://www.cem.va.gov/cem/hmm/replacements.asp"
+          },
+          {
+            "title": "Pre-World War I Era",
+            "href": "https://www.cem.va.gov/cem/hmm/pre_WWI_era.asp"
+          },
+          {
+            "title": "Inscription Abbreviations",
+            "href": "https://www.cem.va.gov/cem/hmm/abbreviations.asp"
+          },
+          {
+            "title": "Available Emblems of Belief",
+            "href": "https://www.cem.va.gov/cem/hmm/emblems.asp"
+          },
+          {
+            "title": "Discharge Documents Needed",
+            "href": "https://www.cem.va.gov/cem/hmm/discharge_documents.asp"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Burial Flags",
+        "href": "/burials-memorials/memorial-items/burial-flags",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Presidential Memorial Certificates",
+        "href": "/burials-memorials/memorial-items/presidential-memorial-certificates",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "burials-memorials/memorial-items/presidential-memorial-certificates/index.html",
+    "sidebarTitle": "Burials and Memorials",
+    "backLink": {
+      "title": "Memorial Items",
+      "href": "/burials-memorials/memorial-items"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Headstones, Markers or Medallions",
+        "href": "/burials-memorials/memorial-items/headstones-markers-medallions",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Burial Flags",
+        "href": "/burials-memorials/memorial-items/burial-flags",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Presidential Memorial Certificates",
+        "href": "/burials-memorials/memorial-items/presidential-memorial-certificates",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/about-affordable-care-act/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": [
+              {
+                "title": "Your Care Team",
+                "href": "/health-care/about-va-health-benefits/your-care-team"
+              },
+              {
+                "title": "Where You'll Go for Care",
+                "href": "/health-care/about-va-health-benefits/where-you-go-for-care"
+              },
+              {
+                "title": "Cost of Care",
+                "href": "https://localhost/HEALTHBENEFITS/cost/index.asp"
+              },
+              {
+                "title": "VA Health Care and Other Insurance",
+                "href": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance"
+              },
+              {
+                "title": "Long-Term Care",
+                "href": "/health-care/about-va-health-benefits/long-term-care"
+              },
+              {
+                "title": "Dental Care",
+                "href": "/health-care/about-va-health-benefits/dental-care"
+              },
+              {
+                "title": "Vision Care",
+                "href": "/health-care/about-va-health-benefits/vision-care"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/after-you-apply/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/eligibility/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": [
+              {
+                "title": "Active Duty Service Members",
+                "href": "https://localhost/HEALTHBENEFITS/apply/active_duty.asp"
+              },
+              {
+                "title": "Returning Service Members",
+                "href": "https://localhost/HEALTHBENEFITS/apply/returning_servicemembers.asp"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/family-caregiver-benefits/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": [
+              {
+                "title": "CHAMPVA Benefits",
+                "href": "/health-care/family-caregiver-benefits/champva"
+              },
+              {
+                "title": "Comprehensive Assistance to Family Caregivers",
+                "href": "/health-care/family-caregiver-benefits/comprehensive-assistance"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/get-medical-records/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": [
+              {
+                "title": "Health Issues Related to Service Era",
+                "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+              },
+              {
+                "title": "Health Topics A-Z",
+                "href": "https://localhost/health/topics/index.asp"
+              },
+              {
+                "title": "Mental Health",
+                "href": "/health-care/health-needs-conditions/mental-health"
+              },
+              {
+                "title": "Military Sexual Trauma",
+                "href": "/health-care/health-needs-conditions/military-sexual-trauma"
+              },
+              {
+                "title": "Substance Use Problems",
+                "href": "/health-care/health-needs-conditions/substance-use-problems"
+              },
+              {
+                "title": "Exposure to Hazardous Materials",
+                "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure"
+              },
+              {
+                "title": "Women’s Health Care Needs",
+                "href": "/health-care/health-needs-conditions/womens-health-needs"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/how-to-apply/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/order-hearing-aid-batteries-prosthetic-socks/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/secure-messaging/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/schedule-view-va-appointments/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/update-health-information/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/view-test-and-lab-results/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/wellness-programs/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/family-caregiver-benefits/champva/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Family and Caregiver Benefits",
+      "href": "/health-care/family-caregiver-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "CHAMPVA Benefits",
+        "href": "/health-care/family-caregiver-benefits/champva",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Comprehensive Assistance to Family Caregivers",
+        "href": "/health-care/family-caregiver-benefits/comprehensive-assistance",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/family-caregiver-benefits/comprehensive-assistance/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Family and Caregiver Benefits",
+      "href": "/health-care/family-caregiver-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "CHAMPVA Benefits",
+        "href": "/health-care/family-caregiver-benefits/champva",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Comprehensive Assistance to Family Caregivers",
+        "href": "/health-care/family-caregiver-benefits/comprehensive-assistance",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/refill-track-prescriptions/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "https://localhost/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "https://localhost/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/dental-care/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "About VA Health Benefits",
+      "href": "/health-care/about-va-health-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Your Care Team",
+        "href": "/health-care/about-va-health-benefits/your-care-team",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Where You'll Go for Care",
+        "href": "/health-care/about-va-health-benefits/where-you-go-for-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cost of Care",
+        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Health Care and Other Insurance",
+        "href": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Care",
+        "href": "/health-care/about-va-health-benefits/long-term-care",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Dental Care",
+        "href": "/health-care/about-va-health-benefits/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vision Care",
+        "href": "/health-care/about-va-health-benefits/vision-care",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/long-term-care/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "About VA Health Benefits",
+      "href": "/health-care/about-va-health-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Your Care Team",
+        "href": "/health-care/about-va-health-benefits/your-care-team",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Where You'll Go for Care",
+        "href": "/health-care/about-va-health-benefits/where-you-go-for-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cost of Care",
+        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Health Care and Other Insurance",
+        "href": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Long-Term Care",
+        "href": "/health-care/about-va-health-benefits/long-term-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/health-care/about-va-health-benefits/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vision Care",
+        "href": "/health-care/about-va-health-benefits/vision-care",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/va-health-care-and-other-insurance/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "About VA Health Benefits",
+      "href": "/health-care/about-va-health-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Your Care Team",
+        "href": "/health-care/about-va-health-benefits/your-care-team",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Where You'll Go for Care",
+        "href": "/health-care/about-va-health-benefits/where-you-go-for-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cost of Care",
+        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "VA Health Care and Other Insurance",
+        "href": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Care",
+        "href": "/health-care/about-va-health-benefits/long-term-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/health-care/about-va-health-benefits/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vision Care",
+        "href": "/health-care/about-va-health-benefits/vision-care",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/vision-care/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "About VA Health Benefits",
+      "href": "/health-care/about-va-health-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Your Care Team",
+        "href": "/health-care/about-va-health-benefits/your-care-team",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Where You'll Go for Care",
+        "href": "/health-care/about-va-health-benefits/where-you-go-for-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cost of Care",
+        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Health Care and Other Insurance",
+        "href": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Care",
+        "href": "/health-care/about-va-health-benefits/long-term-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/health-care/about-va-health-benefits/dental-care",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Vision Care",
+        "href": "/health-care/about-va-health-benefits/vision-care",
+        "items": [
+          {
+            "title": "Blind and Low-Vision Services",
+            "href": "/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services"
+          }
+        ]
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/where-you-go-for-care/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "About VA Health Benefits",
+      "href": "/health-care/about-va-health-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Your Care Team",
+        "href": "/health-care/about-va-health-benefits/your-care-team",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Where You'll Go for Care",
+        "href": "/health-care/about-va-health-benefits/where-you-go-for-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cost of Care",
+        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Health Care and Other Insurance",
+        "href": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Care",
+        "href": "/health-care/about-va-health-benefits/long-term-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/health-care/about-va-health-benefits/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vision Care",
+        "href": "/health-care/about-va-health-benefits/vision-care",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/your-care-team/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "About VA Health Benefits",
+      "href": "/health-care/about-va-health-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Your Care Team",
+        "href": "/health-care/about-va-health-benefits/your-care-team",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Where You'll Go for Care",
+        "href": "/health-care/about-va-health-benefits/where-you-go-for-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cost of Care",
+        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Health Care and Other Insurance",
+        "href": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Care",
+        "href": "/health-care/about-va-health-benefits/long-term-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/health-care/about-va-health-benefits/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vision Care",
+        "href": "/health-care/about-va-health-benefits/vision-care",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Vision Care",
+      "href": "/health-care/about-va-health-benefits/vision-care"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Blind and Low-Vision Services",
+        "href": "/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/chemical-hazardous-materials-exposure/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Needs and Conditions",
+      "href": "/health-care/health-needs-conditions"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Health Issues Related to Service Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "https://localhost/health/topics/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mental Health",
+        "href": "/health-care/health-needs-conditions/mental-health",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Military Sexual Trauma",
+        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Substance Use Problems",
+        "href": "/health-care/health-needs-conditions/substance-use-problems",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Women’s Health Care Needs",
+        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Needs and Conditions",
+      "href": "/health-care/health-needs-conditions"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Health Issues Related to Service Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
+        "items": [
+          {
+            "title": "Operation Enduring Freedom",
+            "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom"
+          },
+          {
+            "title": "Iraq War",
+            "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war"
+          },
+          {
+            "title": "Gulf War",
+            "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war"
+          },
+          {
+            "title": "Cold War Era",
+            "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war"
+          },
+          {
+            "title": "Vietnam War",
+            "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war"
+          },
+          {
+            "title": "Korean War",
+            "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war"
+          },
+          {
+            "title": "World War II",
+            "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "https://localhost/health/topics/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mental Health",
+        "href": "/health-care/health-needs-conditions/mental-health",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Military Sexual Trauma",
+        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Substance Use Problems",
+        "href": "/health-care/health-needs-conditions/substance-use-problems",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Women’s Health Care Needs",
+        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Needs and Conditions",
+      "href": "/health-care/health-needs-conditions"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Health Issues Related to Service Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "https://localhost/health/topics/index.asp",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Mental Health",
+        "href": "/health-care/health-needs-conditions/mental-health",
+        "items": [
+          {
+            "title": "PTSD",
+            "href": "/health-care/health-needs-conditions/mental-health/ptsd"
+          },
+          {
+            "title": "Depression",
+            "href": "/health-care/health-needs-conditions/mental-health/depression"
+          },
+          {
+            "title": "Suicide Prevention",
+            "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Military Sexual Trauma",
+        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Substance Use Problems",
+        "href": "/health-care/health-needs-conditions/substance-use-problems",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Women’s Health Care Needs",
+        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/military-sexual-trauma/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Needs and Conditions",
+      "href": "/health-care/health-needs-conditions"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Health Issues Related to Service Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "https://localhost/health/topics/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mental Health",
+        "href": "/health-care/health-needs-conditions/mental-health",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Military Sexual Trauma",
+        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Substance Use Problems",
+        "href": "/health-care/health-needs-conditions/substance-use-problems",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Women’s Health Care Needs",
+        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/substance-use-problems/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Needs and Conditions",
+      "href": "/health-care/health-needs-conditions"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Health Issues Related to Service Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "https://localhost/health/topics/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mental Health",
+        "href": "/health-care/health-needs-conditions/mental-health",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Military Sexual Trauma",
+        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Substance Use Problems",
+        "href": "/health-care/health-needs-conditions/substance-use-problems",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Women’s Health Care Needs",
+        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/womens-health-needs/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Needs and Conditions",
+      "href": "/health-care/health-needs-conditions"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Health Issues Related to Service Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "https://localhost/health/topics/index.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mental Health",
+        "href": "/health-care/health-needs-conditions/mental-health",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Military Sexual Trauma",
+        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Substance Use Problems",
+        "href": "/health-care/health-needs-conditions/substance-use-problems",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Women’s Health Care Needs",
+        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/depression/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Mental Health",
+      "href": "/health-care/health-needs-conditions/mental-health"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Depression",
+        "href": "/health-care/health-needs-conditions/mental-health/depression",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Suicide Prevention",
+        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/ptsd/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Mental Health",
+      "href": "/health-care/health-needs-conditions/mental-health"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "PTSD",
+        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Depression",
+        "href": "/health-care/health-needs-conditions/mental-health/depression",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Suicide Prevention",
+        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/suicide-prevention/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Mental Health",
+      "href": "/health-care/health-needs-conditions/mental-health"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Depression",
+        "href": "/health-care/health-needs-conditions/mental-health/depression",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Suicide Prevention",
+        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "life-insurance/file-appeal-for-tsgli/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Options and Eligibility",
+            "href": "/life-insurance/options-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Totally Disabled or Terminally Ill",
+            "href": "/life-insurance/totally-disabled-or-terminally-ill",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Financial Counseling and Online Will Prep",
+            "href": "https://www.benefits.va.gov/insurance/bfcs.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Access Your Policy Online",
+            "href": "/life-insurance/manage-your-policy",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Beneficiaries",
+            "href": "https://www.benefits.va.gov/INSURANCE/updatebene.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File a Claim",
+            "href": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Convert to Commercial Policy",
+            "href": "https://www.benefits.va.gov/INSURANCE/converting.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "File a TSGLI Appeal",
+            "href": "/life-insurance/file-appeal-for-tsgli",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Enroll in VGLI Auto Pay",
+            "href": "https://www.benefits.va.gov/INSURANCE/vgli_auto_pay.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Unclaimed Insurance Funds",
+            "href": "https://www.insurance.va.gov/UnclaimedFunds/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Assess Your Life Insurance Needs",
+            "href": "https://www.benefits.va.gov/insurance/lifeins101.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Myths and Rumors about SGLI/VGLI",
+            "href": "https://www.benefits.va.gov/INSURANCE/sgli_myths_rumors.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "About SOES",
+            "href": "https://www.benefits.va.gov/INSURANCE/SOES.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-contact.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Life Insurance Forms",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Publications and Handbooks",
+            "href": "https://www.benefits.va.gov/INSURANCE/ins_publications.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Mandatory Electronic Payments",
+            "href": "https://www.benefits.va.gov/INSURANCE/payments-eft.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Uninsurable Conditions",
+            "href": "https://www.benefits.va.gov/INSURANCE/uninsurable.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "life-insurance/manage-your-policy/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Options and Eligibility",
+            "href": "/life-insurance/options-eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Totally Disabled or Terminally Ill",
+            "href": "/life-insurance/totally-disabled-or-terminally-ill",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Financial Counseling and Online Will Prep",
+            "href": "https://www.benefits.va.gov/insurance/bfcs.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Access Your Policy Online",
+            "href": "/life-insurance/manage-your-policy",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Beneficiaries",
+            "href": "https://www.benefits.va.gov/INSURANCE/updatebene.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File a Claim",
+            "href": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Convert to Commercial Policy",
+            "href": "https://www.benefits.va.gov/INSURANCE/converting.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File a TSGLI Appeal",
+            "href": "/life-insurance/file-appeal-for-tsgli",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Enroll in VGLI Auto Pay",
+            "href": "https://www.benefits.va.gov/INSURANCE/vgli_auto_pay.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Unclaimed Insurance Funds",
+            "href": "https://www.insurance.va.gov/UnclaimedFunds/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Assess Your Life Insurance Needs",
+            "href": "https://www.benefits.va.gov/insurance/lifeins101.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Myths and Rumors about SGLI/VGLI",
+            "href": "https://www.benefits.va.gov/INSURANCE/sgli_myths_rumors.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "About SOES",
+            "href": "https://www.benefits.va.gov/INSURANCE/SOES.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-contact.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Life Insurance Forms",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Publications and Handbooks",
+            "href": "https://www.benefits.va.gov/INSURANCE/ins_publications.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Mandatory Electronic Payments",
+            "href": "https://www.benefits.va.gov/INSURANCE/payments-eft.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Uninsurable Conditions",
+            "href": "https://www.benefits.va.gov/INSURANCE/uninsurable.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "life-insurance/options-eligibility/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Options and Eligibility",
+            "href": "/life-insurance/options-eligibility",
+            "items": [
+              {
+                "title": "Servicemembers’ Group (SGLI)",
+                "href": "/life-insurance/options-eligibility/sgli"
+              },
+              {
+                "title": "Family Servicemembers’ Group (FSGLI)",
+                "href": "/life-insurance/options-eligibility/fsgli"
+              },
+              {
+                "title": "Traumatic Injury Protection (TSGLI)",
+                "href": "/life-insurance/options-eligibility/tsgli"
+              },
+              {
+                "title": "Veterans’ Group (VGLI)",
+                "href": "/life-insurance/options-eligibility/vgli"
+              },
+              {
+                "title": "Service-Disabled Veterans (S-DVI)",
+                "href": "/life-insurance/options-eligibility/s-dvi"
+              },
+              {
+                "title": "Veterans’ Mortgage (VMLI)",
+                "href": "/life-insurance/options-eligibility/vmli"
+              },
+              {
+                "title": "Other VA Programs",
+                "href": "https://www.benefits.va.gov/insurance/select.asp"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Totally Disabled or Terminally Ill",
+            "href": "/life-insurance/totally-disabled-or-terminally-ill",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Financial Counseling and Online Will Prep",
+            "href": "https://www.benefits.va.gov/insurance/bfcs.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Access Your Policy Online",
+            "href": "/life-insurance/manage-your-policy",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Beneficiaries",
+            "href": "https://www.benefits.va.gov/INSURANCE/updatebene.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File a Claim",
+            "href": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Convert to Commercial Policy",
+            "href": "https://www.benefits.va.gov/INSURANCE/converting.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File a TSGLI Appeal",
+            "href": "/life-insurance/file-appeal-for-tsgli",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Enroll in VGLI Auto Pay",
+            "href": "https://www.benefits.va.gov/INSURANCE/vgli_auto_pay.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Unclaimed Insurance Funds",
+            "href": "https://www.insurance.va.gov/UnclaimedFunds/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Assess Your Life Insurance Needs",
+            "href": "https://www.benefits.va.gov/insurance/lifeins101.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Myths and Rumors about SGLI/VGLI",
+            "href": "https://www.benefits.va.gov/INSURANCE/sgli_myths_rumors.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "About SOES",
+            "href": "https://www.benefits.va.gov/INSURANCE/SOES.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-contact.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Life Insurance Forms",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Publications and Handbooks",
+            "href": "https://www.benefits.va.gov/INSURANCE/ins_publications.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Mandatory Electronic Payments",
+            "href": "https://www.benefits.va.gov/INSURANCE/payments-eft.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Uninsurable Conditions",
+            "href": "https://www.benefits.va.gov/INSURANCE/uninsurable.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "life-insurance/totally-disabled-or-terminally-ill/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Options and Eligibility",
+            "href": "/life-insurance/options-eligibility",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Totally Disabled or Terminally Ill",
+            "href": "/life-insurance/totally-disabled-or-terminally-ill",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Financial Counseling and Online Will Prep",
+            "href": "https://www.benefits.va.gov/insurance/bfcs.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Access Your Policy Online",
+            "href": "/life-insurance/manage-your-policy",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Beneficiaries",
+            "href": "https://www.benefits.va.gov/INSURANCE/updatebene.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File a Claim",
+            "href": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Convert to Commercial Policy",
+            "href": "https://www.benefits.va.gov/INSURANCE/converting.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File a TSGLI Appeal",
+            "href": "/life-insurance/file-appeal-for-tsgli",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Enroll in VGLI Auto Pay",
+            "href": "https://www.benefits.va.gov/INSURANCE/vgli_auto_pay.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Unclaimed Insurance Funds",
+            "href": "https://www.insurance.va.gov/UnclaimedFunds/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Assess Your Life Insurance Needs",
+            "href": "https://www.benefits.va.gov/insurance/lifeins101.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Myths and Rumors about SGLI/VGLI",
+            "href": "https://www.benefits.va.gov/INSURANCE/sgli_myths_rumors.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "About SOES",
+            "href": "https://www.benefits.va.gov/INSURANCE/SOES.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-contact.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Life Insurance Forms",
+            "href": "https://www.benefits.va.gov/INSURANCE/resources-forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Publications and Handbooks",
+            "href": "https://www.benefits.va.gov/INSURANCE/ins_publications.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Mandatory Electronic Payments",
+            "href": "https://www.benefits.va.gov/INSURANCE/payments-eft.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Uninsurable Conditions",
+            "href": "https://www.benefits.va.gov/INSURANCE/uninsurable.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "life-insurance/options-eligibility/fsgli/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": {
+      "title": "Options and Eligibility",
+      "href": "/life-insurance/options-eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Servicemembers’ Group (SGLI)",
+        "href": "/life-insurance/options-eligibility/sgli",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Family Servicemembers’ Group (FSGLI)",
+        "href": "/life-insurance/options-eligibility/fsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Traumatic Injury Protection (TSGLI)",
+        "href": "/life-insurance/options-eligibility/tsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Group (VGLI)",
+        "href": "/life-insurance/options-eligibility/vgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service-Disabled Veterans (S-DVI)",
+        "href": "/life-insurance/options-eligibility/s-dvi",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Mortgage (VMLI)",
+        "href": "/life-insurance/options-eligibility/vmli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Other VA Programs",
+        "href": "https://www.benefits.va.gov/insurance/select.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "life-insurance/options-eligibility/s-dvi/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": {
+      "title": "Options and Eligibility",
+      "href": "/life-insurance/options-eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Servicemembers’ Group (SGLI)",
+        "href": "/life-insurance/options-eligibility/sgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Family Servicemembers’ Group (FSGLI)",
+        "href": "/life-insurance/options-eligibility/fsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Traumatic Injury Protection (TSGLI)",
+        "href": "/life-insurance/options-eligibility/tsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Group (VGLI)",
+        "href": "/life-insurance/options-eligibility/vgli",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Service-Disabled Veterans (S-DVI)",
+        "href": "/life-insurance/options-eligibility/s-dvi",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Mortgage (VMLI)",
+        "href": "/life-insurance/options-eligibility/vmli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Other VA Programs",
+        "href": "https://www.benefits.va.gov/insurance/select.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "life-insurance/options-eligibility/sgli/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": {
+      "title": "Options and Eligibility",
+      "href": "/life-insurance/options-eligibility"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Servicemembers’ Group (SGLI)",
+        "href": "/life-insurance/options-eligibility/sgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Family Servicemembers’ Group (FSGLI)",
+        "href": "/life-insurance/options-eligibility/fsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Traumatic Injury Protection (TSGLI)",
+        "href": "/life-insurance/options-eligibility/tsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Group (VGLI)",
+        "href": "/life-insurance/options-eligibility/vgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service-Disabled Veterans (S-DVI)",
+        "href": "/life-insurance/options-eligibility/s-dvi",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Mortgage (VMLI)",
+        "href": "/life-insurance/options-eligibility/vmli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Other VA Programs",
+        "href": "https://www.benefits.va.gov/insurance/select.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "life-insurance/options-eligibility/tsgli/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": {
+      "title": "Options and Eligibility",
+      "href": "/life-insurance/options-eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Servicemembers’ Group (SGLI)",
+        "href": "/life-insurance/options-eligibility/sgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Family Servicemembers’ Group (FSGLI)",
+        "href": "/life-insurance/options-eligibility/fsgli",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Traumatic Injury Protection (TSGLI)",
+        "href": "/life-insurance/options-eligibility/tsgli",
+        "items": [
+          {
+            "title": "TSGLI Loss Standards",
+            "href": "https://www.benefits.va.gov/insurance/tsgli_schedule_Schedule.asp"
+          },
+          {
+            "title": "Retroactive Benefits Questionnaire",
+            "href": "https://www.benefits.va.gov/INSURANCE/tsgli-claim-questionnaire.asp"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Group (VGLI)",
+        "href": "/life-insurance/options-eligibility/vgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service-Disabled Veterans (S-DVI)",
+        "href": "/life-insurance/options-eligibility/s-dvi",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Mortgage (VMLI)",
+        "href": "/life-insurance/options-eligibility/vmli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Other VA Programs",
+        "href": "https://www.benefits.va.gov/insurance/select.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "life-insurance/options-eligibility/vgli/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": {
+      "title": "Options and Eligibility",
+      "href": "/life-insurance/options-eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Servicemembers’ Group (SGLI)",
+        "href": "/life-insurance/options-eligibility/sgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Family Servicemembers’ Group (FSGLI)",
+        "href": "/life-insurance/options-eligibility/fsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Traumatic Injury Protection (TSGLI)",
+        "href": "/life-insurance/options-eligibility/tsgli",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Veterans’ Group (VGLI)",
+        "href": "/life-insurance/options-eligibility/vgli",
+        "items": [
+          {
+            "title": "Compare VGLI to Other Insurance",
+            "href": "https://www.benefits.va.gov/insurance/vgli_rates_compare_vgli.asp"
+          },
+          {
+            "title": "Premium Rates",
+            "href": "https://www.benefits.va.gov/INSURANCE/vgli_rates_new.asp"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Service-Disabled Veterans (S-DVI)",
+        "href": "/life-insurance/options-eligibility/s-dvi",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Mortgage (VMLI)",
+        "href": "/life-insurance/options-eligibility/vmli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Other VA Programs",
+        "href": "https://www.benefits.va.gov/insurance/select.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "life-insurance/options-eligibility/vmli/index.html",
+    "sidebarTitle": "Life Insurance",
+    "backLink": {
+      "title": "Options and Eligibility",
+      "href": "/life-insurance/options-eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Servicemembers’ Group (SGLI)",
+        "href": "/life-insurance/options-eligibility/sgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Family Servicemembers’ Group (FSGLI)",
+        "href": "/life-insurance/options-eligibility/fsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Traumatic Injury Protection (TSGLI)",
+        "href": "/life-insurance/options-eligibility/tsgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Veterans’ Group (VGLI)",
+        "href": "/life-insurance/options-eligibility/vgli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service-Disabled Veterans (S-DVI)",
+        "href": "/life-insurance/options-eligibility/s-dvi",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Veterans’ Mortgage (VMLI)",
+        "href": "/life-insurance/options-eligibility/vmli",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Other VA Programs",
+        "href": "https://www.benefits.va.gov/insurance/select.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/about-disability-ratings/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": [
+              {
+                "title": "Effective Dates",
+                "href": "/disability/about-disability-ratings/effective-date"
+              },
+              {
+                "title": "After You Get a Rating",
+                "href": "/disability/about-disability-ratings/after-you-get-a-rating"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/add-remove-dependent/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/after-you-file-claim/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/eligibility/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": [
+              {
+                "title": "Exposure to Hazardous Materials",
+                "href": "/disability/eligibility/hazardous-materials-exposure"
+              },
+              {
+                "title": "Former POWs",
+                "href": "/disability/eligibility/former-pows"
+              },
+              {
+                "title": "PTSD",
+                "href": "/disability/eligibility/ptsd"
+              },
+              {
+                "title": "Illnesses within 1 Year of Discharge",
+                "href": "/disability/eligibility/illnesses-within-one-year-of-discharge"
+              },
+              {
+                "title": "Special Claims",
+                "href": "/disability/eligibility/special-claims"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/file-an-appeal/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": [
+              {
+                "title": "Board of Veterans' Appeals Hearing",
+                "href": "/disability/file-an-appeal/board-of-veterans-appeals"
+              },
+              {
+                "title": "Request a Priority Review",
+                "href": "/disability/file-an-appeal/request-priority-review"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/get-help-filing-claim/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/how-to-file-claim/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": [
+              {
+                "title": "When to File",
+                "href": "/disability/how-to-file-claim/when-to-file"
+              },
+              {
+                "title": "Evidence Needed",
+                "href": "/disability/how-to-file-claim/evidence-needed"
+              },
+              {
+                "title": "Supplemental Forms",
+                "href": "/disability/how-to-file-claim/supplemental-forms"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/upload-supporting-evidence/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/va-claim-exam/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Supplemental Forms",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/about-disability-ratings/after-you-get-a-rating/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "About Disability Ratings",
+      "href": "/disability/about-disability-ratings"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Effective Dates",
+        "href": "/disability/about-disability-ratings/effective-date",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "After You Get a Rating",
+        "href": "/disability/about-disability-ratings/after-you-get-a-rating",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/about-disability-ratings/effective-date/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "About Disability Ratings",
+      "href": "/disability/about-disability-ratings"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Effective Dates",
+        "href": "/disability/about-disability-ratings/effective-date",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "After You Get a Rating",
+        "href": "/disability/about-disability-ratings/after-you-get-a-rating",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/file-an-appeal/board-of-veterans-appeals/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "File an Appeal",
+      "href": "/disability/file-an-appeal"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Board of Veterans' Appeals Hearing",
+        "href": "/disability/file-an-appeal/board-of-veterans-appeals",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Request a Priority Review",
+        "href": "/disability/file-an-appeal/request-priority-review",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/file-an-appeal/request-priority-review/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "File an Appeal",
+      "href": "/disability/file-an-appeal"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Board of Veterans' Appeals Hearing",
+        "href": "/disability/file-an-appeal/board-of-veterans-appeals",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Request a Priority Review",
+        "href": "/disability/file-an-appeal/request-priority-review",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/former-pows/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Eligibility",
+      "href": "/disability/eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/disability/eligibility/hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Former POWs",
+        "href": "/disability/eligibility/former-pows",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/disability/eligibility/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Illnesses within 1 Year of Discharge",
+        "href": "/disability/eligibility/illnesses-within-one-year-of-discharge",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Special Claims",
+        "href": "/disability/eligibility/special-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Eligibility",
+      "href": "/disability/eligibility"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/disability/eligibility/hazardous-materials-exposure",
+        "items": [
+          {
+            "title": "Specific Environmental Hazards",
+            "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards"
+          },
+          {
+            "title": "Agent Orange",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+          },
+          {
+            "title": "Asbestos",
+            "href": "/disability/eligibility/hazardous-materials-exposure/asbestos"
+          },
+          {
+            "title": "Mustard Gas or Lewisite",
+            "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite"
+          },
+          {
+            "title": "Camp Lejeune Water Contamination",
+            "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination"
+          },
+          {
+            "title": "Radiation Exposure",
+            "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation"
+          },
+          {
+            "title": "Project 112/SHAD",
+            "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad"
+          },
+          {
+            "title": "Gulf War Illness SW Asia",
+            "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia"
+          },
+          {
+            "title": "Gulf War Illness Afghanistan",
+            "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Former POWs",
+        "href": "/disability/eligibility/former-pows",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/disability/eligibility/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Illnesses within 1 Year of Discharge",
+        "href": "/disability/eligibility/illnesses-within-one-year-of-discharge",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Special Claims",
+        "href": "/disability/eligibility/special-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/illnesses-within-one-year-of-discharge/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Eligibility",
+      "href": "/disability/eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/disability/eligibility/hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Former POWs",
+        "href": "/disability/eligibility/former-pows",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/disability/eligibility/ptsd",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Illnesses within 1 Year of Discharge",
+        "href": "/disability/eligibility/illnesses-within-one-year-of-discharge",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Special Claims",
+        "href": "/disability/eligibility/special-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/ptsd/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Eligibility",
+      "href": "/disability/eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/disability/eligibility/hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Former POWs",
+        "href": "/disability/eligibility/former-pows",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "PTSD",
+        "href": "/disability/eligibility/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Illnesses within 1 Year of Discharge",
+        "href": "/disability/eligibility/illnesses-within-one-year-of-discharge",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Special Claims",
+        "href": "/disability/eligibility/special-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Eligibility",
+      "href": "/disability/eligibility"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/disability/eligibility/hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Former POWs",
+        "href": "/disability/eligibility/former-pows",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/disability/eligibility/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Illnesses within 1 Year of Discharge",
+        "href": "/disability/eligibility/illnesses-within-one-year-of-discharge",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Special Claims",
+        "href": "/disability/eligibility/special-claims",
+        "items": [
+          {
+            "title": "Auto Allowance and Adaptive Equipment",
+            "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment"
+          },
+          {
+            "title": "Birth Defects",
+            "href": "/disability/eligibility/special-claims/birth-defects"
+          },
+          {
+            "title": "Clothing Allowance",
+            "href": "/disability/eligibility/special-claims/clothing-allowance"
+          },
+          {
+            "title": "Dental Care",
+            "href": "/disability/eligibility/special-claims/dental-care"
+          },
+          {
+            "title": "Increase after Surgery or Cast",
+            "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast"
+          },
+          {
+            "title": "Increase for Time in Hospital",
+            "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital"
+          },
+          {
+            "title": "Prestabilization Ratings",
+            "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization"
+          },
+          {
+            "title": "Title 38 U.S.C. 1151 Claims",
+            "href": "/disability/eligibility/special-claims/1151-claims-title-38"
+          },
+          {
+            "title": "Unemployability",
+            "href": "/disability/eligibility/special-claims/unemployability"
+          }
+        ]
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/1151-claims-title-38/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/automobile-allowance-adaptive-equipment/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/birth-defects/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/clothing-allowance/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/dental-care/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/temporary-increase-for-time-in-hospital/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/temporary-rating-prestabilization/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/unemployability/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": [
+          {
+            "title": "Registry Health Exam",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam"
+          },
+          {
+            "title": "Related Diseases",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases"
+          },
+          {
+            "title": "Non-Hodgkin's Lymphoma",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma"
+          },
+          {
+            "title": "C-123 Aircraft",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft"
+          },
+          {
+            "title": "Thailand Military Bases",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases"
+          },
+          {
+            "title": "Vietnam Waters",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters"
+          },
+          {
+            "title": "Service in Vietnam or Korea",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea"
+          },
+          {
+            "title": "Service outside Vietnam or Korea",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea"
+          },
+          {
+            "title": "Navy or Coast Guard Ships in Vietnam",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam"
+          },
+          {
+            "title": "Testing and Storage",
+            "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/asbestos/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/ionizing-radiation/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/project-112-shad/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Agent Orange",
+      "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Registry Health Exam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Related Diseases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-Hodgkin's Lymphoma",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/non-hodgkins-lymphoma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "C-123 Aircraft",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Thailand Military Bases",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Vietnam Waters",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/vietnam-waters",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service in Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Service outside Vietnam or Korea",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/service-outside-vietnam-korea",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Navy or Coast Guard Ships in Vietnam",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Testing and Storage",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/evidence-needed/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "How to File a Claim",
+      "href": "/disability/how-to-file-claim"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "When to File",
+        "href": "/disability/how-to-file-claim/when-to-file",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Evidence Needed",
+        "href": "/disability/how-to-file-claim/evidence-needed",
+        "items": [
+          {
+            "title": "Decision Ready Claims",
+            "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims"
+          },
+          {
+            "title": "Fully Developed Claims",
+            "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims"
+          },
+          {
+            "title": "Standard Claims",
+            "href": "/disability/how-to-file-claim/evidence-needed/standard-claims"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Supplemental Forms",
+        "href": "/disability/how-to-file-claim/supplemental-forms",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/supplemental-forms/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "How to File a Claim",
+      "href": "/disability/how-to-file-claim"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "When to File",
+        "href": "/disability/how-to-file-claim/when-to-file",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Evidence Needed",
+        "href": "/disability/how-to-file-claim/evidence-needed",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Supplemental Forms",
+        "href": "/disability/how-to-file-claim/supplemental-forms",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/when-to-file/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "How to File a Claim",
+      "href": "/disability/how-to-file-claim"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "When to File",
+        "href": "/disability/how-to-file-claim/when-to-file",
+        "items": [
+          {
+            "title": "Pre-discharge Claim",
+            "href": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Evidence Needed",
+        "href": "/disability/how-to-file-claim/evidence-needed",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Supplemental Forms",
+        "href": "/disability/how-to-file-claim/supplemental-forms",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/when-to-file/pre-discharge-claim/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "When to File",
+      "href": "/disability/how-to-file-claim/when-to-file"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Pre-discharge Claim",
+        "href": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim",
+        "items": [
+          {
+            "title": "File While Overseas",
+            "href": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim/file-while-overseas"
+          }
+        ]
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/when-to-file/pre-discharge-claim/file-while-overseas/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Pre-discharge Claim",
+      "href": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "File While Overseas",
+        "href": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim/file-while-overseas",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/evidence-needed/decision-ready-claims/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Evidence Needed",
+      "href": "/disability/how-to-file-claim/evidence-needed"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Decision Ready Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Fully Developed Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Standard Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/evidence-needed/fully-developed-claims/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Evidence Needed",
+      "href": "/disability/how-to-file-claim/evidence-needed"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Decision Ready Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Fully Developed Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
+        "items": [
+          {
+            "title": "FDC Walkthrough",
+            "href": "https://www.benefits.va.gov/FDC/walkthrough.asp"
+          },
+          {
+            "title": "FDC Checklist",
+            "href": "https://www.benefits.va.gov/FDC/checklist.asp"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Standard Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/evidence-needed/standard-claims/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Evidence Needed",
+      "href": "/disability/how-to-file-claim/evidence-needed"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Decision Ready Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Fully Developed Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Standard Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/disability-housing-grants/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "VA Home Loans",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA-Backed Home Loans",
+            "href": "/housing-assistance/home-loans",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Disability Housing Grants",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Housing Grants",
+            "href": "/housing-assistance/disability-housing-grants",
+            "items": [
+              {
+                "title": "How to Apply",
+                "href": "/housing-assistance/disability-housing-grants/how-to-apply"
+              },
+              {
+                "title": "Check Appeal Status",
+                "href": "/claim-or-appeal-status/"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "housing-assistance/home-loans/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "VA Home Loans",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "VA-Backed Home Loans",
+            "href": "/housing-assistance/home-loans",
+            "items": [
+              {
+                "title": "Loan Types",
+                "href": "/housing-assistance/home-loans/loan-types"
+              },
+              {
+                "title": "Eligibility",
+                "href": "/housing-assistance/home-loans/eligibility"
+              },
+              {
+                "title": "How to Apply",
+                "href": "/housing-assistance/home-loans/how-to-apply"
+              },
+              {
+                "title": "Check Appeal Status",
+                "href": "/claim-or-appeal-status/"
+              },
+              {
+                "title": "Trouble Making Payments?",
+                "href": "/housing-assistance/home-loans/trouble-making-payments"
+              },
+              {
+                "title": "Warning about Refinancing Offers",
+                "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/"
+              },
+              {
+                "title": "Home Buying Process",
+                "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp"
+              },
+              {
+                "title": "VA Loan Funding Fee",
+                "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp"
+              },
+              {
+                "title": "Find a VA Regional Loan Center",
+                "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp"
+              },
+              {
+                "title": "Find VA-Acquired Properties",
+                "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp"
+              },
+              {
+                "title": "Guidance on Natural Disasters",
+                "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Disability Housing Grants",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Housing Grants",
+            "href": "/housing-assistance/disability-housing-grants",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "housing-assistance/disability-housing-grants/how-to-apply/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Housing Grants",
+      "href": "/housing-assistance/disability-housing-grants"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "How to Apply",
+        "href": "/housing-assistance/disability-housing-grants/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/eligibility/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/how-to-apply/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": [
+          {
+            "title": "Purchase Loan",
+            "href": "/housing-assistance/home-loans/loan-types/purchase-loan"
+          },
+          {
+            "title": "Cash Out Refinance Loan",
+            "href": "/housing-assistance/home-loans/loan-types/cash-out-loan"
+          },
+          {
+            "title": "Native American Direct Loan",
+            "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan"
+          },
+          {
+            "title": "Interest Rate Reduction Refinance Loan",
+            "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/trouble-making-payments/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/cash-out-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/interest-rate-reduction-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/native-american-direct-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": [
+          {
+            "title": "Tribes with Memorandums of Understanding",
+            "href": "https://www.benefits.va.gov/homeloans/nadl_mou.asp"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/purchase-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": [
+              {
+                "title": "Post-9/11 GI Bill",
+                "href": "/education/about-gi-bill-benefits/post-9-11"
+              },
+              {
+                "title": "Montgomery GI Bill Active Duty",
+                "href": "/education/about-gi-bill-benefits/montgomery-active-duty"
+              },
+              {
+                "title": "Montgomery GI Bill Selected Reserve",
+                "href": "/education/about-gi-bill-benefits/montgomery-selected-reserve"
+              },
+              {
+                "title": "How to Use Your Benefits",
+                "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/after-you-apply/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/benefit-rates/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/change-gi-bill-benefits/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/choosing-a-school/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": [
+              {
+                "title": "Principles of Excellence Program",
+                "href": "/education/choosing-a-school/principles-of-excellence"
+              },
+              {
+                "title": "WEAMS Institution Search",
+                "href": "https://www.benefits.va.gov/gibill/school_locator.asp"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/eligibility/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/how-to-apply/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/opt-out-information-sharing/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/other-va-education-benefits/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": [
+              {
+                "title": "REAP",
+                "href": "/education/other-va-education-benefits/reap"
+              },
+              {
+                "title": "VEAP",
+                "href": "/education/other-va-education-benefits/veap"
+              },
+              {
+                "title": "National Call to Service Program",
+                "href": "/education/other-va-education-benefits/national-call-to-service-program"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/survivor-dependent-benefits/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": [
+              {
+                "title": "Fry Scholarship",
+                "href": "/education/survivor-dependent-benefits/fry-scholarship"
+              },
+              {
+                "title": "Dependents Education Assistance (DEA)",
+                "href": "/education/survivor-dependent-benefits/dependents-education-assistance"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/transfer-post-9-11-gi-bill-benefits/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/choosing-a-school/principles-of-excellence/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Choosing a School",
+      "href": "/education/choosing-a-school"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Principles of Excellence Program",
+        "href": "/education/choosing-a-school/principles-of-excellence",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "WEAMS Institution Search",
+        "href": "https://www.benefits.va.gov/gibill/school_locator.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/other-va-education-benefits/national-call-to-service-program/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Other Education Benefits",
+      "href": "/education/other-va-education-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "REAP",
+        "href": "/education/other-va-education-benefits/reap",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VEAP",
+        "href": "/education/other-va-education-benefits/veap",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "National Call to Service Program",
+        "href": "/education/other-va-education-benefits/national-call-to-service-program",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/other-va-education-benefits/reap/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Other Education Benefits",
+      "href": "/education/other-va-education-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "REAP",
+        "href": "/education/other-va-education-benefits/reap",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VEAP",
+        "href": "/education/other-va-education-benefits/veap",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "National Call to Service Program",
+        "href": "/education/other-va-education-benefits/national-call-to-service-program",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/other-va-education-benefits/veap/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Other Education Benefits",
+      "href": "/education/other-va-education-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "REAP",
+        "href": "/education/other-va-education-benefits/reap",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "VEAP",
+        "href": "/education/other-va-education-benefits/veap",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "National Call to Service Program",
+        "href": "/education/other-va-education-benefits/national-call-to-service-program",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/survivor-dependent-benefits/dependents-education-assistance/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Survivor and Dependent Benefits",
+      "href": "/education/survivor-dependent-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Fry Scholarship",
+        "href": "/education/survivor-dependent-benefits/fry-scholarship",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Dependents Education Assistance (DEA)",
+        "href": "/education/survivor-dependent-benefits/dependents-education-assistance",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/survivor-dependent-benefits/fry-scholarship/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Survivor and Dependent Benefits",
+      "href": "/education/survivor-dependent-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Fry Scholarship",
+        "href": "/education/survivor-dependent-benefits/fry-scholarship",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dependents Education Assistance (DEA)",
+        "href": "/education/survivor-dependent-benefits/dependents-education-assistance",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/gi-bill/post-9-11/ch-33-benefit/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill",
+            "href": "/education/about-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/education/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/education/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/education/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Benefits",
+            "href": "/education/survivor-dependent-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Other Education Benefits",
+            "href": "/education/other-va-education-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Check Post-9/11 GI Bill Benefits",
+            "href": "/education/gi-bill/post-9-11/ch-33-benefit",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Transfer Post-9/11 GI Bill Benefits",
+            "href": "/education/transfer-post-9-11-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Your GI Bill School or Program",
+            "href": "/education/change-gi-bill-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check VA Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Verify School Enrollment",
+            "href": "https://www.gibill.va.gov/wave/index.do",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply to Restore GI Bill Benefits",
+            "href": "https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "GI Bill School Comparison",
+            "href": "/gi-bill-comparison-tool",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Benefit Rates",
+            "href": "/education/benefit-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Choosing a School",
+            "href": "/education/choosing-a-school",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Overpayments and Debts",
+            "href": "https://www.benefits.va.gov/gibill/resources/education_resources/debt_info.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Contact Us",
+            "href": "https://www.benefits.va.gov/gibill/contact_us.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "GI Bill School Feedback",
+            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Handouts and Forms",
+            "href": "https://www.benefits.va.gov/gibill/handouts_forms.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How Others Use the GI Bill",
+            "href": "https://www.benefits.va.gov/gibill/my_story.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Non-VA Resources",
+            "href": "https://www.benefits.va.gov/gibill/non_va_resources.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Compare Education Benefits",
+            "href": "https://www.benefits.va.gov/gibill/comparison_tool.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "GI Bill",
+      "href": "/education/about-gi-bill-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Post-9/11 GI Bill",
+        "href": "/education/about-gi-bill-benefits/post-9-11",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Montgomery GI Bill Active Duty",
+        "href": "/education/about-gi-bill-benefits/montgomery-active-duty",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Montgomery GI Bill Selected Reserve",
+        "href": "/education/about-gi-bill-benefits/montgomery-selected-reserve",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "How to Use Your Benefits",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits",
+        "items": [
+          {
+            "title": "Undergraduate and Graduate Degrees",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs"
+          },
+          {
+            "title": "Foreign Programs",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools"
+          },
+          {
+            "title": "Independent and Distance Learning",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning"
+          },
+          {
+            "title": "Correspondence Training",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training"
+          },
+          {
+            "title": "Tutorial Assistance",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance"
+          },
+          {
+            "title": "Test Fees",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees"
+          },
+          {
+            "title": "Non-College Degree Programs",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs"
+          },
+          {
+            "title": "High-Tech Programs",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs"
+          },
+          {
+            "title": "Flight Training",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training"
+          },
+          {
+            "title": "Entrepreneurship Training",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training"
+          },
+          {
+            "title": "Work Study",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study"
+          },
+          {
+            "title": "Co-op Training",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training"
+          },
+          {
+            "title": "On-the-Job Training",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships"
+          },
+          {
+            "title": "Tuition Assistance Top-Up",
+            "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up"
+          }
+        ]
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/montgomery-active-duty/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "GI Bill",
+      "href": "/education/about-gi-bill-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Post-9/11 GI Bill",
+        "href": "/education/about-gi-bill-benefits/post-9-11",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Montgomery GI Bill Active Duty",
+        "href": "/education/about-gi-bill-benefits/montgomery-active-duty",
+        "items": [
+          {
+            "title": "$600 Buy-Up Program",
+            "href": "/education/about-gi-bill-benefits/montgomery-active-duty/buy-up"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Montgomery GI Bill Selected Reserve",
+        "href": "/education/about-gi-bill-benefits/montgomery-selected-reserve",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Use Your Benefits",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/montgomery-selected-reserve/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "GI Bill",
+      "href": "/education/about-gi-bill-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Post-9/11 GI Bill",
+        "href": "/education/about-gi-bill-benefits/post-9-11",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Montgomery GI Bill Active Duty",
+        "href": "/education/about-gi-bill-benefits/montgomery-active-duty",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Montgomery GI Bill Selected Reserve",
+        "href": "/education/about-gi-bill-benefits/montgomery-selected-reserve",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Use Your Benefits",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/post-9-11/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "GI Bill",
+      "href": "/education/about-gi-bill-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Post-9/11 GI Bill",
+        "href": "/education/about-gi-bill-benefits/post-9-11",
+        "items": [
+          {
+            "title": "Yellow Ribbon Program",
+            "href": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Montgomery GI Bill Active Duty",
+        "href": "/education/about-gi-bill-benefits/montgomery-active-duty",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Montgomery GI Bill Selected Reserve",
+        "href": "/education/about-gi-bill-benefits/montgomery-selected-reserve",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Use Your Benefits",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/co-op-training/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/flight-training/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/test-fees/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/how-to-use-benefits/work-study/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "How to Use Your Benefits",
+      "href": "/education/about-gi-bill-benefits/how-to-use-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Undergraduate and Graduate Degrees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/undergraduate-graduate-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Foreign Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent and Distance Learning",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Correspondence Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tutorial Assistance",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tutor-assistance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Test Fees",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/test-fees",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Non-College Degree Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "High-Tech Programs",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/high-tech-programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Flight Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/flight-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Entrepreneurship Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/entrepreneurship-training",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Work Study",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/work-study",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Co-op Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/co-op-training",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "On-the-Job Training",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Tuition Assistance Top-Up",
+        "href": "/education/about-gi-bill-benefits/how-to-use-benefits/tuition-assistance-top-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/montgomery-active-duty/buy-up/index.html",
+    "sidebarTitle": "GI Bill",
+    "backLink": {
+      "title": "Montgomery GI Bill Active Duty",
+      "href": "/education/about-gi-bill-benefits/montgomery-active-duty"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "$600 Buy-Up Program",
+        "href": "/education/about-gi-bill-benefits/montgomery-active-duty/buy-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Post-9/11 GI Bill",
+      "href": "/education/about-gi-bill-benefits/post-9-11"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Yellow Ribbon Program",
+        "href": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program",
+        "items": []
+      }
+    ],
+    "menus": []
+  }
+]

--- a/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
+++ b/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\va_gov_migrate\EventSubscriber;
 
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\migration_tools\Message;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\va_gov_migrate\ParagraphMigrator;
 use Drupal\migrate\Event\MigratePostRowSaveEvent;
@@ -44,6 +46,7 @@ class PostRowSave implements EventSubscriberInterface {
         $migrator->process('featured_content', 'field_featured_content');
         $migrator->process(['body', 'nav_linkslist'], 'field_content_block');
         $this->setChangedDate($event);
+        $this->setNodeAlias($event);
         break;
 
       case 'va_alert_block':
@@ -54,11 +57,15 @@ class PostRowSave implements EventSubscriberInterface {
         $this->convertIntroTextToPlainText($event->getDestinationIdValues()[0]);
         $migrator->process('related_links', 'field_related_links');
         $migrator->process('hub_links', 'field_spokes');
+        $this->setNodeAlias($event);
         break;
 
       case 'va_promo':
         $migrator->process('body', 'field_promo_link');
         break;
+
+      case 'va_benefits_menu':
+        $this->setMenuParent($event);
     }
   }
 
@@ -102,6 +109,65 @@ class PostRowSave implements EventSubscriberInterface {
     $last_update = $event->getRow()->getSourceProperty('lastupdate') + 3600 * 4;
     $node->set('changed', $last_update);
     $node->save();
+  }
+
+  /**
+   * Delete any existing alias for this node and set a new one from 'path'.
+   *
+   * Also turns off automatic URL alias generation for this node.
+   *
+   * @param \Drupal\migrate\Event\MigratePostRowSaveEvent $event
+   *   The postRowSave event.
+   */
+  public function setNodeAlias(MigratePostRowSaveEvent $event) {
+    $alias = $event->getRow()->getSourceProperty('path');
+    if (empty($alias)) {
+      return;
+    }
+
+    $alias_storage_helper = \Drupal::service('pathauto.alias_storage_helper');
+    $source = '/node/' . $event->getDestinationIdValues()[0];
+
+    $alias_storage_helper->deleteBySourcePrefix($source);
+    $alias_storage_helper->save([
+      'source' => $source,
+      'alias' => $alias,
+      'language' => 'en',
+    ]);
+
+    // Tell pathauto not to override alias.
+    $pathauto_store = \Drupal::keyValue('pathauto_state.node');
+    $pathauto_store->set($event->getDestinationIdValues()[0], 0);
+  }
+
+  /**
+   * Sets the parent item of the menu item being migrated.
+   *
+   * @param \Drupal\migrate\Event\MigratePostRowSaveEvent $event
+   *   The PostRowSave event.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\migrate\MigrateException
+   */
+  public function setMenuParent(MigratePostRowSaveEvent $event) {
+    $parent_id = $event->getRow()->getSourceProperty('parent_id');
+    if (!empty($parent_id)) {
+      $parent_link_array = $event->getMigration()->getIdMap()->lookupDestinationIds([$parent_id]);
+      if (empty($parent_link_array)) {
+        Message::make("Couldn't find dest for @id", ['@id' => $parent_id], Message::ERROR);
+      }
+      else {
+        $menu_link = MenuLinkContent::load($event->getDestinationIdValues()[0]);
+        $parent_link = MenuLinkContent::load($parent_link_array[0][0]);
+        if (empty($parent_link)) {
+          Message::make("Couldn't find menu link for @id", ['@id' => $parent_link_array[0][0]], Message::ERROR);
+        }
+        else {
+          $menu_link->set('parent', 'menu_link_content:' . $parent_link->get('uuid')->value);
+          $menu_link->save();
+        }
+      }
+    }
   }
 
 }

--- a/docroot/modules/custom/va_gov_migrate/src/Form/VaMenuTruncateForm.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Form/VaMenuTruncateForm.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * A form with a button to delete main menu items.
+ *
+ * @package Drupal\va_gov_migrate\Form
+ */
+class VaMenuTruncateForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'va_menu_truncate_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Remove All Menu Links From Main Menu'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    \Drupal::service('plugin.manager.menu.link')->deleteLinksInMenu('main');
+    return TRUE;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/AlertBlockSource.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/AlertBlockSource.php
@@ -95,7 +95,7 @@ class AlertBlockSource extends MetalsmithSource {
       $body = str_replace(['<code>', '</code>', '<pre>', '</pre>'], '', $body);
       $row['alert_body'] = html_entity_decode($body);
 
-      $row['url'] = self::getPageUrl($url, $row);
+      self::setPagePath($url, $row);
 
       $this->rows[] = $row;
 

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Plugin\migrate\source;
+
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+use Drupal\migrate\Plugin\MigrationInterface;
+
+/**
+ * Source to read from sidebar.json.
+ *
+ * @MigrateSource(
+ *   id = "va_benefits_menu_source"
+ * )
+ */
+class VaBenefitsMenu extends SourcePluginBase {
+  protected $sections;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration);
+
+    // Path is required.
+    if (empty($this->configuration['sections'])) {
+      throw new MigrateException('You must declare the "sections" in your source settings.');
+    }
+
+    $this->sections = $configuration['sections'];
+  }
+
+  /**
+   * Return a string representing the source file path.
+   *
+   * @return string
+   *   The file path.
+   */
+  public function __toString() {
+    return 'sidebar.json';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function initializeIterator() {
+    $contents = file_get_contents("modules/custom/va_gov_migrate/data/sidebar.json");
+    $json_sidebar = json_decode($contents, TRUE);
+    // Get top level menus.
+    $menus = [];
+    foreach ($json_sidebar as $page) {
+      if (!empty($page['sidebarTitle']) && in_array($page['sidebarTitle'], $this->sections)) {
+        if (empty($menus[$page['sidebarTitle']])) {
+          $menu_name = strtolower(str_replace(' ', '-', $page['sidebarTitle'])) . '-benefits-hub';
+          $menus[$page['sidebarTitle']] = [
+            'title' => $page['sidebarTitle'],
+            'href' => 'route:<nolink>',
+            'items' => [],
+            'menu' => $menu_name,
+          ];
+        }
+        if (!empty($page['menus'])) {
+          $menus[$page['sidebarTitle']]['items'] = $this->mergeMenus($page['menus'], $menus[$page['sidebarTitle']]['items']);
+        }
+        $menus[$page['sidebarTitle']]['menu'] = strtolower(str_replace(' ', '-', $page['sidebarTitle'])) . '-benefits-hub';
+      }
+    }
+
+    foreach ($json_sidebar as $page) {
+      if (!empty($page['sidebarTitle']) && in_array($page['sidebarTitle'], $this->sections)) {
+        if (!empty($page['items'])) {
+          $this->findMergeMenus($page, $menus[$page['sidebarTitle']]['items']);
+        }
+      }
+    }
+
+    $this->setIds($menus);
+    $this->setWeights($menus);
+    $flat_menu = $this->flattenMenu($menus);
+
+    return new \ArrayIterator($flat_menu);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids['id']['type'] = 'string';
+    return $ids;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields['href'] = 'Link Path';
+    $fields['title'] = 'Link Title';
+    $fields['external'] = 'External Path';
+    $fields['weight'] = 'Weight';
+    $fields['parent_id'] = 'Parent Id';
+    $fields['menu'] = 'Menu machine name';
+
+    return $fields;
+  }
+
+  /**
+   * Add weights to menu items based on their order in the array.
+   *
+   * @param array $menu_tree
+   *   The array of menu items.
+   */
+  protected function setWeights(array &$menu_tree) {
+    $relative_weight = 0;
+    foreach ($menu_tree as &$item) {
+      $item['weight'] = -50 + $relative_weight;
+      $relative_weight++;
+      if (!empty($item['items'])) {
+        $this->setWeights($item['items']);
+      }
+    }
+  }
+
+  /**
+   * Create a unique id for each menu item.
+   *
+   * The ids are used in post processing to set parent items.
+   *
+   * @param array $menu_tree
+   *   The menu tree to set ids on.
+   * @param string $parent_id
+   *   The id of the current menu tree's parent.
+   */
+  protected function setIds(array &$menu_tree, $parent_id = '') {
+    foreach ($menu_tree as $index => &$item) {
+      $item['id'] = $parent_id . '-' . $index;
+      if (!empty($item['items'])) {
+        $this->setIds($item['items'], $item['id']);
+      }
+    }
+  }
+
+  /**
+   * Transform a menu tree into a flat menu with parent href set for children.
+   *
+   * Also clean up the hrefs and set 'external'.
+   *
+   * @param array $menu_tree
+   *   The tree to transform.
+   * @param string $parent_id
+   *   The parent id, if any.
+   * @param string $parent_menu
+   *   The parent menu name (will be filled in during recursion from top item).
+   *
+   * @return array
+   *   A one-dimensional array of menu items.
+   */
+  protected function flattenMenu(array $menu_tree, $parent_id = '', $parent_menu = '') {
+    $flat_menu = [];
+    foreach ($menu_tree as $index => $item) {
+      if (parse_url($item['href'], PHP_URL_SCHEME)) {
+        $item['href'] = str_replace('localhost', 'www.va.gov', $item['href']);
+        $item['external'] = 1;
+      }
+      else {
+        if (empty($item['href'])) {
+          $item['href'] = 'route:<nolink>';
+        }
+        else {
+          $item['href'] = rtrim($item['href'], '/');
+        }
+        $item['external'] = 0;
+      }
+
+      if (!empty($parent_menu)) {
+        $item['menu'] = $parent_menu;
+      }
+      $item['parent_id'] = $parent_id;
+      $flat_menu[] = $item;
+
+      if (!empty($item['items'])) {
+        $flat_menu = array_merge($flat_menu, $this->flattenMenu($item['items'], $item['id'], $item['menu']));
+      }
+      unset($item['items']);
+
+    }
+
+    return $flat_menu;
+  }
+
+  /**
+   * Takes two page menus and merges them into one.
+   *
+   * Assumes that no two menu items have the same title & link.
+   *
+   * @param array $menu
+   *   Array of menu trees.
+   * @param array $menu2
+   *   Another array of menu trees.
+   *
+   * @return array
+   *   The consolidated menu tree.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   */
+  protected function mergeMenus(array $menu, array $menu2) {
+    $merge_menu = $menu2;
+
+    foreach ($menu as $menu_item) {
+      $found = FALSE;
+      foreach ($merge_menu as &$merge_item) {
+        if ($menu_item['title'] == $merge_item['title'] && $menu_item['href'] == $merge_item['href']) {
+          if (!empty($menu_item['items'])) {
+            if (empty($merge_item['items'])) {
+              $merge_item['items'] = $menu_item['items'];
+            }
+            else {
+              $merge_item['items'] = $this->mergeMenus($menu_item['items'], $merge_item['items']);
+            }
+          }
+          $found = TRUE;
+          break;
+        }
+      }
+      if (!$found) {
+        $merge_menu[] = $menu_item;
+      }
+    }
+
+    return $merge_menu;
+  }
+
+  /**
+   * Find the parent item for submenus and merge them in.
+   *
+   * @param array $page
+   *   The page structure containing the submenu.
+   * @param array $menu
+   *   The full menu to merge the submenus into.
+   *
+   * @return bool
+   *   True if a parent item was found.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   */
+  protected function findMergeMenus(array $page, array &$menu) {
+    $page_link = $page['backLink']['href'];
+    foreach ($menu as &$menu_item) {
+      if ($menu_item['href'] == $page_link) {
+        if (empty($menu_item['items'])) {
+          $menu_item['items'] = $page['items'];
+        }
+        else {
+          $menu_item['items'] = $this->mergeMenus($page['items'], $menu_item['items']);
+        }
+        return TRUE;
+      }
+      if (!empty($menu_item['items'])) {
+        if ($this->findMergeMenus($page, $menu_item['items'])) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_migrate/va_gov_migrate.routing.yml
+++ b/docroot/modules/custom/va_gov_migrate/va_gov_migrate.routing.yml
@@ -1,0 +1,7 @@
+va_gov_migrate.truncate_menu:
+  path: '/admin/config/structure/va_gov_migrate/truncate-menu'
+  defaults:
+    _form: '\Drupal\va_gov_migrate\Form\VaMenuTruncateForm'
+    _title: 'Truncate main menu'
+  requirements:
+    _permission: 'administer menus'


### PR DESCRIPTION
Before running menu migration ('Import menu links for health care benefits main menus'):
1. Create a menu with machine name 'health-care-benefits-hub'.
2. Run an update migration for benefits pages ('Import basic pages and paragraphs from va.gov'). This will give them all the same aliases they have on the current site, which the menu migration uses for generating menu link routes.

This migration only pulls in Health Care, but I've set it up so that other sections can be specified in the yaml.

I've also included a form to delete items from the main menu. No need to run it for this migration, but it'll be useful when we do the main menu migration. There's no menu link for it, but it's at /admin/config/structure/va_gov_migrate/truncate-menu.

Let me know when this is pushed and I'll do the setup and migration on dev (and on stg if you want).