### PR TITLE
VAGOV-1568 migrate main nav

### DIFF
--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: 62532edd-50c6-4d85-93c5-9caf9ef23bf4
+uuid: 52e6cc89-65e6-417d-b5b9-57dcf5fd6c56
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_healthcare.yml
+++ b/config/sync/migrate_plus.migration.va_healthcare.yml
@@ -1,4 +1,4 @@
-uuid: 7a66e788-5e5e-4c4a-a93d-b2e58f61289d
+uuid: 0980bc17-5910-4b7a-9489-2f64b5270abe
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: 9214d793-4c08-42da-9826-a45164af2549
+uuid: c91f498a-0429-4e1b-806c-4a90742a3bc7
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_main_menu.yml
+++ b/config/sync/migrate_plus.migration.va_main_menu.yml
@@ -1,4 +1,4 @@
-uuid: 79098cc3-2eb3-4279-94d0-1f30f0352e8c
+uuid: 66e2423b-81c1-4b45-bdbd-34c340fd8a3d
 langcode: en
 status: true
 dependencies:
@@ -6,26 +6,25 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: sxp-IVoyBjPFHPO4E57juhIlG1cyNzS3DLFz8Jvi8FE
-id: va_benefits_menu
+  default_config_hash: gzZ0JI19uo_Xtqw1qz0o9XT_cBcfwWA_OJ7zD_rRdSc
+id: va_main_menu
 class: null
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null
 migration_group: va_gov
-label: 'Import menu links for health care benefits hub menus'
+label: 'Import menu links for health care benefits main menus'
 source:
-  plugin: va_benefits_menu_source
-  sections:
-    - 'Health Care'
+  plugin: va_main_menu_source
   constants:
     bundle: menu_link_content
+    menu: main
     zero: 0
     one: 1
 process:
   bundle: constants/bundle
   title: title
-  menu_name: menu
+  menu_name: constants/menu
   link/uri:
     plugin: link_uri
     source:

--- a/config/sync/migrate_plus.migration.va_outreach.yml
+++ b/config/sync/migrate_plus.migration.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: 072d8ed7-c947-4fc1-ba41-12b7b5b75725
+uuid: 605de86c-1c35-4411-941a-5fb6e4e5b6e9
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
@@ -1,4 +1,4 @@
-uuid: d1df7e5a-bdeb-4953-87b6-8416233d6337
+uuid: 13932057-3c25-498f-976d-d7c714f3594c
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
@@ -1,4 +1,4 @@
-uuid: bd58e04f-0c52-4532-a75d-53edb8998b54
+uuid: 9e28e8da-3926-4222-989c-8807359e93f8
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_files.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_files.yml
@@ -1,4 +1,4 @@
-uuid: c726121a-a3a5-4fde-a9c4-d678ff61dab3
+uuid: a114ae6b-8c62-40c1-96de-5440f93a96e5
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_image_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_image_media.yml
@@ -1,4 +1,4 @@
-uuid: 96b0716d-31bc-4ae8-a1fb-667d33ef9acd
+uuid: 079ccdc9-6a61-4135-ba36-448480cc6d17
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_video.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_video.yml
@@ -1,4 +1,4 @@
-uuid: fd322e35-3df5-4fb6-b75e-2060c546ed21
+uuid: a0633373-1cb7-46eb-93f7-f90091b5b168
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: 3e108262-4886-45f3-8afd-aa097aae6fb1
+uuid: 638155a5-7e07-40d0-b11a-403d6332ee8d
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: d43040e9-d6b4-4c75-8548-c083bb031752
+uuid: b858a84d-f6e9-40ef-9b63-f1250ec73db3
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: 816cd603-0b76-4de5-bafb-40c46b7b54d1
+uuid: 86a2ad84-17fd-45f2-9542-ea7fcbcce753
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: 81e68992-9c42-492d-8130-3e040c2bda0b
+uuid: a6c2cccd-76ed-4484-a818-364822d7db74
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_work_areas.yml
+++ b/config/sync/migrate_plus.migration.va_work_areas.yml
@@ -1,4 +1,4 @@
-uuid: da0dac3d-ccaf-41af-8d12-9ec7c4db57ac
+uuid: 227483a8-91f4-412c-87ea-8d59c8a409a7
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: 9382ac10-47ab-4d36-8eed-34c44fd52013
+uuid: 2e6cf580-0dee-477b-a072-d795ea7362e0
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_outreach.yml
+++ b/config/sync/migrate_plus.migration_group.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: f6cf5696-f1a4-4d44-bae8-67a4e8933660
+uuid: 49149d61-2632-4281-b39e-40a4fd202dd3
 langcode: en
 status: true
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_main_menu.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_main_menu.yml
@@ -1,20 +1,19 @@
-id: va_benefits_menu
-label: Import menu links for health care benefits hub menus
+id: va_main_menu
+label: Import menu links for health care benefits main menus
 migration_group: va_gov
 
 source:
