### PR TITLE
VAGOV-4302: life insurance migration

### DIFF
--- a/config/sync/menu_breadcrumb.settings.yml
+++ b/config/sync/menu_breadcrumb.settings.yml
@@ -64,6 +64,11 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
+  life-insurance-benefits-hub:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
   sections:
     weight: 0
     enabled: 0

--- a/config/sync/migrate_plus.migration.va_alert_block.yml
+++ b/config/sync/migrate_plus.migration.va_alert_block.yml
@@ -1,4 +1,4 @@
-uuid: 46b76c36-0cab-42b3-b4c4-f9f2fd8688ea
+uuid: ac705221-7100-4b93-adae-736e778879ca
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_careers.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_careers.yml
@@ -1,4 +1,4 @@
-uuid: 3e08b6e5-4a2d-4561-b015-95414fe0038e
+uuid: 41de459b-41aa-460c-a7c3-737aa06c6c1b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_careers_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_careers_menu.yml
@@ -1,4 +1,4 @@
-uuid: d27bdf5f-3f75-4d9f-a1d3-74db559147ca
+uuid: ce429838-ac9f-49b9-b3f5-5dc2360182f1
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_housing.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_housing.yml
@@ -1,4 +1,4 @@
-uuid: 2735f6b2-c0ef-4d17-a46e-ea072349099f
+uuid: 0ab670b9-027f-4a7a-b479-9c9915c46d5c
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_housing_extra.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_housing_extra.yml
@@ -1,4 +1,4 @@
-uuid: 07929800-b090-4065-a84f-20efd3d68c86
+uuid: 174d628f-ab51-4a13-b0b8-937bec948365
 langcode: en
 status: true
 dependencies:
@@ -6,34 +6,30 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: JUHRzsgJpxaS6nYJ4UO17Fc-njZHgYaJ11qGRCTsm4s
-id: va_new_hubs
+  default_config_hash: jaRDU_6z8CiDiOM7pB61MiBiKPHhnaZ4ZmXmGVmtiOM
+id: va_benefits_housing_extra
 class: null
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null
-migration_group: va_tests
-label: 'Migrate Remaining benefits detail pages from VA.gov'
+migration_group: va_new_benefits
+label: 'Migrate additional Housing benefits pages from Heroku'
 source:
-  plugin: metalsmith_source
-  urls:
-    - /disability
-    - /education
-    - /careers-employment
-    - /pension
-    - /housing-assistance
-    - /life-insurance
-    - /burials-memorials
-    - /records
-    - /decision-reviews
-    - /discharge-upgrade-instructions
-  templates:
-    - detail-page
-  fields:
-    - description
-    - plainlanguage_date
-    - lastupdate
-    - title
+  plugin: embedded_data
+  data_rows:
+    -
+      title: 'VA Home Loan Limits'
+      url: 'https://vagov-content-pr-325.herokuapp.com/housing-assistance/home-loans/loan-limits/'
+      description: 'Learn about VA home loan limits (also called VA home loan maximums). Find out the current loan limits and how they may affect the amount of money you can borrow using a VA-backed home loan, without a down payment.'
+      lastupdate: 0
+    -
+      title: 'VA Funding Fee And Loan Closing Costs'
+      url: 'https://vagov-content-pr-325.herokuapp.com/housing-assistance/home-loans/funding-fee-and-closing-costs/'
+      description: 'The VA funding fee is a one-time payment that the Veteran, service member, or survivor pays on a VA-backed or VA direct home loan. Learn about the VA funding fee and other loan closing costs you may need to pay on your loan.'
+      lastupdate: 0
+  ids:
+    url:
+      type: string
   migration_tools:
     -
       source: url
@@ -79,7 +75,7 @@ source:
               job: addSearch
               method: pluckSelectorAndTest
               arguments:
-                - .usa-alert
+                - .usa-alert-heading
                 - '@title'
                 - '@url'
         related_links:
@@ -185,7 +181,7 @@ process:
   field_administration:
     -
       plugin: default_value
-      default_value: 51
+      default_value: 68
   moderation_state:
     plugin: default_value
     default_value: draft

