### PR TITLE
VAGOV-1755: Add a field to choose an icon for hub landing page titles

### DIFF
--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.landing_page.field_related_links
     - field.field.node.landing_page.field_spokes
     - field.field.node.landing_page.field_support_services
+    - field.field.node.landing_page.field_title_icon
     - node.type.landing_page
   module:
     - content_moderation
@@ -232,6 +233,12 @@ content:
       allow_duplicate: false
     third_party_settings: {  }
     type: inline_entity_form_complex
+    region: content
+  field_title_icon:
+    weight: 22
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   moderation_state:
     type: moderation_state_default

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -14,11 +14,13 @@ dependencies:
     - field.field.node.landing_page.field_related_links
     - field.field.node.landing_page.field_spokes
     - field.field.node.landing_page.field_support_services
+    - field.field.node.landing_page.field_title_icon
     - node.type.landing_page
   module:
     - datetime
     - entity_reference_revisions
     - metatag
+    - options
     - user
 id: node.landing_page.default
 targetEntityType: node
@@ -119,6 +121,13 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_title_icon:
+    weight: 12
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
     region: content
 hidden:
   links: true

--- a/config/sync/field.field.node.landing_page.field_title_icon.yml
+++ b/config/sync/field.field.node.landing_page.field_title_icon.yml
@@ -1,0 +1,23 @@
+uuid: e1d6be36-0d2a-4229-a369-c6749160f180
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_title_icon
+    - node.type.landing_page
+  module:
+    - options
+id: node.landing_page.field_title_icon
+field_name: field_title_icon
+entity_type: node
+bundle: landing_page
+label: 'Hub Icon'
+description: 'Select an icon to appear next to this hub landing page''s title. '
+required: false
+translatable: false
+default_value:
+  -
+    value: health-care
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.node.field_title_icon.yml
+++ b/config/sync/field.storage.node.field_title_icon.yml
@@ -1,0 +1,33 @@
+uuid: 31076f3b-555a-45af-9528-ffaf4d8f10cc
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_title_icon
+field_name: field_title_icon
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: health-care
+      label: 'Health care'
+    -
+      value: disability
+      label: Disability
+    -
+      value: education
+      label: Education
+    -
+      value: records
+      label: Records
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Adds a field to choose an icon that will appear next to hub landing page titles. This config is required by this front-end PR: https://github.com/department-of-veterans-affairs/vets-website/pull/9784