### PR TITLE
VAGOV-4625: Add a featured content block for health services page.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -9,7 +9,10 @@ dependencies:
     - field.field.node.health_care_region_page.field_clinical_health_care_servi
     - field.field.node.health_care_region_page.field_clinical_health_services
     - field.field.node.health_care_region_page.field_description
+    - field.field.node.health_care_region_page.field_email_subscription
+    - field.field.node.health_care_region_page.field_email_subscription_links
     - field.field.node.health_care_region_page.field_facebook
+    - field.field.node.health_care_region_page.field_featured_content_healthser
     - field.field.node.health_care_region_page.field_flickr
     - field.field.node.health_care_region_page.field_instagram
     - field.field.node.health_care_region_page.field_intro_text
@@ -28,6 +31,7 @@ dependencies:
     - field.field.node.health_care_region_page.field_other_va_locations
     - field.field.node.health_care_region_page.field_press_release_blurb
     - field.field.node.health_care_region_page.field_related_links
+    - field.field.node.health_care_region_page.field_sign_up_for_emergency_emai
     - field.field.node.health_care_region_page.field_twitter
     - node.type.health_care_region_page
   module:
@@ -89,17 +93,19 @@ third_party_settings:
       region: content
     group_clinical_health_services:
       children:
+        - group_featured_content
         - field_clinical_health_care_servi
         - field_clinical_health_services
       parent_name: ''
       weight: 12
       format_type: details
       format_settings:
+        description: 'This content will appear on the Health Services page, (eg va.gov/pittsburgh-health-care/health-services). '
         required_fields: true
         id: ''
         classes: ''
         open: false
-      label: 'Regional and local descriptions of health services'
+      label: 'Health services page'
       region: content
     group_additional_details_about_t:
       children:
@@ -209,6 +215,19 @@ third_party_settings:
         open: false
       label: Leadership
       region: content
+    group_featured_content:
+      children:
+        - field_featured_content_healthser
+      parent_name: group_clinical_health_services
+      weight: 29
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Featured content'
+      region: content
 id: node.health_care_region_page.default
 targetEntityType: node
 bundle: health_care_region_page
@@ -234,7 +253,7 @@ content:
     type: boolean_checkbox
     region: content
   field_clinical_health_care_servi:
-    weight: 11
+    weight: 30
     settings:
       rows: 5
       placeholder: ''
@@ -242,7 +261,7 @@ content:
     type: text_textarea
     region: content
   field_clinical_health_services:
-    weight: 12
+    weight: 31
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -268,6 +287,18 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  field_featured_content_healthser:
+    type: entity_reference_paragraphs
+    weight: 30
+    settings:
+      title: 'Featured content'
+      title_plural: 'Featured content'
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: link_teaser
+    third_party_settings: {  }
     region: content
   field_flickr:
     weight: 17
@@ -299,7 +330,7 @@ content:
     type: string_textarea_with_counter
     region: content
   field_intro_text_events_page:
-    weight: 23
+    weight: 24
     settings:
       rows: 5
       placeholder: ''
@@ -312,7 +343,7 @@ content:
     type: text_textarea_with_counter
     region: content
   field_intro_text_leadership:
-    weight: 20
+    weight: 24
     settings:
       rows: 5
       placeholder: ''
@@ -333,7 +364,7 @@ content:
     type: text_textarea_with_counter
     region: content
   field_intro_text_press_releases:
-    weight: 24
+    weight: 25
     settings:
       rows: 5
       placeholder: ''
@@ -341,7 +372,7 @@ content:
     type: string_textarea
     region: content
   field_leadership:
-    weight: 21
+    weight: 25
     settings:
       form_mode: inline_entity_form
       override_labels: true
@@ -535,4 +566,7 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_email_subscription: true
+  field_email_subscription_links: true
+  field_sign_up_for_emergency_emai: true

--- a/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
@@ -8,7 +8,10 @@ dependencies:
     - field.field.node.health_care_region_page.field_clinical_health_care_servi
     - field.field.node.health_care_region_page.field_clinical_health_services
     - field.field.node.health_care_region_page.field_description
