### PR TITLE
VAGOV-1757 Fix trusted host pattern to support PR/TEST ENVs.

### DIFF
--- a/docroot/sites/default/settings/settings.test.php
+++ b/docroot/sites/default/settings/settings.test.php
@@ -20,6 +20,6 @@ $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Local';
 
 $settings['trusted_host_patterns'] = [
-    '^pr-*\.va\.agile6\.com$',
+    '^pr.*\.va\.agile6\.com$',
     '^*\.us-gov-west-1\.elb\.amazonaws\.com$',
 ];


### PR DESCRIPTION
Currently getting this on pr-123.* hostnames for https://github.com/department-of-veterans-affairs/va.gov-cms/pull/198:
> Warning: preg_match(): Compilation failed: nothing to repeat at offset 1 in Symfony\Component\HttpFoundation\Request->getHost() (line 1303 of /app/docroot/vendor/symfony/http-foundation/Request.php).The provided host name is not valid for this server.