### PR TITLE
VAGOV-1999: Add 'Primary button' option to link styles in wysiwyg.

### DIFF
--- a/config/sync/editor.editor.rich_text.yml
+++ b/config/sync/editor.editor.rich_text.yml
@@ -43,7 +43,7 @@ settings:
             - Styles
   plugins:
     stylescombo:
-      styles: "p.va-address-block|Address Block\r\na.usa-button|Link button\r\na.usa-button.usa-button-secondary|Secondary link button"
+      styles: "p.va-address-block|Address Block\r\na.usa-button|Link button\r\na.usa-button-primary|Primary link button\r\na.usa-button.usa-button-secondary|Secondary link button\r\n"
     language:
       language_list: un
 image_upload:

--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -47,7 +47,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid data-align data-caption> <hr> <br> <drupal-entity data-* title alt> <a href hreflang class=" usa-button usa-button-secondary"> <p class="va-address-block">'
+      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid data-align data-caption> <hr> <br> <drupal-entity data-* title alt> <a href hreflang class=" usa-button usa-button-primary usa-button-secondary"> <p class="va-address-block">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:


### PR DESCRIPTION
Fixes lack of button styling in alert block on https://staging.va.gov/health-care/get-medical-records/

When you're in drupal wysiwyg and on a link, the style list should now include "Primary link button". Selecting it should add class "usa-button-primary" to the link.