### PR TITLE
VAGOV-2945 Write new Nightwatch tests for new content types

### DIFF
--- a/tests/nightwatch/features/accessibilityCreateBenefitsDetailPage.test.js
+++ b/tests/nightwatch/features/accessibilityCreateBenefitsDetailPage.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Benefits detail page': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/page')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Benefits detail page | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateBenefitsHubLandingPage.test.js
+++ b/tests/nightwatch/features/accessibilityCreateBenefitsHubLandingPage.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test add Benefits Hub Landing Page ': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/landing_page')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Benefits hub landing page | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateDocumentationPage.test.js
+++ b/tests/nightwatch/features/accessibilityCreateDocumentationPage.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Documentation Page': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/documentation_page')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Documentation page | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateEvent.test.js
+++ b/tests/nightwatch/features/accessibilityCreateEvent.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Event': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/event')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Event | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateHealthCareLocalFacility.test.js
+++ b/tests/nightwatch/features/accessibilityCreateHealthCareLocalFacility.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Health Care Local Facility': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/health_care_local_facility')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Health Care Local Facility | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateHealthCareRegionDetailPage.test.js
+++ b/tests/nightwatch/features/accessibilityCreateHealthCareRegionDetailPage.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Health Care Region Detail Page': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/health_care_region_detail_page')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Health Care Region Detail Page | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateHealthCareRegionPage.test.js
+++ b/tests/nightwatch/features/accessibilityCreateHealthCareRegionPage.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Health Care Region Landing Page': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/health_care_region_page')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Health Care Region Landing Page | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateOffice.test.js
+++ b/tests/nightwatch/features/accessibilityCreateOffice.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Office': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/office')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Office | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateOutreachAsset.test.js
+++ b/tests/nightwatch/features/accessibilityCreateOutreachAsset.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Outreach asset': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/outreach_asset')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Outreach asset | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreatePersonProfile.test.js
+++ b/tests/nightwatch/features/accessibilityCreatePersonProfile.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Staff profile': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/person_profile')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Staff profile | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreatePressRelease.test.js
+++ b/tests/nightwatch/features/accessibilityCreatePressRelease.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Press release': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/press_release')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Press release | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateRegional-LocalHealthCareServiceDescription.test.js
+++ b/tests/nightwatch/features/accessibilityCreateRegional-LocalHealthCareServiceDescription.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Regional/Local Health Care Service Description': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/regional_health_care_service_des')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Regional/Local Health Care Service Description | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateStory.test.js
+++ b/tests/nightwatch/features/accessibilityCreateStory.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility'],
+
+    'Test Create Story': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            .url(siteUrl+'/node/add/news_story')
+            .waitForElementVisible('.page-title', 6000)
+            .assert.title('Create Story | Veterans Affairs')
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}

--- a/tests/nightwatch/features/accessibilityCreateSupportService.test.js
+++ b/tests/nightwatch/features/accessibilityCreateSupportService.test.js
@@ -27,22 +27,22 @@ const contextOptions = {
 }
 
 const exclusions = {
-    exclude: [['#content'], ['#behavior']]
+    exclude: [['#content', '#behavior']]
 }
 
 module.exports
     = {
     '@tags': ['accessibility'],
 
-    'Test add node': function (browser) {
+    'Test Create Support Service': function (browser) {
         browser
             .url(siteUrl)
             .setValue('input[name="name"]', name)
             .setValue('input[name="pass"]', pass)
             .click('input[id="edit-submit"]')
-            .url(siteUrl+'/node/add/page')
+            .url(siteUrl+'/node/add/support_service')
             .waitForElementVisible('.page-title', 6000)
-            .assert.title('Create Benefits detail page | Veterans Affairs')
+            .assert.title('Create Support Service | Veterans Affairs')
             .initAccessibility()
             .verify.accessibility(contextOptions, axeOptions)
             .end(function(err, res){

--- a/tests/nightwatch/features/accessibilityDashboard.test.js
+++ b/tests/nightwatch/features/accessibilityDashboard.test.js
@@ -1,0 +1,51 @@
+/**
+ * @file Run Axe accessibility tests on page node edit form with Nightwatch.
+ */
+
+const axeOptions = {
+    timeout: 500,
+    runOnly: {
+        type: 'tag',
+        values: ['wcag2a'], //, 'wcag2aa'
+    },
+    verbose: true,
+    reporter: 'v2',
+    elementRef: true,
+    abortOnAssertionFailure: false,
+    end_session_on_fail: false,
+    skip_testcases_on_fail: true,
+};
+
+// Environmental variables must be set before running test
+const siteUrl = process.env.TESTURL;
+const name = process.env.TESTUSERNAME;
+const pass = process.env.TESTUSERPASS;
+
+const contextOptions = {
+    include: [['body']],
+    exclude: [['#content'], ['#behavior'], ['.hidden']]
+}
+
+const exclusions = {
+    exclude: [['#content'], ['#behavior']]
+}
+
+module.exports
+    = {
+    '@tags': ['accessibility', 'dashboard'],
+
+    'Test add node': function (browser) {
+        browser
+            .url(siteUrl)
+            .setValue('input[name="name"]', name)
+            .setValue('input[name="pass"]', pass)
+            .click('input[id="edit-submit"]')
+            // todo use current environment url
+            .waitForElementVisible('body', 6000)
+            .initAccessibility()
+            .verify.accessibility(contextOptions, axeOptions)
+            .end(function(err, res){
+                console.log(res);
+            });
+    }
+}


### PR DESCRIPTION
Create accessibility tests for node/add forms for all Content Types.
NOTE: There is a known failure in each of these tests. Inclusion in deployment should not fail build.
 
renamed tests/nightwatch/features/{accessibilityEdit.test.js => accessibilityCreateBenefitsDetailPage.test.js} (95%)
tests/nightwatch/features/accessibilityCreateBenefitsHubLandingPage.test.js
tests/nightwatch/features/accessibilityCreateDocumentationPage.test.js
tests/nightwatch/features/accessibilityCreateEvent.test.js
tests/nightwatch/features/accessibilityCreateHealthCareLocalFacility.test.js
tests/nightwatch/features/accessibilityCreateHealthCareRegionDetailPage.test.js
tests/nightwatch/features/accessibilityCreateHealthCareRegionPage.test.js
tests/nightwatch/features/accessibilityCreateOffice.test.js
tests/nightwatch/features/accessibilityCreateOutreachAsset.test.js
tests/nightwatch/features/accessibilityCreatePersonProfile.test.js
tests/nightwatch/features/accessibilityCreatePressRelease.test.js
tests/nightwatch/features/accessibilityCreateRegional-LocalHealthCareServiceDescription.test.js
tests/nightwatch/features/accessibilityCreateStory.test.js
tests/nightwatch/features/accessibilityCreateSupportService.test.js
tests/nightwatch/features/accessibilityDashboard.test.js