--- a/config/sync/migrate_plus.migration.va_benefits_housing_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_housing_menu.yml
@@ -1,4 +1,4 @@
-uuid: 15656385-4021-4538-8988-78c5c8ff5835
+uuid: 87c9482d-4fcc-4576-8a36-58e57b1caca2
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_benefits_life_insurance.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_life_insurance.yml
@@ -1,4 +1,4 @@
-uuid: 07929800-b090-4065-a84f-20efd3d68c86
+uuid: a64f4a51-3843-47bd-8db0-5152dfae8490
 langcode: en
 status: true
 dependencies:
@@ -6,27 +6,18 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: JUHRzsgJpxaS6nYJ4UO17Fc-njZHgYaJ11qGRCTsm4s
-id: va_new_hubs
+  default_config_hash: cCpxfxg2kvOFo_FpNox9MrxJbnuHRg4iXHmaZ2MMmPk
+id: va_benefits_life_insurance
 class: null
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null
-migration_group: va_tests
-label: 'Migrate Remaining benefits detail pages from VA.gov'
+migration_group: va_new_benefits
+label: 'Migrate Life insurance pages from va.gov'
 source:
   plugin: metalsmith_source
   urls:
-    - /disability
-    - /education
-    - /careers-employment
-    - /pension
-    - /housing-assistance
     - /life-insurance
-    - /burials-memorials
-    - /records
-    - /decision-reviews
-    - /discharge-upgrade-instructions
   templates:
     - detail-page
   fields:
@@ -79,7 +70,7 @@ source:
               job: addSearch
               method: pluckSelectorAndTest
               arguments:
-                - .usa-alert
+                - .usa-alert-heading
                 - '@title'
                 - '@url'
         related_links:
@@ -185,7 +176,7 @@ process:
   field_administration:
     -
       plugin: default_value
-      default_value: 51
+      default_value: 66
   moderation_state:
     plugin: default_value
     default_value: draft

--- a/config/sync/migrate_plus.migration.va_benefits_life_insurance_menu.yml
+++ b/config/sync/migrate_plus.migration.va_benefits_life_insurance_menu.yml
@@ -1,4 +1,4 @@
-uuid: e3b2f18a-0c83-4a3f-b5df-aa97264b41bb
+uuid: b0070d2e-d28f-4f06-a31d-1da88fb3a887
 langcode: en
 status: true
 dependencies:
@@ -6,18 +6,18 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: hOm-_djjsEKfWU8zVuCavEozHhbiEKTW4Lx8jtOFhLk
-id: va_benefits_menu
+  default_config_hash: timdsVm18UiraBSmo-MZ4w2rZN5HJd8lYB_qc3-BycY
+id: va_benefits_life_insurance_menu
 class: null
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null
-migration_group: va_tests
-label: 'Migrate health care sidebar menu'
+migration_group: va_new_benefits
+label: 'Migrate Life insurance sidebar menu'
 source:
   plugin: va_benefits_menu_source
   sections:
-    - Records
+    - 'Life insurance'
   constants:
     bundle: menu_link_content
     zero: 0

--- a/config/sync/migrate_plus.migration.va_hub.yml
+++ b/config/sync/migrate_plus.migration.va_hub.yml
@@ -1,4 +1,4 @@
-uuid: 4d7aef49-df9e-486b-85c5-4fa7c27b9b0b
+uuid: 461d05d6-411a-4b87-bdec-1deab96e396c
 langcode: en
 status: true
 dependencies:
@@ -6,18 +6,19 @@ dependencies:
     module:
       - va_gov_migrate
 _core:
-  default_config_hash: Y-bU9HdVSli_2_uN9OKeKoaR7I3qv_IigAfFnyfZ81s
+  default_config_hash: VwcI7pW_qmWsyg8KTnlDmclkSFw7_D6FAPxhV4KeLa0
 id: va_hub
 class: null
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null
 migration_group: va_new_benefits
-label: 'Migrate Careers & Employment landing page - NEVER ROLLBACK'
+label: 'Migrate Housing and Life insurance landing pages - NEVER ROLLBACK'
 source:
   plugin: metalsmith_source
   urls:
-    - /careers-employment/index.md
+    - /housing-assistance/index.md
+    - /life-insurance/index.md
   templates:
     - level2-index
   fields:

