### PR TITLE
VAGOV-3259 Fix migration title casing

### DIFF
--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: 6b0ad136-2f0c-4ad9-a24a-61ee7d216b5b
+uuid: fb9431b3-8e69-45b3-a074-6c6a7d91c749
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_menu.yml
@@ -1,4 +1,4 @@
-uuid: 68325c73-9ca6-4698-87b2-c408a7a2c651
+uuid: a7337c19-63a6-45de-bf23-08f468ef500a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_records.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_records.yml
@@ -1,4 +1,4 @@
-uuid: 23174558-2aaa-449f-b7a9-c176d380dc22
+uuid: 5a4ab162-211b-4182-b01f-96f2a447ec2b
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: YnYB-5nflywilDk6gQ-7zh8ANelF2E4N6hHoEDPEhiE
+  default_config_hash: fo_ZxygqLrJL7uhoIbynzenvRuljLS-JA_fKeiLgg7E
 id: va_benefits_records
 class: null
 field_plugin_method: null
@@ -34,7 +34,7 @@ source:
           modifier: basicCleanup
       fields:
         title:
-          obtainer: ObtainTitle
+          obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleUncased
           jobs:
             -
               job: addSearch

--- a/config/sync/migrate_plus.migration.va_benefits_records_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_records_menu.yml
@@ -1,4 +1,4 @@
-uuid: 5a2e9058-1d1f-4786-a2bd-098293a767db
+uuid: 32238543-c4b3-45bd-8842-ab872e024b95
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: 0e7af25e-f9d5-49f1-a593-abd2269741a7
+uuid: 650722c2-9d50-4f38-b446-d4fd030ee520
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: 1MQ42h9vbGtUTlQsqeqXbAKmuTg2gwWb0iiuNROySX8
+  default_config_hash: aOZ4JOhR03gB4fnJFL25B9JRf9H6NZnIC-rMIeetwyo
 id: va_hub
 class: null
 field_plugin_method: null
@@ -35,7 +35,7 @@ source:
           modifier: basicCleanup
       fields:
         title:
-          obtainer: ObtainTitle
+          obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleUncased
           jobs:
             -
               job: addSearch

--- a/config/sync/migrate_plus.migration.va_main_menu.yml
+++ b/config/sync/migrate_plus.migration.va_main_menu.yml
@@ -1,4 +1,4 @@
-uuid: e56d01f1-e742-4cd9-b488-4cc921b4832c
+uuid: fbd85ab9-c23b-40f1-b36b-74e058342296
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_hubs.yml
+++ b/config/sync/migrate_plus.migration.va_new_hubs.yml
@@ -1,4 +1,4 @@
-uuid: 1f8f80f9-4323-43ff-af69-fceb1c947a33
+uuid: 589bda6b-d1a3-4c06-89d5-1a6c91b60ada
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: sjZj4tAc70PK0W3A5VoOoQqwjBc7vFYjtjQMw8o8VPs
+  default_config_hash: dyYm-C3ZVxbesSU7fi5eHL3Lb34mQcqeW24ni-IkleQ
 id: va_new_hubs
 class: null
 field_plugin_method: null
@@ -43,7 +43,7 @@ source:
           modifier: basicCleanup
       fields:
         title:
-          obtainer: ObtainTitle
+          obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleUncased
           jobs:
             -
               job: addSearch

--- a/config/sync/migrate_plus.migration.va_new_landing_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_landing_pages.yml
@@ -1,4 +1,4 @@
-uuid: b67e02c4-7640-4c2d-a957-9588ddc2a830
+uuid: d247cef0-a425-43ec-ac9b-80e9b664c6b5
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: R1lmhtw-cYFoXZ3twxUbK7n-8b4Fxl8PXkQhVW4C6do
+  default_config_hash: I9bEAEbfRkHuATuFCtj4qNIo7Q_MAzzwjBumYfSOkN4
 id: va_new_landing_pages
 class: null
 field_plugin_method: null
