### PR TITLE
VAGOV-3531: Add paragraph migration for tables.

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/Table.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/Table.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Paragraph;
+
+use Drupal\va_gov_migrate\ParagraphType;
+use QueryPath\DOMQuery;
+
+/**
+ * Table paragraph type.
+ *
+ * @package Drupal\va_gov_migrate\Paragraph
+ */
+class Table extends ParagraphType {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getParagraphName() {
+    return 'table';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function isParagraph(DOMQuery $query_path) {
+    return $query_path->tag() == 'table';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getFieldValues(DOMQuery $query_path) {
+    $contents = [];
+
+    $rows = $query_path->find('tr');
+    foreach ($rows as $row) {
+      $contents[] = $this->parseTableRow($row);
+    }
+
+    return [
+      'field_table' => [
+        'value' => $contents,
+        'format' => 'rich_text',
+      ],
+    ];
+  }
+
+  /**
+   * Return contents of a HTML table row as an array.
+   *
+   * @param \QueryPath\DOMQuery $html_row
+   *   The row to parse.
+   *
+   * @return array
+   *   The resulting array
+   */
+  protected function parseTableRow(DOMQuery $html_row) {
+    $columns = $html_row->find('td, th');
+    $return_row = [];
+    /** @var \QueryPath\DOMQuery $column */
+    foreach ($columns as $column) {
+      $return_row[] = $column->text();
+    }
+    return $return_row;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_migrate/src/Paragraph/Table.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Paragraph/Table.php
@@ -12,6 +12,8 @@ use QueryPath\DOMQuery;
  */
 class Table extends ParagraphType {
 
+  private $captionTags = ['h2', 'h3'];
+
   /**
    * {@inheritdoc}
    */
@@ -30,8 +32,10 @@ class Table extends ParagraphType {
    * {@inheritdoc}
    */
   protected function getFieldValues(DOMQuery $query_path) {
+    if (in_array($query_path->prev()->tag(), $this->captionTags)) {
+      $caption = $query_path->prev()->text();
+    }
     $contents = [];
-
     $rows = $query_path->find('tr');
     foreach ($rows as $row) {
       $contents[] = $this->parseTableRow($row);
@@ -41,8 +45,16 @@ class Table extends ParagraphType {
       'field_table' => [
         'value' => $contents,
         'format' => 'rich_text',
+        'caption' => $caption,
       ],
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function isExternalContent(DOMQuery $query_path) {
+    return in_array($query_path->tag(), $this->captionTags) && $this->isParagraph($query_path->next());
   }
 
   /**


### PR DESCRIPTION
Code identifies and gets contents from html tables.

To test:
1. Go to /admin/structure/migrate/manage/va_tests/migrations/va_new_hubs/execute and press the "Execute" button.
2. Go have dinner, take a walk, see a movie (this will take a while).
3. When the migration's done, edit "VA Pension Rates For Veterans". There should be 3 table paragraphs and their contents should match https://www.va.gov/pension/veterans-pension-rates/