--- a/config/sync/migrate_plus.migration.va_main_menu.yml
+++ b/config/sync/migrate_plus.migration.va_main_menu.yml
@@ -1,4 +1,4 @@
-uuid: 56f58174-a3d7-491a-9f6c-c8a04635ce57
+uuid: f0fc2f3c-7ee0-44d5-aceb-fb9ca5a4300f
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_landing_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_landing_pages.yml
@@ -1,4 +1,4 @@
-uuid: 96b19cbf-c949-41a9-9073-3caf38a88d39
+uuid: 3b53d3cb-cc5a-4515-b7b6-beabcae0beef
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_new_pages.yml
+++ b/config/sync/migrate_plus.migration.va_new_pages.yml
@@ -1,4 +1,4 @@
-uuid: a6cf9b03-774e-40d9-9dd5-9a0d783d308c
+uuid: 14eef240-b249-41f8-9cfc-8f11d8b7819b
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo.yml
+++ b/config/sync/migrate_plus.migration.va_promo.yml
@@ -1,4 +1,4 @@
-uuid: 5df99b2f-524a-4af9-b6c2-3f85e4a9333c
+uuid: 45570aea-ae1b-405a-a695-cbafb87702f0
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_images.yml
+++ b/config/sync/migrate_plus.migration.va_promo_images.yml
@@ -1,4 +1,4 @@
-uuid: 331b34df-d500-4929-9089-fd1a7091a263
+uuid: 459d1e2c-d4b9-4be7-bc20-b073f39515f0
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_promo_media.yml
+++ b/config/sync/migrate_plus.migration.va_promo_media.yml
@@ -1,4 +1,4 @@
-uuid: 0096a1d9-c480-4001-a1f6-fc202e6a6975
+uuid: 564642e0-b035-48c2-99b4-5113d0638646
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_root_pages.yml
+++ b/config/sync/migrate_plus.migration.va_root_pages.yml
@@ -1,4 +1,4 @@
-uuid: 200c4c65-f4d3-404a-9f8c-ca769c137101
+uuid: 7a25c2b3-571e-496d-93bb-78de85e8ee59
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration.va_support_service.yml
+++ b/config/sync/migrate_plus.migration.va_support_service.yml
@@ -1,4 +1,4 @@
-uuid: a31fe66f-340b-450b-8393-ecbe393b3f16
+uuid: b59c0217-aa11-4eca-a9da-9dfc617dbc7d
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_gov.yml
+++ b/config/sync/migrate_plus.migration_group.va_gov.yml
@@ -1,4 +1,4 @@
-uuid: 99d6dfe0-a661-4e67-a142-44626e016fc1
+uuid: 0fc68292-db4c-49e6-99f6-b33d21784ccc
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_new_benefits.yml
+++ b/config/sync/migrate_plus.migration_group.va_new_benefits.yml
@@ -1,4 +1,4 @@
-uuid: f73aac4b-5248-49bf-a871-a967b0c8bdb9
+uuid: 48a6ce78-555d-4a03-b3c5-4b9616f748ed
 langcode: en
 status: true
 dependencies:

--- a/config/sync/migrate_plus.migration_group.va_tests.yml
+++ b/config/sync/migrate_plus.migration_group.va_tests.yml
@@ -1,4 +1,4 @@
-uuid: 4cda927c-35ca-4564-b1fe-9b54bdb8c062
+uuid: 9ce2ed98-318f-4d5d-a37d-325d7ca0d16c
 langcode: en
 status: true
 dependencies:

--- a/config/sync/node.type.page.yml
+++ b/config/sync/node.type.page.yml
@@ -11,6 +11,7 @@ third_party_settings:
       - careers-employment-benefits
       - health-care-benefits-hub
       - housing-assistance-benefits
+      - life-insurance-benefits-hub
       - pension-benefits-hub
       - records-benefits-hub
     parent: 'health-care-benefits-hub:'

