### PR TITLE
VAGOV-4629: Media governance updates.

### DIFF
--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - field.field.media.document.field_document
     - field.field.media.document.field_media_in_library
+    - field.field.media.document.field_media_submission_guideline
     - field.field.media.document.field_owner
     - media.type.document
   module:
     - field_group
     - file
+    - markup
 third_party_settings:
   field_group:
     group_governance:
@@ -17,7 +19,7 @@ third_party_settings:
         - field_owner
         - field_media_in_library
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -34,7 +36,7 @@ bundle: document
 mode: default
 content:
   field_document:
-    weight: 1
+    weight: 2
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
@@ -47,6 +49,12 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_media_submission_guideline:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: markup
+    region: content
   field_owner:
     weight: 3
     settings: {  }
@@ -55,7 +63,7 @@ content:
     region: content
   name:
     type: string_textfield
-    weight: 0
+    weight: 1
     settings:
       size: 60
       placeholder: ''

--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -5,9 +5,27 @@ dependencies:
   config:
     - field.field.media.document.field_document
     - field.field.media.document.field_media_in_library
+    - field.field.media.document.field_owner
     - media.type.document
   module:
+    - field_group
     - file
+third_party_settings:
+  field_group:
+    group_governance:
+      children:
+        - field_owner
+        - field_media_in_library
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: Governance
+      region: content
 _core:
   default_config_hash: xFJUl0MccoGPEv1eb_I_XnxzjqvZ8M5HA1G3PBtv9IE
 id: media.document.default
@@ -22,6 +40,19 @@ content:
     third_party_settings: {  }
     type: file_generic
     region: content
+  field_media_in_library:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_owner:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -32,7 +63,6 @@ content:
     region: content
 hidden:
   created: true
-  field_media_in_library: true
   moderation_state: true
   path: true
   revision_log_message: true

--- a/config/sync/core.entity_form_display.media.document.media_browser.yml
+++ b/config/sync/core.entity_form_display.media.document.media_browser.yml
@@ -1,11 +1,12 @@
 uuid: 789a0832-84c5-482d-8071-8cb3e8aef649
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_form_mode.media.media_browser
     - field.field.media.document.field_document
     - field.field.media.document.field_media_in_library
+    - field.field.media.document.field_owner
     - media.type.document
   module:
     - file
@@ -34,6 +35,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  field_owner: true
   moderation_state: true
   path: true
   revision_log_message: true

--- a/config/sync/core.entity_form_display.media.document.media_browser.yml
+++ b/config/sync/core.entity_form_display.media.document.media_browser.yml
@@ -35,6 +35,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  field_media_submission_guideline: true
   field_owner: true
   moderation_state: true
   path: true

--- a/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -1,11 +1,12 @@
 uuid: aabcef09-c5d4-43ff-bec1-8095a6b28d61
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.document.field_document
     - field.field.media.document.field_media_in_library
+    - field.field.media.document.field_media_submission_guideline
     - field.field.media.document.field_owner
     - media.type.document
   module:
@@ -64,6 +65,7 @@ content:
     region: content
 hidden:
   created: true
+  field_media_submission_guideline: true
   moderation_state: true
   path: true
   revision_log_message: true

--- a/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -1,17 +1,16 @@
-uuid: 46977bd4-384a-41e2-b8f4-160c07864c79
+uuid: aabcef09-c5d4-43ff-bec1-8095a6b28d61
 langcode: en
-status: true
+status: false
 dependencies:
   config:
-    - field.field.media.image.field_media_in_library
-    - field.field.media.image.field_owner
-    - field.field.media.image.image
-    - image.style.3_2_medium_thumbnail
-    - media.type.image
+    - core.entity_form_mode.media.media_library
+    - field.field.media.document.field_document
+    - field.field.media.document.field_media_in_library
+    - field.field.media.document.field_owner
+    - media.type.document
   module:
     - field_group
-    - image_widget_crop
-    - lightning_media
+    - file
 third_party_settings:
   field_group:
     group_governance:
@@ -29,12 +28,19 @@ third_party_settings:
       label: Governance
       region: content
 _core:
-  default_config_hash: kyoAHlZTGIuGTaQuBblGBk8EhfnVKOl19_0j5WbpQqM
-id: media.image.default
+  default_config_hash: xFJUl0MccoGPEv1eb_I_XnxzjqvZ8M5HA1G3PBtv9IE
+id: media.document.media_library
 targetEntityType: media
-bundle: image
-mode: default
+bundle: document
+mode: media_library
 content:
+  field_document:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
   field_media_in_library:
     type: boolean_checkbox
     weight: 4
@@ -47,23 +53,6 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_select
-    region: content
-  image:
-    type: image_widget_crop
-    weight: 1
-    settings:
-      show_crop_area: true
-      show_default_crop: true
-      preview_image_style: 3_2_medium_thumbnail
-      crop_preview_image_style: crop_thumbnail
-      progress_indicator: throbber
-      crop_list: {  }
-      crop_types_required: {  }
-      warn_multiple_usages: false
-    third_party_settings:
-      lightning_media:
-        file_links: true
-        remove_button: true
     region: content
   name:
     type: string_textfield

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.image.field_media_in_library
+    - field.field.media.image.field_media_submission_guideline
     - field.field.media.image.field_owner
     - field.field.media.image.image
     - image.style.3_2_medium_thumbnail
@@ -12,6 +13,7 @@ dependencies:
     - field_group
     - image_widget_crop
     - lightning_media
+    - markup
 third_party_settings:
   field_group:
     group_governance:
@@ -19,7 +21,7 @@ third_party_settings:
         - field_owner
         - field_media_in_library
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -42,6 +44,12 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_media_submission_guideline:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: markup
+    region: content
   field_owner:
     weight: 3
     settings: {  }
@@ -50,7 +58,7 @@ content:
     region: content
   image:
     type: image_widget_crop
-    weight: 1
+    weight: 2
     settings:
       show_crop_area: true
       show_default_crop: true
@@ -67,7 +75,7 @@ content:
     region: content
   name:
     type: string_textfield
-    weight: 0
+    weight: 1
     settings:
       size: 60
       placeholder: ''

