### PR TITLE
VAGOV-1895: Revert: Hide history and revision tabs on node edit pages.

### DIFF
--- a/docroot/themes/custom/vagovadmin/css/admin-styles.css
+++ b/docroot/themes/custom/vagovadmin/css/admin-styles.css
@@ -1,4 +1,0 @@
-.is-horizontal .tabs__tab + .tabs__tab a[href*="/moderation-history"],
-.is-horizontal .tabs__tab + .tabs__tab a[href*="/revisions"] {
-    display: none;
-}


### PR DESCRIPTION
This reverts commit 2b8fbbfd7b0e4e33eb224d0fa80fbc97c8770254. 