+    - field.field.node.health_care_region_page.field_email_subscription
+    - field.field.node.health_care_region_page.field_email_subscription_links
     - field.field.node.health_care_region_page.field_facebook
+    - field.field.node.health_care_region_page.field_featured_content_healthser
     - field.field.node.health_care_region_page.field_flickr
     - field.field.node.health_care_region_page.field_instagram
     - field.field.node.health_care_region_page.field_intro_text
@@ -27,6 +30,7 @@ dependencies:
     - field.field.node.health_care_region_page.field_other_va_locations
     - field.field.node.health_care_region_page.field_press_release_blurb
     - field.field.node.health_care_region_page.field_related_links
+    - field.field.node.health_care_region_page.field_sign_up_for_emergency_emai
     - field.field.node.health_care_region_page.field_twitter
     - node.type.health_care_region_page
   module:
@@ -166,6 +170,15 @@ content:
       target: ''
     third_party_settings: {  }
     type: link
+    region: content
+  field_featured_content_healthser:
+    type: entity_reference_revisions_entity_view
+    weight: 26
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
     region: content
   field_flickr:
     weight: 14
@@ -326,5 +339,8 @@ content:
     type: link
     region: content
 hidden:
+  field_email_subscription: true
+  field_email_subscription_links: true
   field_meta_tags: true
+  field_sign_up_for_emergency_emai: true
   links: true

--- a/config/sync/field.field.node.health_care_region_page.field_featured_content_healthser.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_featured_content_healthser.yml
@@ -1,0 +1,91 @@
+uuid: 37da088e-8e0a-436f-b613-0deb59fe6d22
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_featured_content_healthser
+    - node.type.health_care_region_page
+    - paragraphs.paragraphs_type.link_teaser
+  module:
+    - entity_reference_revisions
+id: node.health_care_region_page.field_featured_content_healthser
+field_name: field_featured_content_healthser
+entity_type: node
+bundle: health_care_region_page
+label: 'Featured content on health-services page'
+description: 'Add up to three link teasers. These will appear below the table of contents, and above the list of health services.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      link_teaser: link_teaser
+    target_bundles_drag_drop:
+      address:
+        weight: 22
+        enabled: false
+      alert:
+        weight: 23
+        enabled: false
+      collapsible_panel:
+        weight: 24
+        enabled: false
+      collapsible_panel_item:
+        weight: 25
+        enabled: false
+      expandable_text:
+        weight: 26
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 27
+        enabled: false
+      link_teaser:
+        enabled: true
+        weight: 28
+      list_of_link_teasers:
+        weight: 29
+        enabled: false
+      media:
+        weight: 30
+        enabled: false
+      megamenu_links_column:
+        weight: 31
+        enabled: false
+      megamenu_menu_item:
+        weight: 32
+        enabled: false
+      number_callout:
+        weight: 33
+        enabled: false
+      process:
+        weight: 34
+        enabled: false
+      q_a:
+        weight: 35
+        enabled: false
+      q_a_section:
+        weight: 36
+        enabled: false
+      react_widget:
+        weight: 37
+        enabled: false
+      spanish_translation_summary:
+        weight: 38
+        enabled: false
+      staff_profile:
+        weight: 39
+        enabled: false
+      starred_horizontal_rule:
+        weight: 40
+        enabled: false
+      table:
+        weight: 41
+        enabled: false
+      wysiwyg:
+        weight: 42
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.storage.node.field_featured_content_healthser.yml
+++ b/config/sync/field.storage.node.field_featured_content_healthser.yml
@@ -1,0 +1,21 @@
+uuid: 4bbdd969-6ffc-485a-a3e2-027fe7864a41
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_featured_content_healthser
+field_name: field_featured_content_healthser
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
* Go to /node/318/edit
* In the Health Services fieldset, note the new Featured content paragraphs field.
* You should be able to add 3 link teasers to it, but no more. 