--- a/config/sync/core.entity_form_display.media.image.media_browser.yml
+++ b/config/sync/core.entity_form_display.media.image.media_browser.yml
@@ -1,10 +1,11 @@
 uuid: 3c752a6e-b497-44cf-906c-652c5a95e4eb
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_form_mode.media.media_browser
     - field.field.media.image.field_media_in_library
+    - field.field.media.image.field_owner
     - field.field.media.image.image
     - image.style.2_1_medium_thumbnail
     - media.type.image
@@ -46,6 +47,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  field_owner: true
   moderation_state: true
   path: true
   revision_log_message: true

--- a/config/sync/core.entity_form_display.media.image.media_browser.yml
+++ b/config/sync/core.entity_form_display.media.image.media_browser.yml
@@ -47,6 +47,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  field_media_submission_guideline: true
   field_owner: true
   moderation_state: true
   path: true

--- a/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -1,8 +1,9 @@
-uuid: 46977bd4-384a-41e2-b8f4-160c07864c79
+uuid: 14f3871c-799e-4362-9b48-40e34af5c34a
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_form_mode.media.media_library
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_submission_guideline
     - field.field.media.image.field_owner
@@ -19,6 +20,7 @@ third_party_settings:
     group_governance:
       children:
         - field_owner
+        - field_media_in_library
       parent_name: ''
       weight: 3
       format_type: fieldset
@@ -31,11 +33,18 @@ third_party_settings:
       region: content
 _core:
   default_config_hash: kyoAHlZTGIuGTaQuBblGBk8EhfnVKOl19_0j5WbpQqM
-id: media.image.default
+id: media.image.media_library
 targetEntityType: media
 bundle: image
-mode: default
+mode: media_library
 content:
+  field_media_in_library:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_media_submission_guideline:
     weight: 0
     settings: {  }
@@ -75,7 +84,6 @@ content:
     region: content
 hidden:
   created: true
-  field_media_in_library: true
   moderation_state: true
   path: true
   revision_log_message: true

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -15,6 +15,13 @@ targetEntityType: media
 bundle: video
 mode: default
 content:
+  field_media_in_library:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_media_video_embed_field:
     type: video_embed_field_textfield
     weight: 1
@@ -31,7 +38,6 @@ content:
     region: content
 hidden:
   created: true
-  field_media_in_library: true
   moderation_state: true
   path: true
   preview: true

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -5,9 +5,27 @@ dependencies:
   config:
     - field.field.media.video.field_media_in_library
     - field.field.media.video.field_media_video_embed_field
+    - field.field.media.video.field_owner
     - media.type.video
   module:
+    - field_group
     - video_embed_field
+third_party_settings:
+  field_group:
+    group_governance:
+      children:
+        - field_owner
+        - field_media_in_library
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: Governance
+      region: content
 _core:
   default_config_hash: OUea_b_jf81XjPvIY9J8KrRUckqz2APuLv4bkxYfdT4
 id: media.video.default
@@ -17,7 +35,7 @@ mode: default
 content:
   field_media_in_library:
     type: boolean_checkbox
-    weight: 2
+    weight: 5
     region: content
     settings:
       display_label: true
@@ -27,6 +45,12 @@ content:
     weight: 1
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_owner:
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   name:
     type: string_textfield

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.media.video.field_media_in_library
+    - field.field.media.video.field_media_submission_guideline
     - field.field.media.video.field_media_video_embed_field
     - field.field.media.video.field_owner
     - media.type.video
   module:
     - field_group
+    - markup
     - video_embed_field
 third_party_settings:
   field_group:
@@ -17,7 +19,7 @@ third_party_settings:
         - field_owner
         - field_media_in_library
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -40,9 +42,15 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_media_submission_guideline:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: markup
+    region: content
   field_media_video_embed_field:
     type: video_embed_field_textfield
-    weight: 1
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -54,7 +62,7 @@ content:
     region: content
   name:
     type: string_textfield
-    weight: 0
+    weight: 1
     settings:
       size: 60
       placeholder: ''

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -17,7 +17,6 @@ third_party_settings:
     group_governance:
       children:
         - field_owner
-        - field_media_in_library
       parent_name: ''
       weight: 3
       format_type: fieldset
@@ -35,13 +34,6 @@ targetEntityType: media
 bundle: video
 mode: default
 content:
-  field_media_in_library:
-    type: boolean_checkbox
-    weight: 5
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   field_media_submission_guideline:
     weight: 0
     settings: {  }
@@ -70,6 +62,7 @@ content:
     region: content
 hidden:
   created: true
+  field_media_in_library: true
   moderation_state: true
   path: true
   preview: true

--- a/config/sync/core.entity_form_display.media.video.media_browser.yml
+++ b/config/sync/core.entity_form_display.media.video.media_browser.yml
@@ -5,9 +5,12 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_browser
     - field.field.media.video.field_media_in_library
+    - field.field.media.video.field_media_submission_guideline
     - field.field.media.video.field_media_video_embed_field
+    - field.field.media.video.field_owner
     - media.type.video
   module:
+    - markup
     - video_embed_field
 _core:
   default_config_hash: Wft8ifOMAlgFjAvTyWmpKS_RnTcBkckjM2u90vzd7cM
@@ -16,15 +19,21 @@ targetEntityType: media
 bundle: video
 mode: media_browser
 content:
+  field_media_submission_guideline:
+    type: markup
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_video_embed_field:
     type: video_embed_field_textfield
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: 1
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -38,6 +47,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  field_owner: true
   moderation_state: true
   path: true
   revision_log_message: true

--- a/config/sync/core.entity_form_display.media.video.media_library.yml
+++ b/config/sync/core.entity_form_display.media.video.media_library.yml
@@ -1,22 +1,24 @@
-uuid: de7085f5-1807-415d-ac80-47e460cddcd4
+uuid: f2f9d26f-5661-49d0-bcba-88cd986d8be2
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.media.document.field_document
-    - field.field.media.document.field_media_in_library
-    - field.field.media.document.field_media_submission_guideline
-    - field.field.media.document.field_owner
-    - media.type.document
+    - core.entity_form_mode.media.media_library
+    - field.field.media.video.field_media_in_library
+    - field.field.media.video.field_media_submission_guideline
+    - field.field.media.video.field_media_video_embed_field
+    - field.field.media.video.field_owner
+    - media.type.video
   module:
     - field_group
