### PR TITLE
VAGOV-3305 records migration content bugs

### DIFF
--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: b3f8ba28-035e-44bb-8409-87bff5005580
+uuid: 6b0ad136-2f0c-4ad9-a24a-61ee7d216b5b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_menu.yml
@@ -1,4 +1,4 @@
-uuid: 5a0a2b9d-a56b-4909-b5fd-0d1d9ef1ac9a
+uuid: 68325c73-9ca6-4698-87b2-c408a7a2c651
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_records.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_records.yml
@@ -1,4 +1,4 @@
-uuid: 8d9a7a60-21ff-488b-8ba7-bfa95d103c4f
+uuid: 23174558-2aaa-449f-b7a9-c176d380dc22
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_records_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_records_menu.yml
@@ -1,4 +1,4 @@
-uuid: ebe2bf56-0e2a-492d-b151-247afa9f48f2
+uuid: 5a2e9058-1d1f-4786-a2bd-098293a767db
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: 84db9f89-8aa8-4877-80b7-50df9d04799b
+uuid: 0e7af25e-f9d5-49f1-a593-abd2269741a7
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: D694t3whQGnUbacT6LNwpJAVT4QZtVy5SWPlrt9T8vA
+  default_config_hash: 1MQ42h9vbGtUTlQsqeqXbAKmuTg2gwWb0iiuNROySX8
 id: va_hub
 class: null
 field_plugin_method: null
@@ -209,6 +209,15 @@ process:
   field_administration:
     plugin: default_value
     default_value: 76
+  field_title_icon:
+    -
+      plugin: explode
+      source: url
+      delimiter: /
+    -
+      plugin: extract
+      index:
+        - 3
   moderation_state:
     plugin: default_value
     default_value: draft

--- a/config/sync/migrate_plus.migration.va_main_menu.yml
+++ b/config/sync/migrate_plus.migration.va_main_menu.yml
@@ -1,4 +1,4 @@
-uuid: fbd76df5-6032-4c4f-943c-be98f050e7c3
+uuid: e56d01f1-e742-4cd9-b488-4cc921b4832c
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_hubs.yml
+++ b/config/sync/migrate_plus.migration.va_new_hubs.yml
@@ -1,4 +1,4 @@
-uuid: c7800085-cd29-4b74-8dc7-9dcdbf9923e3
+uuid: 1f8f80f9-4323-43ff-af69-fceb1c947a33
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_landing_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_landing_pages.yml
@@ -1,4 +1,4 @@
-uuid: 5eb0c9e9-75c8-4118-85d9-9895f62dc4eb
+uuid: b67e02c4-7640-4c2d-a957-9588ddc2a830
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: efpFcgp9DLGjMf2KnVsoa5ugrG2Y04X_PGCUHMhcUCk
+  default_config_hash: R1lmhtw-cYFoXZ3twxUbK7n-8b4Fxl8PXkQhVW4C6do
 id: va_new_landing_pages
 class: null
 field_plugin_method: null
@@ -212,10 +212,21 @@ process:
           migration: va_support_service
           source: title
   field_alert:
+    plugin: migration_lookup
+    migration: va_alert_block
+    source: alert_title
+  field_administration:
+    plugin: default_value
+    default_value: 76
+  field_title_icon:
     -
-      plugin: migration_lookup
-      migration: va_alert_block
-      source: alert_title
+      plugin: explode
+      source: url
+      delimiter: /
+    -
+      plugin: extract
+      index:
+        - 3
   moderation_state:
     plugin: default_value
     default_value: draft

