### PR TITLE
VAGOV-5323 - Fix PeformanceLoginTest failure, decrease threshold from 5 > 2.

### DIFF
--- a/tests/phpunit/PerformanceLoginTest.php
+++ b/tests/phpunit/PerformanceLoginTest.php
@@ -18,11 +18,13 @@ class LoginPerformance extends ExistingSiteBase {
    * @dataProvider benchmarkTime
    */
   public function testLoginPerformance($benchmark) {
-    // Warm some cache before testing so login test will be more realistic.
-    // @todo Move this higher up so it runs once before all tests.
-    $this->visit('/');
 
     $author = $this->createUser();
+    $author->addRole('content_editor');
+    $author->save();
+
+    // Warm some cache before testing so login test will be more realistic.
+    $this->drupalLogin($author);
 
     // Start timer.
     $mtime = microtime();
@@ -56,7 +58,7 @@ class LoginPerformance extends ExistingSiteBase {
    */
   public function benchmarkTime() {
     return array(
-      array(5),
+      array(2),
     );
   }
 


### PR DESCRIPTION
Test was failing because SAML local_users login setting excluded the
default authenticated_user role.

![image](https://user-images.githubusercontent.com/1504756/62499608-2bd80480-b798-11e9-9c84-edb22c64fd00.png)


Added a login before the test to prime the opcache and Drupal cache to
test a real-world login scenario, this means we can test for under 2
seconds now.