### PR TITLE
VAGOV-000: Adding additional menu option to detail pages.

### DIFF
--- a/config/sync/field.field.node.page.field_meta_tags.yml
+++ b/config/sync/field.field.node.page.field_meta_tags.yml
@@ -17,7 +17,7 @@ label: 'Meta tags'
 description: ''
 required: false
 translatable: false
-default_value: { }
+default_value: {  }
 default_value_callback: ''
 settings: {  }
 field_type: metatag

--- a/config/sync/node.type.health_care_region_detail_page.yml
+++ b/config/sync/node.type.health_care_region_detail_page.yml
@@ -8,6 +8,7 @@ dependencies:
 third_party_settings:
   menu_ui:
     available_menus:
+      - outreach-and-events
       - pittsburgh-health-care
     parent: 'pittsburgh-health-care:'
   node_title_help_text:

--- a/config/sync/node_revisions_autoclean.settings.yml
+++ b/config/sync/node_revisions_autoclean.settings.yml
@@ -6,11 +6,11 @@ node:
   documentation_page: 50
   event: 50
   health_care_local_facility: 50
-  health_care_region_detail_page: 50
+  health_care_region_detail_page: '50'
   health_care_region_page: 50
   landing_page: 50
   news_story: 50
-  office: '50'
+  office: 50
   outreach_asset: 50
   page: 100
   person_profile: 50
@@ -22,11 +22,11 @@ interval:
   documentation_page: '0'
   event: '0'
   health_care_local_facility: '0'
-  health_care_region_detail_page: '0'
+  health_care_region_detail_page: 0
   health_care_region_page: '0'
   landing_page: '0'
   news_story: '0'
-  office: 0
+  office: '0'
   outreach_asset: '0'
   page: '0'
   person_profile: '0'


### PR DESCRIPTION
This enables the new outreach and events menu on Detail pages. Just a check box that was missed, so didn't create a task, @andyhawks - hope to get this one merged in and part of the build.