### PR TITLE
VAGOV-1532: Update Twitter Metatag Config.

### DIFF
--- a/config/sync/metatag.metatag_defaults.global.yml
+++ b/config/sync/metatag.metatag_defaults.global.yml
@@ -11,5 +11,5 @@ tags:
   og_site_name: '[site:name]'
   og_title: '[current-page:title] | [site:name]'
   twitter_cards_site: '@DeptVetAffairs'
-  twitter_cards_type: summary
+  twitter_cards_type: summary_large_image
   twitter_cards_title: '[current-page:title] | [site:name]'

--- a/config/sync/metatag.metatag_defaults.node__event.yml
+++ b/config/sync/metatag.metatag_defaults.node__event.yml
@@ -8,3 +8,4 @@ tags:
   og_image_width: '600'
   og_image: '[node:field_media:entity:image:entity:url]'
   og_image_height: '314'
+  twitter_cards_image: '[node:field_media:entity:image:entity:url]'

--- a/config/sync/metatag.metatag_defaults.node__event.yml
+++ b/config/sync/metatag.metatag_defaults.node__event.yml
@@ -1,0 +1,10 @@
+uuid: 301c6331-5b77-46ac-b7a7-a3d8af67269b
+langcode: en
+status: true
+dependencies: {  }
+id: node__event
+label: 'Content: Event'
+tags:
+  og_image_width: '600'
+  og_image: '[node:field_media:entity:image:entity:url]'
+  og_image_height: '314'


### PR DESCRIPTION
Changes twitter card config in metatag module to display a card with summary and a large image.

[JIRA ticket](https://va-gov.atlassian.net/browse/VAGOV-1532)

Has a non-breaking relationship with this PR: https://github.com/department-of-veterans-affairs/vets-website/pull/9758 Non-breaking meaning that these PRs will work without each other and merging one before the other won't break any builds. Note: Merge in the va.gov-cms one first to get correct styling for the share cards tho.