### PR TITLE
VAGOV-2014: Allow <b> tags in rich text editor.

### DIFF
--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -47,7 +47,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid data-align data-caption> <hr> <br> <drupal-entity data-* title alt> <a href hreflang class=" usa-button usa-button-secondary"> <p class="va-address-block">'
+      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid data-align data-caption> <hr> <br> <drupal-entity data-* title alt> <a href hreflang class=" usa-button usa-button-secondary"> <p class="va-address-block">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:


### PR DESCRIPTION
Migrated content has a 45 <b> tags that are not currently getting stripped out by Drupal.