@@ -44,7 +44,7 @@ source:
           modifier: basicCleanup
       fields:
         title:
-          obtainer: ObtainTitle
+          obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleUncased
           jobs:
             -
               job: addSearch

--- a/config/sync/migrate_plus.migration.va_new_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_pages.yml
@@ -1,4 +1,4 @@
-uuid: 561e5af1-da1e-4d9f-9bfa-3e5c09194ee9
+uuid: 60f0231b-96db-4138-9f7c-848535494827
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: 6HgkCpMHskDDZyxQECu8Cnherjkqt-uF_Sk4gpWFOZI
+  default_config_hash: 9CykfHrpVA4_8_ZkYkJoIBVj4W8-R_coYf63PIYrf5o
 id: va_new_pages
 class: null
 field_plugin_method: null
@@ -42,7 +42,7 @@ source:
           modifier: basicCleanup
       fields:
         title:
-          obtainer: ObtainTitle
+          obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleUncased
           jobs:
             -
               job: addSearch

--- a/config/sync/migrate_plus.migration.va_outreach.yml
+++ b/config/sync/migrate_plus.migration.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: c830deb4-1bc8-49f4-be51-02207b4d220f
+uuid: 1ff16243-6b29-4dc6-8a01-2285ff79f654
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
@@ -1,4 +1,4 @@
-uuid: 6928d4a6-451e-4a0b-b053-305a0f583aa4
+uuid: ea38fd38-0105-4d0b-a4e1-fe38019f6cad
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
@@ -1,4 +1,4 @@
-uuid: c79e0bb3-1e66-4467-89c0-6b2fa7e49bbd
+uuid: d2e03862-8abf-43ab-a5b8-460aac09acd2
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_files.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_files.yml
@@ -1,4 +1,4 @@
-uuid: 13c5da7d-0869-4bff-8499-bded2aab5c42
+uuid: cb60473a-df7c-4cbf-8f2a-97b1996b6b16
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_image_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_image_media.yml
@@ -1,4 +1,4 @@
-uuid: 4cc48a9d-71e8-4792-a0c0-c1c9ce3b53b9
+uuid: c35657be-8e7f-49fe-9f5d-dc563b73d3ed
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_video.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_video.yml
@@ -1,4 +1,4 @@
-uuid: 526a2f15-8a43-4231-ac66-92d1c3461a2d
+uuid: ebdda253-a1bb-4706-9d1c-bd624ea9de41
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: 76d61080-6030-430b-a450-e3f769ad4fd7
+uuid: c60eeadf-f204-499b-a477-d53791a58563
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: 1f888cd9-630b-4584-bb2c-ffd68a4c6feb
+uuid: 1da497f4-772a-498e-b06d-c01e9dcfb34e
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: 06d7a3ad-e916-4d06-9e2e-23939b7d58b8
+uuid: aff771a0-daf4-4479-a6be-2dd8f5b701cf
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: 40804123-7365-4623-86cd-1edf3e20669b
+uuid: a6d42f09-5c1b-400d-ab8f-5a5fed7b1904
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: 30f1a8c0-8375-46e5-b481-7d63f287431b
+uuid: a70b8be5-0f40-4f68-ae96-2b2dcbbcce1b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_new_benefits.yml
+++ b/config/sync/migrate_plus.migration_group.va_new_benefits.yml
@@ -1,4 +1,4 @@
-uuid: 569bcad0-1239-41e7-ba93-13db8813c6c7
+uuid: 45f461e3-2723-449d-a551-a20de13845fc
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_outreach.yml
+++ b/config/sync/migrate_plus.migration_group.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: d95fcb1d-e695-4871-9925-9660fc1f4ba3
+uuid: ef5429c3-f0b9-423c-bed1-c5d93bd8d3d5
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_tests.yml
+++ b/config/sync/migrate_plus.migration_group.va_tests.yml
@@ -1,4 +1,4 @@
-uuid: 335d0388-9190-4e2b-b115-c87056ab3ef3
+uuid: 75642aca-1b33-4684-b7b6-7b4047f18db4
 langcode: en
 status: true
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_records.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_records.yml
@@ -24,7 +24,7 @@ source:
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
         title:  # This is the recipe for a field called 'title'.
