### PR TITLE
VAGOV-3365 migrate meta title

### DIFF
--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: 57f4b79d-c515-4aab-b77c-c6b3ed9c3ef7
+uuid: 77325b2c-8ded-4cf6-87d4-b402c577fa4a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_careers.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_careers.yml
@@ -1,4 +1,4 @@
-uuid: a0c1ea49-a056-4dde-a157-4da2c01767a7
+uuid: 279dda86-964b-4048-946f-dd078fcd394c
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: pFYiV_yw4vUwnMWj3X5-lHAUs_EkDTSnngOl5Adfl0I
+  default_config_hash: L54dHnV6nwdyXy3swDL9hZsnKrhYPp7hKyhoKNd_BxQ
 id: va_benefits_careers
 class: null
 field_plugin_method: null
@@ -24,6 +24,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
   migration_tools:
     -
       source: url
@@ -33,7 +34,7 @@ source:
           operation: modifier
           modifier: basicCleanup
       fields:
-        title:
+        page_title:
           obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleNoCaseChange
           jobs:
             -
@@ -106,7 +107,7 @@ source:
       dom_operations:
         -
           operation: get_field
-          field: title
+          field: page_title
         -
           operation: get_field
           field: intro_text
@@ -140,8 +141,20 @@ source:
         -
           operation: get_field
           field: body
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 process:
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/config/sync/migrate_plus.migration.va_benefits_careers_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_careers_menu.yml
@@ -1,4 +1,4 @@
-uuid: 841bbac6-b614-4e7a-817b-77197e606ade
+uuid: 4e39c295-5c11-45a9-9e44-b800693960fe
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_menu.yml
@@ -1,4 +1,4 @@
-uuid: 921d8395-90df-4477-a8db-5d4f33ee1830
+uuid: 620dfded-f1a2-414c-9545-ccd08fe03f01
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_pension.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_pension.yml
@@ -1,4 +1,4 @@
-uuid: 6e4c953a-0c64-4b32-9ab5-5ef7526f6624
+uuid: e3088a6f-6f6c-4635-a161-42fb63fcf280
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: V_6vyKiqTYvN9g6il3189C4NmIuS40dzUcSxxvDXszQ
+  default_config_hash: fgRx7hUeroLNuk4nPxDkDlSUVymoDfd6kE_4muMS1UQ
 id: va_benefits_pension
 class: null
 field_plugin_method: null
@@ -24,6 +24,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
   migration_tools:
     -
       source: url
@@ -33,7 +34,7 @@ source:
           operation: modifier
           modifier: basicCleanup
       fields:
-        title:
+        page_title:
           obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleNoCaseChange
           jobs:
             -
@@ -106,7 +107,7 @@ source:
       dom_operations:
         -
           operation: get_field
-          field: title
+          field: page_title
         -
           operation: get_field
           field: intro_text
@@ -140,8 +141,20 @@ source:
         -
           operation: get_field
           field: body
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 process:
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/config/sync/migrate_plus.migration.va_benefits_pension_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_pension_menu.yml
@@ -1,4 +1,4 @@
-uuid: a214ac86-4ea4-49e8-a2d9-bb24e6228887
+uuid: cc29e68f-3c30-4324-b65b-146749d0f609
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: 1e3c150f-09e0-4b57-8b9e-87035c1e2ea8
+uuid: 1ac202bc-e4d1-4bef-b48d-4ecf3ff2c939
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: 5WUPrkkHcnbFMsaomkaz9-_sUbHWlwoixuiymRnoKEA
+  default_config_hash: Y-bU9HdVSli_2_uN9OKeKoaR7I3qv_IigAfFnyfZ81s
 id: va_hub
 class: null
 field_plugin_method: null
@@ -25,6 +25,7 @@ source:
     - plainlanguage_date
     - lastupdate
     - social
+    - title
   migration_tools:
     -
       source: url
@@ -34,7 +35,7 @@ source:
           operation: modifier
           modifier: basicCleanup
       fields:
-        title:
+        page_title:
           obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleNoCaseChange
           jobs:
             -
@@ -118,7 +119,7 @@ source:
       dom_operations:
         -
           operation: get_field
-          field: title
+          field: page_title
         -
           operation: get_field
           field: intro_text
@@ -169,8 +170,20 @@ source:
         -
           operation: get_field
           field: hub_links
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 process:
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp: lastupdate
   field_intro_text: intro_text
   field_description: description