--- a/config/sync/system.menu.life-insurance-benefits-hub.yml
+++ b/config/sync/system.menu.life-insurance-benefits-hub.yml
@@ -1,0 +1,8 @@
+uuid: 8a4eca34-ad64-4688-8c53-db46e06130db
+langcode: en
+status: true
+dependencies: {  }
+id: life-insurance-benefits-hub
+label: 'Life insurance benefits hub'
+description: va.gov/life-insurance
+locked: false

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_housing_extra.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_housing_extra.yml
@@ -1,0 +1,198 @@
+id: va_benefits_housing_extra
+label: Migrate additional Housing benefits pages from Heroku
+migration_group: va_new_benefits
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      title: 'VA Home Loan Limits'
+      url: 'https://vagov-content-pr-325.herokuapp.com/housing-assistance/home-loans/loan-limits/'
+      description: 'Learn about VA home loan limits (also called VA home loan maximums). Find out the current loan limits and how they may affect the amount of money you can borrow using a VA-backed home loan, without a down payment.'
+      lastupdate: 0
+    -
+      title: 'VA Funding Fee And Loan Closing Costs'
+      url: 'https://vagov-content-pr-325.herokuapp.com/housing-assistance/home-loans/funding-fee-and-closing-costs/'
+      description: 'The VA funding fee is a one-time payment that the Veteran, service member, or survivor pays on a VA-backed or VA direct home loan. Learn about the VA funding fee and other loan closing costs you may need to pay on your loan.'
+      lastupdate: 0
+  ids:
+    url:
+      type: string
+
+  migration_tools:
+    -
+      # Just leave this as is, if using metalsmith_source or url_list source.
+      source: url # The field we're passing to migration_tools is called 'url'.
+      source_type: url  # Source type can be either 'url' or 'html'.
+
+      source_operations:
+        -
+          operation: modifier
+          modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
+      fields:
+        page_title:  # This is the recipe for a field called 'title'.
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
+          jobs:
+            -
+              job: addSearch  # Run a job to search the DOM and assign the results to this field.
+              method: pluckSelector # Also remove it from the DOM (so it doesn't show up in body, too).
+              arguments:
+                - 'h1'  # Look for h1 tags.
+        intro_text:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAndTestPlainTextWithNewLines"
+          jobs:
+            -
+              job: addSearch
+              method: pluckSelectorAndTest
+              arguments:
+                - '.va-introtext'
+                - '@title'
+                - '@url'
+        featured_content:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAndTestFeature"
+          jobs:
+            -
+              job: addSearch
+              method: pluckSelectorAndTest
+              arguments:
+                - '.feature' # find something with class, 'feature'
+                - '@title'
+                - '@url'
+                - innerHTML  # Get any html it contains.
+        alert_title:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAlertBlockTitles"
+          jobs:
+            - job: 'addSearch'
+              method: 'pluckSelectorAndTest'
+              arguments:
+                - '.usa-alert-heading'
+                - '@title'
+                - '@url'
+        related_links:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '.va-nav-linkslist--related'
+                - '1'
+                - innerHTML
+        body:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAndTestBody"
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelectorAndTest'
+              arguments:
+                - 'article'
+                - '@title'
+                - '@url'
+                - innerHTML
+        nav_linkslist:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - 'aside.va-nav-linkslist'
+                - '1'
+                - innerHTML
+      dom_operations:
+        -
+          # This runs first.
+          operation: get_field
+          field: page_title  # Use the 'title' recipe from above to create the field.
+        -
+          # This runs next.
+          operation: get_field
+          field: intro_text
+        -
+          # And so on...
+          operation: get_field
+          field: featured_content
+        -
+          # Remove expander trigger before getting alert title
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - '#crisis-expander-link'
+        -
+          operation: get_field
+          field: alert_title
+        -
+          operation: get_field
+          field: related_links
+        -
+          operation: get_field
+          field: nav_linkslist
+        -
+          # Clean things up before getting the body.
+          # Remove javascript cruft.
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'button.va-btn-sidebarnav-trigger'
+        -
+          # Remove any scripts
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'script'
+        -
+          operation: get_field
+          field: body  # Now that we've plucked all the other fields and cleaned up, run the 'body' recipe on what's left.
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
+process:  # assign the fields we collected above to Drupal fields.
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
+  revision_timestamp:
+    -
+      plugin: default_value
+      source: lastupdate
+      default_value: 1
+  changed:
+    -
+      plugin: default_value
+      source: lastupdate
+      default_value: 1
+  field_intro_text: intro_text
+  field_description: description
+  field_plainlanguage_date:
+    plugin: format_date
+    from_format: 'n/j/y'
+    to_format: 'Y-m-d'
+    source: plainlanguage_date
+  'field_alert/target_id': alert_title
+  field_administration:
+    -
+      plugin: default_value
+      default_value: 68
+  moderation_state:
+    plugin: default_value
+    default_value: draft
+  type:
+    plugin: default_value   # We want to assign the 'type' field a static value.
+    default_value: page # The value is 'page'.
+
+destination:
+  plugin: 'entity:node'
+
+migration_dependencies: {}
+
+# This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate  # The module this migration script belongs to.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_life_insurance.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_life_insurance.yml
@@ -1,0 +1,193 @@
+id: va_benefits_life_insurance
+label: Migrate Life insurance pages from va.gov
+migration_group: va_new_benefits
+source:
+  plugin: metalsmith_source  # This is where the page urls and frontmatter come from (see MetalsmithSource.php)
+  urls:     # This can be a list urls to crawl or .md files to read.
+    - "/life-insurance"
+  templates:  # A list of Metalsmith templates to process (detail-page=basic page, level2-index=hub page)
+    - detail-page
+  fields:  # :ist any frontmatter fields you want to migrate.
+    - description
+    - plainlanguage_date
+    - lastupdate
+    - title
+
+  migration_tools:
+    -
+      # Just leave this as is, if using metalsmith_source or url_list source.
+      source: url # The field we're passing to migration_tools is called 'url'.
+      source_type: url  # Source type can be either 'url' or 'html'.
+
+      source_operations:
+        -
+          operation: modifier
+          modifier: basicCleanup  # Tell migration_tools to run some basic cleanup of the page it just read.
+      fields:
+        page_title:  # This is the recipe for a field called 'title'.
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainTitleNoCaseChange"
+          jobs:
+            -
+              job: addSearch  # Run a job to search the DOM and assign the results to this field.
+              method: pluckSelector # Also remove it from the DOM (so it doesn't show up in body, too).
+              arguments:
+                - 'h1'  # Look for h1 tags.
+        intro_text:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAndTestPlainTextWithNewLines"
+          jobs:
+            -
+              job: addSearch
+              method: pluckSelectorAndTest
+              arguments:
+                - '.va-introtext'
+                - '@title'
+                - '@url'
+        featured_content:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAndTestFeature"
+          jobs:
+            -
+              job: addSearch
+              method: pluckSelectorAndTest
+              arguments:
+                - '.feature' # find something with class, 'feature'
+                - '@title'
+                - '@url'
+                - innerHTML  # Get any html it contains.
+        alert_title:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAlertBlockTitles"
+          jobs:
+            - job: 'addSearch'
+              method: 'pluckSelectorAndTest'
+              arguments:
+                - '.usa-alert-heading'
+                - '@title'
+                - '@url'
+        related_links:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '.va-nav-linkslist--related'
+                - '1'
+                - innerHTML
+        body:
+          obtainer: "\\Drupal\\va_gov_migrate\\Obtainer\\ObtainAndTestBody"
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelectorAndTest'
+              arguments:
+                - 'article'
+                - '@title'
+                - '@url'
+                - innerHTML
+        nav_linkslist:
+          obtainer: ObtainHtml
+          jobs:
+            -
+              job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - 'aside.va-nav-linkslist'
+                - '1'
+                - innerHTML
+      dom_operations:
+        -
+          # This runs first.
+          operation: get_field
+          field: page_title  # Use the 'title' recipe from above to create the field.
+        -
+          # This runs next.
+          operation: get_field
+          field: intro_text
+        -
+          # And so on...
+          operation: get_field
+          field: featured_content
+        -
+          # Remove expander trigger before getting alert title
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - '#crisis-expander-link'
+        -
+          operation: get_field
+          field: alert_title
+        -
+          operation: get_field
+          field: related_links
+        -
+          operation: get_field
+          field: nav_linkslist
+        -
+          # Clean things up before getting the body.
+          # Remove javascript cruft.
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'button.va-btn-sidebarnav-trigger'
+        -
+          # Remove any scripts
+          operation: modifier
+          modifier: removeSelectorAll
+          arguments:
+            - 'script'
+        -
+          operation: get_field
+          field: body  # Now that we've plucked all the other fields and cleaned up, run the 'body' recipe on what's left.
+  constants:
+    meta_title_suffix: ' | Veterans Affairs'
+
+process:  # assign the fields we collected above to Drupal fields.
+  title: page_title
+  meta_title:
+    plugin: substr
+    source: title
+    length: 51
+  field_meta_title:
+    -
+      plugin: concat
+      source:
+        - '@meta_title'
+        - constants/meta_title_suffix
+  revision_timestamp:
+    -
+      plugin: default_value
+      source: lastupdate
+      default_value: 1
+  changed:
+    -
+      plugin: default_value
+      source: lastupdate
+      default_value: 1
+  field_intro_text: intro_text
+  field_description: description
+  field_plainlanguage_date:
+    plugin: format_date
+    from_format: 'n/j/y'
+    to_format: 'Y-m-d'
+    source: plainlanguage_date
+  'field_alert/target_id': alert_title
+  field_administration:
+    -
+      plugin: default_value
+      default_value: 66
+  moderation_state:
+    plugin: default_value
+    default_value: draft
+  type:
+    plugin: default_value   # We want to assign the 'type' field a static value.
+    default_value: page # The value is 'page'.
+
+destination:
+  plugin: 'entity:node'
+
+migration_dependencies: {}
+
+# This belongs in all migration scripts. Without it the module the migration script belongs to won't uninstall cleanly.
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate  # The module this migration script belongs to.

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_life_insurance_menu.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_benefits_life_insurance_menu.yml
@@ -1,0 +1,43 @@
+id: va_benefits_life_insurance_menu
+label: Migrate Life insurance sidebar menu
+migration_group: va_new_benefits
+
+source:
+  plugin: va_benefits_menu_source
+  sections:
+    - "Life insurance"
+  constants:
+    bundle: menu_link_content
+    zero: 0
+    one: 1
+
+process:
+  bundle: 'constants/bundle'
+  title: title
+  menu_name: menu
+  'link/uri':
+    plugin: link_uri
+    source:
+      - href
+    validate_route: false
+  route:
+    plugin: route
+    source: href
+  route_name: '@route/route_name'
+  route_parameters: '@route/route_parameters'
+  url: '@route/url'
+  options: '@route/options'
+  external: external
+  weight: weight
+  expanded: 'constants/zero'
+  enabled: 'constants/one'
+
+destination:
+  plugin: entity:menu_link_content
+  no_stub: true
+
+migration_dependencies: {}
+dependencies:
+  enforced:
+    module:
+      - va_gov_migrate

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_hub.yml
@@ -1,16 +1,16 @@
 id: va_hub
