### PR TITLE
VAGOV-4662: Patch drupal core to allow unpublished parent menu items.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,9 @@
         },
         "enable-patching": true,
         "patches": {
+            "drupal/core": {
+                "Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch"
+            },
             "drupal/migration_tools": {
                 "Add changeHtmlContents DomModifier method": "https://www.drupal.org/files/issues/2018-11-26/change_html_contents-3015381-3.patch",
                 "Allow migration script to set curl options": "https://www.drupal.org/files/issues/2019-02-08/curl_options-3031705-2.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96fc01bb0337f15d3e2684161f5bbcf1",
+    "content-hash": "e6164b493b73887c0439731a0d51f76c",
     "packages": [
         {
             "name": "acquia/headless_lightning",
@@ -62,7 +62,8 @@
                     "drupal/core": "-p2"
                 },
                 "patches_applied": {
-                    "Fix empty form id in redirect": "patches/nullFormIDFixInRedirect.patch"
+                    "Fix empty form id in redirect": "patches/nullFormIDFixInRedirect.patch",
+                    "Fix moderation sidebar": "patches/moderationSidebar.patch"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3689,6 +3690,7 @@
                     "merge-extra": false
                 },
                 "patches_applied": {
+                    "Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch",
                     "3032548 - ContentModerationRouteSubscriber assumes all parameters in an entity form route contain a 'type' key": "https://www.drupal.org/files/issues/2019-02-13/3032548-2.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",


### PR DESCRIPTION
https://va-gov.atlassian.net/browse/VAGOV-4662