-  plugin: va_benefits_menu_source
-  sections:
-    - "Health Care"
+  plugin: va_main_menu_source
   constants:
     bundle: menu_link_content
+    menu: main
     zero: 0
     one: 1
 
 process:
   bundle: 'constants/bundle'
   title: title
-  menu_name: menu
+  menu_name: 'constants/menu'
   'link/uri':
     plugin: link_uri
     source:

--- a/docroot/modules/custom/va_gov_migrate/data/megamenu.json
+++ b/docroot/modules/custom/va_gov_migrate/data/megamenu.json
@@ -1,0 +1,692 @@
+[
+    {
+        "title": "VA Benefits and Health Care",
+        "menuSections": [
+            {
+                "title": "Health Care",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Health Care Benefits",
+                        "links": [
+                            {
+                                "text": "About VA Health Benefits",
+                                "href": "https://www.va.gov/health-care/about-va-health-benefits/"
+                            },
+                            {
+                                "text": "How to Apply",
+                                "href": "https://www.va.gov/health-care/how-to-apply/"
+                            },
+                            {
+                                "text": "Family and Caregiver Health Benefits",
+                                "href": "https://www.va.gov/health-care/family-caregiver-benefits/"
+                            },
+                            {
+                                "text": "Apply Now for Health Care",
+                                "href": "https://www.va.gov/health-care/apply/application"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Manage Your Health",
+                        "links": [
+                            {
+                                "text": "Refill and Track Your Prescriptions",
+                                "href": "https://www.va.gov/health-care/refill-track-prescriptions"
+                            },
+                            {
+                                "text": "Send a Secure Message to Your Health Care Team",
+                                "href": "https://www.va.gov/health-care/secure-messaging"
+                            },
+                            {
+                                "text": "Schedule and View VA Appointments",
+                                "href": "https://www.va.gov/health-care/schedule-view-va-appointments/"
+                            },
+                            {
+                                "text": "View Your Lab and Test Results",
+                                "href": "https://www.va.gov/health-care/view-test-and-lab-results/"
+                            },
+                            {
+                                "text": "Order Hearing Aid Batteries and Prosthetic Socks",
+                                "href": "https://www.va.gov/health-care/order-hearing-aid-batteries-prosthetic-socks/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Health Care",
+                        "href": "https://www.va.gov/health-care/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/health-care.png",
+                            "alt": "VA Telehealth Services"
+                        },
+                        "link": {
+                            "text": "VA Telehealth Services",
+                            "href": "https://www.telehealth.va.gov/"
+                        },
+                        "description": "Find out how we use telehealth technologies to provide specialty care and health monitoring to Veterans at their local VA clinic or in their own home."
+                    }
+                }
+            },
+            {
+                "title": "Disability",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Disability Benefits",
+                        "links": [
+                            {
+                                "text": "Eligibility",
+                                "href": "https://www.va.gov/disability/eligibility/"
+                            },
+                            {
+                                "text": "How to File a Claim",
+                                "href": "https://www.va.gov/disability/how-to-file-claim/"
+                            },
+                            {
+                                "text": "Survivor and Dependent Compensation (DIC)",
+                                "href": "https://www.va.gov/burials-memorials/dependency-indemnity-compensation/"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Manage Your Benefits",
+                        "links": [
+                            {
+                                "text": "Check Your Claim or Appeal Status",
+                                "href": "https://www.va.gov/claim-or-appeal-status/"
+                            },
+                            {
+                                "text": "View Your VA Payment History",
+                                "href": "https://www.va.gov/va-payment-history/"
+                            },
+                            {
+                                "text": "Upload Evidence to Support Your Claim",
+                                "href": "https://www.va.gov/disability/upload-supporting-evidence/"
+                            },
+                            {
+                                "text": "File for a VA Disability Increase",
+                                "href": "https://www.va.gov/disability-benefits/apply/form-526-disability-claim/"
+                            },
+                            {
+                                "text": "File an Appeal",
+                                "href": "https://www.va.gov/disability/file-an-appeal/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Disability",
+                        "href": "https://www.va.gov/disability/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/disability.png",
+                            "alt": "Fully Developed Claims Program"
+                        },
+                        "link": {
+                            "text": "Fully Developed Claims Program",
+                            "href": "https://www.va.gov/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+                        },
+                        "description": "Use this program to get a faster decision by submitting evidence along with your claim."
+                    }
+                }
+            },
+            {
+                "title": "Education and Training",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Education Benefits",
+                        "links": [
+                            {
+                                "text": "About GI Bill Benefits",
+                                "href": "https://www.va.gov/education/about-gi-bill-benefits/"
+                            },
+                            {
+                                "text": "Eligibility",
+                                "href": "https://www.va.gov/education/eligibility/"
+                            },
+                            {
+                                "text": "How to Apply",
+                                "href": "https://www.va.gov/education/how-to-apply/"
+                            },
+                            {
+                                "text": "Vocational Rehabilitation and Employment",
+                                "href": "https://www.va.gov/careers-employment/vocational-rehabilitation/"
+                            },
+                            {
+                                "text": "Survivor and Dependent Education Benefits",
+                                "href": "https://www.va.gov/education/survivor-dependent-benefits/"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Manage Your Benefits",
+                        "links": [
+                            {
+                                "text": "View Your VA Payment History",
+                                "href": "https://www.va.gov/va-payment-history/"
+                            },
+                            {
+                                "text": "Check Your Post-9/11 GI Bill Benefits",
+                                "href": "https://www.va.gov/education/gi-bill/post-9-11/ch-33-benefit/"
+                            },
+                            {
+                                "text": "Transfer Your Post-9/11 GI Bill Benefits",
+                                "href": "https://www.va.gov/education/transfer-post-9-11-gi-bill-benefits/"
+                            },
+                            {
+                                "text": "Change Your GI Bill School or Program",
+                                "href": "https://www.va.gov/education/change-gi-bill-benefits/"
+                            },
+                            {
+                                "text": "Change Your Direct Deposit Information",
+                                "href": "https://www.va.gov/change-direct-deposit-and-contact-information/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Education",
+                        "href": "https://www.va.gov/education/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/education.png",
+                            "alt": "GI Bill School Feedback"
+                        },
+                        "link": {
+                            "text": "GI Bill® Comparison Tool",
+                            "href": "/gi-bill-comparison-tool"
+                        },
+                        "description": "Learn about education programs and compare benefits by school."
+                    }
+                }
+            },
+            {
+                "title": "Careers and Employment",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Employment Benefits",
+                        "links": [
+                            {
+                                "text": "About Vocational Rehabilitation and Employment",
+                                "href": "https://www.va.gov/careers-employment/vocational-rehabilitation/"
+                            },
+                            {
+                                "text": "How to Apply",
+                                "href": "https://www.va.gov/careers-employment/vocational-rehabilitation/how-to-apply/"
+                            },
+                            {
+                                "text": "Veteran-Owned Small Business Support",
+                                "href": "https://www.va.gov/careers-employment/veteran-owned-business-support/"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Manage Your Career",
+                        "links": [
+                            {
+                                "text": "VA Transition Assistance",
+                                "href": "https://www.benefits.va.gov/tap/"
+                            },
+                            {
+                                "text": "CareerScope Assessment",
+                                "href": "https://www.va.gov/careers-employment/careerscope-skills-assessment/"
+                            },
+                            {
+                                "text": "Find a Job",
+                                "href": "https://www.dol.gov/veterans/findajob/",
+                                "target": "_blank"
+                            },
+                            {
+                                "text": "Find VA Careers and Support",
+                                "href": "https://www.va.gov/jobs/"
+                            },
+                            {
+                                "text": "Print Your Civil Service Preference Letter",
+                                "href": "https://www.va.gov/records/download-va-letters/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Careers and Employment",
+                        "href": "https://www.va.gov/careers-employment/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/careers.png",
+                            "alt": "VA for Vets"
+                        },
+                        "link": {
+                            "text": "VA for Vets",
+                            "href": "https://www.vaforvets.va.gov/"
+                        },
+                        "description": "Get help transitioning to a civilian career and matching your skills and experiences to VA job opportunities."
+                    }
+                }
+            },
+            {
+                "title": "Pension",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Pension Benefits",
+                        "links": [
+                            {
+                                "text": "Veterans Pension Eligibility",
+                                "href": "https://www.va.gov/pension/eligibility/"
+                            },
+                            {
+                                "text": "How to Apply",
+                                "href": "https://www.va.gov/pension/how-to-apply/"
+                            },
+                            {
+                                "text": "Aid and Attendance Benefits and Housebound Allowance",
+                                "href": "https://www.va.gov/pension/aid-attendance-housebound/"
+                            },
+                            {
+                                "text": "Survivors Pension",
+                                "href": "https://www.va.gov/pension/survivors-pension/"
+                            },
+                            {
+                                "text": "Apply Now for a Veterans Pension",
+                                "href": "https://www.va.gov/pension/application/527EZ"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Manage Your Benefits",
+                        "links": [
+                            {
+                                "text": "Check Your Claim or Appeal Status",
+                                "href": "https://www.va.gov/claim-or-appeal-status/"
+                            },
+                            {
+                                "text": "View Your VA Payment History",
+                                "href": "https://www.va.gov/va-payment-history/"
+                            },
+                            {
+                                "text": "Change Your Direct Deposit and Contact Information",
+                                "href": "https://www.va.gov/change-direct-deposit-and-contact-information/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Pension",
+                        "href": "https://www.va.gov/pension/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/pension.png",
+                            "alt": "Electronic Pension Payments"
+                        },
+                        "link": {
+                            "text": "Get Your Pension Payments Electronically",
+                            "href": "https://www.godirect.gov/gpw",
+                            "target": "_blank"
+                        },
+                        "description": "Sign up for direct deposit or a pre-paid debit card."
+                    }
+                }
+            },
+            {
+                "title": "Housing Assistance",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Home Loan Benefits",
+                        "links": [
+                            {
+                                "text": "About VA Home Loan Types",
+                                "href": "https://www.va.gov/housing-assistance/home-loans/loan-types/"
+                            },
+                            {
+                                "text": "Check Your Appeal Status",
+                                "href": "https://www.va.gov/claim-or-appeal-status/"
+                            },
+                            {
+                                "text": "How to Apply for Your COE",
+                                "href": "https://www.va.gov/housing-assistance/home-loans/how-to-apply/"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Get Veterans Housing Grants",
+                        "links": [
+                            {
+                                "text": "About Disability Housing Grants",
+                                "href": "https://www.va.gov/housing-assistance/disability-housing-grants/"
+                            },
+                            {
+                                "text": "Check Your SAH Claim Status",
+                                "href": "https://www.va.gov/claim-or-appeal-status/"
+                            },
+                            {
+                                "text": "How to Apply for an SAH Grant",
+                                "href": "https://www.va.gov/housing-assistance/disability-housing-grants/how-to-apply/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Housing Assistance",
+                        "href": "https://www.va.gov/housing-assistance/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/housing.png",
+                            "alt": "National Call Center for Homeless Veterans"
+                        },
+                        "link": {
+                            "text": "National Call Center for Homeless Veterans",
+                            "href": "https://www.va.gov/homeless/nationalcallcenter.asp"
+                        },
+                        "description": "Find out how we can help you or a Veteran you care about connect with VA and local resources 24 hours a day, 7 days a week."
+                    }
+                }
+            },
+            {
+                "title": "Life Insurance",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Life Insurance",
+                        "links": [
+                            {
+                                "text": "About Life Insurance Options",
+                                "href": "https://www.va.gov/life-insurance/options-eligibility/"
+                            },
+                            {
+                                "text": "Benefits for Totally Disabled or Terminally Ill Policyholders",
+                                "href": "https://www.va.gov/life-insurance/totally-disabled-or-terminally-ill/"
+                            },
+                            {
+                                "text": "Beneficiary Financial Counseling and Online Will Preparation",
+                                "href": "https://www.benefits.va.gov/insurance/bfcs.asp"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Manage Your Life Insurance",
+                        "links": [
+                            {
+                                "text": "Access Your Policy Online",
+                                "href": "https://www.va.gov/life-insurance/manage-your-policy/"
+                            },
+                            {
+                                "text": "Update Your Beneficiaries",
+                                "href": "https://www.benefits.va.gov/INSURANCE/updatebene.asp"
+                            },
+                            {
+                                "text": "File a Claim for Insurance Benefits",
+                                "href": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp"
+                            },
+                            {
+                                "text": "Check Your Appeal Status",
+                                "href": "https://www.va.gov/claim-or-appeal-status/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Life Insurance",
+                        "href": "https://www.va.gov/life-insurance/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/life-insurance.png",
+                            "alt": "SGLI Online Enrollment System (SOES)"
+                        },
+                        "link": {
+                            "text": "SGLI Online Enrollment System (SOES)",
+                            "href": "https://www.benefits.va.gov/INSURANCE/SOES.asp"
+                        },
+                        "description": "Learn about our new online enrollment system for Servicemembers' Group Life Insurance."
+                    }
+                }
+            },
+            {
+                "title": "Burials and Memorials",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Burial Benefits",
+                        "links": [
+                            {
+                                "text": "Eligibility",
+                                "href": "https://www.va.gov/burials-memorials/eligibility/"
+                            },
+                            {
+                                "text": "Pre-need Burial Eligibility Determination",
+                                "href": "https://www.va.gov/burials-memorials/pre-need-eligibility/"
+                            },
+                            {
+                                "text": "Veteran Burial Allowance",
+                                "href": "https://www.va.gov/burials-memorials/veterans-burial-allowance/"
+                            },
+                            {
+                                "text": "Memorial Items",
+                                "href": "https://www.va.gov/burials-memorials/memorial-items/"
+                            },
+                            {
+                                "text": "Survivor and Dependent Compensation (DIC)",
+                                "href": "https://www.va.gov/burials-memorials/dependency-indemnity-compensation/"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "Plan a Burial",
+                        "links": [
+                            {
+                                "text": "Plan a Burial for a Family Member",
+                                "href": "https://www.va.gov/burials-memorials/plan-a-burial/"
+                            },
+                            {
+                                "text": "Schedule a Burial in a VA National Cemetery",
+                                "href": "https://www.cem.va.gov/cem/burial_benefits/need.asp"
+                            },
+                            {
+                                "text": "Find a Cemetery",
+                                "href": "https://www.cem.va.gov/cems/listcem.asp"
+                            },
+                            {
+                                "text": "Request Military Records (DD214)",
+                                "href": "https://www.va.gov/records/get-military-service-records/"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Burials and Memorials",
+                        "href": "https://www.va.gov/burials-memorials/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/burials.png",
+                            "alt": "National Cemetery Administration Mobile Site"
+                        },
+                        "link": {
+                            "text": "National Cemetery Administration Mobile Site",
+                            "href": "https://m.va.gov/"
+                        },
+                        "description": "Locate a grave, search for cemeteries, and find benefits information and resources from your mobile phone or tablet."
+                    }
+                }
+            },
+            {
+                "title": "Records",
+                "links": {
+                    "columnOne": {
+                        "title": "Get Your Records",
+                        "links": [
+                            {
+                                "text": "Get Your VA Medical Records (Blue Button)",
+                                "href": "https://www.va.gov/health-care/get-medical-records/"
+                            },
+                            {
+                                "text": "Download Your VA Benefit Letters",
+                                "href": "https://www.va.gov/records/download-va-letters/"
+                            },
+                            {
+                                "text": "Learn How to Apply for a Home Loan COE",
+                                "href": "https://www.va.gov/housing-assistance/home-loans/how-to-apply/"
+                            },
+                            {
+                                "text": "Get Veteran ID Cards",
+                                "href": "https://www.va.gov/records/get-veteran-id-cards/"
+                            }
+                        ]
+                    },
+                    "columnTwo": {
+                        "title": "VA",
+                        "links": [
+                            {
+                                "text": "Request Your Military Records (DD214)",
+                                "href": "https://www.va.gov/records/get-military-service-records/"
+                            },
+                            {
+                                "text": "How to Apply for a Discharge Upgrade",
+                                "href": "https://www.va.gov/discharge-upgrade-instructions"
+                            },
+                            {
+                                "text": "View Your VA Payment History",
+                                "href": "https://www.va.gov/va-payment-history/"
+                            },
+                            {
+                                "text": "Search Historical Military Records (National Archives)",
+                                "href": "https://www.archives.gov/",
+                                "target": "_blank"
+                            }
+                        ]
+                    },
+                    "seeAllLink": {
+                        "text": "Records",
+                        "href": "https://www.va.gov/records/"
+                    },
+                    "columnThree": {
+                        "img": {
+                            "src": "https://www.va.gov/img/hub-illustrations/records.png",
+                            "alt": "Veteran ID Card"
+                        },
+                        "link": {
+                            "text": "Confirm Your VA Benefit Status",
+                            "href": "https://www.va.gov/records/download-va-letters/"
+                        },
+                        "description": "Download letters like your eligibility or award letter for certain benefits."
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "title": "About VA",
+        "menuSections": {
+            "mainColumn": {
+                "title": "VA Organizations",
+                "links": [
+                    {
+                        "text": "Veterans Health Administration",
+                        "href": "https://www.va.gov/health/"
+                    },
+                    {
+                        "text": "Veterans Benefits Administration",
+                        "href": "https://www.benefits.va.gov/benefits/"
+                    },
+                    {
+                        "text": "National Cemetery Administration",
+                        "href": "https://www.cem.va.gov"
+                    },
+                    {
+                        "text": "VA Leadership",
+                        "href": "https://www.va.gov/opa/bios/index.asp"
+                    },
+                    {
+                        "text": "Public Affairs",
+                        "href": "https://www.va.gov/OPA/index.asp"
+                    },
+                    {
+                        "text": "Congressional Affairs",
+                        "href": "https://www.va.gov/oca/index.asp"
+                    },
+                    {
+                        "text": "All VA Offices and Organizations",
+                        "href": "https://www.va.gov/landing_organizations.htm"
+                    }
+                ]
+            },
+            "columnOne": {
+                "title": "Innovation at VA",
+                "links": [
+                    {
+                        "text": "Health Research",
+                        "href": "https://www.research.va.gov"
+                    },
+                    {
+                        "text": "Public Health",
+                        "href": "https://www.publichealth.va.gov"
+                    },
+                    {
+                        "text": "Veterans Choice Program",
+                        "href": "https://www.va.gov/COMMUNITYCARE/programs/veterans/VCP/index.asp"
+                    },
+                    {
+                        "text": "VA Open Data",
+                        "href": "https://www.data.va.gov",
+                        "target": "_blank"
+                    },
+                    {
+                        "text": "Veterans Analysis and Statistics",
+                        "href": "https://www.va.gov/VETDATA/index.asp"
+                    },
+                    {
+                        "text": "Appeals Modernization",
+                        "href": "https://www.benefits.va.gov/benefits/appeals.asp"
+                    },
+                    {
+                        "text": "VA Center for Innovation",
+                        "href": "https://www.innovation.va.gov"
+                    },
+                    {
+                        "text": "Recovery Act",
+                        "href": "https://www.va.gov/recovery/"
+                    }
+                ]
+            },
+            "columnTwo": {
+                "title": "Learn About VA",
+                "links": [
+                    {
+                        "text": "VA Mission, Vision, and Values",
+                        "href": "https://www.va.gov/ABOUT_VA/index.asp"
+                    },
+                    {
+                        "text": "History of VA",
+                        "href": "https://www.va.gov/about_va/vahistory.asp"
+                    },
+                    {
+                        "text": "VA Plans, Budget, and Performance",
+                        "href": "https://www.va.gov/performance/"
+                    },
+                    {
+                        "text": "National Cemetery History Program",
+                        "href": "https://www.cem.va.gov/cem/history/index.asp"
+                    },
+                    {
+                        "text": "Veterans Legacy Program",
+                        "href": "https://www.cem.va.gov/cem/legacy/index.asp"
+                    },
+                    {
+                        "text": "Volunteer or Donate",
+                        "href": "https://www.volunteer.va.gov/index.asp"
+                    }
+                ]
+            },
+            "columnThree": {
+                "img": {
+                    "src": "https://www.va.gov/img/va-financial-report-fy2018.jpeg",
+                    "alt": "Agency Financial Report"
+                },
+                "link": {
+                    "text": "Agency Financial Report",
+                    "href": "https://www.va.gov/finance/afr/index.asp"
+                },
+                "description": "View the 2018 report on VA’s progress in providing benefits and health care."
+            }
+        }
+    },
+    {
+        "title": "Find a VA Location",
+        "href": "https://www.va.gov/find-locations/"
+    }
+]

--- a/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
+++ b/docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
@@ -65,7 +65,9 @@ class PostRowSave implements EventSubscriberInterface {
         break;
 
       case 'va_benefits_menu':
+      case 'va_main_menu':
         $this->setMenuParent($event);
+        break;
     }
   }
 

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
@@ -109,13 +109,13 @@ class VaBenefitsMenu extends SourcePluginBase {
    * @param array $menu_tree
    *   The array of menu items.
    */
-  protected function setWeights(array &$menu_tree) {
+  public static function setWeights(array &$menu_tree) {
     $relative_weight = 0;
     foreach ($menu_tree as &$item) {
       $item['weight'] = -50 + $relative_weight;
       $relative_weight++;
       if (!empty($item['items'])) {
-        $this->setWeights($item['items']);
+        self::setWeights($item['items']);
       }
     }
   }
@@ -130,11 +130,11 @@ class VaBenefitsMenu extends SourcePluginBase {
    * @param string $parent_id
    *   The id of the current menu tree's parent.
    */
-  protected function setIds(array &$menu_tree, $parent_id = '') {
+  public static function setIds(array &$menu_tree, $parent_id = '') {
     foreach ($menu_tree as $index => &$item) {
       $item['id'] = $parent_id . '-' . $index;
       if (!empty($item['items'])) {
-        $this->setIds($item['items'], $item['id']);
+        self::setIds($item['items'], $item['id']);
       }
     }
   }
@@ -154,7 +154,7 @@ class VaBenefitsMenu extends SourcePluginBase {
    * @return array
    *   A one-dimensional array of menu items.
    */
-  protected function flattenMenu(array $menu_tree, $parent_id = '', $parent_menu = '') {
+  public static function flattenMenu(array $menu_tree, $parent_id = '', $parent_menu = '') {
     $flat_menu = [];
     foreach ($menu_tree as $index => $item) {
       if (parse_url($item['href'], PHP_URL_SCHEME)) {
@@ -178,7 +178,7 @@ class VaBenefitsMenu extends SourcePluginBase {
       $flat_menu[] = $item;
 
       if (!empty($item['items'])) {
-        $flat_menu = array_merge($flat_menu, $this->flattenMenu($item['items'], $item['id'], $item['menu']));
+        $flat_menu = array_merge($flat_menu, self::flattenMenu($item['items'], $item['id'], $item['menu']));
       }
       unset($item['items']);
 

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMainMenu.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMainMenu.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Plugin\migrate\source;
+
+use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+
+/**
+ * Source to read from sidebar.json.
+ *
+ * @MigrateSource(
+ *   id = "va_main_menu_source"
+ * )
+ */
+class VaMainMenu extends SourcePluginBase {
+
+  /**
+   * Return a string representing the source file path.
+   *
+   * @return string
+   *   The file path.
+   */
+  public function __toString() {
+    return 'megamenu.json';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function initializeIterator() {
+    $contents = file_get_contents("modules/custom/va_gov_migrate/data/megamenu.json");
+    $json_main = json_decode($contents, TRUE);
+    // Get top level menus.
+    $menus = [];
+    foreach ($json_main as $section) {
+      $main_section = [
+        'title' => $section['title'],
+        'href' => empty($section['href']) ? 'route:<nolink>' : $section['href'],
+      ];
+      if (!empty($section['menuSections'])) {
+        foreach ($section['menuSections'] as $menu_section) {
+          $main_section['items'][] = $this->makeSection($menu_section);
+        }
+      }
+      $menus[] = $main_section;
+    }
+
+    VaBenefitsMenu::setIds($menus);
+    VaBenefitsMenu::setWeights($menus);
+    $flat_menu = VaBenefitsMenu::flattenMenu($menus);
+
+    return new \ArrayIterator($flat_menu);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids['id']['type'] = 'string';
+    return $ids;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields['href'] = 'Link Path';
+    $fields['title'] = 'Link Title';
+    $fields['external'] = 'External Path';
+    $fields['weight'] = 'Weight';
+    $fields['parent_id'] = 'Parent Id';
+
+    return $fields;
+  }
+
+  /**
+   * Generate a menu tree from a menu section.
+   *
+   * @param array $section
+   *   The menu section from json.
+   *
+   * @return array
+   *   The menu tree.
+   */
+  protected function makeSection(array $section) {
+    $menu_section['title'] = $section['title'];
+    $menu_section['href'] = 'route:<nolink>';
+    $menu_section['items'] = [];
+    foreach ($section['links'] as $name => $link) {
+      if (!empty($link['title'])) {
+        $column = [
+          'title' => $link['title'],
+          'href' => $link['href'],
+          'items' => [],
+        ];
+        foreach ($link['links'] as $item) {
+          $column['items'][] = [
+            'title' => $item['text'],
+            'href' => $item['href'],
+          ];
+        }
+        $menu_section['items'][] = $column;
+      }
+      elseif (!empty($link['text'])) {
+        $menu_section['items'][] = [
+          'title' => 'View all in ' . $link['text'],
+          'href' => $link['href'],
+        ];
+      }
+    }
+    return $menu_section;
+  }
+
+}


### PR DESCRIPTION
This got lost in the shuffle last sprint, but here it is. 

To test:

1. Go to /admin/config/structure/va_gov_migrate/truncate-menu to delete all the items currently in the main menu.
2. Run the 'Import menu links for health care benefits main menus' migration.

The main menu should now match the one on va.gov.