-label: Migrate Careers & Employment landing page - NEVER ROLLBACK
+label: Migrate Housing and Life insurance landing pages - NEVER ROLLBACK
 migration_group: va_new_benefits
 source:
   plugin: metalsmith_source  # This is where the page urls and frontmatter come from (see MetalsmithSource.php)
   urls:     # This can be a list urls to crawl or .md files to read.
 #    - "/disability/index.md"
 #    - "/education/index.md"
-    - "/careers-employment/index.md"
+#    - "/careers-employment/index.md"
 #    - "/records/index.md"
 #    - "/pension/index.md"
-#    - "/housing-assistance/index.md"
-#    - "/life-insurance/index.md"
+    - "/housing-assistance/index.md"
+    - "/life-insurance/index.md"
 #    - "/burials-memorials/index.md"
 #    - "/records/index.md"
 #    - "/family-member-benefits.md"


### PR DESCRIPTION
New/updated migrations (/admin/structure/migrate/manage/va_new_benefits/migrations):

- "Migrate additional Housing benefits pages from Heroku"
- "Migrate Housing and Life insurance landing pages - NEVER ROLLBACK"
- "Migrate Life insurance pages from va.gov"
- "Migrate Life insurance sidebar menu"

Also adds "Life insurance benefits hub" menu in config.