### PR TITLE
VAGOV-3079 Fix public private S3 bucket, backup issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,9 @@ node_modules/
 
 # Ignore SQL dumps
 /.dumps/cmsapp_files.tgz
-/.dumps/cms-db-latest.sql.gz
-/.dumps/db-latest.sql.gz
+/.dumps/cms-app-files-latest.tgz
+/.dumps/cms-db-latest.sql*
+/.dumps/db-latest.sql*
 
 # Ignore IntelliJ/PhpStorm
 .idea

--- a/.lando.yml
+++ b/.lando.yml
@@ -5,13 +5,9 @@ config:
   php: "7.2"
 
 events:
-  # Clear caches after a database import
-  post-db-import:
-    - appserver: cd $LANDO_WEBROOT && drush cr -y
-
   # Mirrors what is in lando-entrypoint-app.sh, keep in sync with that file.
   # @todo don't use absolute path, somehow lando is not detecting drush in path right now. Fix this.
-  post-sync-db:
+  post-db-import:
     - appserver: cd $LANDO_WEBROOT && /app/docroot/vendor/bin/drush cache-rebuild -y
     - appserver: cd $LANDO_WEBROOT && /app/docroot/vendor/bin/drush updatedb -y
     - appserver: cd $LANDO_WEBROOT && /app/docroot/vendor/bin/drush config:import -y
@@ -109,26 +105,10 @@ tooling:
     service: node
   sync-db:
     service: appserver
-    description: Import a manually downloaded, santized PROD DB and run cache-clear, updatedb, config:import & cache-clear. You must manually download DB to .dumps/db-latest.sql.gz.
-    cmd: >
-      bash -c
-      '
-      echo "Download the latest sanitized PROD DB into .dumps/db-latest.sql.gz." &&
-      read -n1 -r -p "Press any key after you placed .dumps/db-latest.sql.gz..." &&
-      gunzip /app/.dumps/db-latest.sql.gz 2> /dev/null || true &&
-      /app/docroot/vendor/bin/drush sql-drop --yes &&
-      `/app/docroot/vendor/bin/drush sql-connect` < /app/.dumps/db-latest.sql &&
-      echo "PROD database import to LOCAL complete. Running post database import Drush commands: cache-clear, updatedb, config-import, cache-clear"
-      '
+    description: This command has moved to a non-lando command, from app root run like this `scripts/sync-db.sh`.
+    cmd: 'echo "This command has moved to a non-lando command, from app root run like this `scripts/sync-db.sh`."'
+
   sync-files:
     service: appserver
-    description: Import files from PROD. You must manually download files to /app/.dumps/cmsapp_files.tgz.
-    cmd: >
-      bash -c
-      '
-      echo "Download the latest files dump from PROD into /app/.dumps/cmsapp_files.tgz" &&
-      read -n1 -r -p "Press any key after you placed /app/.dumps/cmsapp_files.tgz..." &&
-      rm -fR /app/docroot/sites/default/files/* &&
-      tar -xzvf ./.dumps/cmsapp_files.tgz --directory /app/docroot/sites/default/files &&
-      echo "PROD file sync to LOCAL complete."
-      '
+    description: This command has moved to a non-lando command, from app root run like this `scripts/sync-files.sh`.
+    cmd: 'echo "This command has moved to a non-lando command, from app root run like this `scripts/sync-files.sh`."'

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ How to start:
 * `git clone git@github.com:department-of-veterans-affairs/va.gov-cms.git vagov`
 * `cd vagov`
 * `lando start`
-* `lando sync-db`
-* `lando sync-files`
+* `scripts/sync-db.sh`
+* `scripts/sync-files.sh`
 
 Example workflow:
 * `git fetch --all`

--- a/scripts/sync-db.sh
+++ b/scripts/sync-db.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 
-# Meant to be run with `lando db-sync-stg`
-
-# debug output
-set -x
-
 # Exit immediately if a command fails with a non-zero status code
 set -e
 
+echo "You must have your PROXY running `ssh socks -D 2001 -N &`"
 # Setup
-mkdir --parents .dumps
 cd .dumps
 # @todo check if Lando stack is running, if not return error message or just start it
 echo "Downloading latest PROD database"
-curl --remote-name --remote-header-name https://s3-us-gov-west-1.amazonaws.com/vagov-cms-backups-pub/mysql/db-latest.sql.gz
-gunzip db-latest.sql.gz --force
+curl --remote-name --remote-header-name --proxy socks5h://127.0.0.1:2001 10.247.89.58:8000/cms-db-latest.sql.gz
+gunzip --force cms-db-latest.sql.gz 2> /dev/null || true &&
 
-echo "Downloaded PROD Database to ./.dumps/db-latest.sql"
+echo "Downloaded PROD Database to .dumps/cms-db-latest.sql"
+
+echo "Importing PROD database"
+lando db-import cms-db-latest.sql

--- a/scripts/sync-files.sh
+++ b/scripts/sync-files.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command fails with a non-zero status code
+set -e
+
+cd .dumps
+echo "You must have your PROXY running e.g. `ssh socks -D 2001 -N &`"
+curl --remote-name --remote-header-name --proxy socks5h://127.0.0.1:2001 10.247.89.58:8000/cms-app-files-latest.tgz
+rm --force --recursive /app/docroot/sites/default/files/*
+echo "Extracting files to sites/default/files."
+tar --extract --gunzip --verbose --file cms-app-files-latest.tgz --directory ../docroot/sites/default/files
+echo "PROD file sync to LOCAL complete."


### PR DESCRIPTION
These dumps exist now and these commands are testable. 

Sorry, `lando sync-db` and `lando sync-files` are no more due to us having to access through the proxy. 

New commands are `scripts/sync-db.sh` and `scripts/sync-files.sh` and you must have the proxy running. README.md has also been updated with this PR. 