### PR TITLE
VAGOV-3600 pension migration alert

### DIFF
--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: 275de9b7-2fb7-4138-90da-bae52995b5dd
+uuid: 6a010f92-b644-479a-93b7-9827c5469e42
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: esGEqZX430J594iTZa6p7bnOhEoqKq9rmvsEnW21Ujw
+  default_config_hash: NzRLhmuuxYnmLgVq3XcomGDg5mJJaU5vV-7FunMJc1M
 id: va_alert_block
 class: null
 field_plugin_method: null
@@ -17,7 +17,7 @@ label: 'Migrate alert blocks from VA.gov'
 source:
   plugin: alert_block
   urls:
-    - /records
+    - /pension/index.md
   fields:
     - alert_type
     - alert_title

--- a/config/sync/migrate_plus.migration.va_benefits_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_menu.yml
@@ -1,4 +1,4 @@
-uuid: af31a1a9-317d-4045-aae0-b2b37a8d232e
+uuid: 5b175852-7e8c-4fa6-986e-4ea5c61fa2b3
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_pension.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_pension.yml
@@ -1,4 +1,4 @@
-uuid: 15e83178-f2b3-4273-9da4-83413d1ecc78
+uuid: 40176485-65ca-462a-9d6a-5daac678182e
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_pension_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_pension_menu.yml
@@ -1,4 +1,4 @@
-uuid: 7d75c837-4c34-4ced-890f-c82c3b66b091
+uuid: ec178102-0485-48b7-b84d-892486993e88
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_records.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_records.yml
@@ -1,4 +1,4 @@
-uuid: c5f1e564-e24d-4f66-90e5-e7a1877c555d
+uuid: fbd21977-b0d3-4708-8298-69037ebf9ae9
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_records_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_records_menu.yml
@@ -1,4 +1,4 @@
-uuid: 5dcce33b-83b2-48a1-90cd-cd883696444c
+uuid: 15c93c72-5aaa-4360-a946-e532c4964416
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: d9eb7491-05a4-4c48-b210-194abafa7728
+uuid: 3e72c533-07fb-4a08-8556-054f370ff090
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_main_menu.yml
+++ b/config/sync/migrate_plus.migration.va_main_menu.yml
@@ -1,4 +1,4 @@
-uuid: edaf540a-270c-4e22-960b-643053adce56
+uuid: 30b49dac-4f99-4da4-99ec-ad89d3f22be9
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_hubs.yml
+++ b/config/sync/migrate_plus.migration.va_new_hubs.yml
@@ -1,4 +1,4 @@
-uuid: 8329b67f-a92a-437f-8a34-aa5dc28d4663
+uuid: 48c6eebb-cc28-472d-acc3-92daf6b9791d
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_landing_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_landing_pages.yml
@@ -1,4 +1,4 @@
-uuid: f7f00dab-5a35-421a-a70a-aec17cf29e7f
+uuid: 052252cf-f286-49ab-9440-7b3839119fda
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_pages.yml
@@ -1,4 +1,4 @@
-uuid: 408ceee1-3563-4c13-bdca-aacd329c1195
+uuid: 66f7196b-fa68-4005-ade2-98212c55a02e
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach.yml
+++ b/config/sync/migrate_plus.migration.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: 99f6915f-1437-48f8-94de-2d422084be5e
+uuid: 8d9c3007-52e8-4b3a-b870-fce7839bb5aa
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_doc_media.yml
@@ -1,4 +1,4 @@
-uuid: 60af2aed-9e45-4529-a450-318310924d53
+uuid: f54be2d0-9ce3-4ad4-9265-2aea1ed585c4
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_embedded_images.yml
@@ -1,4 +1,4 @@
-uuid: d49ce1b4-dcb3-47a5-b5ea-5b9865cf6b9a
+uuid: b8ba4d88-2810-49a5-b80d-e421e475864f
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_files.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_files.yml
@@ -1,4 +1,4 @@
-uuid: c6689970-aebe-4318-a4d6-72ca7e77fed1
+uuid: 0fc988d2-6fae-4cf0-aa91-d58d5f806bf3
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_image_media.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_image_media.yml
@@ -1,4 +1,4 @@
-uuid: c250acd0-5a68-40b1-8dde-2405e2b18e3f
+uuid: 015ab583-70ca-45d6-b791-a8d874403822
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_outreach_video.yml
+++ b/config/sync/migrate_plus.migration.va_outreach_video.yml
@@ -1,4 +1,4 @@
-uuid: 40b3ee7d-6e48-40f1-9c57-106174f01904
+uuid: b0d19130-b2f1-4fcd-b4c0-bb319f8a424a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: 51f7bb59-c296-4910-a6ab-2d26c52a77ed
+uuid: cc40996c-3bef-42d7-af78-af37e78267a2
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: 741afdf5-6ce3-4d70-940b-2280c9f67386
+uuid: 2bf43b4b-a80c-40d0-ae2b-d40143865498
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: 869cafa5-36f2-467d-9f6c-3297db840cd1
+uuid: 07e9abdc-1b57-49cc-9550-a81f187f7c7f
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: 23c1662f-d7e7-411a-aa10-6967e9e24c68
+uuid: 9432de06-ec80-4758-bf8a-bb7e9d172d7c
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: e6176f6f-6d53-4d03-8231-ba8b76d5f0f0
+uuid: 4b153982-c7d8-493e-82b5-7e92f1ef54a2
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_new_benefits.yml
+++ b/config/sync/migrate_plus.migration_group.va_new_benefits.yml
@@ -1,4 +1,4 @@
-uuid: bd739b82-c6d7-4df7-9932-16ca2f1c9038
+uuid: 6e8eea34-757e-40ac-a03d-45d37a49c8e5
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_outreach.yml
+++ b/config/sync/migrate_plus.migration_group.va_outreach.yml
@@ -1,4 +1,4 @@
-uuid: 356e09b0-704e-4d2c-b6f8-88645cbe2738
+uuid: 069ded90-464b-44ff-882b-941d75608689
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_tests.yml
+++ b/config/sync/migrate_plus.migration_group.va_tests.yml
@@ -1,4 +1,4 @@
-uuid: 04420c9e-85d5-46e2-831c-41f1c42d65c3
+uuid: d3c665d8-c3a5-4fe7-8498-e7c0ba73872f
 langcode: en
 status: true
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_alert_block.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_alert_block.yml
@@ -5,7 +5,7 @@ migration_group: va_gov
 source:
   plugin: alert_block
   urls:
-    - "/records"
+    - "/pension/index.md"
   fields:
     - alert_type
     - alert_title


### PR DESCRIPTION
Not much here. This just specifies that only alert blocks on the pension landing page get migrated, and currently, there aren't any.

So to test, go to /admin/structure/migrate/manage/va_gov/migrations and confirm that "Migrate alert blocks from VA.gov" has 'TOTAL' of zero.