-          obtainer: ObtainTitle # Good for grabbing titles.
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleUncased"
           jobs:
             -
               job: addSearch  # Run a job to search the DOM and assign the results to this field.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
@@ -35,7 +35,7 @@ source:
       modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
     fields:
       title:  # This is the recipe for a field called 'title'.
-        obtainer: ObtainTitle # Good for grabbing titles, but could just as well have used ObtainHtml here.
+        obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleUncased"
         jobs:
         -
           job: addSearch  # Run a job to search the DOM and assign the results to this field.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_hubs.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_hubs.yml
@@ -33,7 +33,7 @@ source:
       modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
     fields:
       title:  # This is the recipe for a field called 'title'.
-        obtainer: ObtainTitle # Good for grabbing titles.
+        obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleUncased"
         jobs:
         -
           job: addSearch  # Run a job to search the DOM and assign the results to this field.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_landing_pages.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_landing_pages.yml
@@ -35,7 +35,7 @@ source:
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
         title:  # This is the recipe for a field called 'title'.
-          obtainer: ObtainTitle # Good for grabbing titles, but could just as well have used ObtainHtml here.
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleUncased"
           jobs:
             -
               job: addSearch  # Run a job to search the DOM and assign the results to this field.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_pages.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_pages.yml
@@ -33,7 +33,7 @@ source:
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
         title:  # This is the recipe for a field called 'title'.
-          obtainer: ObtainTitle # Good for grabbing titles.
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleUncased"
           jobs:
             -
               job: addSearch  # Run a job to search the DOM and assign the results to this field.

--- a/docroot/modules/custom/va_gov_migrate/src/Obtainer/ObtainTitleUncased.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Obtainer/ObtainTitleUncased.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\va_gov_migrate\Obtainer;
+
+use Drupal\migration_tools\Obtainer\ObtainTitle;
+use Drupal\migration_tools\StringTools;
+
+/**
+ * Like ObtainTitle, but doesn't affect case.
+ *
+ * @package Drupal\va_gov_migrate\Obtainer
+ */
+class ObtainTitleUncased extends ObtainTitle {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function cleanString($text) {
+    // Breaks need to be converted to spaces to avoid lines running together.
+    // @codingStandardsIgnoreStart
+    $break_tags = ['<br>', '<br/>', '<br />', '</br>'];
+    // @codingStandardsIgnoreEnd
+    $text = str_ireplace($break_tags, ' ', $text);
+    $text = strip_tags($text);
+    // Titles can not have html entities.
+    $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+
+    // There are also numeric html special chars, let's change those.
+    $text = StringTools::decodeHtmlEntityNumeric($text);
+
+    // We want out titles to be only digits and ascii chars so we can produce
+    // clean aliases.
+    $text = StringTools::convertNonASCIItoASCII($text);
+    // Remove undesirable chars and strings.
+    $remove = [
+      '&raquo;',
+      '&nbsp;',
+      '»',
+      // Weird space character.'.
+      ' ',
+    ];
+    $text = str_ireplace($remove, ' ', $text);
+
+    // Remove white space-like things from the ends and decodes html entities.
+    $text = StringTools::superTrim($text);
+    // Remove multiple spaces.
+    $text = preg_replace(['/\s{2,}/', '/[\t\n]/'], ' ', $text);
+
+    return $text;
+  }
+
+}


### PR DESCRIPTION
To test:
1. Go to /admin/structure/migrate/manage/va_new_benefits/migrations/va_benefits_records/execute and run migration
2. Check the 4 newly created records detail pages (all in draft, all updated on 04/18/2019 - 20:00, all with Owner 'Records benefits hub'). Their titles should all be sentence case, like their titles on va.gov.