### PR TITLE
VAGOV-4361

### DIFF
--- a/config/sync/core.entity_form_display.node.office.default.yml
+++ b/config/sync/core.entity_form_display.node.office.default.yml
@@ -3,12 +3,16 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.office.field_asset_library_description
+    - field.field.node.office.field_body
     - field.field.node.office.field_description
+    - field.field.node.office.field_event_listing_description
     - node.type.office
   module:
     - content_moderation
     - hide_revision_field
     - path
+    - text
 id: node.office.default
 targetEntityType: node
 bundle: office
@@ -16,27 +20,51 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_asset_library_description:
+    type: string_textfield
+    weight: 11
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_body:
+    type: text_textarea
+    weight: 13
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_description:
-    weight: 122
+    weight: 10
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_event_listing_description:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 8
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -44,12 +72,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 3
     region: content
     third_party_settings: {  }
   revision_log:
     type: hide_revision_field_log_widget
-    weight: 80
+    weight: 7
     region: content
     settings:
       show: true
@@ -63,19 +91,19 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
+    weight: 9
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 4
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -83,7 +111,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     settings:
       match_operator: CONTAINS
       size: 60
@@ -91,8 +119,8 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 6
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/config/sync/field.field.node.office.field_asset_library_description.yml
+++ b/config/sync/field.field.node.office.field_asset_library_description.yml
@@ -1,0 +1,19 @@
+uuid: ba0ad03f-c84e-4218-b552-2bdddd7e5560
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_asset_library_description
+    - node.type.office
+id: node.office.field_asset_library_description
+field_name: field_asset_library_description
+entity_type: node
+bundle: office
+label: 'Asset Library Description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.office.field_body.yml
+++ b/config/sync/field.field.node.office.field_body.yml
@@ -1,0 +1,21 @@
+uuid: 6097e11c-6f80-4305-8067-a21a4fd5ed50
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_body
+    - node.type.office
+  module:
+    - text
+id: node.office.field_body
+field_name: field_body
+entity_type: node
+bundle: office
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.node.office.field_event_listing_description.yml
+++ b/config/sync/field.field.node.office.field_event_listing_description.yml
@@ -1,0 +1,19 @@
+uuid: f2db50af-8ed6-4b53-aa74-a8916b82465c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_listing_description
+    - node.type.office
+id: node.office.field_event_listing_description
+field_name: field_event_listing_description
+entity_type: node
+bundle: office
+label: 'Event Listing Description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_asset_library_description.yml
+++ b/config/sync/field.storage.node.field_asset_library_description.yml
@@ -1,0 +1,21 @@
+uuid: 315a72a5-edbe-4044-8f01-b571b15f2a6d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_asset_library_description
+field_name: field_asset_library_description
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_event_listing_description.yml
+++ b/config/sync/field.storage.node.field_event_listing_description.yml
@@ -1,0 +1,21 @@
+uuid: e583e56f-59bf-4882-809e-ad931ac0392f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_listing_description
+field_name: field_event_listing_description
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.install
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.install
@@ -5,6 +5,9 @@
  * Install file for Va Gov Backend.
  */
 
+use Drupal\node\Entity\Node;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+
 /**
  * Removing Local hospital paragraph entities.
  */
