### PR TITLE
VAGOV-4033: Add 2 new environment variables so the CMS can control the devops repo

### DIFF
--- a/docker/env_files/common.env
+++ b/docker/env_files/common.env
@@ -3,3 +3,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/www/.comp
 LANDO_WEBROOT=/app/docroot
 LANDO_MOUNT=/app
 LANDO_APP_NAME=vagovcms
+VAGOV_CMS_DEVOPS_REPO=https://github.com/department-of-veterans-affairs/va.gov-cms-devops
+VAGOV_CMS_DEVOPS_REF=VAGOV-2142-tests


### PR DESCRIPTION
Right now you have to go into the jenkins job to configure what branch of the devops repo is used.

This PR simply adds environment variables that we can source in the jenkins job so that the CMS repo can control what version of the devops repo to use.

This would remove the need to add a github tag called "devops", for the main build job could source this file and just use that repo.  (git url and ref supported.)