-    - file
     - markup
+    - video_embed_field
 third_party_settings:
   field_group:
     group_governance:
       children:
         - field_owner
+        - field_media_in_library
       parent_name: ''
       weight: 3
       format_type: fieldset
@@ -28,27 +30,33 @@ third_party_settings:
       label: Governance
       region: content
 _core:
-  default_config_hash: xFJUl0MccoGPEv1eb_I_XnxzjqvZ8M5HA1G3PBtv9IE
-id: media.document.default
+  default_config_hash: OUea_b_jf81XjPvIY9J8KrRUckqz2APuLv4bkxYfdT4
+id: media.video.media_library
 targetEntityType: media
-bundle: document
-mode: default
+bundle: video
+mode: media_library
 content:
-  field_document:
-    weight: 2
-    settings:
-      progress_indicator: throbber
-    third_party_settings: {  }
-    type: file_generic
+  field_media_in_library:
+    type: boolean_checkbox
+    weight: 5
     region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_media_submission_guideline:
     weight: 0
     settings: {  }
     third_party_settings: {  }
     type: markup
     region: content
+  field_media_video_embed_field:
+    type: video_embed_field_textfield
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   field_owner:
-    weight: 3
+    weight: 4
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -63,9 +71,9 @@ content:
     region: content
 hidden:
   created: true
-  field_media_in_library: true
   moderation_state: true
   path: true
+  preview: true
   revision_log_message: true
   status: true
   uid: true

--- a/config/sync/core.entity_form_display.node.outreach_asset.default.yml
+++ b/config/sync/core.entity_form_display.node.outreach_asset.default.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - entity_browser.browser.media_browser
     - field.field.node.outreach_asset.field_administration
     - field.field.node.outreach_asset.field_benefits
     - field.field.node.outreach_asset.field_description
@@ -14,9 +13,9 @@ dependencies:
     - node.type.outreach_asset
   module:
     - content_moderation
-    - entity_browser
     - field_group
     - hide_revision_field
+    - media_library
     - metatag
     - path
 third_party_settings:
@@ -87,18 +86,9 @@ content:
     type: options_select
     region: content
   field_media:
-    type: entity_browser_entity_reference
+    type: media_library_widget
     weight: 12
-    settings:
-      entity_browser: media_browser
-      field_widget_display: rendered_entity
-      field_widget_edit: true
-      field_widget_remove: true
-      selection_mode: selection_append
-      field_widget_display_settings:
-        view_mode: media_library
-      field_widget_replace: false
-      open: false
+    settings: {  }
     region: content
     third_party_settings: {  }
   field_meta_tags:

--- a/config/sync/core.entity_view_display.media.document.default.yml
+++ b/config/sync/core.entity_view_display.media.document.default.yml
@@ -5,12 +5,14 @@ dependencies:
   config:
     - field.field.media.document.field_document
     - field.field.media.document.field_media_in_library
+    - field.field.media.document.field_media_submission_guideline
     - field.field.media.document.field_owner
     - image.style.thumbnail
     - media.type.document
   module:
     - file
     - image
+    - markup
     - user
 _core:
   default_config_hash: 4tgcXj_iKv9Fw3xmONUfCHKqO7OeOa11qVesruN4k4k
@@ -47,6 +49,13 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
+  field_media_submission_guideline:
+    weight: 7
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: markup
+    region: content
   field_owner:
     weight: 6
     label: above

--- a/config/sync/core.entity_view_display.media.document.default.yml
+++ b/config/sync/core.entity_view_display.media.document.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.media.document.field_document
     - field.field.media.document.field_media_in_library
+    - field.field.media.document.field_owner
     - image.style.thumbnail
     - media.type.document
   module:
@@ -46,6 +47,14 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
+  field_owner:
+    weight: 6
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   name:
     label: above
     type: string

--- a/config/sync/core.entity_view_display.media.image.default.yml
+++ b/config/sync/core.entity_view_display.media.image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.image.field_media_in_library
+    - field.field.media.image.field_media_submission_guideline
     - field.field.media.image.field_owner
     - field.field.media.image.image
     - image.style.full_content_width
@@ -17,9 +18,19 @@ targetEntityType: media
 bundle: image
 mode: default
 content:
-  field_owner:
+  field_media_in_library:
+    type: boolean
     weight: 2
-    label: above
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+  field_owner:
+    weight: 3
+    label: inline
     settings:
       link: true
     third_party_settings: {  }
@@ -28,7 +39,7 @@ content:
   image:
     type: image
     weight: 1
-    label: above
+    label: hidden
     settings:
       image_style: full_content_width
       image_link: ''
@@ -38,12 +49,12 @@ content:
     type: string
     weight: 0
     region: content
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
 hidden:
   created: true
-  field_media_in_library: true
+  field_media_submission_guideline: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.default.yml
+++ b/config/sync/core.entity_view_display.media.image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.image.field_media_in_library
+    - field.field.media.image.field_owner
     - field.field.media.image.image
     - image.style.full_content_width
     - media.type.image
@@ -16,6 +17,14 @@ targetEntityType: media
 bundle: image
 mode: default
 content:
+  field_owner:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   image:
     type: image
     weight: 1

--- a/config/sync/core.entity_view_display.media.video.default.yml
+++ b/config/sync/core.entity_view_display.media.video.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.media.video.field_media_in_library
     - field.field.media.video.field_media_video_embed_field
+    - field.field.media.video.field_owner
     - image.style.large
     - media.type.video
   module:
@@ -37,6 +38,14 @@ content:
       height: 480
       autoplay: true
     third_party_settings: {  }
+    region: content
+  field_owner:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   name:
     label: hidden

--- a/config/sync/core.entity_view_display.media.video.default.yml
+++ b/config/sync/core.entity_view_display.media.video.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - media.type.video
   module:
     - image