--- a/config/sync/migrate_plus.migration.va_main_menu.yml
+++ b/config/sync/migrate_plus.migration.va_main_menu.yml
@@ -1,4 +1,4 @@
-uuid: 070fc043-480c-4a0f-994d-25d30f086500
+uuid: a15118f8-63d9-43a0-89d4-f8e3550b37d1
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_hubs.yml
+++ b/config/sync/migrate_plus.migration.va_new_hubs.yml
@@ -1,4 +1,4 @@
-uuid: 07a1a553-9e30-4798-8f28-3d485715877c
+uuid: 42043fe6-31fa-452a-913d-3f7259b2c6f1
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: '-_O6hgxrKHJB4xKM-C1tlpRw6IHJshzFW2H41dLgdM0'
+  default_config_hash: JUHRzsgJpxaS6nYJ4UO17Fc-njZHgYaJ11qGRCTsm4s
 id: va_new_hubs
 class: null
 field_plugin_method: null
@@ -33,6 +33,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
   migration_tools:
     -
       source: url
@@ -42,7 +43,7 @@ source:
           operation: modifier
           modifier: basicCleanup
       fields:
-        title:
+        page_title:
           obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleNoCaseChange
           jobs:
             -
@@ -115,7 +116,7 @@ source:
       dom_operations:
         -
           operation: get_field
-          field: title
+          field: page_title
         -
           operation: get_field
           field: intro_text
@@ -149,8 +150,20 @@ source:
         -
           operation: get_field
           field: body
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 process:
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/config/sync/migrate_plus.migration.va_new_landing_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_landing_pages.yml
@@ -1,4 +1,4 @@
-uuid: 521478df-a6e2-44d6-9944-86320149f925
+uuid: e861d083-8225-4d83-9f4b-c2a702a2e538
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: Ph0uz0B_Y-OEQh5X6tYRoEhAm9WNfMGVzZQEbVHYwik
+  default_config_hash: lt5EgpvedXyFOyeeEzt3GmH5n9pItBS6DlGv5hoqxgE
 id: va_new_landing_pages
 class: null
 field_plugin_method: null
@@ -34,6 +34,7 @@ source:
     - plainlanguage_date
     - lastupdate
     - social
+    - title
   migration_tools:
     -
       source: url
@@ -43,7 +44,7 @@ source:
           operation: modifier
           modifier: basicCleanup
       fields:
-        title:
+        page_title:
           obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleNoCaseChange
           jobs:
             -
@@ -127,7 +128,7 @@ source:
       dom_operations:
         -
           operation: get_field
-          field: title
+          field: page_title
         -
           operation: get_field
           field: intro_text
@@ -178,8 +179,20 @@ source:
         -
           operation: get_field
           field: hub_links
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 process:
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp: lastupdate
   field_intro_text: intro_text
   field_description: description

--- a/config/sync/migrate_plus.migration.va_new_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_pages.yml
@@ -1,4 +1,4 @@
-uuid: 60f2df14-a415-4408-9fd7-640316f83d61
+uuid: ed88a514-70d1-47cd-aeda-7e6a888244b4
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: O9ICiOSfxYew0IHtefTTLJFmtVynxc3hBz9N5nXfsFc
+  default_config_hash: Rmh2SDBSTNHkwA8lcf8FuGpzcM-YwT6rPO0OiaxX3qU
 id: va_new_pages
 class: null
 field_plugin_method: null
@@ -30,6 +30,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
   migration_tools:
     -
       source: url
@@ -39,7 +40,7 @@ source:
           operation: modifier
           modifier: basicCleanup
       fields:
-        title:
+        page_title:
           obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleNoCaseChange
           jobs:
             -
@@ -112,7 +113,7 @@ source:
       dom_operations:
         -
           operation: get_field
-          field: title
+          field: page_title
         -
           operation: get_field
           field: intro_text
@@ -146,8 +147,20 @@ source:
         -
           operation: get_field
           field: body
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 process:
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: 7174b3c5-0674-4ff4-9cd0-de03e371b94a
+uuid: cf176d30-8ced-4ed9-9d11-244170cd07ba
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: 6cd5a306-64b6-4bcb-b924-4905488143ac
+uuid: 57426d90-f3e6-475a-b93f-910f800fd381
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: f0e7edde-0391-494c-a723-360cabb6a1da
+uuid: b09630cb-c472-40cf-91e6-ef9092a7c70a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_root_pages.yml
+++ b/config/sync/migrate_plus.migration.va_root_pages.yml
@@ -1,4 +1,4 @@
-uuid: 9d82db64-d087-4584-8f3b-23fe82dcf8c9
+uuid: baa6106c-d5bf-4861-b26c-597dd96f14b9
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,7 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: 0oX_zqruupz3Y94vQR0fU6_n_q0xqIqtjhytpam7QRU
+  default_config_hash: NJn61QYNR3yRyFTXMwalePOSTNpOx-q2vdOgaAkQ610
 id: va_root_pages
 class: null
 field_plugin_method: null
