### PR TITLE
VAGOV-4154: Changing additional info event field to rich text.

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -124,12 +124,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_additional_information_abo:
-    weight: 34
+    weight: 41
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: string_textarea
+    type: text_textarea
     region: content
   field_address:
     weight: 40

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -103,11 +103,11 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_additional_information_abo:
-    weight: 19
+    weight: 29
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    type: text_default
     region: content
   field_address:
     weight: 15

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.event.field_additional_information_abo
     - field.field.node.event.field_address
     - field.field.node.event.field_administration
     - field.field.node.event.field_body
@@ -36,7 +35,6 @@ content:
     region: content
 hidden:
   content_moderation_control: true
-  field_additional_information_abo: true
   field_address: true
   field_administration: true
   field_body: true

--- a/config/sync/field.field.node.event.field_additional_information_abo.yml
+++ b/config/sync/field.field.node.event.field_additional_information_abo.yml
@@ -1,19 +1,21 @@
-uuid: 50282ca7-b7e5-4990-be89-eb2c83f0dced
+uuid: 4816b16a-6f64-4237-9435-d7ba0b53774d
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_additional_information_abo
     - node.type.event
+  module:
+    - text
 id: node.event.field_additional_information_abo
 field_name: field_additional_information_abo
 entity_type: node
 bundle: event
 label: 'Additional information about registration'
-description: 'Eg: "Call 412-360-3520".'
+description: ''
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string_long
+field_type: text_long

--- a/config/sync/field.storage.node.field_additional_information_abo.yml
+++ b/config/sync/field.storage.node.field_additional_information_abo.yml
@@ -1,16 +1,16 @@
-uuid: 07015e5a-4bb0-46ea-a1c6-9a8db801595e
+uuid: 27193f11-0a35-4835-a3e1-5c040763c322
 langcode: en
 status: true
 dependencies:
   module:
     - node
+    - text
 id: node.field_additional_information_abo
 field_name: field_additional_information_abo
 entity_type: node
-type: string_long
-settings:
-  case_sensitive: false
-module: core
+type: text_long
+settings: {  }
+module: text
 locked: false
 cardinality: 1
 translatable: true

--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -71,7 +71,7 @@ filters:
   filter_url:
     id: filter_url
     provider: filter
-    status: false
+    status: true
     weight: -42
     settings:
       filter_url_length: 72

--- a/config/sync/node_revisions_autoclean.settings.yml
+++ b/config/sync/node_revisions_autoclean.settings.yml
@@ -4,35 +4,35 @@ _core:
   default_config_hash: UblN00sCWoyDV-yZe4SE80vKQEQmZHLWmxtaQmJLLaI
 node:
   documentation_page: 50
-  event: '50'
+  event: 50
   health_care_local_facility: 50
   health_care_region_detail_page: 50
-  health_care_region_page: '50'
+  health_care_region_page: 50
   landing_page: 50
-  news_story: '50'
+  news_story: 50
   office: 50
   outreach_asset: 50
   page: 100
-  person_profile: '50'
-  press_release: '50'
-  regional_health_care_service_des: '50'
-  support_service: '50'
+  person_profile: 50
+  press_release: 50
+  regional_health_care_service_des: 50
+  support_service: 50
   library: 0
-  health_care_local_health_service: '0'
+  health_care_local_health_service: 0
 interval:
   documentation_page: '0'
-  event: 0
+  event: '0'
   health_care_local_facility: '0'
   health_care_region_detail_page: '0'
-  health_care_region_page: 0
+  health_care_region_page: '0'
   landing_page: '0'
-  news_story: 0
+  news_story: '0'
   office: '0'
   outreach_asset: '0'
   page: '0'
-  person_profile: 0
-  press_release: 0
-  regional_health_care_service_des: 0
-  support_service: 0
+  person_profile: '0'
+  press_release: '0'
+  regional_health_care_service_des: '0'
+  support_service: '0'
   library: '0'
-  health_care_local_health_service: 0
+  health_care_local_health_service: '0'


### PR DESCRIPTION
This changes the additional info field on event nodes to be rich text.
Use case: we need hyperlinks to automagically become hyperlinks. This isn't possible with plain text.