-    - user
     - video_embed_field
 _core:
   default_config_hash: ULSDSeb1LGUAS40ia_8qngabv0GTcJAaHGl67xDUNsA
@@ -19,29 +18,19 @@ bundle: video
 mode: default
 content:
   created:
-    label: above
-    type: timestamp
-    weight: 3
+    label: hidden
+    type: timestamp_ago
+    weight: 4
     settings:
-      date_format: medium
-      custom_date_format: ''
-      timezone: ''
+      future_format: '@interval hence'
+      past_format: '@interval ago'
+      granularity: 1
     third_party_settings: {  }
     region: content
-  field_media_in_library:
-    type: boolean
-    weight: 5
-    region: content
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
   field_media_video_embed_field:
     type: video_embed_field_video
     weight: 1
-    label: above
+    label: hidden
     settings:
       responsive: true
       width: 854
@@ -50,7 +39,7 @@ content:
     third_party_settings: {  }
     region: content
   name:
-    label: above
+    label: hidden
     type: string
     weight: 0
     settings:
@@ -61,16 +50,18 @@ content:
     type: image
     weight: 2
     region: content
-    label: above
+    label: hidden
     settings:
       image_style: large
       image_link: ''
     third_party_settings: {  }
   uid:
-    label: above
-    type: author
-    weight: 4
-    settings: {  }
-    third_party_settings: {  }
+    type: entity_reference_label
+    weight: 3
     region: content
-hidden: {  }
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+hidden:
+  field_media_in_library: true

--- a/config/sync/core.entity_view_display.media.video.default.yml
+++ b/config/sync/core.entity_view_display.media.video.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.video.field_media_in_library
+    - field.field.media.video.field_media_submission_guideline
     - field.field.media.video.field_media_video_embed_field
     - field.field.media.video.field_owner
     - image.style.large
@@ -28,6 +29,16 @@ content:
       granularity: 1
     third_party_settings: {  }
     region: content
+  field_media_in_library:
+    type: boolean
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
   field_media_video_embed_field:
     type: video_embed_field_video
     weight: 1
@@ -36,7 +47,7 @@ content:
       responsive: true
       width: 854
       height: 480
-      autoplay: true
+      autoplay: false
     third_party_settings: {  }
     region: content
   field_owner:
@@ -73,4 +84,4 @@ content:
       link: true
     third_party_settings: {  }
 hidden:
-  field_media_in_library: true
+  field_media_submission_guideline: true

--- a/config/sync/core.entity_view_display.media.video.embedded.yml
+++ b/config/sync/core.entity_view_display.media.video.embedded.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - core.entity_view_mode.media.embedded
     - field.field.media.video.field_media_in_library
+    - field.field.media.video.field_media_submission_guideline
     - field.field.media.video.field_media_video_embed_field
+    - field.field.media.video.field_owner
     - media.type.video
   module:
     - video_embed_field
@@ -24,12 +26,14 @@ content:
       responsive: true
       width: 854
       height: 480
-      autoplay: true
+      autoplay: false
     third_party_settings: {  }
     region: content
 hidden:
   created: true
   field_media_in_library: true
+  field_media_submission_guideline: true
+  field_owner: true
   name: true
   thumbnail: true
   uid: true

--- a/config/sync/field.field.media.document.field_document.yml
+++ b/config/sync/field.field.media.document.field_document.yml
@@ -21,8 +21,8 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'pdf doc docx'
-  max_filesize: ''
+  file_extensions: 'pdf doc docx xlsx xls csv'
+  max_filesize: '100 MB'
   description_field: false
   handler: 'default:file'
   handler_settings: {  }

--- a/config/sync/field.field.media.document.field_media_in_library.yml
+++ b/config/sync/field.field.media.document.field_media_in_library.yml
@@ -11,8 +11,8 @@ id: media.document.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: document
-label: 'Show in media library'
-description: "By default, documents you upload to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors.\_"
+label: Reusable
+description: 'By default, documents you upload to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors.'
 required: false
 translatable: true
 default_value:

--- a/config/sync/field.field.media.document.field_media_in_library.yml
+++ b/config/sync/field.field.media.document.field_media_in_library.yml
@@ -12,7 +12,7 @@ field_name: field_media_in_library
 entity_type: media
 bundle: document
 label: 'Show in media library'
-description: ''
+description: "By default, documents you upload to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors.\_"
 required: false
 translatable: true
 default_value:

--- a/config/sync/field.field.media.document.field_media_submission_guideline.yml
+++ b/config/sync/field.field.media.document.field_media_submission_guideline.yml
@@ -1,0 +1,25 @@
+uuid: e9881062-8b8b-4322-911a-90c4fa7ada8e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_submission_guideline
+    - media.type.document
+  module:
+    - markup
+id: media.document.field_media_submission_guideline
+field_name: field_media_submission_guideline
+entity_type: media
+bundle: document
+label: 'Media submission guidelines'
+description: ''
+required: false
+translatable: false
+default_value:
+  - {  }
+default_value_callback: ''
+settings:
+  markup:
+    value: "<p>Provide a name that will help other users of the CMS find and reuse this document. The name is not visible to end users.</p>\r\n"
+    format: rich_text
+field_type: markup

--- a/config/sync/field.field.media.document.field_owner.yml
+++ b/config/sync/field.field.media.document.field_owner.yml
@@ -1,0 +1,29 @@
+uuid: 1728e1e1-aad5-4100-9004-8c1180335bef
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_owner
+    - media.type.document
+    - taxonomy.vocabulary.administration
+id: media.document.field_owner
+field_name: field_owner
+entity_type: media
+bundle: document
+label: Owner
+description: 'Only members of the section you select here will be able to make changes to this document. '
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.document.field_owner.yml
+++ b/config/sync/field.field.media.document.field_owner.yml
@@ -11,7 +11,7 @@ field_name: field_owner
 entity_type: media
 bundle: document
 label: Owner
-description: 'Only members of the section you select here will be able to make changes to this document. '
+description: 'Only members of the section you select here will be able to make changes to this document.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.media.image.field_media_in_library.yml
+++ b/config/sync/field.field.media.image.field_media_in_library.yml
@@ -12,7 +12,7 @@ field_name: field_media_in_library
 entity_type: media
 bundle: image
 label: 'Show in media library'
