### PR TITLE
VAGOV-000: Make menu links to va.gov teamsite pages absolute.

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/VaBenefitsMenu.php
@@ -90,7 +90,7 @@ class VaBenefitsMenu extends VaMenuBase {
    * {@inheritdoc}
    */
   protected function sanitizeDomain($href) {
-    return str_replace('http://localhost:3001', '', $href);
+    return str_replace('http://localhost:3001', 'https://www.va.gov', $href);
   }
 
 }


### PR DESCRIPTION
This is a request from Jeff Balboni. Apparently, when the menu links to va.gov teamsite pages are relative, the broken link checker thinks they're broken links.