### PR TITLE
VAGOV-5237: Changing outreach menu name to sentence case.

### DIFF
--- a/config/sync/system.menu.outreach-and-events.yml
+++ b/config/sync/system.menu.outreach-and-events.yml
@@ -3,6 +3,6 @@ langcode: en
 status: true
 dependencies: {  }
 id: outreach-and-events
-label: 'Outreach and Events'
+label: 'Outreach and events'
 description: ''
 locked: false


### PR DESCRIPTION
## Description
Updates the `Outreach and Events` menu name to sentence case, e.g.: `Outreach and events`
This is the drupal portion of task 5237. There is a second component: make Outreach and events menu on `/outreach-and-events` (frontend) path open by default. Merged pr = https://github.com/department-of-veterans-affairs/vets-website/pull/10525

## Testing done
Visual

## Screenshots
![Screenshot_2019-08-01_11-05-29](https://user-images.githubusercontent.com/2404547/62315181-cd8ee700-b462-11e9-9531-cb9af659f749.png)

## Acceptance criteria
- [ ] Outreach menu title reads as `Outreach and events` on this path: `/admin/structure/menu/manage/outreach-and-events`