@@ -21,7 +21,6 @@ source:
     - /change-direct-deposit.md
     - /claim-or-appeal-status.md
     - /privacy-policy.md
-    - /session-expired.md
     - /sign-in-faq.md
     - /va-payment-history.md
     - /veterans-portrait-project.md
@@ -30,6 +29,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
   migration_tools:
     -
       source: url
@@ -39,7 +39,7 @@ source:
           operation: modifier
           modifier: basicCleanup
       fields:
-        title:
+        page_title:
           obtainer: \Drupal\va_gov_migrate\Obtainer\ObtainTitleNoCaseChange
           jobs:
             -
@@ -120,7 +120,7 @@ source:
       dom_operations:
         -
           operation: get_field
-          field: title
+          field: page_title
         -
           operation: get_field
           field: intro_text
@@ -154,8 +154,20 @@ source:
         -
           operation: get_field
           field: body
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 process:
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: c22da51d-e0d5-4a5a-b9ac-f8e39b86458d
+uuid: 0b0f65d9-9587-4871-a75f-61ba97c3917c
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: c2fadd37-3bcc-48a6-b58d-c9b1debd9229
+uuid: 421485ba-0f5c-486a-9450-83a3b6e7c7d4
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_new_benefits.yml
+++ b/config/sync/migrate_plus.migration_group.va_new_benefits.yml
@@ -1,4 +1,4 @@
-uuid: 40a6102e-5753-4616-97a6-d888e4986836
+uuid: 50768e4f-48d7-4563-98e8-88084bee740c
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_tests.yml
+++ b/config/sync/migrate_plus.migration_group.va_tests.yml
@@ -1,4 +1,4 @@
-uuid: d52dd8f0-3661-4318-a188-3a480a99c057
+uuid: 9a819cdf-619d-4ca7-9896-d6f4b4b6830a
 langcode: en
 status: true
 dependencies:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_careers.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_careers.yml
@@ -11,6 +11,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
 
   migration_tools:
     -
@@ -23,7 +24,7 @@ source:
           operation: modifier
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
-        title:  # This is the recipe for a field called 'title'.
+        page_title:  # This is the recipe for a field called 'title'.
           obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
           jobs:
             -
@@ -96,7 +97,7 @@ source:
         -
           # This runs first.
           operation: get_field
-          field: title  # Use the 'title' recipe from above to create the field.
+          field: page_title  # Use the 'title' recipe from above to create the field.
         -
           # This runs next.
           operation: get_field
@@ -136,9 +137,21 @@ source:
         -
           operation: get_field
           field: body  # Now that we've plucked all the other fields and cleaned up, run the 'body' recipe on what's left.
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
 
 process:  # assign the fields we collected above to Drupal fields.
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_pension.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_pension.yml
@@ -11,6 +11,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
 
   migration_tools:
     -
@@ -23,7 +24,7 @@ source:
           operation: modifier
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
-        title:  # This is the recipe for a field called 'title'.
+        page_title:  # This is the recipe for a field called 'title'.
           obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
           jobs:
             -
@@ -96,7 +97,7 @@ source:
         -
           # This runs first.
           operation: get_field
-          field: title  # Use the 'title' recipe from above to create the field.
+          field: page_title  # Use the 'title' recipe from above to create the field.
         -
           # This runs next.
           operation: get_field
@@ -137,8 +138,21 @@ source:
           operation: get_field
           field: body  # Now that we've plucked all the other fields and cleaned up, run the 'body' recipe on what's left.
 
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
 process:  # assign the fields we collected above to Drupal fields.
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
@@ -22,6 +22,7 @@ source:
     - plainlanguage_date
     - lastupdate
     - social
+    - title
 
   migration_tools:
   -
@@ -34,7 +35,7 @@ source:
       operation: modifier
       modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
     fields:
-      title:  # This is the recipe for a field called 'title'.
+      page_title:  # This is the recipe for a field called 'title'.
         obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
         jobs:
         -
@@ -122,7 +123,7 @@ source:
     -
       # This runs first.
       operation: get_field
-      field: title  # Use the 'title' recipe from above to create the field.
+      field: page_title  # Use the 'title' recipe from above to create the field.
     -
       # This runs next.
       operation: get_field
