### PR TITLE
VAGOV-4371: Rename press release and health service node types.

### DIFF
--- a/config/sync/node.type.health_care_local_health_service.yml
+++ b/config/sync/node.type.health_care_local_health_service.yml
@@ -12,7 +12,7 @@ third_party_settings:
     parent: 'pittsburgh-health-care:'
   node_title_help_text:
     title_help: ''
-name: 'Local Health Service Offering'
+name: 'Local Health Service'
 type: health_care_local_health_service
 description: 'A facility specific description of a health care service, always embedded within a regional description'
 help: ''

--- a/config/sync/node.type.press_release.yml
+++ b/config/sync/node.type.press_release.yml
@@ -11,11 +11,11 @@ third_party_settings:
       - pittsburgh-health-care
     parent: 'pittsburgh-health-care:'
   node_title_help_text:
-    title_help: "The topic of this press release, in sentence case.<br/>\r\n<em>Maximum characters: 150</em>"
-name: 'Press release'
+    title_help: "The topic of this news release, in sentence case.<br/>\r\n<em>Maximum characters: 150</em>"
+name: 'News release'
 type: press_release
 description: 'Announcements directed at members of the media for the purpose of publicizing newsworthy events/happenings/programs at specific facilities or healthcare systems.'
-help: "A press release is directed at members of the media for the purpose of announcing something  newsworthy. All press releases should be:\r\n<ul><li>timely (like: announcing a new development, or an event)</li>\r\n<li>focused on a specific facility or healthcare system (so: not a national program)</li>\r\n<li>approved by the Office of Public Affairs, or equivalent, for that facility</li></ul>\r\n\r\n<p>Community stories (like case studies or human interest stories) should be entered as <a href=\"/node/add/news_story\">stories</a>.</p>"
+help: "A news release is directed at members of the media for the purpose of announcing something  newsworthy. All press releases should be:\r\n<ul><li>timely (like: announcing a new development, or an event)</li>\r\n<li>focused on a specific facility or healthcare system (so: not a national program)</li>\r\n<li>approved by the Office of Public Affairs, or equivalent, for that facility</li></ul>\r\n\r\n<p>Community stories (like case studies or human interest stories) should be entered as <a href=\"/node/add/news_story\">stories</a>.</p>"
 new_revision: true
 preview_mode: 1
 display_submitted: false

--- a/config/sync/node.type.regional_health_care_service_des.yml
+++ b/config/sync/node.type.regional_health_care_service_des.yml
@@ -12,10 +12,10 @@ third_party_settings:
     parent: 'pittsburgh-health-care:'
   node_title_help_text:
     title_help: ''
-name: 'Regional Health Service Offering'
+name: 'Regional Health Service'
 type: regional_health_care_service_des
 description: 'Each specific healthcare services (like geriatrics, audiology, psychiatry, and so on) has a description written at the national level. When regional healthcare systems need to add regional info the default description, they do it here.'
-help: "<ol><li><a href=\"/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview\">Ensure the health service exists in the national taxonomy</a></li>\r\n<li>Add a regional health service offering, and link it to the health care system by filling out this form.</li>\r\n<li>Add <a href=\"/node/add/health_care_local_health_service\">a local health service offering</a> and point it to a regional one.</li></ol>"
+help: "<ol><li><a href=\"/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview\">Ensure the health service exists in the national taxonomy</a></li>\r\n<li>Add a regional health service, and link it to the health care system by filling out this form.</li>\r\n<li>Add <a href=\"/node/add/health_care_local_health_service\">a local health service</a> and point it to a regional one.</li></ol>"
 new_revision: true
 preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
QA:
* Go to /node/add
* You shouldn't see the word "offering" anwyhere.
* You should see "news release" as an option. 