-description: ''
+description: "By default, images you upload to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors.\_"
 required: false
 translatable: false
 default_value:

--- a/config/sync/field.field.media.image.field_media_in_library.yml
+++ b/config/sync/field.field.media.image.field_media_in_library.yml
@@ -11,8 +11,8 @@ id: media.image.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: image
-label: 'Show in media library'
-description: "By default, images you upload to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors.\_"
+label: Reusable
+description: 'By default, images you upload to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors.'
 required: false
 translatable: false
 default_value:

--- a/config/sync/field.field.media.image.field_media_submission_guideline.yml
+++ b/config/sync/field.field.media.image.field_media_submission_guideline.yml
@@ -1,0 +1,25 @@
+uuid: 54e00f85-5b50-45ef-b997-d2f70dd8dd9b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_submission_guideline
+    - media.type.image
+  module:
+    - markup
+id: media.image.field_media_submission_guideline
+field_name: field_media_submission_guideline
+entity_type: media
+bundle: image
+label: 'Media submission guidelines'
+description: ''
+required: false
+translatable: true
+default_value:
+  - {  }
+default_value_callback: ''
+settings:
+  markup:
+    value: "<p>Provide a name that will help other users of the CMS find and reuse this image. The name is not visible to end users.</p>\r\n"
+    format: rich_text
+field_type: markup

--- a/config/sync/field.field.media.image.field_owner.yml
+++ b/config/sync/field.field.media.image.field_owner.yml
@@ -1,0 +1,29 @@
+uuid: 73668c1a-d70f-427a-a51b-6bf7a113d73d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_owner
+    - media.type.image
+    - taxonomy.vocabulary.administration
+id: media.image.field_owner
+field_name: field_owner
+entity_type: media
+bundle: image
+label: Owner
+description: 'Only members of the section you select here will be able to make changes to this image. '
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.image.field_owner.yml
+++ b/config/sync/field.field.media.image.field_owner.yml
@@ -11,7 +11,7 @@ field_name: field_owner
 entity_type: media
 bundle: image
 label: Owner
-description: 'Only members of the section you select here will be able to make changes to this image. '
+description: 'Only members of the section you select here will be able to make changes to this image.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.media.video.field_media_in_library.yml
+++ b/config/sync/field.field.media.video.field_media_in_library.yml
@@ -12,7 +12,7 @@ field_name: field_media_in_library
 entity_type: media
 bundle: video
 label: 'Show in media library'
-description: ''
+description: "By default, videos you add to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors. \r\n"
 required: false
 translatable: true
 default_value:

--- a/config/sync/field.field.media.video.field_media_in_library.yml
+++ b/config/sync/field.field.media.video.field_media_in_library.yml
@@ -11,8 +11,8 @@ id: media.video.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: video
-label: 'Show in media library'
-description: "By default, videos you add to the CMS can be reused by other VA.gov CMS editors. Uncheck this box if to prevent reuse by other CMS editors. \r\n"
+label: Reusable
+description: 'By default, videos you add to the CMS can be reused by other VA.gov CMS editors. Uncheck this box to prevent reuse by other CMS editors.'
 required: false
 translatable: true
 default_value:

--- a/config/sync/field.field.media.video.field_media_submission_guideline.yml
+++ b/config/sync/field.field.media.video.field_media_submission_guideline.yml
@@ -1,0 +1,25 @@
+uuid: e8f4c101-862d-4008-86a5-1c69e52ec5bd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_submission_guideline
+    - media.type.video
+  module:
+    - markup
+id: media.video.field_media_submission_guideline
+field_name: field_media_submission_guideline
+entity_type: media
+bundle: video
+label: 'Media submission guidelines'
+description: ''
+required: false
+translatable: true
+default_value:
+  - {  }
+default_value_callback: ''
+settings:
+  markup:
+    value: "<p>Provide a name that will help other users of the CMS find and reuse this video. The name is not visible to end users.</p>\r\n"
+    format: rich_text
+field_type: markup

--- a/config/sync/field.field.media.video.field_media_video_embed_field.yml
+++ b/config/sync/field.field.media.video.field_media_video_embed_field.yml
@@ -14,7 +14,7 @@ field_name: field_media_video_embed_field
 entity_type: media
 bundle: video
 label: 'Video URL'
-description: 'Currently supports YouTube and Vimeo URLs. '
+description: 'Currently supports YouTube and Vimeo URLs.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.media.video.field_media_video_embed_field.yml
+++ b/config/sync/field.field.media.video.field_media_video_embed_field.yml
@@ -14,11 +14,14 @@ field_name: field_media_video_embed_field
 entity_type: media
 bundle: video
 label: 'Video URL'
-description: ''
+description: 'Currently supports YouTube and Vimeo URLs. '
 required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  allowed_providers: {  }
+  allowed_providers:
+    vimeo: vimeo
+    youtube: youtube
+    youtube_playlist: youtube_playlist
 field_type: video_embed_field

--- a/config/sync/field.field.media.video.field_owner.yml
+++ b/config/sync/field.field.media.video.field_owner.yml
@@ -1,0 +1,29 @@
+uuid: 5a5246af-2ad6-4981-8e1a-32c900ebb9e5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_owner
+    - media.type.video
+    - taxonomy.vocabulary.administration
+id: media.video.field_owner
+field_name: field_owner
+entity_type: media
+bundle: video
+label: Owner
+description: 'Only members of the section you select here will be able to make changes to this video.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.media.field_media_submission_guideline.yml
+++ b/config/sync/field.storage.media.field_media_submission_guideline.yml
@@ -1,0 +1,19 @@
+uuid: 7b7ddea6-e8a4-4d30-8cf0-35303a0c9b87
+langcode: en
+status: true
+dependencies:
+  module:
+    - markup
+    - media
+id: media.field_media_submission_guideline
+field_name: field_media_submission_guideline
+entity_type: media
+type: markup
+settings: {  }
+module: markup
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.media.field_owner.yml
+++ b/config/sync/field.storage.media.field_owner.yml
@@ -1,0 +1,20 @@
+uuid: 48f03f88-bd8b-442d-ba37-dd4019e01797
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.field_owner
+field_name: field_owner
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -4,15 +4,19 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.media_library
+    - field.storage.media.field_media_in_library
+    - field.storage.media.field_owner
     - image.style.medium
     - image.style.thumbnail
     - media.type.document
     - media.type.image
