### PR TITLE
VAGOV-4035

### DIFF
--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -12,6 +12,7 @@ permissions:
   - 'access content'
   - 'access environment indicator'
   - 'access site-wide contact form'
+  - 'access taxonomy overview'
   - 'execute graphql requests'
   - 'execute persisted graphql requests'
   - 'view media'

--- a/tests/phpunit/SecurityRolesPermissionsTest.php
+++ b/tests/phpunit/SecurityRolesPermissionsTest.php
@@ -58,6 +58,7 @@ class SecurityRolesPermissions extends ExistingSiteBase {
           'access content',
           'access environment indicator',
           'access site-wide contact form',
+          'access taxonomy overview',
           'execute graphql requests',
           'execute persisted graphql requests',
           'view media',


### PR DESCRIPTION
Adds taxonomy access perm to authenticated user role.
Task: https://va-gov.atlassian.net/browse/VAGOV-4035

**QA:**

- As and admin, visit `admin/people/permissions`
- Visually verify that `Access the taxonomy vocabulary overview page
- Get an overview of all taxonomy vocabularies.` is set to `authenticated user`