### PR TITLE
Vagov 000 update menus

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/data/sidebar.json
+++ b/docroot/modules/custom/va_gov_migrate/data/sidebar.json
@@ -76,6 +76,209 @@
     ]
   },
   {
+    "fileName": "dst/index.html",
+    "sidebarTitle": "",
+    "backLink": null,
+    "items": [],
+    "menus": []
+  },
+  {
+    "fileName": "records/download-va-letters/index.html",
+    "sidebarTitle": "Records",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Records",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get VA Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Types of Veteran ID Cards",
+            "href": "/records/get-veteran-id-cards",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Learn How to Apply for a Home Loan COE",
+            "href": "/housing-assistance/home-loans/how-to-apply/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Discharge Upgrade",
+            "href": "/discharge-upgrade-instructions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "records/get-military-service-records/index.html",
+    "sidebarTitle": "Records",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Records",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get VA Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Types of Veteran ID Cards",
+            "href": "/records/get-veteran-id-cards",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Learn How to Apply for a Home Loan COE",
+            "href": "/housing-assistance/home-loans/how-to-apply/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Discharge Upgrade",
+            "href": "/discharge-upgrade-instructions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "records/get-veteran-id-cards/index.html",
+    "sidebarTitle": "Records",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Records",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Request Military Records",
+            "href": "/records/get-military-service-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get VA Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Types of Veteran ID Cards",
+            "href": "/records/get-veteran-id-cards",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Learn How to Apply for a Home Loan COE",
+            "href": "/housing-assistance/home-loans/how-to-apply/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Discharge Upgrade",
+            "href": "/discharge-upgrade-instructions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Search Historical Military Records",
+            "href": "https://www.archives.gov/",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "records/get-veteran-id-cards/vic/index.html",
+    "sidebarTitle": "Records",
+    "backLink": {
+      "title": "Types of Veteran ID Cards",
+      "href": "/records/get-veteran-id-cards"
+    },
+    "items": [],
+    "menus": []
+  },
+  {
     "fileName": "pension/aid-attendance-housebound/index.html",
     "sidebarTitle": "Pension Benefits",
     "backLink": null,
@@ -497,110 +700,6 @@
     ]
   },
   {
-    "fileName": "pension/survivors-pension/index.html",
-    "sidebarTitle": "Pension Benefits",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Eligibility",
-            "href": "/pension/eligibility",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "How to Apply",
-            "href": "/pension/how-to-apply",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Apply Now",
-            "href": "/pension/application/527EZ",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Aid and Attendance Benefits and Housebound Allowance",
-            "href": "/pension/aid-attendance-housebound",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Survivors Pension",
-            "href": "/pension/survivors-pension",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Check Claim or Appeal Status",
-            "href": "/claim-or-appeal-status/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "View VA Payment History",
-            "href": "/va-payment-history/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Change Direct Deposit and Contact Information",
-            "href": "/change-direct-deposit-and-contact-information/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Veterans Pension Rates",
-            "href": "/pension/veterans-pension-rates",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Survivors Pension Rates",
-            "href": "/pension/survivors-pension-rates",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Protected Pension Rates",
-            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VA Claim Exam (C&P Exam)",
-            "href": "/disability/va-claim-exam/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Pension Management Centers",
-            "href": "/pension/pension-management-centers",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
     "fileName": "pension/survivors-pension-rates/index.html",
     "sidebarTitle": "Pension Benefits",
     "backLink": null,
@@ -678,6 +777,110 @@
           },
           {
             "active": true,
+            "title": "Survivors Pension Rates",
+            "href": "/pension/survivors-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Protected Pension Rates",
+            "href": "https://www.benefits.va.gov/PENSION/current_protected_pension_rate_tables.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Pension Management Centers",
+            "href": "/pension/pension-management-centers",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "pension/survivors-pension/index.html",
+    "sidebarTitle": "Pension Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/pension/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/pension/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/pension/application/527EZ",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Aid and Attendance Benefits and Housebound Allowance",
+            "href": "/pension/aid-attendance-housebound",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Survivors Pension",
+            "href": "/pension/survivors-pension",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View VA Payment History",
+            "href": "/va-payment-history/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Information",
+            "href": "/change-direct-deposit-and-contact-information/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Veterans Pension Rates",
+            "href": "/pension/veterans-pension-rates",
+            "items": []
+          },
+          {
+            "active": false,
             "title": "Survivors Pension Rates",
             "href": "/pension/survivors-pension-rates",
             "items": []
@@ -820,1561 +1023,6 @@
         "active": true,
         "title": "Fully Developed Claim Program",
         "href": "/pension/how-to-apply/fully-developed-claim",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "records/download-va-letters/index.html",
-    "sidebarTitle": "Records",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Records",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Request Military Records",
-            "href": "/records/get-military-service-records",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get VA Medical Records",
-            "href": "/health-care/get-medical-records/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Types of Veteran ID Cards",
-            "href": "/records/get-veteran-id-cards",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Download VA Benefit Letters",
-            "href": "/records/download-va-letters",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Learn How to Apply for a Home Loan COE",
-            "href": "/housing-assistance/home-loans/how-to-apply/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Discharge Upgrade",
-            "href": "/discharge-upgrade-instructions",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "View VA Payment History",
-            "href": "/va-payment-history",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Search Historical Military Records",
-            "href": "https://www.archives.gov/",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "records/get-military-service-records/index.html",
-    "sidebarTitle": "Records",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Records",
-        "open": true,
-        "items": [
-          {
-            "active": true,
-            "title": "Request Military Records",
-            "href": "/records/get-military-service-records",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get VA Medical Records",
-            "href": "/health-care/get-medical-records/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Types of Veteran ID Cards",
-            "href": "/records/get-veteran-id-cards",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Download VA Benefit Letters",
-            "href": "/records/download-va-letters",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Learn How to Apply for a Home Loan COE",
-            "href": "/housing-assistance/home-loans/how-to-apply/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Discharge Upgrade",
-            "href": "/discharge-upgrade-instructions",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "View VA Payment History",
-            "href": "/va-payment-history",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Search Historical Military Records",
-            "href": "https://www.archives.gov/",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "records/get-veteran-id-cards/index.html",
-    "sidebarTitle": "Records",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Records",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Request Military Records",
-            "href": "/records/get-military-service-records",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get VA Medical Records",
-            "href": "/health-care/get-medical-records/",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Types of Veteran ID Cards",
-            "href": "/records/get-veteran-id-cards",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Download VA Benefit Letters",
-            "href": "/records/download-va-letters",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Learn How to Apply for a Home Loan COE",
-            "href": "/housing-assistance/home-loans/how-to-apply/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Discharge Upgrade",
-            "href": "/discharge-upgrade-instructions",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "View VA Payment History",
-            "href": "/va-payment-history",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Search Historical Military Records",
-            "href": "https://www.archives.gov/",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "records/get-veteran-id-cards/vic/index.html",
-    "sidebarTitle": "Records",
-    "backLink": {
-      "title": "Types of Veteran ID Cards",
-      "href": "/records/get-veteran-id-cards"
-    },
-    "items": [],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/careerscope-skills-assessment/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/dependent-benefits/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/education-and-career-counseling/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/family-resources/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/veteran-owned-business-support/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/veteran-resources/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/vetsuccess-on-campus/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": true,
-        "items": [
-          {
-            "active": true,
-            "title": "Vocational Rehab and Employment",
-            "href": "/careers-employment/vocational-rehabilitation",
-            "items": [
-              {
-                "title": "Programs",
-                "href": "/careers-employment/vocational-rehabilitation/programs"
-              },
-              {
-                "title": "Eligibility",
-                "href": "/careers-employment/vocational-rehabilitation/eligibility"
-              },
-              {
-                "title": "How to Apply",
-                "href": "/careers-employment/vocational-rehabilitation/how-to-apply"
-              },
-              {
-                "title": "Accessing VR&E Through IDES",
-                "href": "/careers-employment/vocational-rehabilitation/ides"
-              }
-            ]
-          },
-          {
-            "active": false,
-            "title": "Educational and Career Counseling",
-            "href": "/careers-employment/education-and-career-counseling",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran-Owned Business Support",
-            "href": "/careers-employment/veteran-owned-business-support",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Dependent Benefits",
-            "href": "/careers-employment/dependent-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA Transition Assistance",
-            "href": "https://www.benefits.va.gov/tap/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "CareerScope",
-            "href": "/careers-employment/careerscope-skills-assessment",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find a Job",
-            "href": "https://www.dol.gov/veterans/findajob/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Find VA Careers and Support",
-            "href": "https://localhost/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Print Civil Service Preference Letter",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get LinkedIn Classes",
-            "href": "https://www.veterans.linkedin.com/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Subsistence Allowance Rates",
-            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VetSuccess on Campus",
-            "href": "/careers-employment/vetsuccess-on-campus",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Program Definitions",
-            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Success Stories",
-            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veteran Resources",
-            "href": "/careers-employment/veteran-resources",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family Resources",
-            "href": "/careers-employment/family-resources",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/eligibility/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Vocational Rehab and Employment",
-      "href": "/careers-employment/vocational-rehabilitation"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Programs",
-        "href": "/careers-employment/vocational-rehabilitation/programs",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Eligibility",
-        "href": "/careers-employment/vocational-rehabilitation/eligibility",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "How to Apply",
-        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Accessing VR&E Through IDES",
-        "href": "/careers-employment/vocational-rehabilitation/ides",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/how-to-apply/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Vocational Rehab and Employment",
-      "href": "/careers-employment/vocational-rehabilitation"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Programs",
-        "href": "/careers-employment/vocational-rehabilitation/programs",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Eligibility",
-        "href": "/careers-employment/vocational-rehabilitation/eligibility",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "How to Apply",
-        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Accessing VR&E Through IDES",
-        "href": "/careers-employment/vocational-rehabilitation/ides",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/ides/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Vocational Rehab and Employment",
-      "href": "/careers-employment/vocational-rehabilitation"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Programs",
-        "href": "/careers-employment/vocational-rehabilitation/programs",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Eligibility",
-        "href": "/careers-employment/vocational-rehabilitation/eligibility",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "How to Apply",
-        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Accessing VR&E Through IDES",
-        "href": "/careers-employment/vocational-rehabilitation/ides",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/programs/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Vocational Rehab and Employment",
-      "href": "/careers-employment/vocational-rehabilitation"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "Programs",
-        "href": "/careers-employment/vocational-rehabilitation/programs",
-        "items": [
-          {
-            "title": "Reemployment",
-            "href": "/careers-employment/vocational-rehabilitation/programs/reemployment"
-          },
-          {
-            "title": "Rapid Access to Employment",
-            "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment"
-          },
-          {
-            "title": "Self-Employment",
-            "href": "/careers-employment/vocational-rehabilitation/programs/self-employment"
-          },
-          {
-            "title": "Long-Term Services",
-            "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services"
-          },
-          {
-            "title": "Independent Living",
-            "href": "/careers-employment/vocational-rehabilitation/programs/independent-living"
-          }
-        ]
-      },
-      {
-        "active": false,
-        "title": "Eligibility",
-        "href": "/careers-employment/vocational-rehabilitation/eligibility",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "How to Apply",
-        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Accessing VR&E Through IDES",
-        "href": "/careers-employment/vocational-rehabilitation/ides",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/programs/independent-living/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Programs",
-      "href": "/careers-employment/vocational-rehabilitation/programs"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Reemployment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Rapid Access to Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Self-Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Long-Term Services",
-        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Independent Living",
-        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/programs/long-term-services/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Programs",
-      "href": "/careers-employment/vocational-rehabilitation/programs"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Reemployment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Rapid Access to Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Self-Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Long-Term Services",
-        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Independent Living",
-        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Programs",
-      "href": "/careers-employment/vocational-rehabilitation/programs"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Reemployment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Rapid Access to Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Self-Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Long-Term Services",
-        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Independent Living",
-        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/programs/reemployment/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Programs",
-      "href": "/careers-employment/vocational-rehabilitation/programs"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "Reemployment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Rapid Access to Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Self-Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Long-Term Services",
-        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Independent Living",
-        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "careers-employment/vocational-rehabilitation/programs/self-employment/index.html",
-    "sidebarTitle": "Careers and Employment",
-    "backLink": {
-      "title": "Programs",
-      "href": "/careers-employment/vocational-rehabilitation/programs"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Reemployment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Rapid Access to Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Self-Employment",
-        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Long-Term Services",
-        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Independent Living",
-        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
         "items": []
       }
     ],
@@ -3635,6 +2283,1365 @@
     "menus": []
   },
   {
+    "fileName": "careers-employment/education-and-career-counseling/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/careerscope-skills-assessment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/dependent-benefits/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/family-resources/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/veteran-owned-business-support/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/veteran-resources/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": [
+              {
+                "title": "Programs",
+                "href": "/careers-employment/vocational-rehabilitation/programs"
+              },
+              {
+                "title": "Eligibility",
+                "href": "/careers-employment/vocational-rehabilitation/eligibility"
+              },
+              {
+                "title": "How to Apply",
+                "href": "/careers-employment/vocational-rehabilitation/how-to-apply"
+              },
+              {
+                "title": "Accessing VR&E Through IDES",
+                "href": "/careers-employment/vocational-rehabilitation/ides"
+              }
+            ]
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/vetsuccess-on-campus/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Vocational Rehab and Employment",
+            "href": "/careers-employment/vocational-rehabilitation",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Educational and Career Counseling",
+            "href": "/careers-employment/education-and-career-counseling",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran-Owned Business Support",
+            "href": "/careers-employment/veteran-owned-business-support",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Dependent Benefits",
+            "href": "/careers-employment/dependent-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA Transition Assistance",
+            "href": "https://www.benefits.va.gov/tap/tap-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "CareerScope",
+            "href": "/careers-employment/careerscope-skills-assessment",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find a Job",
+            "href": "https://www.dol.gov/veterans/findajob/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Find VA Careers and Support",
+            "href": "http://localhost:3001/jobs/?utm_source=jobs_button&utm_campaign=ChooseVA_Website_Buttons",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Print Civil Service Preference Letter",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get LinkedIn Classes",
+            "href": "https://www.veterans.linkedin.com/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Subsistence Allowance Rates",
+            "href": "https://www.benefits.va.gov/vocrehab/subsistence_allowance_rates.asp",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "VetSuccess on Campus",
+            "href": "/careers-employment/vetsuccess-on-campus",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Program Definitions",
+            "href": "https://www.benefits.va.gov/vocrehab/program_definitions.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Success Stories",
+            "href": "https://www.benefits.va.gov/vocrehab/success_stories.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veteran Resources",
+            "href": "/careers-employment/veteran-resources",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family Resources",
+            "href": "/careers-employment/family-resources",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/eligibility/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/how-to-apply/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/ides/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Vocational Rehab and Employment",
+      "href": "/careers-employment/vocational-rehabilitation"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Programs",
+        "href": "/careers-employment/vocational-rehabilitation/programs",
+        "items": [
+          {
+            "title": "Reemployment",
+            "href": "/careers-employment/vocational-rehabilitation/programs/reemployment"
+          },
+          {
+            "title": "Rapid Access to Employment",
+            "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment"
+          },
+          {
+            "title": "Self-Employment",
+            "href": "/careers-employment/vocational-rehabilitation/programs/self-employment"
+          },
+          {
+            "title": "Long-Term Services",
+            "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services"
+          },
+          {
+            "title": "Independent Living",
+            "href": "/careers-employment/vocational-rehabilitation/programs/independent-living"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/careers-employment/vocational-rehabilitation/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/careers-employment/vocational-rehabilitation/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Accessing VR&E Through IDES",
+        "href": "/careers-employment/vocational-rehabilitation/ides",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/independent-living/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/long-term-services/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/reemployment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "careers-employment/vocational-rehabilitation/programs/self-employment/index.html",
+    "sidebarTitle": "Careers and Employment",
+    "backLink": {
+      "title": "Programs",
+      "href": "/careers-employment/vocational-rehabilitation/programs"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Reemployment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/reemployment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Rapid Access to Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Self-Employment",
+        "href": "/careers-employment/vocational-rehabilitation/programs/self-employment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Long-Term Services",
+        "href": "/careers-employment/vocational-rehabilitation/programs/long-term-services",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Independent Living",
+        "href": "/careers-employment/vocational-rehabilitation/programs/independent-living",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
     "fileName": "health-care/about-affordable-care-act/index.html",
     "sidebarTitle": "Health Care",
     "backLink": null,
@@ -3731,7 +3738,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -3749,7 +3756,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -3761,7 +3768,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -3791,7 +3798,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -3815,13 +3822,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -3853,7 +3860,7 @@
               },
               {
                 "title": "Cost of Care",
-                "href": "https://localhost/HEALTHBENEFITS/cost/index.asp"
+                "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp"
               },
               {
                 "title": "VA Health Care and Other Insurance",
@@ -3954,7 +3961,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -3972,7 +3979,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -3984,7 +3991,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -4014,7 +4021,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -4038,13 +4045,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -4148,7 +4155,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -4166,7 +4173,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -4178,7 +4185,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -4208,7 +4215,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -4232,13 +4239,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -4268,11 +4275,11 @@
             "items": [
               {
                 "title": "Active Duty Service Members",
-                "href": "https://localhost/HEALTHBENEFITS/apply/active_duty.asp"
+                "href": "http://localhost:3001/HEALTHBENEFITS/apply/active_duty.asp"
               },
               {
                 "title": "Returning Service Members",
-                "href": "https://localhost/HEALTHBENEFITS/apply/returning_servicemembers.asp"
+                "href": "http://localhost:3001/HEALTHBENEFITS/apply/returning_servicemembers.asp"
               }
             ]
           },
@@ -4351,7 +4358,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -4369,7 +4376,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -4381,7 +4388,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -4411,7 +4418,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -4435,13 +4442,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -4554,7 +4561,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -4572,7 +4579,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -4584,7 +4591,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -4614,7 +4621,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -4638,13 +4645,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -4748,7 +4755,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -4766,7 +4773,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -4778,7 +4785,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -4808,7 +4815,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -4832,13 +4839,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -4942,7 +4949,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -4960,7 +4967,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -4972,7 +4979,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -4983,10 +4990,6 @@
               {
                 "title": "Health Issues Related to Service Era",
                 "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
-              },
-              {
-                "title": "Health Topics A-Z",
-                "href": "https://localhost/health/topics/index.asp"
               },
               {
                 "title": "Mental Health",
@@ -5007,6 +5010,10 @@
               {
                 "title": "Women’s Health Care Needs",
                 "href": "/health-care/health-needs-conditions/womens-health-needs"
+              },
+              {
+                "title": "Health Topics A-Z",
+                "href": "http://localhost:3001/health/topics/index.asp"
               }
             ]
           },
@@ -5031,7 +5038,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -5055,13 +5062,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -5165,7 +5172,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -5183,7 +5190,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -5195,7 +5202,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -5225,7 +5232,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -5249,13 +5256,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -5359,7 +5366,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -5377,7 +5384,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -5389,7 +5396,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -5419,7 +5426,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -5443,207 +5450,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "health-care/secure-messaging/index.html",
-    "sidebarTitle": "Health Care",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "About VA Health Benefits",
-            "href": "/health-care/about-va-health-benefits",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Eligibility",
-            "href": "/health-care/eligibility",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "How to Apply",
-            "href": "/health-care/how-to-apply",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Apply Now",
-            "href": "/health-care/apply/application",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "After You Apply",
-            "href": "/health-care/after-you-apply",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Family and Caregiver Benefits",
-            "href": "/health-care/family-caregiver-benefits",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": true,
-        "items": [
-          {
-            "active": false,
-            "title": "Refill and Track Prescriptions",
-            "href": "/health-care/refill-track-prescriptions",
-            "items": []
-          },
-          {
-            "active": true,
-            "title": "Use Secure Messaging",
-            "href": "/health-care/secure-messaging",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Schedule and View Appointments",
-            "href": "/health-care/schedule-view-va-appointments",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "View Lab and Test Results",
-            "href": "/health-care/view-test-and-lab-results",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
-            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get Medical Records",
-            "href": "/health-care/get-medical-records",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Update Health Benefits Info",
-            "href": "/health-care/update-health-information",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Make a Payment",
-            "href": "https://www.pay.gov/public/form/start/25987221",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Check Appeal Status",
-            "href": "/claim-or-appeal-status/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Health Needs and Conditions",
-            "href": "/health-care/health-needs-conditions",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Health Benefits Explorer",
-            "href": "http://hbexplorer.vacloud.us/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Wellness Programs",
-            "href": "/health-care/wellness-programs",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Chemical or Hazardous Material Exposures",
-            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Affordable Care Act",
-            "href": "/health-care/about-affordable-care-act",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "The Million Veteran Program",
-            "href": "https://www.research.va.gov/mvp/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Access and Quality in VA Health Care",
-            "href": "https://www.accesstocare.va.gov/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -5747,7 +5560,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -5765,7 +5578,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -5777,7 +5590,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -5807,7 +5620,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -5831,13 +5644,207 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "health-care/secure-messaging/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "About VA Health Benefits",
+            "href": "/health-care/about-va-health-benefits",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/health-care/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to Apply",
+            "href": "/health-care/how-to-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Apply Now",
+            "href": "/health-care/apply/application",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You Apply",
+            "href": "/health-care/after-you-apply",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Family and Caregiver Benefits",
+            "href": "/health-care/family-caregiver-benefits",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": true,
+        "items": [
+          {
+            "active": false,
+            "title": "Refill and Track Prescriptions",
+            "href": "/health-care/refill-track-prescriptions",
+            "items": []
+          },
+          {
+            "active": true,
+            "title": "Use Secure Messaging",
+            "href": "/health-care/secure-messaging",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Schedule and View Appointments",
+            "href": "/health-care/schedule-view-va-appointments",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Lab and Test Results",
+            "href": "/health-care/view-test-and-lab-results",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Order Hearing Aid Batteries and Prosthetic Socks",
+            "href": "/health-care/order-hearing-aid-batteries-prosthetic-socks",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Medical Records",
+            "href": "/health-care/get-medical-records",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Update Health Benefits Info",
+            "href": "/health-care/update-health-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Travel Pay",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Make a Payment",
+            "href": "https://www.pay.gov/public/form/start/25987221",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Check Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Request a Health ID Card",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Cost of Care",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Needs and Conditions",
+            "href": "/health-care/health-needs-conditions",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Health Benefits Explorer",
+            "href": "http://hbexplorer.vacloud.us/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Wellness Programs",
+            "href": "/health-care/wellness-programs",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Chemical or Hazardous Material Exposures",
+            "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Veterans Choice Program",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Affordable Care Act",
+            "href": "/health-care/about-affordable-care-act",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "The Million Veteran Program",
+            "href": "https://www.research.va.gov/mvp/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Access and Quality in VA Health Care",
+            "href": "https://www.accesstocare.va.gov/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Patient Rights and Responsibilities",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Community Care",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -5941,7 +5948,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -5959,7 +5966,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -5971,7 +5978,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -6001,7 +6008,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -6025,13 +6032,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -6135,7 +6142,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -6153,7 +6160,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -6165,7 +6172,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -6195,7 +6202,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -6219,13 +6226,13 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
@@ -6329,7 +6336,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -6347,7 +6354,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -6359,7 +6366,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -6389,7 +6396,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -6413,64 +6420,18 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
       }
     ]
-  },
-  {
-    "fileName": "health-care/family-caregiver-benefits/champva/index.html",
-    "sidebarTitle": "Health Care",
-    "backLink": {
-      "title": "Family and Caregiver Benefits",
-      "href": "/health-care/family-caregiver-benefits"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "CHAMPVA Benefits",
-        "href": "/health-care/family-caregiver-benefits/champva",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Comprehensive Assistance to Family Caregivers",
-        "href": "/health-care/family-caregiver-benefits/comprehensive-assistance",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "health-care/family-caregiver-benefits/comprehensive-assistance/index.html",
-    "sidebarTitle": "Health Care",
-    "backLink": {
-      "title": "Family and Caregiver Benefits",
-      "href": "/health-care/family-caregiver-benefits"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "CHAMPVA Benefits",
-        "href": "/health-care/family-caregiver-benefits/champva",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Comprehensive Assistance to Family Caregivers",
-        "href": "/health-care/family-caregiver-benefits/comprehensive-assistance",
-        "items": []
-      }
-    ],
-    "menus": []
   },
   {
     "fileName": "health-care/refill-track-prescriptions/index.html",
@@ -6569,7 +6530,7 @@
           {
             "active": false,
             "title": "Get Travel Pay",
-            "href": "https://localhost/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vtp/Beneficiary_Travel.asp",
             "items": []
           },
           {
@@ -6587,7 +6548,7 @@
           {
             "active": false,
             "title": "Request a Health ID Card",
-            "href": "https://localhost/HEALTHBENEFITS/vhic/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/vhic/index.asp",
             "items": []
           }
         ]
@@ -6599,7 +6560,7 @@
           {
             "active": false,
             "title": "Cost of Care",
-            "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+            "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
             "items": []
           },
           {
@@ -6629,7 +6590,7 @@
           {
             "active": false,
             "title": "Veterans Choice Program",
-            "href": "https://localhost/COMMUNITYCARE/programs/veterans/VCP/index.asp",
+            "href": "http://localhost:3001/COMMUNITYCARE/programs/veterans/VCP/index.asp",
             "items": []
           },
           {
@@ -6653,18 +6614,64 @@
           {
             "active": false,
             "title": "Patient Rights and Responsibilities",
-            "href": "https://localhost/health/rights/patientrights.asp",
+            "href": "http://localhost:3001/health/rights/patientrights.asp",
             "items": []
           },
           {
             "active": false,
             "title": "Community Care",
-            "href": "https://localhost/communitycare/index.asp",
+            "href": "http://localhost:3001/communitycare/index.asp",
             "items": []
           }
         ]
       }
     ]
+  },
+  {
+    "fileName": "health-care/family-caregiver-benefits/comprehensive-assistance/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Family and Caregiver Benefits",
+      "href": "/health-care/family-caregiver-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "CHAMPVA Benefits",
+        "href": "/health-care/family-caregiver-benefits/champva",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Comprehensive Assistance to Family Caregivers",
+        "href": "/health-care/family-caregiver-benefits/comprehensive-assistance",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/family-caregiver-benefits/champva/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Family and Caregiver Benefits",
+      "href": "/health-care/family-caregiver-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "CHAMPVA Benefits",
+        "href": "/health-care/family-caregiver-benefits/champva",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Comprehensive Assistance to Family Caregivers",
+        "href": "/health-care/family-caregiver-benefits/comprehensive-assistance",
+        "items": []
+      }
+    ],
+    "menus": []
   },
   {
     "fileName": "health-care/about-va-health-benefits/dental-care/index.html",
@@ -6689,7 +6696,7 @@
       {
         "active": false,
         "title": "Cost of Care",
-        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
         "items": []
       },
       {
@@ -6742,7 +6749,7 @@
       {
         "active": false,
         "title": "Cost of Care",
-        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
         "items": []
       },
       {
@@ -6795,7 +6802,7 @@
       {
         "active": false,
         "title": "Cost of Care",
-        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
         "items": []
       },
       {
@@ -6848,7 +6855,7 @@
       {
         "active": false,
         "title": "Cost of Care",
-        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
         "items": []
       },
       {
@@ -6906,7 +6913,7 @@
       {
         "active": false,
         "title": "Cost of Care",
-        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
         "items": []
       },
       {
@@ -6959,7 +6966,7 @@
       {
         "active": false,
         "title": "Cost of Care",
-        "href": "https://localhost/HEALTHBENEFITS/cost/index.asp",
+        "href": "http://localhost:3001/HEALTHBENEFITS/cost/index.asp",
         "items": []
       },
       {
@@ -7022,12 +7029,6 @@
       },
       {
         "active": false,
-        "title": "Health Topics A-Z",
-        "href": "https://localhost/health/topics/index.asp",
-        "items": []
-      },
-      {
-        "active": false,
         "title": "Mental Health",
         "href": "/health-care/health-needs-conditions/mental-health",
         "items": []
@@ -7054,6 +7055,78 @@
         "active": false,
         "title": "Women’s Health Care Needs",
         "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "http://localhost:3001/health/topics/index.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Health Needs and Conditions",
+      "href": "/health-care/health-needs-conditions"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Health Issues Related to Service Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Mental Health",
+        "href": "/health-care/health-needs-conditions/mental-health",
+        "items": [
+          {
+            "title": "PTSD",
+            "href": "/health-care/health-needs-conditions/mental-health/ptsd"
+          },
+          {
+            "title": "Depression",
+            "href": "/health-care/health-needs-conditions/mental-health/depression"
+          },
+          {
+            "title": "Suicide Prevention",
+            "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Military Sexual Trauma",
+        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Substance Use Problems",
+        "href": "/health-care/health-needs-conditions/substance-use-problems",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Exposure to Hazardous Materials",
+        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Women’s Health Care Needs",
+        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "http://localhost:3001/health/topics/index.asp",
         "items": []
       }
     ],
@@ -7104,12 +7177,6 @@
       },
       {
         "active": false,
-        "title": "Health Topics A-Z",
-        "href": "https://localhost/health/topics/index.asp",
-        "items": []
-      },
-      {
-        "active": false,
         "title": "Mental Health",
         "href": "/health-care/health-needs-conditions/mental-health",
         "items": []
@@ -7137,71 +7204,11 @@
         "title": "Women’s Health Care Needs",
         "href": "/health-care/health-needs-conditions/womens-health-needs",
         "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "health-care/health-needs-conditions/mental-health/index.html",
-    "sidebarTitle": "Health Care",
-    "backLink": {
-      "title": "Health Needs and Conditions",
-      "href": "/health-care/health-needs-conditions"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Health Issues Related to Service Era",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era",
-        "items": []
       },
       {
         "active": false,
         "title": "Health Topics A-Z",
-        "href": "https://localhost/health/topics/index.asp",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Mental Health",
-        "href": "/health-care/health-needs-conditions/mental-health",
-        "items": [
-          {
-            "title": "PTSD",
-            "href": "/health-care/health-needs-conditions/mental-health/ptsd"
-          },
-          {
-            "title": "Depression",
-            "href": "/health-care/health-needs-conditions/mental-health/depression"
-          },
-          {
-            "title": "Suicide Prevention",
-            "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention"
-          }
-        ]
-      },
-      {
-        "active": false,
-        "title": "Military Sexual Trauma",
-        "href": "/health-care/health-needs-conditions/military-sexual-trauma",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Substance Use Problems",
-        "href": "/health-care/health-needs-conditions/substance-use-problems",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Exposure to Hazardous Materials",
-        "href": "/health-care/health-needs-conditions/chemical-hazardous-materials-exposure",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Women’s Health Care Needs",
-        "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "href": "http://localhost:3001/health/topics/index.asp",
         "items": []
       }
     ],
@@ -7223,12 +7230,6 @@
       },
       {
         "active": false,
-        "title": "Health Topics A-Z",
-        "href": "https://localhost/health/topics/index.asp",
-        "items": []
-      },
-      {
-        "active": false,
         "title": "Mental Health",
         "href": "/health-care/health-needs-conditions/mental-health",
         "items": []
@@ -7255,6 +7256,12 @@
         "active": false,
         "title": "Women’s Health Care Needs",
         "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "http://localhost:3001/health/topics/index.asp",
         "items": []
       }
     ],
@@ -7276,12 +7283,6 @@
       },
       {
         "active": false,
-        "title": "Health Topics A-Z",
-        "href": "https://localhost/health/topics/index.asp",
-        "items": []
-      },
-      {
-        "active": false,
         "title": "Mental Health",
         "href": "/health-care/health-needs-conditions/mental-health",
         "items": []
@@ -7308,6 +7309,12 @@
         "active": false,
         "title": "Women’s Health Care Needs",
         "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "http://localhost:3001/health/topics/index.asp",
         "items": []
       }
     ],
@@ -7329,12 +7336,6 @@
       },
       {
         "active": false,
-        "title": "Health Topics A-Z",
-        "href": "https://localhost/health/topics/index.asp",
-        "items": []
-      },
-      {
-        "active": false,
         "title": "Mental Health",
         "href": "/health-care/health-needs-conditions/mental-health",
         "items": []
@@ -7361,6 +7362,99 @@
         "active": true,
         "title": "Women’s Health Care Needs",
         "href": "/health-care/health-needs-conditions/womens-health-needs",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Health Topics A-Z",
+        "href": "http://localhost:3001/health/topics/index.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/ptsd/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Mental Health",
+      "href": "/health-care/health-needs-conditions/mental-health"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "PTSD",
+        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Depression",
+        "href": "/health-care/health-needs-conditions/mental-health/depression",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Suicide Prevention",
+        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/suicide-prevention/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Mental Health",
+      "href": "/health-care/health-needs-conditions/mental-health"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Depression",
+        "href": "/health-care/health-needs-conditions/mental-health/depression",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Suicide Prevention",
+        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "health-care/health-needs-conditions/mental-health/depression/index.html",
+    "sidebarTitle": "Health Care",
+    "backLink": {
+      "title": "Mental Health",
+      "href": "/health-care/health-needs-conditions/mental-health"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "PTSD",
+        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Depression",
+        "href": "/health-care/health-needs-conditions/mental-health/depression",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Suicide Prevention",
+        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
         "items": []
       }
     ],
@@ -7632,59 +7726,6 @@
     "menus": []
   },
   {
-    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war/index.html",
-    "sidebarTitle": "Health Care",
-    "backLink": {
-      "title": "Health Issues Related to Service Era",
-      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Operation Enduring Freedom",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Iraq War",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Gulf War",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Cold War Era",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Vietnam War",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Korean War",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "World War II",
-        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
     "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii/index.html",
     "sidebarTitle": "Health Care",
     "backLink": {
@@ -7738,87 +7779,53 @@
     "menus": []
   },
   {
-    "fileName": "health-care/health-needs-conditions/mental-health/depression/index.html",
+    "fileName": "health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war/index.html",
     "sidebarTitle": "Health Care",
     "backLink": {
-      "title": "Mental Health",
-      "href": "/health-care/health-needs-conditions/mental-health"
+      "title": "Health Issues Related to Service Era",
+      "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era"
     },
     "items": [
       {
         "active": false,
-        "title": "PTSD",
-        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "title": "Operation Enduring Freedom",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Iraq War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cold War Era",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war",
         "items": []
       },
       {
         "active": true,
-        "title": "Depression",
-        "href": "/health-care/health-needs-conditions/mental-health/depression",
+        "title": "Vietnam War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war",
         "items": []
       },
       {
         "active": false,
-        "title": "Suicide Prevention",
-        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "health-care/health-needs-conditions/mental-health/ptsd/index.html",
-    "sidebarTitle": "Health Care",
-    "backLink": {
-      "title": "Mental Health",
-      "href": "/health-care/health-needs-conditions/mental-health"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "PTSD",
-        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
+        "title": "Korean War",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war",
         "items": []
       },
       {
         "active": false,
-        "title": "Depression",
-        "href": "/health-care/health-needs-conditions/mental-health/depression",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Suicide Prevention",
-        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "health-care/health-needs-conditions/mental-health/suicide-prevention/index.html",
-    "sidebarTitle": "Health Care",
-    "backLink": {
-      "title": "Mental Health",
-      "href": "/health-care/health-needs-conditions/mental-health"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "PTSD",
-        "href": "/health-care/health-needs-conditions/mental-health/ptsd",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Depression",
-        "href": "/health-care/health-needs-conditions/mental-health/depression",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Suicide Prevention",
-        "href": "/health-care/health-needs-conditions/mental-health/suicide-prevention",
+        "title": "World War II",
+        "href": "/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii",
         "items": []
       }
     ],
@@ -8750,155 +8757,6 @@
     "menus": []
   },
   {
-    "fileName": "disability/about-disability-ratings/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "Get Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Eligibility",
-            "href": "/disability/eligibility",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "How to File a Claim",
-            "href": "/disability/how-to-file-claim",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "After You File Your Claim",
-            "href": "/disability/after-you-file-claim",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Survivor and Dependent Compensation (DIC)",
-            "href": "/burials-memorials/dependency-indemnity-compensation/",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Manage Benefits",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Check Claim or Appeal Status",
-            "href": "/claim-or-appeal-status/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "File for Increased Disability",
-            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "File an Appeal",
-            "href": "/disability/file-an-appeal",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Add or Remove a Dependent",
-            "href": "/disability/add-remove-dependent",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Upload Evidence to Support Your Claim",
-            "href": "/disability/upload-supporting-evidence",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "File Supplemental Forms",
-            "href": "/disability/how-to-file-claim/supplemental-forms/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Change Direct Deposit and Contact Info",
-            "href": "/change-direct-deposit-and-contact-information",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Share Medical Records",
-            "href": "/health-care/get-medical-records/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Download VA Benefit Letters",
-            "href": "/records/download-va-letters/",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "View Disability Payment History",
-            "href": "/va-payment-history",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "More Resources",
-        "open": true,
-        "items": [
-          {
-            "active": true,
-            "title": "About Disability Ratings",
-            "href": "/disability/about-disability-ratings",
-            "items": [
-              {
-                "title": "Effective Dates",
-                "href": "/disability/about-disability-ratings/effective-date"
-              },
-              {
-                "title": "After You Get a Rating",
-                "href": "/disability/about-disability-ratings/after-you-get-a-rating"
-              }
-            ]
-          },
-          {
-            "active": false,
-            "title": "Compensation Rates",
-            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "VA Claim Exam (C&P Exam)",
-            "href": "/disability/va-claim-exam",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "Get Help Filing a Claim",
-            "href": "/disability/get-help-filing-claim",
-            "items": []
-          },
-          {
-            "active": false,
-            "title": "DBQ Forms",
-            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
     "fileName": "disability/add-remove-dependent/index.html",
     "sidebarTitle": "Disability Benefits",
     "backLink": null,
@@ -8964,13 +8822,13 @@
           },
           {
             "active": false,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -9009,6 +8867,155 @@
             "title": "About Disability Ratings",
             "href": "/disability/about-disability-ratings",
             "items": []
+          },
+          {
+            "active": false,
+            "title": "Compensation Rates",
+            "href": "http://www.benefits.va.gov/compensation/rates-index.asp",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "VA Claim Exam (C&P Exam)",
+            "href": "/disability/va-claim-exam",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Get Help Filing a Claim",
+            "href": "/disability/get-help-filing-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "DBQ Forms",
+            "href": "https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "disability/about-disability-ratings/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "Get Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Eligibility",
+            "href": "/disability/eligibility",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "How to File a Claim",
+            "href": "/disability/how-to-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "After You File Your Claim",
+            "href": "/disability/after-you-file-claim",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Survivor and Dependent Compensation (DIC)",
+            "href": "/burials-memorials/dependency-indemnity-compensation/",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Manage Benefits",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Check Claim or Appeal Status",
+            "href": "/claim-or-appeal-status/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File for Increased Disability",
+            "href": "/disability-benefits/apply/form-526-disability-claim/introduction",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File an Appeal",
+            "href": "/disability/file-an-appeal",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Add or Remove a Dependent",
+            "href": "/disability/add-remove-dependent",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Upload Evidence to Support Your Disability Claim",
+            "href": "/disability/upload-supporting-evidence",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "File Additional Forms for Your Disability Claim",
+            "href": "/disability/how-to-file-claim/supplemental-forms/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Change Direct Deposit and Contact Info",
+            "href": "/change-direct-deposit-and-contact-information",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Share Medical Records",
+            "href": "/health-care/get-medical-records/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "Download VA Benefit Letters",
+            "href": "/records/download-va-letters/",
+            "items": []
+          },
+          {
+            "active": false,
+            "title": "View Disability Payment History",
+            "href": "/va-payment-history",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "More Resources",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "About Disability Ratings",
+            "href": "/disability/about-disability-ratings",
+            "items": [
+              {
+                "title": "Effective Dates",
+                "href": "/disability/about-disability-ratings/effective-date"
+              },
+              {
+                "title": "After You Get a Rating",
+                "href": "/disability/about-disability-ratings/after-you-get-a-rating"
+              }
+            ]
           },
           {
             "active": false,
@@ -9104,13 +9111,13 @@
           },
           {
             "active": false,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -9265,13 +9272,13 @@
           },
           {
             "active": false,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -9414,13 +9421,13 @@
           },
           {
             "active": false,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -9554,13 +9561,13 @@
           },
           {
             "active": false,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -9658,7 +9665,7 @@
                 "href": "/disability/how-to-file-claim/evidence-needed"
               },
               {
-                "title": "Supplemental Forms",
+                "title": "Additional Forms",
                 "href": "/disability/how-to-file-claim/supplemental-forms"
               }
             ]
@@ -9707,13 +9714,13 @@
           },
           {
             "active": false,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -9847,13 +9854,13 @@
           },
           {
             "active": true,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -9987,13 +9994,13 @@
           },
           {
             "active": false,
-            "title": "Upload Evidence to Support Your Claim",
+            "title": "Upload Evidence to Support Your Disability Claim",
             "href": "/disability/upload-supporting-evidence",
             "items": []
           },
           {
             "active": false,
-            "title": "File Supplemental Forms",
+            "title": "File Additional Forms for Your Disability Claim",
             "href": "/disability/how-to-file-claim/supplemental-forms/",
             "items": []
           },
@@ -10062,52 +10069,6 @@
     ]
   },
   {
-    "fileName": "disability/about-disability-ratings/after-you-get-a-rating/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "About Disability Ratings",
-      "href": "/disability/about-disability-ratings"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Effective Dates",
-        "href": "/disability/about-disability-ratings/effective-date",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "After You Get a Rating",
-        "href": "/disability/about-disability-ratings/after-you-get-a-rating",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "disability/about-disability-ratings/effective-date/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "About Disability Ratings",
-      "href": "/disability/about-disability-ratings"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "Effective Dates",
-        "href": "/disability/about-disability-ratings/effective-date",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "After You Get a Rating",
-        "href": "/disability/about-disability-ratings/after-you-get-a-rating",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
     "fileName": "disability/file-an-appeal/board-of-veterans-appeals/index.html",
     "sidebarTitle": "Disability Benefits",
     "backLink": {
@@ -10148,6 +10109,52 @@
         "active": true,
         "title": "Request a Priority Review",
         "href": "/disability/file-an-appeal/request-priority-review",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/about-disability-ratings/after-you-get-a-rating/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "About Disability Ratings",
+      "href": "/disability/about-disability-ratings"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Effective Dates",
+        "href": "/disability/about-disability-ratings/effective-date",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "After You Get a Rating",
+        "href": "/disability/about-disability-ratings/after-you-get-a-rating",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/about-disability-ratings/effective-date/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "About Disability Ratings",
+      "href": "/disability/about-disability-ratings"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Effective Dates",
+        "href": "/disability/about-disability-ratings/effective-date",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "After You Get a Rating",
+        "href": "/disability/about-disability-ratings/after-you-get-a-rating",
         "items": []
       }
     ],
@@ -10433,71 +10440,6 @@
     "menus": []
   },
   {
-    "fileName": "disability/eligibility/special-claims/1151-claims-title-38/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "Special Claims",
-      "href": "/disability/eligibility/special-claims"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Auto Allowance and Adaptive Equipment",
-        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Birth Defects",
-        "href": "/disability/eligibility/special-claims/birth-defects",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Clothing Allowance",
-        "href": "/disability/eligibility/special-claims/clothing-allowance",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Dental Care",
-        "href": "/disability/eligibility/special-claims/dental-care",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Increase after Surgery or Cast",
-        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Increase for Time in Hospital",
-        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Prestabilization Ratings",
-        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Title 38 U.S.C. 1151 Claims",
-        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Unemployability",
-        "href": "/disability/eligibility/special-claims/unemployability",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
     "fileName": "disability/eligibility/special-claims/automobile-allowance-adaptive-equipment/index.html",
     "sidebarTitle": "Disability Benefits",
     "backLink": {
@@ -10693,6 +10635,71 @@
     "menus": []
   },
   {
+    "fileName": "disability/eligibility/special-claims/1151-claims-title-38/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
     "fileName": "disability/eligibility/special-claims/dental-care/index.html",
     "sidebarTitle": "Disability Benefits",
     "backLink": {
@@ -10823,71 +10830,6 @@
     "menus": []
   },
   {
-    "fileName": "disability/eligibility/special-claims/temporary-increase-for-time-in-hospital/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "Special Claims",
-      "href": "/disability/eligibility/special-claims"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Auto Allowance and Adaptive Equipment",
-        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Birth Defects",
-        "href": "/disability/eligibility/special-claims/birth-defects",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Clothing Allowance",
-        "href": "/disability/eligibility/special-claims/clothing-allowance",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Dental Care",
-        "href": "/disability/eligibility/special-claims/dental-care",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Increase after Surgery or Cast",
-        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Increase for Time in Hospital",
-        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Prestabilization Ratings",
-        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Title 38 U.S.C. 1151 Claims",
-        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Unemployability",
-        "href": "/disability/eligibility/special-claims/unemployability",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
     "fileName": "disability/eligibility/special-claims/temporary-rating-prestabilization/index.html",
     "sidebarTitle": "Disability Benefits",
     "backLink": {
@@ -10933,6 +10875,71 @@
       },
       {
         "active": true,
+        "title": "Prestabilization Ratings",
+        "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Title 38 U.S.C. 1151 Claims",
+        "href": "/disability/eligibility/special-claims/1151-claims-title-38",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Unemployability",
+        "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/special-claims/temporary-increase-for-time-in-hospital/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Special Claims",
+      "href": "/disability/eligibility/special-claims"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Auto Allowance and Adaptive Equipment",
+        "href": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Birth Defects",
+        "href": "/disability/eligibility/special-claims/birth-defects",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Clothing Allowance",
+        "href": "/disability/eligibility/special-claims/clothing-allowance",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dental Care",
+        "href": "/disability/eligibility/special-claims/dental-care",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Increase after Surgery or Cast",
+        "href": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Increase for Time in Hospital",
+        "href": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital",
+        "items": []
+      },
+      {
+        "active": false,
         "title": "Prestabilization Ratings",
         "href": "/disability/eligibility/special-claims/temporary-rating-prestabilization",
         "items": []
@@ -11012,6 +11019,71 @@
         "active": true,
         "title": "Unemployability",
         "href": "/disability/eligibility/special-claims/unemployability",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/asbestos/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
         "items": []
       }
     ],
@@ -11124,71 +11196,6 @@
     "menus": []
   },
   {
-    "fileName": "disability/eligibility/hazardous-materials-exposure/asbestos/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "Exposure to Hazardous Materials",
-      "href": "/disability/eligibility/hazardous-materials-exposure"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Specific Environmental Hazards",
-        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Agent Orange",
-        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Asbestos",
-        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Mustard Gas or Lewisite",
-        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Camp Lejeune Water Contamination",
-        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Radiation Exposure",
-        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Project 112/SHAD",
-        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Gulf War Illness SW Asia",
-        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Gulf War Illness Afghanistan",
-        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
     "fileName": "disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination/index.html",
     "sidebarTitle": "Disability Benefits",
     "backLink": {
@@ -11222,6 +11229,71 @@
       },
       {
         "active": true,
+        "title": "Camp Lejeune Water Contamination",
+        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Radiation Exposure",
+        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Project 112/SHAD",
+        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness SW Asia",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Gulf War Illness Afghanistan",
+        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Exposure to Hazardous Materials",
+      "href": "/disability/eligibility/hazardous-materials-exposure"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Specific Environmental Hazards",
+        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Agent Orange",
+        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Asbestos",
+        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Mustard Gas or Lewisite",
+        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
+        "items": []
+      },
+      {
+        "active": false,
         "title": "Camp Lejeune Water Contamination",
         "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
         "items": []
@@ -11423,71 +11495,6 @@
       },
       {
         "active": true,
-        "title": "Radiation Exposure",
-        "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Project 112/SHAD",
-        "href": "/disability/eligibility/hazardous-materials-exposure/project-112-shad",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Gulf War Illness SW Asia",
-        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Gulf War Illness Afghanistan",
-        "href": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "Exposure to Hazardous Materials",
-      "href": "/disability/eligibility/hazardous-materials-exposure"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Specific Environmental Hazards",
-        "href": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Agent Orange",
-        "href": "/disability/eligibility/hazardous-materials-exposure/agent-orange",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Asbestos",
-        "href": "/disability/eligibility/hazardous-materials-exposure/asbestos",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Mustard Gas or Lewisite",
-        "href": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Camp Lejeune Water Contamination",
-        "href": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination",
-        "items": []
-      },
-      {
-        "active": false,
         "title": "Radiation Exposure",
         "href": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation",
         "items": []
@@ -12373,10 +12380,6 @@
         "href": "/disability/how-to-file-claim/evidence-needed",
         "items": [
           {
-            "title": "Decision Ready Claims",
-            "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims"
-          },
-          {
             "title": "Fully Developed Claims",
             "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims"
           },
@@ -12388,7 +12391,7 @@
       },
       {
         "active": false,
-        "title": "Supplemental Forms",
+        "title": "Additional Forms",
         "href": "/disability/how-to-file-claim/supplemental-forms",
         "items": []
       }
@@ -12417,7 +12420,7 @@
       },
       {
         "active": true,
-        "title": "Supplemental Forms",
+        "title": "Additional Forms",
         "href": "/disability/how-to-file-claim/supplemental-forms",
         "items": []
       }
@@ -12451,8 +12454,63 @@
       },
       {
         "active": false,
-        "title": "Supplemental Forms",
+        "title": "Additional Forms",
         "href": "/disability/how-to-file-claim/supplemental-forms",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/evidence-needed/fully-developed-claims/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Evidence Needed",
+      "href": "/disability/how-to-file-claim/evidence-needed"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Fully Developed Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
+        "items": [
+          {
+            "title": "FDC Walkthrough",
+            "href": "https://www.benefits.va.gov/FDC/walkthrough.asp"
+          },
+          {
+            "title": "FDC Checklist",
+            "href": "https://www.benefits.va.gov/FDC/checklist.asp"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Standard Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "disability/how-to-file-claim/evidence-needed/standard-claims/index.html",
+    "sidebarTitle": "Disability Benefits",
+    "backLink": {
+      "title": "Evidence Needed",
+      "href": "/disability/how-to-file-claim/evidence-needed"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Fully Developed Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Standard Claims",
+        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
         "items": []
       }
     ],
@@ -12492,713 +12550,6 @@
         "active": true,
         "title": "File While Overseas",
         "href": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim/file-while-overseas",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "disability/how-to-file-claim/evidence-needed/decision-ready-claims/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "Evidence Needed",
-      "href": "/disability/how-to-file-claim/evidence-needed"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "Decision Ready Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Fully Developed Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Standard Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "disability/how-to-file-claim/evidence-needed/fully-developed-claims/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "Evidence Needed",
-      "href": "/disability/how-to-file-claim/evidence-needed"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Decision Ready Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Fully Developed Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
-        "items": [
-          {
-            "title": "FDC Walkthrough",
-            "href": "https://www.benefits.va.gov/FDC/walkthrough.asp"
-          },
-          {
-            "title": "FDC Checklist",
-            "href": "https://www.benefits.va.gov/FDC/checklist.asp"
-          }
-        ]
-      },
-      {
-        "active": false,
-        "title": "Standard Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "disability/how-to-file-claim/evidence-needed/standard-claims/index.html",
-    "sidebarTitle": "Disability Benefits",
-    "backLink": {
-      "title": "Evidence Needed",
-      "href": "/disability/how-to-file-claim/evidence-needed"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Decision Ready Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Fully Developed Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Standard Claims",
-        "href": "/disability/how-to-file-claim/evidence-needed/standard-claims",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/disability-housing-grants/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "VA Home Loans",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "VA-Backed Home Loans",
-            "href": "/housing-assistance/home-loans",
-            "items": []
-          }
-        ]
-      },
-      {
-        "title": "Disability Housing Grants",
-        "open": true,
-        "items": [
-          {
-            "active": true,
-            "title": "Housing Grants",
-            "href": "/housing-assistance/disability-housing-grants",
-            "items": [
-              {
-                "title": "How to Apply",
-                "href": "/housing-assistance/disability-housing-grants/how-to-apply"
-              },
-              {
-                "title": "Check Appeal Status",
-                "href": "/claim-or-appeal-status/"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "housing-assistance/home-loans/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": null,
-    "items": [],
-    "menus": [
-      {
-        "title": "VA Home Loans",
-        "open": true,
-        "items": [
-          {
-            "active": true,
-            "title": "VA-Backed Home Loans",
-            "href": "/housing-assistance/home-loans",
-            "items": [
-              {
-                "title": "Loan Types",
-                "href": "/housing-assistance/home-loans/loan-types"
-              },
-              {
-                "title": "Eligibility",
-                "href": "/housing-assistance/home-loans/eligibility"
-              },
-              {
-                "title": "How to Apply",
-                "href": "/housing-assistance/home-loans/how-to-apply"
-              },
-              {
-                "title": "Check Appeal Status",
-                "href": "/claim-or-appeal-status/"
-              },
-              {
-                "title": "Trouble Making Payments?",
-                "href": "/housing-assistance/home-loans/trouble-making-payments"
-              },
-              {
-                "title": "Warning about Refinancing Offers",
-                "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/"
-              },
-              {
-                "title": "Home Buying Process",
-                "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp"
-              },
-              {
-                "title": "VA Loan Funding Fee",
-                "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp"
-              },
-              {
-                "title": "Find a VA Regional Loan Center",
-                "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp"
-              },
-              {
-                "title": "Find VA-Acquired Properties",
-                "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp"
-              },
-              {
-                "title": "Guidance on Natural Disasters",
-                "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "title": "Disability Housing Grants",
-        "open": false,
-        "items": [
-          {
-            "active": false,
-            "title": "Housing Grants",
-            "href": "/housing-assistance/disability-housing-grants",
-            "items": []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "fileName": "housing-assistance/disability-housing-grants/how-to-apply/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "Housing Grants",
-      "href": "/housing-assistance/disability-housing-grants"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "How to Apply",
-        "href": "/housing-assistance/disability-housing-grants/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Check Appeal Status",
-        "href": "/claim-or-appeal-status/",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/eligibility/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "VA-Backed Home Loans",
-      "href": "/housing-assistance/home-loans"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Loan Types",
-        "href": "/housing-assistance/home-loans/loan-types",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Eligibility",
-        "href": "/housing-assistance/home-loans/eligibility",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "How to Apply",
-        "href": "/housing-assistance/home-loans/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Check Appeal Status",
-        "href": "/claim-or-appeal-status/",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Trouble Making Payments?",
-        "href": "/housing-assistance/home-loans/trouble-making-payments",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Warning about Refinancing Offers",
-        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Home Buying Process",
-        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "VA Loan Funding Fee",
-        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find a VA Regional Loan Center",
-        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find VA-Acquired Properties",
-        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Guidance on Natural Disasters",
-        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/how-to-apply/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "VA-Backed Home Loans",
-      "href": "/housing-assistance/home-loans"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Loan Types",
-        "href": "/housing-assistance/home-loans/loan-types",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Eligibility",
-        "href": "/housing-assistance/home-loans/eligibility",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "How to Apply",
-        "href": "/housing-assistance/home-loans/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Check Appeal Status",
-        "href": "/claim-or-appeal-status/",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Trouble Making Payments?",
-        "href": "/housing-assistance/home-loans/trouble-making-payments",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Warning about Refinancing Offers",
-        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Home Buying Process",
-        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "VA Loan Funding Fee",
-        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find a VA Regional Loan Center",
-        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find VA-Acquired Properties",
-        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Guidance on Natural Disasters",
-        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/loan-types/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "VA-Backed Home Loans",
-      "href": "/housing-assistance/home-loans"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "Loan Types",
-        "href": "/housing-assistance/home-loans/loan-types",
-        "items": [
-          {
-            "title": "Purchase Loan",
-            "href": "/housing-assistance/home-loans/loan-types/purchase-loan"
-          },
-          {
-            "title": "Cash Out Refinance Loan",
-            "href": "/housing-assistance/home-loans/loan-types/cash-out-loan"
-          },
-          {
-            "title": "Native American Direct Loan",
-            "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan"
-          },
-          {
-            "title": "Interest Rate Reduction Refinance Loan",
-            "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan"
-          }
-        ]
-      },
-      {
-        "active": false,
-        "title": "Eligibility",
-        "href": "/housing-assistance/home-loans/eligibility",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "How to Apply",
-        "href": "/housing-assistance/home-loans/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Check Appeal Status",
-        "href": "/claim-or-appeal-status/",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Trouble Making Payments?",
-        "href": "/housing-assistance/home-loans/trouble-making-payments",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Warning about Refinancing Offers",
-        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Home Buying Process",
-        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "VA Loan Funding Fee",
-        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find a VA Regional Loan Center",
-        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find VA-Acquired Properties",
-        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Guidance on Natural Disasters",
-        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/trouble-making-payments/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "VA-Backed Home Loans",
-      "href": "/housing-assistance/home-loans"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Loan Types",
-        "href": "/housing-assistance/home-loans/loan-types",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Eligibility",
-        "href": "/housing-assistance/home-loans/eligibility",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "How to Apply",
-        "href": "/housing-assistance/home-loans/how-to-apply",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Check Appeal Status",
-        "href": "/claim-or-appeal-status/",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Trouble Making Payments?",
-        "href": "/housing-assistance/home-loans/trouble-making-payments",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Warning about Refinancing Offers",
-        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Home Buying Process",
-        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "VA Loan Funding Fee",
-        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find a VA Regional Loan Center",
-        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Find VA-Acquired Properties",
-        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Guidance on Natural Disasters",
-        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/loan-types/cash-out-loan/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "Loan Types",
-      "href": "/housing-assistance/home-loans/loan-types"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Purchase Loan",
-        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Cash Out Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Native American Direct Loan",
-        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Interest Rate Reduction Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/loan-types/interest-rate-reduction-loan/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "Loan Types",
-      "href": "/housing-assistance/home-loans/loan-types"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Purchase Loan",
-        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Cash Out Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Native American Direct Loan",
-        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Interest Rate Reduction Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/loan-types/native-american-direct-loan/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "Loan Types",
-      "href": "/housing-assistance/home-loans/loan-types"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Purchase Loan",
-        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Cash Out Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Native American Direct Loan",
-        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
-        "items": [
-          {
-            "title": "Tribes with Memorandums of Understanding",
-            "href": "https://www.benefits.va.gov/homeloans/nadl_mou.asp"
-          }
-        ]
-      },
-      {
-        "active": false,
-        "title": "Interest Rate Reduction Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "housing-assistance/home-loans/loan-types/purchase-loan/index.html",
-    "sidebarTitle": "Housing Assistance",
-    "backLink": {
-      "title": "Loan Types",
-      "href": "/housing-assistance/home-loans/loan-types"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "Purchase Loan",
-        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Cash Out Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Native American Direct Loan",
-        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Interest Rate Reduction Refinance Loan",
-        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
         "items": []
       }
     ],
@@ -13372,7 +12723,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -13554,7 +12905,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -13736,7 +13087,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -13918,7 +13269,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -14109,7 +13460,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -14291,7 +13642,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -14473,7 +13824,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -14655,7 +14006,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -14850,7 +14201,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -15041,7 +14392,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -15223,7 +14574,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -15272,6 +14623,52 @@
         "active": false,
         "title": "WEAMS Institution Search",
         "href": "https://www.benefits.va.gov/gibill/school_locator.asp",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/survivor-dependent-benefits/dependents-education-assistance/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Survivor and Dependent Benefits",
+      "href": "/education/survivor-dependent-benefits"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Fry Scholarship",
+        "href": "/education/survivor-dependent-benefits/fry-scholarship",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Dependents Education Assistance (DEA)",
+        "href": "/education/survivor-dependent-benefits/dependents-education-assistance",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/survivor-dependent-benefits/fry-scholarship/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Survivor and Dependent Benefits",
+      "href": "/education/survivor-dependent-benefits"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Fry Scholarship",
+        "href": "/education/survivor-dependent-benefits/fry-scholarship",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Dependents Education Assistance (DEA)",
+        "href": "/education/survivor-dependent-benefits/dependents-education-assistance",
         "items": []
       }
     ],
@@ -15359,52 +14756,6 @@
         "active": false,
         "title": "National Call to Service Program",
         "href": "/education/other-va-education-benefits/national-call-to-service-program",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "education/survivor-dependent-benefits/dependents-education-assistance/index.html",
-    "sidebarTitle": "Education and Training",
-    "backLink": {
-      "title": "Survivor and Dependent Benefits",
-      "href": "/education/survivor-dependent-benefits"
-    },
-    "items": [
-      {
-        "active": false,
-        "title": "Fry Scholarship",
-        "href": "/education/survivor-dependent-benefits/fry-scholarship",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Dependents Education Assistance (DEA)",
-        "href": "/education/survivor-dependent-benefits/dependents-education-assistance",
-        "items": []
-      }
-    ],
-    "menus": []
-  },
-  {
-    "fileName": "education/survivor-dependent-benefits/fry-scholarship/index.html",
-    "sidebarTitle": "Education and Training",
-    "backLink": {
-      "title": "Survivor and Dependent Benefits",
-      "href": "/education/survivor-dependent-benefits"
-    },
-    "items": [
-      {
-        "active": true,
-        "title": "Fry Scholarship",
-        "href": "/education/survivor-dependent-benefits/fry-scholarship",
-        "items": []
-      },
-      {
-        "active": false,
-        "title": "Dependents Education Assistance (DEA)",
-        "href": "/education/survivor-dependent-benefits/dependents-education-assistance",
         "items": []
       }
     ],
@@ -15561,7 +14912,7 @@
           {
             "active": false,
             "title": "GI Bill School Feedback",
-            "href": "https://www.benefits.va.gov/GIBILL/Feedback.asp",
+            "href": "/education/submit-school-feedback/",
             "items": []
           },
           {
@@ -15685,7 +15036,7 @@
     "menus": []
   },
   {
-    "fileName": "education/about-gi-bill-benefits/montgomery-active-duty/index.html",
+    "fileName": "education/about-gi-bill-benefits/post-9-11/index.html",
     "sidebarTitle": "Education and Training",
     "backLink": {
       "title": "GI Bill",
@@ -15693,21 +15044,21 @@
     },
     "items": [
       {
-        "active": false,
+        "active": true,
         "title": "Post-9/11 GI Bill",
         "href": "/education/about-gi-bill-benefits/post-9-11",
-        "items": []
-      },
-      {
-        "active": true,
-        "title": "Montgomery GI Bill Active Duty",
-        "href": "/education/about-gi-bill-benefits/montgomery-active-duty",
         "items": [
           {
-            "title": "$600 Buy-Up Program",
-            "href": "/education/about-gi-bill-benefits/montgomery-active-duty/buy-up"
+            "title": "Yellow Ribbon Program",
+            "href": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program"
           }
         ]
+      },
+      {
+        "active": false,
+        "title": "Montgomery GI Bill Active Duty",
+        "href": "/education/about-gi-bill-benefits/montgomery-active-duty",
+        "items": []
       },
       {
         "active": false,
@@ -15760,7 +15111,7 @@
     "menus": []
   },
   {
-    "fileName": "education/about-gi-bill-benefits/post-9-11/index.html",
+    "fileName": "education/about-gi-bill-benefits/montgomery-active-duty/index.html",
     "sidebarTitle": "Education and Training",
     "backLink": {
       "title": "GI Bill",
@@ -15768,21 +15119,21 @@
     },
     "items": [
       {
-        "active": true,
+        "active": false,
         "title": "Post-9/11 GI Bill",
         "href": "/education/about-gi-bill-benefits/post-9-11",
-        "items": [
-          {
-            "title": "Yellow Ribbon Program",
-            "href": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program"
-          }
-        ]
+        "items": []
       },
       {
-        "active": false,
+        "active": true,
         "title": "Montgomery GI Bill Active Duty",
         "href": "/education/about-gi-bill-benefits/montgomery-active-duty",
-        "items": []
+        "items": [
+          {
+            "title": "$600 Buy-Up Program",
+            "href": "/education/about-gi-bill-benefits/montgomery-active-duty/buy-up"
+          }
+        ]
       },
       {
         "active": false,
@@ -15794,6 +15145,40 @@
         "active": false,
         "title": "How to Use Your Benefits",
         "href": "/education/about-gi-bill-benefits/how-to-use-benefits",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/montgomery-active-duty/buy-up/index.html",
+    "sidebarTitle": "GI Bill",
+    "backLink": {
+      "title": "Montgomery GI Bill Active Duty",
+      "href": "/education/about-gi-bill-benefits/montgomery-active-duty"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "$600 Buy-Up Program",
+        "href": "/education/about-gi-bill-benefits/montgomery-active-duty/buy-up",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/index.html",
+    "sidebarTitle": "Education and Training",
+    "backLink": {
+      "title": "Post-9/11 GI Bill",
+      "href": "/education/about-gi-bill-benefits/post-9-11"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Yellow Ribbon Program",
+        "href": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program",
         "items": []
       }
     ],
@@ -17130,34 +16515,611 @@
     "menus": []
   },
   {
-    "fileName": "education/about-gi-bill-benefits/montgomery-active-duty/buy-up/index.html",
-    "sidebarTitle": "GI Bill",
+    "fileName": "housing-assistance/disability-housing-grants/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "VA Home Loans",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "VA-Backed Home Loans",
+            "href": "/housing-assistance/home-loans",
+            "items": []
+          }
+        ]
+      },
+      {
+        "title": "Disability Housing Grants",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "Housing Grants",
+            "href": "/housing-assistance/disability-housing-grants",
+            "items": [
+              {
+                "title": "How to Apply",
+                "href": "/housing-assistance/disability-housing-grants/how-to-apply"
+              },
+              {
+                "title": "Check Appeal Status",
+                "href": "/claim-or-appeal-status/"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "housing-assistance/home-loans/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": null,
+    "items": [],
+    "menus": [
+      {
+        "title": "VA Home Loans",
+        "open": true,
+        "items": [
+          {
+            "active": true,
+            "title": "VA-Backed Home Loans",
+            "href": "/housing-assistance/home-loans",
+            "items": [
+              {
+                "title": "Loan Types",
+                "href": "/housing-assistance/home-loans/loan-types"
+              },
+              {
+                "title": "Eligibility",
+                "href": "/housing-assistance/home-loans/eligibility"
+              },
+              {
+                "title": "How to Apply",
+                "href": "/housing-assistance/home-loans/how-to-apply"
+              },
+              {
+                "title": "Check Appeal Status",
+                "href": "/claim-or-appeal-status/"
+              },
+              {
+                "title": "Trouble Making Payments?",
+                "href": "/housing-assistance/home-loans/trouble-making-payments"
+              },
+              {
+                "title": "Warning about Refinancing Offers",
+                "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/"
+              },
+              {
+                "title": "Home Buying Process",
+                "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp"
+              },
+              {
+                "title": "VA Loan Funding Fee",
+                "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp"
+              },
+              {
+                "title": "Find a VA Regional Loan Center",
+                "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp"
+              },
+              {
+                "title": "Find VA-Acquired Properties",
+                "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp"
+              },
+              {
+                "title": "Guidance on Natural Disasters",
+                "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Disability Housing Grants",
+        "open": false,
+        "items": [
+          {
+            "active": false,
+            "title": "Housing Grants",
+            "href": "/housing-assistance/disability-housing-grants",
+            "items": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "fileName": "housing-assistance/disability-housing-grants/how-to-apply/index.html",
+    "sidebarTitle": "Housing Assistance",
     "backLink": {
-      "title": "Montgomery GI Bill Active Duty",
-      "href": "/education/about-gi-bill-benefits/montgomery-active-duty"
+      "title": "Housing Grants",
+      "href": "/housing-assistance/disability-housing-grants"
     },
     "items": [
       {
         "active": true,
-        "title": "$600 Buy-Up Program",
-        "href": "/education/about-gi-bill-benefits/montgomery-active-duty/buy-up",
+        "title": "How to Apply",
+        "href": "/housing-assistance/disability-housing-grants/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
         "items": []
       }
     ],
     "menus": []
   },
   {
-    "fileName": "education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/index.html",
-    "sidebarTitle": "Education and Training",
+    "fileName": "housing-assistance/home-loans/eligibility/index.html",
+    "sidebarTitle": "Housing Assistance",
     "backLink": {
-      "title": "Post-9/11 GI Bill",
-      "href": "/education/about-gi-bill-benefits/post-9-11"
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/how-to-apply/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/trouble-making-payments/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "VA-Backed Home Loans",
+      "href": "/housing-assistance/home-loans"
     },
     "items": [
       {
         "active": true,
-        "title": "Yellow Ribbon Program",
-        "href": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program",
+        "title": "Loan Types",
+        "href": "/housing-assistance/home-loans/loan-types",
+        "items": [
+          {
+            "title": "Purchase Loan",
+            "href": "/housing-assistance/home-loans/loan-types/purchase-loan"
+          },
+          {
+            "title": "Cash Out Refinance Loan",
+            "href": "/housing-assistance/home-loans/loan-types/cash-out-loan"
+          },
+          {
+            "title": "Native American Direct Loan",
+            "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan"
+          },
+          {
+            "title": "Interest Rate Reduction Refinance Loan",
+            "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Eligibility",
+        "href": "/housing-assistance/home-loans/eligibility",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "How to Apply",
+        "href": "/housing-assistance/home-loans/how-to-apply",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Check Appeal Status",
+        "href": "/claim-or-appeal-status/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Trouble Making Payments?",
+        "href": "/housing-assistance/home-loans/trouble-making-payments",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Warning about Refinancing Offers",
+        "href": "https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Home Buying Process",
+        "href": "https://www.benefits.va.gov/homeloans/resources_veteran.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "VA Loan Funding Fee",
+        "href": "https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find a VA Regional Loan Center",
+        "href": "https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Find VA-Acquired Properties",
+        "href": "https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Guidance on Natural Disasters",
+        "href": "https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/cash-out-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/interest-rate-reduction-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/native-american-direct-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": false,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": true,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": [
+          {
+            "title": "Tribes with Memorandums of Understanding",
+            "href": "https://www.benefits.va.gov/homeloans/nadl_mou.asp"
+          }
+        ]
+      },
+      {
+        "active": false,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
+        "items": []
+      }
+    ],
+    "menus": []
+  },
+  {
+    "fileName": "housing-assistance/home-loans/loan-types/purchase-loan/index.html",
+    "sidebarTitle": "Housing Assistance",
+    "backLink": {
+      "title": "Loan Types",
+      "href": "/housing-assistance/home-loans/loan-types"
+    },
+    "items": [
+      {
+        "active": true,
+        "title": "Purchase Loan",
+        "href": "/housing-assistance/home-loans/loan-types/purchase-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Cash Out Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/cash-out-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Native American Direct Loan",
+        "href": "/housing-assistance/home-loans/loan-types/native-american-direct-loan",
+        "items": []
+      },
+      {
+        "active": false,
+        "title": "Interest Rate Reduction Refinance Loan",
+        "href": "/housing-assistance/home-loans/loan-types/interest-rate-reduction-loan",
         "items": []
       }
     ],

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
@@ -3,7 +3,6 @@
 namespace Drupal\va_gov_migrate\Plugin\migrate\source;
 
 use Drupal\migrate\MigrateException;
-use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
 use Drupal\migrate\Plugin\MigrationInterface;
 
 /**
@@ -13,7 +12,7 @@ use Drupal\migrate\Plugin\MigrationInterface;
  *   id = "va_benefits_menu_source"
  * )
  */
-class VaBenefitsMenu extends SourcePluginBase {
+class VaBenefitsMenu extends VaMenuBase {
   protected $sections;
 
   /**
@@ -74,198 +73,24 @@ class VaBenefitsMenu extends SourcePluginBase {
       }
     }
 
-    $this->setIds($menus);
-    $this->setWeights($menus);
-    $flat_menu = $this->flattenMenu($menus);
-
-    return new \ArrayIterator($flat_menu);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getIds() {
-    $ids['id']['type'] = 'string';
-    return $ids;
+    return new \ArrayIterator($this->process($menus));
   }
 
   /**
    * {@inheritdoc}
    */
   public function fields() {
-    $fields['href'] = 'Link Path';
-    $fields['title'] = 'Link Title';
-    $fields['external'] = 'External Path';
-    $fields['weight'] = 'Weight';
-    $fields['parent_id'] = 'Parent Id';
+    $fields['href'] = parent::fields();
     $fields['menu'] = 'Menu machine name';
 
     return $fields;
   }
 
   /**
-   * Add weights to menu items based on their order in the array.
-   *
-   * @param array $menu_tree
-   *   The array of menu items.
+   * {@inheritdoc}
    */
-  public static function setWeights(array &$menu_tree) {
-    $relative_weight = 0;
-    foreach ($menu_tree as &$item) {
-      $item['weight'] = -50 + $relative_weight;
-      $relative_weight++;
-      if (!empty($item['items'])) {
-        self::setWeights($item['items']);
-      }
-    }
-  }
-
-  /**
-   * Create a unique id for each menu item.
-   *
-   * The ids are used in post processing to set parent items.
-   *
-   * @param array $menu_tree
-   *   The menu tree to set ids on.
-   * @param string $parent_id
-   *   The id of the current menu tree's parent.
-   */
-  public static function setIds(array &$menu_tree, $parent_id = '') {
-    foreach ($menu_tree as $index => &$item) {
-      $item['id'] = $parent_id . '-' . $index;
-      if (!empty($item['items'])) {
-        self::setIds($item['items'], $item['id']);
-      }
-    }
-  }
-
-  /**
-   * Transform a menu tree into a flat menu with parent href set for children.
-   *
-   * Also clean up the hrefs and set 'external'.
-   *
-   * @param array $menu_tree
-   *   The tree to transform.
-   * @param string $parent_id
-   *   The parent id, if any.
-   * @param string $parent_menu
-   *   The parent menu name (will be filled in during recursion from top item).
-   *
-   * @return array
-   *   A one-dimensional array of menu items.
-   */
-  public static function flattenMenu(array $menu_tree, $parent_id = '', $parent_menu = '') {
-    $flat_menu = [];
-    foreach ($menu_tree as $index => $item) {
-      if (empty($item['href'])) {
-        $item['href'] = 'route:<nolink>';
-        $item['external'] = 0;
-      }
-      elseif (parse_url($item['href'], PHP_URL_SCHEME)) {
-        $item['href'] = str_replace('http://localhost:3001', '', $item['href']);
-        $item['external'] = 1;
-      }
-      else {
-        $item['href'] = rtrim($item['href'], '/');
-        $item['external'] = 0;
-      }
-
-      if (!empty($parent_menu)) {
-        $item['menu'] = $parent_menu;
-      }
-      $item['parent_id'] = $parent_id;
-      $flat_menu[] = $item;
-
-      if (!empty($item['items'])) {
-        $new_parent = '';
-        if (!empty($item['menu'])) {
-          $new_parent = $item['menu'];
-        }
-        $flat_menu = array_merge($flat_menu, self::flattenMenu($item['items'], $item['id'], $new_parent));
-      }
-      unset($item['items']);
-
-    }
-
-    return $flat_menu;
-  }
-
-  /**
-   * Takes two page menus and merges them into one.
-   *
-   * Assumes that no two menu items have the same title & link.
-   *
-   * @param array $menu
-   *   Array of menu trees.
-   * @param array $menu2
-   *   Another array of menu trees.
-   *
-   * @return array
-   *   The consolidated menu tree.
-   *
-   * @throws \Drupal\migrate\MigrateException
-   */
-  protected function mergeMenus(array $menu, array $menu2) {
-    $merge_menu = $menu2;
-
-    foreach ($menu as $menu_item) {
-      $found = FALSE;
-      foreach ($merge_menu as &$merge_item) {
-        if ($menu_item['title'] == $merge_item['title'] &&
-          ((empty($menu_item['href']) && empty($merge_item['href'])) ||
-            $menu_item['href'] == $merge_item['href'])) {
-          if (!empty($menu_item['items'])) {
-            if (empty($merge_item['items'])) {
-              $merge_item['items'] = $menu_item['items'];
-            }
-            else {
-              $merge_item['items'] = $this->mergeMenus($menu_item['items'], $merge_item['items']);
-            }
-          }
-          $found = TRUE;
-          break;
-        }
-      }
-      if (!$found) {
-        $merge_menu[] = $menu_item;
-      }
-    }
-
-    return $merge_menu;
-  }
-
-  /**
-   * Find the parent item for submenus and merge them in.
-   *
-   * @param array $page
-   *   The page structure containing the submenu.
-   * @param array $menu
-   *   The full menu to merge the submenus into.
-   *
-   * @return bool
-   *   True if a parent item was found.
-   *
-   * @throws \Drupal\migrate\MigrateException
-   */
-  protected function findMergeMenus(array $page, array &$menu) {
-    $page_link = $page['backLink']['href'];
-    foreach ($menu as &$menu_item) {
-      if (!empty($menu_item['href']) && $menu_item['href'] == $page_link) {
-        if (empty($menu_item['items'])) {
-          $menu_item['items'] = $page['items'];
-        }
-        else {
-          $menu_item['items'] = $this->mergeMenus($page['items'], $menu_item['items']);
-        }
-        return TRUE;
-      }
-      if (!empty($menu_item['items'])) {
-        if ($this->findMergeMenus($page, $menu_item['items'])) {
-          return TRUE;
-        }
-      }
-    }
-    return FALSE;
+  protected function sanitizeDomain($href) {
+    return str_replace('http://localhost:3001', '', $href);
   }
 
 }

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMainMenu.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMainMenu.php
@@ -38,7 +38,9 @@ class VaMainMenu extends SourcePluginBase {
       ];
       if (!empty($section['menuSections'])) {
         foreach ($section['menuSections'] as $menu_section) {
-          $main_section['items'][] = $this->makeSection($menu_section);
+          if (!empty($menu_section['title'])) {
+            $main_section['items'][] = $this->makeSection($menu_section);
+          }
         }
       }
       $menus[] = $main_section;
@@ -89,7 +91,7 @@ class VaMainMenu extends SourcePluginBase {
       if (!empty($link['title'])) {
         $column = [
           'title' => $link['title'],
-          'href' => $link['href'],
+          'href' => empty($link['href']) ? '' : $link['href'],
           'items' => [],
         ];
         foreach ($link['links'] as $item) {

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMainMenu.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMainMenu.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\va_gov_migrate\Plugin\migrate\source;
 
-use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
-
 /**
  * Source to read from sidebar.json.
  *
@@ -11,7 +9,7 @@ use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
  *   id = "va_main_menu_source"
  * )
  */
-class VaMainMenu extends SourcePluginBase {
+class VaMainMenu extends VaMenuBase {
 
   /**
    * Return a string representing the source file path.
@@ -46,11 +44,7 @@ class VaMainMenu extends SourcePluginBase {
       $menus[] = $main_section;
     }
 
-    VaBenefitsMenu::setIds($menus);
-    VaBenefitsMenu::setWeights($menus);
-    $flat_menu = VaBenefitsMenu::flattenMenu($menus);
-
-    return new \ArrayIterator($flat_menu);
+    return new \ArrayIterator($this->process($menus));
   }
 
   /**
@@ -64,14 +58,8 @@ class VaMainMenu extends SourcePluginBase {
   /**
    * {@inheritdoc}
    */
-  public function fields() {
-    $fields['href'] = 'Link Path';
-    $fields['title'] = 'Link Title';
-    $fields['external'] = 'External Path';
-    $fields['weight'] = 'Weight';
-    $fields['parent_id'] = 'Parent Id';
-
-    return $fields;
+  protected function sanitizeDomain($href) {
+    return str_replace('https://www.va.gov', '', $href);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMenuBase.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaMenuBase.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Plugin\migrate\source;
+
+use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+
+/**
+ * Source to read from sidebar.json.
+ *
+ * @MigrateSource(
+ *   id = "va_benefits_menu_source"
+ * )
+ */
+abstract class VaMenuBase extends SourcePluginBase {
+  protected $sections;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids['id']['type'] = 'string';
+    return $ids;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields['href'] = 'Link Path';
+    $fields['title'] = 'Link Title';
+    $fields['external'] = 'External Path';
+    $fields['weight'] = 'Weight';
+    $fields['parent_id'] = 'Parent Id';
+
+    return $fields;
+  }
+
+  /**
+   * Turn array into a flat array of menu items for migration.
+   *
+   * @param array $menus
+   *   Array of hierarchical menus to process.
+   *
+   * @return array
+   *   The resulting array.
+   */
+  protected function process(array &$menus) {
+    $this->setIds($menus);
+    $this->setWeights($menus);
+    return $this->flattenMenu($menus);
+  }
+
+  /**
+   * Remove or repair domains in menu links.
+   *
+   * @param string $href
+   *   The url to check.
+   *
+   * @return mixed
+   *   The sanitized url.
+   */
+  abstract protected function sanitizeDomain($href);
+
+  /**
+   * Add weights to menu items based on their order in the array.
+   *
+   * @param array $menu_tree
+   *   The array of menu items.
+   */
+  protected function setWeights(array &$menu_tree) {
+    $relative_weight = 0;
+    foreach ($menu_tree as &$item) {
+      $item['weight'] = -50 + $relative_weight;
+      $relative_weight++;
+      if (!empty($item['items'])) {
+        $this->setWeights($item['items']);
+      }
+    }
+  }
+
+  /**
+   * Create a unique id for each menu item.
+   *
+   * The ids are used in post processing to set parent items.
+   *
+   * @param array $menu_tree
+   *   The menu tree to set ids on.
+   * @param string $parent_id
+   *   The id of the current menu tree's parent.
+   */
+  protected function setIds(array &$menu_tree, $parent_id = '') {
+    foreach ($menu_tree as $index => &$item) {
+      $item['id'] = $parent_id . '-' . $index;
+      if (!empty($item['items'])) {
+        $this->setIds($item['items'], $item['id']);
+      }
+    }
+  }
+
+  /**
+   * Transform a menu tree into a flat menu with parent href set for children.
+   *
+   * Also clean up the hrefs and set 'external'.
+   *
+   * @param array $menu_tree
+   *   The tree to transform.
+   * @param string $parent_id
+   *   The parent id, if any.
+   * @param string $parent_menu
+   *   The parent menu name (will be filled in during recursion from top item).
+   *
+   * @return array
+   *   A one-dimensional array of menu items.
+   */
+  protected function flattenMenu(array $menu_tree, $parent_id = '', $parent_menu = '') {
+    $flat_menu = [];
+    foreach ($menu_tree as $index => $item) {
+      if (empty($item['href'])) {
+        $item['href'] = 'route:<nolink>';
+        $item['external'] = 0;
+      }
+      elseif (parse_url($item['href'], PHP_URL_SCHEME)) {
+        $item['href'] = $this->sanitizeDomain($item['href']);
+        $item['external'] = 1;
+      }
+      else {
+        $item['href'] = rtrim($item['href'], '/');
+        $item['external'] = 0;
+      }
+
+      if (!empty($parent_menu)) {
+        $item['menu'] = $parent_menu;
+      }
+      $item['parent_id'] = $parent_id;
+      $flat_menu[] = $item;
+
+      if (!empty($item['items'])) {
+        $new_parent = '';
+        if (!empty($item['menu'])) {
+          $new_parent = $item['menu'];
+        }
+        $flat_menu = array_merge($flat_menu, $this->flattenMenu($item['items'], $item['id'], $new_parent));
+      }
+      unset($item['items']);
+
+    }
+
+    return $flat_menu;
+  }
+
+  /**
+   * Takes two page menus and merges them into one.
+   *
+   * Assumes that no two menu items have the same title & link.
+   *
+   * @param array $menu
+   *   Array of menu trees.
+   * @param array $menu2
+   *   Another array of menu trees.
+   *
+   * @return array
+   *   The consolidated menu tree.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   */
+  protected function mergeMenus(array $menu, array $menu2) {
+    $merge_menu = $menu2;
+
+    foreach ($menu as $menu_item) {
+      $found = FALSE;
+      foreach ($merge_menu as &$merge_item) {
+        if ($menu_item['title'] == $merge_item['title'] &&
+          ((empty($menu_item['href']) && empty($merge_item['href'])) ||
+            $menu_item['href'] == $merge_item['href'])) {
+          if (!empty($menu_item['items'])) {
+            if (empty($merge_item['items'])) {
+              $merge_item['items'] = $menu_item['items'];
+            }
+            else {
+              $merge_item['items'] = $this->mergeMenus($menu_item['items'], $merge_item['items']);
+            }
+          }
+          $found = TRUE;
+          break;
+        }
+      }
+      if (!$found) {
+        $merge_menu[] = $menu_item;
+      }
+    }
+
+    return $merge_menu;
+  }
+
+  /**
+   * Find the parent item for submenus and merge them in.
+   *
+   * @param array $page
+   *   The page structure containing the submenu.
+   * @param array $menu
+   *   The full menu to merge the submenus into.
+   *
+   * @return bool
+   *   True if a parent item was found.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   */
+  protected function findMergeMenus(array $page, array &$menu) {
+    $page_link = $page['backLink']['href'];
+    foreach ($menu as &$menu_item) {
+      if (!empty($menu_item['href']) && $menu_item['href'] == $page_link) {
+        if (empty($menu_item['items'])) {
+          $menu_item['items'] = $page['items'];
+        }
+        else {
+          $menu_item['items'] = $this->mergeMenus($page['items'], $menu_item['items']);
+        }
+        return TRUE;
+      }
+      if (!empty($menu_item['items'])) {
+        if ($this->findMergeMenus($page, $menu_item['items'])) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
Code cleanup, removed unneeded 'va.gov' domains from main menu links, and updated sidebar data to be up-to-date with latest menu changes on va.gov.

To test:
Perform update migrations on 'Migrate health care sidebar menu' and 'Migrate VA.gov main menu'. 
Healthcare Benefits Hub menu and Main menu should match va.gov and links should only include domains if they link to sites outside of va.gov.