+    - taxonomy.vocabulary.administration
   module:
     - entity_browser
     - file
     - image
     - media
+    - taxonomy
     - user
     - views_infinite_scroll
 _core:
@@ -194,7 +198,8 @@ display:
           hide_alter_empty: true
           action_title: Action
           include_exclude: exclude
-          selected_actions: {  }
+          selected_actions:
+            - media_delete_action
           entity_type: media
           plugin_id: bulk_form
         thumbnail__target_id:
@@ -310,6 +315,57 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        operations:
+          id: operations
+          table: media
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: media
+          plugin_id: entity_operations
         bundle:
           id: bundle
           table: media_field_data
@@ -448,7 +504,7 @@ display:
           group_type: group
           admin_label: ''
           label: Status
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -574,14 +630,14 @@ display:
           entity_type: media
           entity_field: changed
           plugin_id: field
-        operations:
-          id: operations
-          table: media
-          field: operations
+        field_owner:
+          id: field_owner
+          table: media__field_owner
+          field: field_owner
           relationship: none
           group_type: group
           admin_label: ''
-          label: Operations
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -622,9 +678,86 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          destination: true
-          entity_type: media
-          plugin_id: entity_operations
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_media_in_library:
+          id: field_media_in_library
+          table: media__field_media_in_library
+          field: field_media_in_library
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Show in media library'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: ✓
+            format_custom_false: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
       filters:
         name:
           id: name
@@ -707,77 +840,38 @@ display:
           entity_type: media
           entity_field: bundle
           plugin_id: bundle
-        status:
-          id: status
-          table: media_field_data
-          field: status
+        field_owner_target_id:
+          id: field_owner_target_id
+          table: media__field_owner
+          field: field_owner_target_id
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'True'
-            description: null
-            use_operator: false
-            operator: status_op
-            identifier: status
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: true
-          group_info:
-            label: 'Published status'
-            description: ''
-            identifier: status
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: Published
-                operator: '='
-                value: '1'
-              2:
-                title: Unpublished
-                operator: '='
-                value: '0'
-          plugin_id: boolean
-          entity_type: media
-          entity_field: status
-        langcode:
-          id: langcode
-          table: media_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
+          operator: or
           value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: langcode_op
-            label: Language
+            operator_id: field_owner_target_id_op
+            label: Section
             description: ''
             use_operator: false
-            operator: langcode_op
-            identifier: langcode
+            operator: field_owner_target_id_op
+            identifier: field_owner_target_id
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
+              content_api_consumer: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              admnistrator_users: '0'
               administrator: '0'
+              redirect_administrator: '0'
+              documentation_editor: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -791,9 +885,16 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: langcode
-          plugin_id: language
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: administration
+          hierarchy: true
+          error_message: true
+          parent: 0
+          level_labels: ''
+          force_deepest: false
+          plugin_id: taxonomy_index_tid
       sorts:
         created:
           id: created
@@ -835,8 +936,11 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.media.field_media_in_library'
+        - 'config:field.storage.media.field_owner'
   entity_browser_1:
     display_plugin: entity_browser
     id: entity_browser_1
@@ -1312,14 +1416,15 @@ display:
         - user.permissions
       tags:
         - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.download_link'
+        - 'config:core.entity_view_display.media.document.embedded'
         - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.download_link'
         - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.media_library'
         - 'config:core.entity_view_display.media.image.thumbnail'
-        - 'config:core.entity_view_display.media.document.download_link'
-        - 'config:core.entity_view_display.media.document.embedded'
-        - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
         - 'config:core.entity_view_display.media.video.thumbnail'
@@ -2124,6 +2229,7 @@ display:
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.download_link'
         - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.media_library'
         - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
@@ -2144,5 +2250,8 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.media.field_media_in_library'
+        - 'config:field.storage.media.field_owner'

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -701,7 +701,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'Show in media library'
+          label: Reusable
           exclude: false
           alter:
             alter_text: false
@@ -909,7 +909,7 @@ display:
           exposed: true
           expose:
             operator_id: ''
-            label: 'Show in media library (field_media_in_library)'
+            label: Reusable
             description: null
             use_operator: false
             operator: field_media_in_library_value_op
@@ -932,11 +932,11 @@ display:
             default_group_multiple: {  }
             group_items:
               1:
-                title: 'Yes, shows up in media library'
+                title: Reusable
                 operator: '='
                 value: '1'
               2:
-                title: 'No, does not show in media library'
+                title: 'Not reusable'
                 operator: '='
                 value: '0'
           plugin_id: boolean

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -10,6 +10,7 @@ dependencies:
     - image.style.thumbnail
     - media.type.document
     - media.type.image
+    - system.menu.admin
     - taxonomy.vocabulary.administration
   module:
     - entity_browser
@@ -196,8 +197,8 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          action_title: Action
-          include_exclude: exclude
+          action_title: 'Bulk action'
+          include_exclude: include
           selected_actions:
             - media_delete_action
           entity_type: media
@@ -1463,13 +1464,13 @@ display:
         - 'config:core.entity_view_display.media.document.media_library'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.document.download_link'
         - 'config:core.entity_view_display.media.document.embedded'
         - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.image.download_link'
         - 'config:core.entity_view_display.media.image.embedded'
         - 'config:core.entity_view_display.media.image.thumbnail'
-        - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
         - 'config:core.entity_view_display.media.video.thumbnail'
   entity_browser_2:
@@ -2285,8 +2286,31 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: admin/content/media-table
+      path: admin/content/media
       display_description: ''