--- a/config/sync/migrate_plus.migration.va_new_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_pages.yml
@@ -1,4 +1,4 @@
-uuid: 06aad480-fc80-426d-ac16-642837c50f54
+uuid: 561e5af1-da1e-4d9f-9bfa-3e5c09194ee9
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach.yml
+++ b/config/sync/migrate_plus.migration.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: 8f576191-3f54-42bd-8cbb-be32dfc76818
+uuid: c830deb4-1bc8-49f4-be51-02207b4d220f
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
@@ -1,4 +1,4 @@
-uuid: 25ccd1a0-27f2-4dd2-8eed-7114695fd339
+uuid: 6928d4a6-451e-4a0b-b053-305a0f583aa4
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
@@ -1,4 +1,4 @@
-uuid: cba22cc0-544b-4d97-8fee-a496ce72c485
+uuid: c79e0bb3-1e66-4467-89c0-6b2fa7e49bbd
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_files.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_files.yml
@@ -1,4 +1,4 @@
-uuid: 4ed48e14-536c-4389-870f-d96f670dbaa4
+uuid: 13c5da7d-0869-4bff-8499-bded2aab5c42
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_image_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_image_media.yml
@@ -1,4 +1,4 @@
-uuid: e5e26dc5-2447-418b-9d7a-db0801f01f5a
+uuid: 4cc48a9d-71e8-4792-a0c0-c1c9ce3b53b9
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_video.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_video.yml
@@ -1,4 +1,4 @@
-uuid: 1eb9df88-cd5a-407f-b042-87a0af081bd4
+uuid: 526a2f15-8a43-4231-ac66-92d1c3461a2d
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: 971931af-6f03-4f4d-9579-7b75ce676632
+uuid: 76d61080-6030-430b-a450-e3f769ad4fd7
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: e7c27205-36f1-4528-a540-4c1da9d74480
+uuid: 1f888cd9-630b-4584-bb2c-ffd68a4c6feb
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: f781b015-d44f-4e77-b447-2df85617d7ba
+uuid: 06d7a3ad-e916-4d06-9e2e-23939b7d58b8
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: 931abb21-c1b1-43bd-872c-7a4482158aae
+uuid: 40804123-7365-4623-86cd-1edf3e20669b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: 0c3339f2-f993-4611-85a1-be8df793ba12
+uuid: 30f1a8c0-8375-46e5-b481-7d63f287431b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_new_benefits.yml
+++ b/config/sync/migrate_plus.migration_group.va_new_benefits.yml
@@ -1,4 +1,4 @@
-uuid: a2da3de0-badb-460a-8cca-d8ff08d7d627
+uuid: 569bcad0-1239-41e7-ba93-13db8813c6c7
 langcode: en
 status: true
 dependencies:
@@ -6,10 +6,10 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: evKNMFTcfBR3WhrLgY35cspUHE74BIq3F0wugJD3_4Y
+  default_config_hash: HuOKkmbNvo6bWh3uSyqZDZ40wuu_Ovv77dhg8C10UMk
 id: va_new_benefits
-label: 'Migrations for all new benefits pages'
-description: 'Migrate content from VA.gov metalsmith repo and website'
+label: 'Migrate benefits hub'
+description: 'Migrate the next benefits hub to drupal.'
 source_type: 'HTML files'
 module: null
 shared_configuration: null

--- a/config/sync/migrate_plus.migration_group.va_outreach.yml
+++ b/config/sync/migrate_plus.migration_group.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: 1c243e2a-5e9f-4e3c-a4c3-cf67042816c1
+uuid: d95fcb1d-e695-4871-9925-9660fc1f4ba3
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_tests.yml
+++ b/config/sync/migrate_plus.migration_group.va_tests.yml
@@ -1,4 +1,4 @@
-uuid: 63c6dd4e-4033-477c-8da7-c83b56b80503
+uuid: 335d0388-9190-4e2b-b115-c87056ab3ef3
 langcode: en
 status: true
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
@@ -223,6 +223,15 @@ process:  # assign the fields we collected above to Drupal fields.
   field_administration:
     plugin: default_value
     default_value: 76
+  field_title_icon:
+    -
+      plugin: explode
+      source: url
+      delimiter: '/'
+    -
+      plugin: extract
+      index:
+        - 3
   moderation_state:
     plugin: default_value
     default_value: draft

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_landing_pages.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_landing_pages.yml
@@ -24,164 +24,164 @@ source:
     - social
 
   migration_tools:
-  -
-    # Just leave this as is, if using metalsmith_source or url_list source.
-    source: url # The field we're passing to migration_tools is called 'url'.
-    source_type: url  # Source type can be either 'url' or 'html'.
+    -
+      # Just leave this as is, if using metalsmith_source or url_list source.
+      source: url # The field we're passing to migration_tools is called 'url'.
+      source_type: url  # Source type can be either 'url' or 'html'.
 
-    source_operations:
-    -
-      operation: modifier
-      modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
-    fields:
-      title:  # This is the recipe for a field called 'title'.
-        obtainer: ObtainTitle # Good for grabbing titles, but could just as well have used ObtainHtml here.
-        jobs:
+      source_operations:
         -
