### PR TITLE
VAGOV-4506: Allow login-required class in rich text.

### DIFF
--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -47,7 +47,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <hr> <br> <drupal-entity data-* title alt> <p class="va-address-block"> <a href hreflang class=" usa-button usa-button-primary usa-button-secondary va-button-primary">'
+      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <hr> <br> <drupal-entity data-* title alt> <p class="va-address-block"> <a href hreflang class=" usa-button usa-button-primary usa-button-secondary va-button-primary login-required">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:


### PR DESCRIPTION
QA: 
1. Edit a WYSWIYG field with a link in it (eg node/195/edit)
2. Click "Source" button in WYSIWYG
3. Add `login-required` class to link
4. Save node
5. you should see the class on the link (no need to preview)