+      menu:
+        type: normal
+        title: 'Media library'
+        description: ''
+        expanded: false
+        parent: system.admin_content
+        weight: 0
+        context: '0'
+        menu_name: admin
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
+          plugin_id: text_custom
+      defaults:
+        header: false
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -895,6 +895,50 @@ display:
           level_labels: ''
           force_deepest: false
           plugin_id: taxonomy_index_tid
+        field_media_in_library_value:
+          id: field_media_in_library_value
+          table: media__field_media_in_library
+          field: field_media_in_library_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Show in media library (field_media_in_library)'
+            description: null
+            use_operator: false
+            operator: field_media_in_library_value_op
+            identifier: field_media_in_library_value
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: 'Reusable?'
+            description: ''
+            identifier: field_media_in_library_value
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'Yes, shows up in media library'
+                operator: '='
+                value: '1'
+              2:
+                title: 'No, does not show in media library'
+                operator: '='
+                value: '0'
+          plugin_id: boolean
       sorts:
         created:
           id: created
@@ -1416,14 +1460,14 @@ display:
         - user.permissions
       tags:
         - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
         - 'config:core.entity_view_display.media.document.download_link'
         - 'config:core.entity_view_display.media.document.embedded'
-        - 'config:core.entity_view_display.media.document.media_library'
         - 'config:core.entity_view_display.media.document.thumbnail'
-        - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.download_link'
         - 'config:core.entity_view_display.media.image.embedded'
-        - 'config:core.entity_view_display.media.image.media_library'
         - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -331,6 +331,42 @@ display:
           level_labels: ''
           force_deepest: false
           plugin_id: taxonomy_index_tid
+        field_media_in_library_value:
+          id: field_media_in_library_value
+          table: media__field_media_in_library
+          field: field_media_in_library_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
       sorts:
         created:
           id: created
@@ -376,7 +412,18 @@ display:
           entity_field: name
           plugin_id: standard
       title: Media
-      header: {  }
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content: 'This page displays all media on the VA.gov CMS, including media that does not show up in the shared media library.'
+          plugin_id: text_custom
       footer: {  }
       empty:
         area_text_custom:
@@ -434,6 +481,197 @@ display:
         weight: 5
         context: '0'
         menu_name: admin
+      filters:
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: bundle_op
+            label: 'Media type'
+            description: ''
+            use_operator: false
+            operator: bundle_op
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: 'Media type'
+            description: null
+            identifier: bundle
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
+        field_owner_target_id:
+          id: field_owner_target_id
+          table: media__field_owner
+          field: field_owner_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_owner_target_id_op
+            label: Section
+            description: ''
+            use_operator: false
+            operator: field_owner_target_id_op
+            identifier: field_owner_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              redirect_administrator: '0'
+              documentation_editor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: administration
+          hierarchy: true
+          error_message: true
+          parent: 0
+          level_labels: ''
+          force_deepest: false
+          plugin_id: taxonomy_index_tid
+        field_media_in_library_value:
+          id: field_media_in_library_value
+          table: media__field_media_in_library
+          field: field_media_in_library_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Show in media library (field_media_in_library)'
+            description: null
+            use_operator: false
+            operator: field_media_in_library_value_op
+            identifier: field_media_in_library_value
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: 'Reusable?'
+            description: ''
+            identifier: field_media_in_library_value
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'Yes, shows in media library'
+                operator: '='
+                value: '1'
+              2:
+                title: 'No, does not show in media library'
+                operator: '='
+                value: '0'
+          plugin_id: boolean
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.media_library
+    - taxonomy.vocabulary.administration
   enforced:
     module:
       - media_library
   module:
     - media
     - media_library
+    - taxonomy
     - user
 _core:
   default_config_hash: 1F1cSZ5MlvxdwjdyrwnH2I8CWngOp8Pu2SXDzix2QUc
@@ -190,52 +192,6 @@ display:
           entity_type: media
           plugin_id: rendered_entity
       filters:
-        status:
-          id: status
-          table: media_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Publishing status'
-            description: null
-            use_operator: false
-            operator: status_op
-            identifier: status
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: true
-          group_info:
-            label: Published
-            description: ''
-            identifier: status
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: Published
-                operator: '='
-                value: '1'
-              2:
-                title: Unpublished
-                operator: '='
-                value: '0'
-          plugin_id: boolean
-          entity_type: media
-          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -320,6 +276,61 @@ display:
           entity_type: media
           entity_field: bundle
           plugin_id: bundle
+        field_owner_target_id:
+          id: field_owner_target_id
+          table: media__field_owner
+          field: field_owner_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_owner_target_id_op
+            label: Section
+            description: ''
+            use_operator: false
+            operator: field_owner_target_id_op
+            identifier: field_owner_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              redirect_administrator: '0'
+              documentation_editor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: administration
+          hierarchy: true
+          error_message: true
+          parent: 0
+          level_labels: ''
+          force_deepest: false
+          plugin_id: taxonomy_index_tid
       sorts:
         created:
           id: created
@@ -384,14 +395,28 @@ display:
       use_ajax: true
       css_class: 'media-library-view js-media-library-view'
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'url.query_args:sort_by'
+        - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.document.download_link'
+        - 'config:core.entity_view_display.media.document.embedded'
+        - 'config:core.entity_view_display.media.document.thumbnail'
+        - 'config:core.entity_view_display.media.image.download_link'
+        - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.thumbnail'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.embedded'
+        - 'config:core.entity_view_display.media.video.thumbnail'
   page:
     display_plugin: page
     id: page
@@ -410,14 +435,28 @@ display:
         context: '0'
         menu_name: admin
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'url.query_args:sort_by'
+        - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.download_link'
+        - 'config:core.entity_view_display.media.document.embedded'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.document.thumbnail'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.download_link'
+        - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.image.thumbnail'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.embedded'
+        - 'config:core.entity_view_display.media.video.thumbnail'
   widget:
     display_plugin: page
     id: widget
@@ -543,5 +582,19 @@ display:
         - url
         - url.query_args
         - 'url.query_args:sort_by'
+        - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.download_link'
+        - 'config:core.entity_view_display.media.document.embedded'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.document.thumbnail'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.download_link'
+        - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.image.thumbnail'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.embedded'
+        - 'config:core.entity_view_display.media.video.thumbnail'

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -623,7 +623,7 @@ display:
           exposed: true
           expose:
             operator_id: ''