-          job: addSearch  # Run a job to search the DOM and assign the results to this field.
-          method: pluckSelector # Also remove it from the DOM (so it doesn't show up in body, too).
-          arguments:
-          - 'h1'  # Look for h1 tags.
-          - 1     # Only grab the first one.
-          - innerHTML  # Get any html it contains.
-      alert_title:
-        obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAlertBlockTitles"
-        jobs:
-          -
-            job: 'addSearch'
-            method: 'arrayPluckSelector'
-            arguments:
-              - '.usa-alert-heading'
-              - innerHTML
-      intro_text:
-        obtainer: ObtainPlainTextWithNewLines
-        jobs:
-          -
-            job: addSearch
-            method: pluckSelector
-            arguments:
-              - '.va-introtext'
-      featured_content:
-        obtainer: ObtainHtml
-        jobs:
+          operation: modifier
+          modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
+      fields:
+        title:  # This is the recipe for a field called 'title'.
+          obtainer: ObtainTitle # Good for grabbing titles, but could just as well have used ObtainHtml here.
+          jobs:
+            -
+              job: addSearch  # Run a job to search the DOM and assign the results to this field.
+              method: pluckSelector # Also remove it from the DOM (so it doesn't show up in body, too).
+              arguments:
+                - 'h1'  # Look for h1 tags.
+                - 1     # Only grab the first one.
+                - innerHTML  # Get any html it contains.
+        alert_title:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAlertBlockTitles"
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'arrayPluckSelector'
+              arguments:
+                - '.usa-alert-heading'
+                - innerHTML
+        intro_text:
+          obtainer: ObtainPlainTextWithNewLines
+          jobs:
+            -
+              job: addSearch
+              method: pluckSelector
+              arguments:
+                - '.va-introtext'
+        featured_content:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '.feature'
+                - '1'
+                - innerHTML
+        related_links:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '.va-nav-linkslist--related'
+                - '1'
+                - innerHTML
+        hub_links:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - 'article'
+                - '1'
+                - HTML
+        body:
+          obtainer: ObtainBody
+          jobs:
+            -
+              # First, look for a class of 'usa-width-three-fourths'.
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '.usa-width-three-fourths'
+                - '1'
+                - innerHTML
+            -
+              # If it's not there, try '#content .usa-grid-full'.
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '#content .usa-grid-full'
+                - '1'
+                - innerHTML
+            -
+              # If we still haven't found anything, grab the article tag.
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - 'article'
+                - '1'
+                - innerHTML
+      dom_operations:
         -
-          job: 'addSearch'
-          method: 'pluckSelector'
-          arguments:
-            - '.feature'
-            - '1'
-            - innerHTML
-      related_links:
-        obtainer: ObtainHtml
-        jobs:
+          # This runs first.
+          operation: get_field
+          field: title  # Use the 'title' recipe from above to create the field.
         -
-          job: 'addSearch'
-          method: 'pluckSelector'
-          arguments:
-            - '.va-nav-linkslist--related'
-            - '1'
-            - innerHTML
-      hub_links:
-        obtainer: ObtainHtml
-        jobs:
+          # This runs next.
+          operation: get_field
+          field: intro_text
         -
-          job: 'addSearch'
-          method: 'pluckSelector'
-          arguments:
-            - 'article'
-            - '1'
-            - HTML
-      body:
-        obtainer: ObtainBody
-        jobs:
+          # And so on...
+          operation: get_field
+          field: featured_content
         -
-          # First, look for a class of 'usa-width-three-fourths'.
-          job: 'addSearch'
-          method: 'pluckSelector'
+          # Remove expander trigger before getting alert title
+          operation: modifier
+          modifier: removeSelectorAll
           arguments:
-            - '.usa-width-three-fourths'
-            - '1'
-            - innerHTML
+            - '#crisis-expander-link'
         -
-          # If it's not there, try '#content .usa-grid-full'.
-          job: 'addSearch'
-          method: 'pluckSelector'
-          arguments:
-            - '#content .usa-grid-full'
-            - '1'
-            - innerHTML
+          operation: get_field
+          field: alert_title
         -
-          # If we still haven't found anything, grab the article tag.
-          job: 'addSearch'
-          method: 'pluckSelector'
+          operation: get_field
+          field: related_links
+        -
+          # Remove any alert boxes (they'll be attached via 'alert title', above).
+          operation: modifier
+          modifier: removeSelectorAll
           arguments:
