### PR TITLE
VAGOV-1962 Fix PHPUnit tests breaking on builds

### DIFF
--- a/tests/phpunit/PerformancePreviewTest.php
+++ b/tests/phpunit/PerformancePreviewTest.php
@@ -14,6 +14,9 @@ class PreviewPerformance extends ExistingSiteBase {
    *
    * @group performance
    * @group all
+   * Disable this test since we don't have a preview server running for CI/PR
+   * environments and it is breaking builds.
+   * @group disabled
    *
    * @dataProvider benchmarkTime
    */

--- a/tests/phpunit/SecurityRolesPermissionsTest.php
+++ b/tests/phpunit/SecurityRolesPermissionsTest.php
@@ -610,6 +610,7 @@ class SecurityRolesPermissions extends ExistingSiteBase {
           'edit terms in administration',
           'manage password reset',
           'use moderation dashboard',
+          'use text format rich_text',
           'view any moderation dashboard',
           'view workbench access information',
         ],


### PR DESCRIPTION
CI/PR is breaking due to PerformancePreviewTest and SecurityRolesPermissionsTest. 

So far this PR contains fixing the former, which simply adds a `@group disabled`. We need an export for the latter still. 

Update: second part has been committed, tests passing locally. 