@@ -183,8 +184,21 @@ source:
       operation: get_field
       field: hub_links
 
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
 process:  # assign the fields we collected above to Drupal fields.
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp: lastupdate
   field_intro_text: intro_text
   field_description: description

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_hubs.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_hubs.yml
@@ -20,6 +20,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
 
   migration_tools:
   -
@@ -32,7 +33,7 @@ source:
       operation: modifier
       modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
     fields:
-      title:  # This is the recipe for a field called 'title'.
+      page_title:  # This is the recipe for a field called 'title'.
         obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
         jobs:
         -
@@ -106,7 +107,7 @@ source:
     -
       # This runs first.
       operation: get_field
-      field: title  # Use the 'title' recipe from above to create the field.
+      field: page_title  # Use the 'title' recipe from above to create the field.
     -
       # This runs next.
       operation: get_field
@@ -147,8 +148,21 @@ source:
       operation: get_field
       field: body  # Now that we've plucked all the other fields and cleaned up, run the 'body' recipe on what's left.
 
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
 process:  # assign the fields we collected above to Drupal fields.
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_landing_pages.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_landing_pages.yml
@@ -22,6 +22,7 @@ source:
     - plainlanguage_date
     - lastupdate
     - social
+    - title
 
   migration_tools:
     -
@@ -34,7 +35,7 @@ source:
           operation: modifier
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
-        title:  # This is the recipe for a field called 'title'.
+        page_title:  # This is the recipe for a field called 'title'.
           obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
           jobs:
             -
@@ -122,7 +123,7 @@ source:
         -
           # This runs first.
           operation: get_field
-          field: title  # Use the 'title' recipe from above to create the field.
+          field: page_title  # Use the 'title' recipe from above to create the field.
         -
           # This runs next.
           operation: get_field
@@ -183,8 +184,21 @@ source:
           operation: get_field
           field: hub_links
 
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
 process:  # assign the fields we collected above to Drupal fields.
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp: lastupdate
   field_intro_text: intro_text
   field_description: description

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_pages.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_new_pages.yml
@@ -17,6 +17,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
 
   migration_tools:
     -
@@ -29,7 +30,7 @@ source:
           operation: modifier
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
-        title:  # This is the recipe for a field called 'title'.
+        page_title:  # This is the recipe for a field called 'title'.
           obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
           jobs:
             -
@@ -102,7 +103,7 @@ source:
         -
           # This runs first.
           operation: get_field
-          field: title  # Use the 'title' recipe from above to create the field.
+          field: page_title  # Use the 'title' recipe from above to create the field.
         -
           # This runs next.
           operation: get_field
@@ -143,8 +144,21 @@ source:
           operation: get_field
           field: body  # Now that we've plucked all the other fields and cleaned up, run the 'body' recipe on what's left.
 
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
 process:  # assign the fields we collected above to Drupal fields.
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_root_pages.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_root_pages.yml
@@ -16,6 +16,7 @@ source:
     - description
     - plainlanguage_date
     - lastupdate
+    - title
 
   migration_tools:
     -
@@ -28,7 +29,7 @@ source:
           operation: modifier
           modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
       fields:
-        title:  # This is the recipe for a field called 'title'.
+        page_title:  # This is the recipe for a field called 'title'.
           obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
           jobs:
             -
@@ -109,7 +110,7 @@ source:
         -
           # This runs first.
           operation: get_field
-          field: title  # Use the 'title' recipe from above to create the field.
+          field: page_title  # Use the 'title' recipe from above to create the field.
         -
           # This runs next.
           operation: get_field
@@ -150,8 +151,21 @@ source:
           operation: get_field
           field: body  # Now that we've plucked all the other fields and cleaned up, run the 'body' recipe on what's left.
 
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
 process:  # assign the fields we collected above to Drupal fields.
-  title: title
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
   revision_timestamp:
     -
       plugin: default_value

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_root_pages.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_root_pages.yml
@@ -8,7 +8,6 @@ source:
     - "/change-direct-deposit.md"
     - "/claim-or-appeal-status.md"
     - "/privacy-policy.md"
-    - "/session-expired.md"
     - "/sign-in-faq.md"
     - "/va-payment-history.md"
     - "/veterans-portrait-project.md"


### PR DESCRIPTION
To test: 
1. Go to /admin/structure/migrate/manage/va_new_benefits/migrations/va_benefits_careers/execute and run the migration
2. Go to /admin/content?title=&type=page&moderation_state=editorial-draft and view or edit a node with Owner, "Careers and employment benefits hub". Confirm that the "Meta title tag" field contains the page title with the first letter of each word upper cased followed by " | Veterans Affairs". 

Note that testing should be done on the testing env, not locally. The migration needs an ENV var that's not usually on local.