### PR TITLE
Vagov 1993 migration fix

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/AdditionalInformation.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/AdditionalInformation.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Paragraph;
+
+use Drupal\va_gov_migrate\ParagraphType;
+use QueryPath\DOMQuery;
+
+/**
+ * Process Additional Information paragraphs.
+ *
+ * @package Drupal\va_gov_migrate\Paragraph
+ */
+class AdditionalInformation extends ParagraphType {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getParagraphName() {
+    return 'spanish_translation_summary';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function isParagraph(DOMQuery $query_path) {
+    return $query_path->attr('data-widget-type') == 'additional-info';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getFieldValues(DOMQuery $query_path) {
+    return [
+      'field_text_expander' => $query_path->find('.additional-info-title')->text(),
+      'field_wysiwyg' => self::toRichText($query_path->find('.additional-info-content')->html()),
+    ];
+  }
+
+}

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/QaSection.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/QaSection.php
@@ -39,6 +39,10 @@ class QaSection extends ParagraphType {
           return QAAccordion::isQaAccordionGroup($qp);
         }
 
+        if ($this->isOtherParagraph($qp)) {
+          return FALSE;
+        }
+
         $qp = $qp->next();
       }
     }
@@ -127,6 +131,10 @@ class QaSection extends ParagraphType {
             return FALSE;
           }
 
+          if ($this->isOtherParagraph($qp_next)) {
+            return FALSE;
+          }
+
           $qp_next = $qp_next->next();
         }
         return FALSE;
@@ -142,7 +150,29 @@ class QaSection extends ParagraphType {
    * {@inheritdoc}
    */
   public function getWeight() {
-    return -4;
+    return 10;
+  }
+
+  /**
+   * Checks whether a DOM query is a non-qa paragraph.
+   *
+   * @param \QueryPath\DOMQuery $query_path
+   *   The query to test.
+   *
+   * @return bool
+   *   Return true if it is another paragraph type.
+   */
+  protected function isOtherParagraph(DOMQuery $query_path) {
+    $paragraph_classes = self::$migrator->getParagraphClasses();
+    foreach ($paragraph_classes as $paragraph_class) {
+      if (strpos($paragraph_class->getParagraphName(), 'q_a') === 0) {
+        continue;
+      }
+      if ($paragraph_class->isParagraph($query_path)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/docroot/modules/custom/va_gov_migrate/src/ParagraphMigrator.php
+++ b/docroot/modules/custom/va_gov_migrate/src/ParagraphMigrator.php
@@ -136,6 +136,16 @@ class ParagraphMigrator {
   }
 
   /**
+   * Returns all of the paragraph objects used by this migrator.
+   *
+   * @return array
+   *   An array of ParagraphType objects
+   */
+  public function getParagraphClasses() {
+    return $this->paragraphClasses;
+  }
+
+  /**
    * INTERNAL FUNCTION - Extract paragraphs and add them to the parent entity.
    *
    * This shouldn't be called directly. Use process() instead.

--- a/docroot/modules/custom/va_gov_migrate/src/ParagraphMigrator.php
+++ b/docroot/modules/custom/va_gov_migrate/src/ParagraphMigrator.php
@@ -187,27 +187,35 @@ class ParagraphMigrator {
             }
             continue;
           }
-          // Add the opening tag.
-          $attr = '';
-          foreach ($element->attr() as $name => $value) {
-            $attr .= $name . '="' . $value . '" ';
-          }
-          $this->wysiwyg .= "<{$element->tag()} $attr>";
 
           // If the element does contain unwrapped text, that text will be lost.
           if (str_replace(' ', '', $element->text()) !=
-            str_replace(' ', '', $element->childrenText())) {
-            Message::make('Lost text in @file from @element',
+            str_replace(' ', '', $element->children()->text())) {
+            Message::make('Text wrapped only in @tag@file: "@text"',
               [
-                '@file' => $parent_entity->url(),
-                '@element' => "<{$element->tag()} $attr>",
+                '@file' => $parent_entity->url() ? ' in ' . $parent_entity->url() : '',
+                '@tag' => $element->tag(),
+                '@text' => $element->text(),
               ],
               Message::ERROR);
-          }
 
-          // Look for paragraphs in the children.
-          $this->addParagraphs($element->children(), $parent_entity, $parent_field);
-          $this->wysiwyg .= "</{$element->tag()}>";
+            // Better to risk losing nested paragraphs than content, so treat
+            // everything in this element as wysiwyg.
+            $this->wysiwyg .= $element->html();
+          }
+          else {
+            // Add the opening tag.
+            $attr = '';
+            foreach ($element->attr() as $name => $value) {
+              $attr .= $name . '="' . $value . '" ';
+            }
+            $this->wysiwyg .= "<{$element->tag()} $attr>";
+            // Look for paragraphs in the children.
+            $this->addParagraphs($element->children(), $parent_entity, $parent_field);
+            // Add the closing tag.
+            $this->wysiwyg .= "</{$element->tag()}>";
+
+          }
         }
         elseif (self::hasContent($element->html())) {
           $this->wysiwyg .= $element->html();


### PR DESCRIPTION
This fixes issues 1. and 6. that Brauer identified. It also adds the "Additional information" (aka Spanish language translation) paragraph. Fixing the test uncovered the fact that that was missing.

I've done spot checks, comparing metalsmithed pages to the live site on about half the pages and it looks good: problems fixed, no new ones introduced.