-          - 'article'
-          - '1'
-          - innerHTML
-    dom_operations:
-    -
-      # This runs first.
-      operation: get_field
-      field: title  # Use the 'title' recipe from above to create the field.
-    -
-      # This runs next.
-      operation: get_field
-      field: intro_text
-    -
-      # And so on...
-      operation: get_field
-      field: featured_content
-    -
-      # Remove expander trigger before getting alert title
-      operation: modifier
-      modifier: removeSelectorAll
-      arguments:
-        - '#crisis-expander-link'
-    -
-      operation: get_field
-      field: alert_title
-    -
-      operation: get_field
-      field: related_links
-    -
-      # Remove any alert boxes (they'll be attached via 'alert title', above).
-      operation: modifier
-      modifier: removeSelectorAll
-      arguments:
-        - '.usa-alert'
-    -
-      # Clean things up before getting the body.
-      # Remove javascript cruft.
-      operation: modifier
-      modifier: removeSelectorAll
-      arguments:
-      - 'button.va-btn-sidebarnav-trigger'
-    -
-      # Remove any scripts
-      operation: modifier
-      modifier: removeSelectorAll
-      arguments:
-        - 'script'
-    -
-      # Remove jump links section
-      operation: modifier
-      modifier: removeSelectorAll
-      arguments:
-      - 'h3:contains("On This Page")'
-    -
-      operation: modifier
-      modifier: removeSelectorAll
-      arguments:
-      - 'li > a[href^="#"]'
-    -
-      # Remove starred HRs
-      operation: modifier
-      modifier: removeSelectorAll
-      arguments:
-        - '.va-h-ruled--stars'
-    -
-      operation: get_field
-      field: hub_links
+            - '.usa-alert'
+        -
+          # Clean things up before getting the body.
+          # Remove javascript cruft.
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'button.va-btn-sidebarnav-trigger'
+        -
+          # Remove any scripts
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'script'
+        -
+          # Remove jump links section
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'h3:contains("On This Page")'
+        -
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'li > a[href^="#"]'
+        -
+          # Remove starred HRs
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - '.va-h-ruled--stars'
+        -
+          operation: get_field
+          field: hub_links
 
 process:  # assign the fields we collected above to Drupal fields.
   title: title
@@ -217,15 +217,26 @@ process:  # assign the fields we collected above to Drupal fields.
           migration: va_support_service
           source: title
   field_alert:
+    plugin: migration_lookup
+    migration: va_alert_block
+    source: alert_title
+  field_administration:
+    plugin: default_value
+    default_value: 76
+  field_title_icon:
     -
-      plugin: migration_lookup
-      migration: va_alert_block
-      source: alert_title
+      plugin: explode
+      source: url
+      delimiter: '/'
+    -
+      plugin: extract
+      index:
+        - 3
   moderation_state:
     plugin: default_value
     default_value: draft
   type:
-    plugin: default_value   # We want to asign the 'type' field a static value.
+    plugin: default_value   # We want to assign the 'type' field a static value.
     default_value: landing_page # The value is 'landing_page'.
 
 destination:
@@ -241,4 +252,4 @@ migration_dependencies:
 dependencies:
   enforced:
     module:
-    - va_gov_migrate  # The module this migration script belongs to.
+      - va_gov_migrate  # The module this migration script belongs to.

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/LinksList.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/LinksList.php
@@ -23,7 +23,13 @@ class LinksList extends ParagraphType {
    * {@inheritdoc}
    */
   protected function isParagraph(DOMQuery $query_path) {
-    return $query_path->hasClass('hub-page-link-list') || $query_path->hasClass('va-nav-linkslist-list');
+    $is_linkslist = FALSE;
+    if ($query_path->hasClass('hub-page-link-list') || $query_path->hasClass('va-nav-linkslist-list')) {
+      if ($query_path->find('li')->count()) {
+        $is_linkslist = TRUE;
+      }
+    }
+    return $is_linkslist;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/QaSection.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/QaSection.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\va_gov_migrate\Paragraph;
 
-use Drupal\migration_tools\Obtainer\ObtainHtml;
+use Drupal\migration_tools\Obtainer\ObtainPlainTextWithNewLines;
 use Drupal\migration_tools\StringTools;
 use Drupal\va_gov_migrate\ParagraphType;
 use QueryPath\DOMQuery;
@@ -98,8 +98,8 @@ class QaSection extends ParagraphType {
           // Add line breaks between elements.
           $intro_text .= PHP_EOL . PHP_EOL;
         }
-        // Replace br tags with line breaks.
-        $intro_text .= strip_tags(implode(PHP_EOL, ObtainHtml::splitOnBr($qp->html())));
+        // Replace p and br tags with line breaks.
+        $intro_text .= ObtainPlainTextWithNewLines::cleanString($qp->html());
       }
 
       $qp = $qp->next();


### PR DESCRIPTION
Small migration fixes (note that `migrate_plus.migration.va_new_landing_pages.yml` is for testing only. The changes there just bring it up-to-date with the real migration, `va_hub`.)

To test: Go to /admin/structure/migrate/manage/va_new_benefits/migrations and run `Migrate Records benefits pages from VA.gov` and `Records landing page...` (check the 'Update' option for that one). Then 
1. Edit 'Types of Veteran ID cards' and make sure there's a line break in the last Q&A Section intro:
> At this time, all 50 states and Puerto Rico offer a Veteran designation (an identifying mark) printed on state-issued driver’s licenses or IDs. The type of Veteran designation may vary from state to state.
> 
> If you have a Veteran’s designation, you may be able to get discounts offered to Veterans at many stores, businesses, and restaurants.
2. Edit 'VA records' landing page and make sure the 'Records' is selected as the hub icon.
