### PR TITLE
VAGOV-320 Fix fast404 include and add to DEV and TEST/PR

### DIFF
--- a/docroot/sites/default/settings/settings.dev.php
+++ b/docroot/sites/default/settings/settings.dev.php
@@ -27,3 +27,7 @@ $settings['trusted_host_patterns'] = [
     '^dev\.cms\.va\.gov$',
     '^*\.us-gov-west-1\.elb\.amazonaws\.com$',
 ];
+
+if (file_exists($app_root . '/' . $site_path . '/settings/settings.fast_404.php')) {
+  include $app_root . '/' . $site_path . '/settings/settings.fast_404.php';
+}

--- a/docroot/sites/default/settings/settings.fast_404.php
+++ b/docroot/sites/default/settings/settings.fast_404.php
@@ -18,7 +18,7 @@
 
 # Load the fast_404.inc file. This is needed if you wish to do extension
 # checking in settings.php.
-include_once('./modules/contrib/fast_404/fast_404.inc');
+include_once('./modules/contrib/fast_404/fast404.inc');
 
 # Disallowed extensions. Any extension in here will not be served by Drupal and
 # will get a fast 404.

--- a/docroot/sites/default/settings/settings.test.php
+++ b/docroot/sites/default/settings/settings.test.php
@@ -27,3 +27,7 @@ $settings['trusted_host_patterns'] = [
     '^pr.*\.va\.agile6\.com$',
     '^*\.us-gov-west-1\.elb\.amazonaws\.com$',
 ];
+
+if (file_exists($app_root . '/' . $site_path . '/settings/settings.fast_404.php')) {
+  include $app_root . '/' . $site_path . '/settings/settings.fast_404.php';
+}


### PR DESCRIPTION
VAEC deploys were breaking with failed includes on STG and PROD but not DEV. Not sure why this wasn't showing up in A6 STG deploy. Also added to TEST/PR ENVs so we can keep functionality the same across ENVs and catch stuff like this earlier in the process.