@@ -16,4 +19,83 @@ function va_gov_backend_update_8001() {
   foreach ($paragraphs as $paragraph) {
     $paragraph->delete();
   }
+}
+
+/**
+ * Migrate asset and event items to outreach.
+ */
+function va_gov_backend_update_8002() {
+
+  // Delete the outreach and events detail page.
+  $va_bene_items = ['VA benefits outreach', 'Benefit Materials', 'Events'];
+
+  foreach ($va_bene_items as $item) {
+    $storage_handler = \Drupal::entityTypeManager()->getStorage("node");
+    $va_bene_title_result = \Drupal::entityQuery('node')
+      ->condition('title', $item, '=')
+      ->execute();
+    $entities = $storage_handler->loadMultiple($va_bene_title_result);
+    if ($item === 'Benefit Materials') {
+      $swap_key = key($entities);
+    }
+    $storage_handler->delete($entities);
+  }
+
+  // Create outreach and events office.
+  $node = Node::create([
+    'type' => 'office',
+    'title' => 'Outreach and events',
+    'status' => '1',
+    'moderation_state' => 'published',
+    'field_description' => 'The office description',
+    'field_event_listing_description' => 'The event listing description',
+    'field_asset_library_description' => 'The benefits page description',
+    'field_body' => 'Some body text.',
+  ]);
+  $node->save();
+
+  $nid = (int) $node->id();
+
+  // Load the MenuLinkManager.
+  $menu_handler = \Drupal::service('plugin.manager.menu.link');
+
+  $outreach_landing_page = MenuLinkContent::create([
+    'title' => 'Outreach and events',
+    'link' => ['uri' => 'internal:/outreach-and-events'],
+    'menu_name' => 'outreach-and-events',
+    'expanded' => TRUE,
+  ]);
+  $outreach_landing_page->save();
+
+  $second_level_events = MenuLinkContent::create([
+    'title' => 'Events',
+    'link' => ['uri' => 'internal:/outreach-and-events?q=events'],
+    'parent' => $outreach_landing_page->getPluginId(),
+    'expanded' => TRUE,
+  ]);
+  $second_level_events->save();
+
+  $second_level_benefits = MenuLinkContent::create([
+    'title' => 'Benefits',
+    'link' => ['uri' => 'internal:/outreach-and-events?q=benefit'],
+    'parent' => $outreach_landing_page->getPluginId(),
+    'expanded' => TRUE,
+  ]);
+  $second_level_benefits->save();
+
+  // Change our ef to new node.
+  $connection = \Drupal::database();
+  $swap = $connection->update('node__field_office')
+    ->fields([
+      'field_office_target_id' => $nid,
+    ])
+    ->condition('field_office_target_id', $swap_key)
+    ->execute();
+
+  $swap_revision = $connection->update('node_revision__field_office')
+    ->fields([
+      'field_office_target_id' => $nid,
+    ])
+    ->condition('field_office_target_id', $swap_key)
+    ->execute();
 }


### PR DESCRIPTION
**This mr:**
- Adds description for events, description for benefits, and body to office node. @kevwalsh: This content model change is necessary because we are eliminating subordinate office pages for events listing and asset listings, and now accessing them via query parameter (as opposed to node / arg pattern for real node pages). Both event and asset listing views require intro description text, so most logical place to add is the office node with which they are associated.
- Migrates outreach assets to new path
- Cures double events/events in  path bug

**QA:**
- Visit `admin/structure/menu/manage/outreach-and-events` and confirm that three menu items appear
- Visit the edit view for an outreach node and confirm that `Healthcare system or related office` field is set to `Outreach and events`

**Screenshots**
![Screenshot_2019-06-27_11-25-26](https://user-images.githubusercontent.com/2404547/60279004-564bbd80-98ce-11e9-9836-e6b1b8703044.png)
![Screenshot_2019-06-27_00-17-11](https://user-images.githubusercontent.com/2404547/60234171-2cb07900-9871-11e9-9b33-a4ca4638c3a7.png)
![Screenshot_2019-06-27_00-17-36](https://user-images.githubusercontent.com/2404547/60234172-2cb07900-9871-11e9-9741-8254197d2a43.png)
![Screenshot_2019-06-27_00-17-48](https://user-images.githubusercontent.com/2404547/60234174-2cb07900-9871-11e9-9513-56661205af5d.png)
![Screenshot_2019-06-27_00-18-56](https://user-images.githubusercontent.com/2404547/60234175-2cb07900-9871-11e9-9c15-60a92d2f6769.png)