-            label: 'Show in media library (field_media_in_library)'
+            label: Reusable
             description: null
             use_operator: false
             operator: field_media_in_library_value_op
@@ -646,11 +646,11 @@ display:
             default_group_multiple: {  }
             group_items:
               1:
-                title: 'Yes, shows in media library'
+                title: Reusable
                 operator: '='
                 value: '1'
               2:
-                title: 'No, does not show in media library'
+                title: 'Not reusable'
                 operator: '='
                 value: '0'
           plugin_id: boolean

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -16,7 +16,7 @@ dependencies:
 _core:
   default_config_hash: 1F1cSZ5MlvxdwjdyrwnH2I8CWngOp8Pu2SXDzix2QUc
 id: media_library
-label: 'Media library'
+label: 'Media library widget'
 module: views
 description: ''
 tag: ''
@@ -412,18 +412,7 @@ display:
           entity_field: name
           plugin_id: standard
       title: Media
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content: 'This page displays all media on the VA.gov CMS, including media that does not show up in the shared media library.'
-          plugin_id: text_custom
+      header: {  }
       footer: {  }
       empty:
         area_text_custom:
@@ -455,25 +444,25 @@ display:
         - 'config:core.entity_view_display.media.document.media_library'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.document.download_link'
         - 'config:core.entity_view_display.media.document.embedded'
         - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.image.download_link'
         - 'config:core.entity_view_display.media.image.embedded'
         - 'config:core.entity_view_display.media.image.thumbnail'
-        - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
         - 'config:core.entity_view_display.media.video.thumbnail'
   page:
     display_plugin: page
     id: page
-    display_title: Page
+    display_title: 'Deprecated (to follow D8.7 approach)'
     position: 1
     display_options:
       display_extenders: {  }
-      path: admin/content/media
+      path: admin/content/media_old
       menu:
-        type: tab
+        type: none
         title: Media
         description: 'Allows users to browse and administer media items'
         expanded: false
@@ -672,6 +661,8 @@ display:
         operator: AND
         groups:
           1: AND
+      enabled: false
+      display_description: ''
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/sync/workbench_access.access_scheme.section.yml
+++ b/config/sync/workbench_access.access_scheme.section.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - field.field.block_content.alert.field_owner
     - field.field.block_content.promo.field_owner
+    - field.field.media.document.field_owner
+    - field.field.media.image.field_owner
     - field.field.node.event.field_administration
     - field.field.node.event_listing.field_administration
     - field.field.node.health_care_local_facility.field_administration
@@ -37,6 +39,14 @@ scheme_settings:
     -
       entity_type: block_content
       bundle: promo
+      field: field_owner
+    -
+      entity_type: media
+      bundle: document
+      field: field_owner
+    -
+      entity_type: media
+      bundle: image
       field: field_owner
     -
       entity_type: node
@@ -92,11 +102,11 @@ scheme_settings:
       field: field_administration
     -
       entity_type: node
-      bundle: event_listing
+      bundle: health_care_local_health_service
       field: field_administration
     -
       entity_type: node
-      bundle: health_care_local_health_service
+      bundle: event_listing
       field: field_administration
     -
       entity_type: taxonomy_term

--- a/config/sync/workbench_access.access_scheme.section.yml
+++ b/config/sync/workbench_access.access_scheme.section.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.promo.field_owner
     - field.field.media.document.field_owner
     - field.field.media.image.field_owner
+    - field.field.media.video.field_owner
     - field.field.node.event.field_administration
     - field.field.node.event_listing.field_administration
     - field.field.node.health_care_local_facility.field_administration
@@ -47,6 +48,10 @@ scheme_settings:
     -
       entity_type: media
       bundle: image
+      field: field_owner
+    -
+      entity_type: media
+      bundle: video
       field: field_owner
     -
       entity_type: node


### PR DESCRIPTION
This builds on some of the media improvements from VAGOV-5013, adding governance mechanisms and AX improvements. 

Read this for context: 
https://va-gov.atlassian.net/wiki/spaces/VAGOV/pages/131235861

As content_editor
[ ] Go to /media/add/document
[ ] Review help text, it should be well written
[ ] Make the document reusable (show in media library, the default)
[ ] Make the Owner Veteran Benefits administrations

[ ] Go to /media/add/image
[ ] Review help text, it should be well written
[ ] Make it _not_ reusable (do not show in media library)
[ ] Make the owner "Pittsburgh Health Care" (under Veterans Health Administration > Facilities)

[ ] Go to /media/add/video
[ ] Review help text, it should be well written
[ ] Make it reusable (leave default
[ ] Make the owner "VA Central Office" 


As louis.scavnicky (content_publisher member of Pittsburgh Health Care)
[ ] Go to /admin/content and then click on Media tab.
[ ] Make sure you can get to it from Manage > Content > Media 
[ ] You should see all three media items created by content_editor.
[ ] Filter by Reusable. You should only see the reusable document, not the image.
[ ] Test the Owner filter, by filtering for each of the sections above. 

Still as louis.scavnicky
[ ] Try to edit each of the three new media items. You should only be able to edit the one assigned to Pittsburgh Health Care
[ ] Try to edit any of the media items that existed _before_ the three that were just created.  You should be able to edit any of them, but they will now require the Owner field to be filled out, and your only option should be Pittsburgh Health Care 

Still as louis.scavnicky
[ ] Go to /node/add/health_care_region_detail_page and add two Content blocks: 1) Embedded image 2) Link to file or video 
[ ] For each of the above, Browse Media. 
[ ] You should only see media that you set to be reusable as content_editor (document and video). 


As user content_publisher (who has access to all Sections)
[ ] You should be able to edit any of the three new media items from /admin/media

 
Added Aug 3
[ ] Go /media/add/ and open a tab for each of the media types
[ ] You shouldn't see the Reusable form
[ ] Open the "media library" form variants, by going to /node/add/page and adding an Embedded image and a Link to file contentt block.  You should see the reusable checkbox. 

