### PR TITLE
VAGOV-1955 - Workflow Participant notifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
         "drupal/views_tree": "^2.0@alpha",
         "drupal/workbench_access": "^1.0@beta",
         "drupal/workbench_menu_access": "^1.0",
+        "drupal/workflow_participants": "^2.4",
         "drupal/xmlsitemap": "^1.0@alpha",
         "drush-ops/behat-drush-endpoint": "^0.0.4",
         "guzzlehttp/guzzle": "^6.0@dev",
@@ -191,6 +192,9 @@
             },
             "drupal/textfield_counter": {
                 "Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch"
+            },
+            "drupal/workflow_participants": {
+                "Fix uncaught type error by extending class.": "patches/workflowParticipantsUncaughtType.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c00c4c6eede878a4612762429d6dec3b",
+    "content-hash": "f945760e622439322caf88331af9552f",
     "packages": [
         {
             "name": "acquia/headless_lightning",
@@ -684,7 +684,8 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/fengyuanchen/cropper/zipball/30c58b29ee21010e17e58ebab165fbd84285c685",
-                "reference": "30c58b29ee21010e17e58ebab165fbd84285c685"
+                "reference": "30c58b29ee21010e17e58ebab165fbd84285c685",
+                "shasum": null
             },
             "type": "bower-asset",
             "license": [
@@ -702,7 +703,8 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/enyo/dropzone/zipball/08b9e0a763b54a685404dea523a9c54242fbe1b9",
-                "reference": "08b9e0a763b54a685404dea523a9c54242fbe1b9"
+                "reference": "08b9e0a763b54a685404dea523a9c54242fbe1b9",
+                "shasum": null
             },
             "type": "bower-asset"
         },
@@ -717,7 +719,8 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/jquery/jquery-dist/zipball/9e8ec3d10fad04748176144f108d7355662ae75e",
-                "reference": "9e8ec3d10fad04748176144f108d7355662ae75e"
+                "reference": "9e8ec3d10fad04748176144f108d7355662ae75e",
+                "shasum": null
             },
             "type": "bower-asset",
             "license": [
@@ -729,13 +732,14 @@
             "version": "v1.8.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:kenwheeler/slick.git",
+                "url": "https://github.com/kenwheeler/slick.git",
                 "reference": "0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/kenwheeler/slick/zipball/0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee",
-                "reference": "0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee"
+                "reference": "0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee",
+                "shasum": null
             },
             "require": {
                 "bower-asset/jquery": ">=1.7"
@@ -2657,7 +2661,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1554332581",
+                    "datestamp": "1527081784",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2674,16 +2678,8 @@
                     "homepage": "https://www.drupal.org/user/86106"
                 },
                 {
-                    "name": "dww",
-                    "homepage": "https://www.drupal.org/user/46549"
-                },
-                {
                     "name": "googletorp",
                     "homepage": "https://www.drupal.org/user/386230"
-                },
-                {
-                    "name": "mglaman",
-                    "homepage": "https://www.drupal.org/user/2416470"
                 },
                 {
                     "name": "rszrama",
@@ -2693,7 +2689,7 @@
             "description": "Provides functionality for storing, validating and displaying international postal addresses.",
             "homepage": "http://drupal.org/project/address",
             "support": {
-                "source": "https://git.drupalcode.org/project/address"
+                "source": "http://cgit.drupalcode.org/address"
             }
         },
         {
@@ -3136,7 +3132,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1556870881",
+                    "datestamp": "1461060840",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3160,7 +3156,7 @@
             "description": "Registers “component libraries” defined in modules and themes with the Twig system",
             "homepage": "https://www.drupal.org/project/components",
             "support": {
-                "source": "https://git.drupalcode.org/project/components"
+                "source": "http://cgit.drupalcode.org/components"
             }
         },
         {
@@ -3376,7 +3372,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta9",
-                    "datestamp": "1556703480",
+                    "datestamp": "1497478742",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -3412,7 +3408,7 @@
             "description": "Provides storage and edit capability for contact messages.",
             "homepage": "https://www.drupal.org/project/contact_storage",
             "support": {
-                "source": "https://git.drupalcode.org/project/contact_storage"
+                "source": "http://cgit.drupalcode.org/contact_storage"
             }
         },
         {
@@ -4306,6 +4302,65 @@
             "time": "2017-12-06T20:35:40+00:00"
         },
         {
+            "name": "drupal/dynamic_entity_reference",
+            "version": "2.0.0-alpha9",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/dynamic_entity_reference.git",
+                "reference": "8.x-2.0-alpha9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/dynamic_entity_reference-8.x-2.0-alpha9.zip",
+                "reference": "8.x-2.0-alpha9",
+                "shasum": "a1ba9d7c1272a8600a6c5dfce254c7a49d3f8548"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.0-alpha9",
+                    "datestamp": "1554021181",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Lee Rowlands",
+                    "homepage": "https://www.drupal.org/u/larowlan",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jibran Ijaz",
+                    "homepage": "https://www.drupal.org/u/jibran",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                }
+            ],
+            "description": "Provides a field that allows an entity-reference field to reference more than one entity type.",
+            "homepage": "http://drupal.org/project/dynamic_entity_reference",
+            "support": {
+                "source": "http://cgit.drupalcode.org/dynamic_entity_reference",
+                "issues": "http://drupal.org/project/dynamic_entity_reference",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
             "name": "drupal/embed",
             "version": "1.0.0",
             "source": {
@@ -4787,7 +4842,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.5",
-                    "datestamp": "1553405885",
+                    "datestamp": "1546540980",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4811,7 +4866,7 @@
             "description": "Adds a color indicator for the different environments.",
             "homepage": "https://www.drupal.org/project/environment_indicator",
             "support": {
-                "source": "https://git.drupalcode.org/project/environment_indicator"
+                "source": "http://cgit.drupalcode.org/environment_indicator"
             }
         },
         {
@@ -5205,7 +5260,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1555051984",
+                    "datestamp": "1486045984",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5507,7 +5562,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.3",
-                    "datestamp": "1553177584",
+                    "datestamp": "1550761645",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5539,7 +5594,7 @@
             "description": "Provides a JSON API standards-compliant API for accessing and manipulating Drupal content and configuration entities.",
             "homepage": "https://www.drupal.org/project/jsonapi",
             "support": {
-                "source": "https://git.drupalcode.org/project/jsonapi"
+                "source": "http://cgit.drupalcode.org/jsonapi"
             }
         },
         {
@@ -6520,7 +6575,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.8",
-                    "datestamp": "1554988685",
+                    "datestamp": "1549606384",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6560,7 +6615,7 @@
             "description": "Create breadcrumbs from nested menu titles and/or taxonomy membership.",
             "homepage": "https://www.drupal.org/project/menu_breadcrumb",
             "support": {
-                "source": "https://git.drupalcode.org/project/menu_breadcrumb"
+                "source": "http://cgit.drupalcode.org/menu_breadcrumb"
             }
         },
         {
@@ -6758,7 +6813,7 @@
                 },
                 "drupal": {
                     "version": "8.x-4.1",
-                    "datestamp": "1555683487",
+                    "datestamp": "1546879080",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8061,7 +8116,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1554239887",
+                    "datestamp": "1536407884",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8093,7 +8148,7 @@
             "description": "Provides a mechanism for modules to automatically generate aliases for the content they manage.",
             "homepage": "https://www.drupal.org/project/pathauto",
             "support": {
-                "source": "https://git.drupalcode.org/project/pathauto"
+                "source": "http://cgit.drupalcode.org/pathauto"
             }
         },
         {
@@ -8445,7 +8500,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1556903887",
+                    "datestamp": "1459597139",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8458,8 +8513,12 @@
             ],
             "authors": [
                 {
-                    "name": "JeroenT",
-                    "homepage": "https://www.drupal.org/user/2228934"
+                    "name": "Andrew Schulman",
+                    "homepage": "https://www.drupal.org/user/279446"
+                },
+                {
+                    "name": "David Lesieur",
+                    "homepage": "https://www.drupal.org/user/17157"
                 },
                 {
                     "name": "benjy",
@@ -8469,7 +8528,7 @@
             "description": "Allows site administrators to grant some roles the authority to assign selected roles to users.",
             "homepage": "https://www.drupal.org/project/role_delegation",
             "support": {
-                "source": "https://git.drupalcode.org/project/role_delegation"
+                "source": "http://cgit.drupalcode.org/role_delegation"
             }
         },
         {
@@ -8502,7 +8561,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha5",
-                    "datestamp": "1556654285",
+                    "datestamp": "1537628284",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8589,7 +8648,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha5",
-                    "datestamp": "1556654285",
+                    "datestamp": "1537628284",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8637,7 +8696,7 @@
             "description": "Provides a data models for entity types and bundles in JSON schema format.",
             "homepage": "https://www.drupal.org/project/schemata",
             "support": {
-                "source": "https://git.drupalcode.org/project/schemata"
+                "source": "http://cgit.drupalcode.org/schemata"
             }
         },
         {
@@ -8673,7 +8732,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.12",
-                    "datestamp": "1557244685",
+                    "datestamp": "1552334285",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8883,7 +8942,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.14",
-                    "datestamp": "1556659981",
+                    "datestamp": "1549832280",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8908,7 +8967,7 @@
             "description": "The Simple OAuth module for Drupal",
             "homepage": "https://www.drupal.org/project/simple_oauth",
             "support": {
-                "source": "https://git.drupalcode.org/project/simple_oauth"
+                "source": "http://cgit.drupalcode.org/simple_oauth"
             }
         },
         {
@@ -8925,7 +8984,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.14",
-                    "datestamp": "1556659981",
+                    "datestamp": "1549832280",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8949,7 +9008,7 @@
             "description": "OAuth2 extra access grants.",
             "homepage": "https://www.drupal.org/project/simple_oauth",
             "support": {
-                "source": "https://git.drupalcode.org/project/simple_oauth"
+                "source": "http://cgit.drupalcode.org/simple_oauth"
             }
         },
         {
@@ -10101,6 +10160,61 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/workbench_menu_access"
             }
+        },
+        {
+            "name": "drupal/workflow_participants",
+            "version": "dev-2.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/workflow_participants.git",
+                "reference": "be4fcd0261ee1bb0b0aa8047ffff782e5f8dfa35"
+            },
+            "require": {
+                "drupal/core": "*",
+                "drupal/dynamic_entity_reference": "^2.0"
+            },
+            "require-dev": {
+                "drupal/content_moderation_notifications": "^3.0",
+                "drupal/diff": "^1.0",
+                "drupal/token": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.4+4-dev",
+                    "datestamp": "1555002781",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                },
+                "patches_applied": {
+                    "Fix uncaught type error by extending class.": "patches/workflowParticipantsUncaughtType.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "jhedstrom",
+                    "homepage": "https://www.drupal.org/user/208732"
+                }
+            ],
+            "description": "Allows for per-entity workflow participants (editors and reviewers) to be assigned.",
+            "homepage": "https://www.drupal.org/project/workflow_participants",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/workflow_participants",
+                "issues": "https://www.drupal.org/project/issues/workflow_participants"
+            },
+            "time": "2019-04-11T17:27:47+00:00"
         },
         {
             "name": "drupal/xmlsitemap",
@@ -17417,10 +17531,10 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1554383285",
+                    "datestamp": "1508311145",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
+                        "message": "Project has not opted into security advisory coverage!"
                     }
                 }
             },
@@ -17453,7 +17567,7 @@
             "description": "Provides a generic Media source plugin.",
             "homepage": "https://www.drupal.org/project/media_entity_generic",
             "support": {
-                "source": "https://git.drupalcode.org/project/media_entity_generic"
+                "source": "http://cgit.drupalcode.org/media_entity_generic"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -30,6 +30,7 @@ module:
   dblog: 0
   diff: 0
   dropzonejs: 0
+  dynamic_entity_reference: 0
   editor: 0
   embed: 0
   entity_block: 0
@@ -155,6 +156,7 @@ module:
   views_tree: 0
   workbench_access: 0
   workbench_menu_access: 0
+  workflow_participants: 0
   workflows: 0
   xmlsitemap_engines: 0
   hide_revision_field: 1

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -149,6 +149,7 @@ module:
   va_gov_flags: 0
   va_gov_graphql: 0
   va_gov_migrate: 0
+  va_gov_notifications: 0
   video_embed_field: 0
   video_embed_media: 0
   views_bulk_operations: 0

--- a/config/sync/lightning_core.versions.yml
+++ b/config/sync/lightning_core.versions.yml
@@ -211,3 +211,4 @@ entityqueue: 1.0.0-beta5
 views_tree: 2.0.0-alpha1
 redirect_after_login: 2.5.0
 page_manager_ui: 4.0.0-beta3
+va_gov_notifications: 0.0.0

--- a/config/sync/views.view.my_workflow.yml
+++ b/config/sync/views.view.my_workflow.yml
@@ -1,0 +1,643 @@
+uuid: 56c4a306-5e45-410e-8c05-081ff464d216
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_moderation
+    - node
+    - user
+    - workflow_participants
+_core:
+  default_config_hash: J7TrvvhzyZL-8s-qqtDjgbNeVSKC6SCLMzJRaEWl_Bc
+id: my_workflow
+label: 'My Workflow'
+module: views
+description: 'Content a user has access to that is ready for moderation'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'can be workflow participant'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          quantity: 9
+      style:
+        type: table
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Title
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        moderation_state:
+          id: moderation_state
+          table: content_moderation_state_field_data
+          field: moderation_state
+          relationship: moderation_state
+          group_type: group
+          admin_label: ''
+          label: 'Latest state'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: content_moderation_state
+          entity_field: moderation_state
+          plugin_id: field
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Published
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_true: ''
+            format_custom_false: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+        participant_role_field:
+          id: participant_role_field
+          table: workflow_participants
+          field: participant_role_field
+          relationship: reverse__workflow_participants__moderated_entity
+          group_type: group
+          admin_label: ''
+          label: 'My role'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: workflow_participants
+          plugin_id: participant_role_field
+      filters:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              customer: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_op
+            identifier: type
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              customer: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: 'Content type'
+            description: null
+            identifier: type
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        moderation_state:
+          id: moderation_state
+          table: content_moderation_state_field_data
+          field: moderation_state
+          relationship: moderation_state
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: content_moderation_state
+          entity_field: moderation_state
+          plugin_id: string
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: status_op
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              customer: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        participant_role_filter:
+          id: participant_role_filter
+          table: workflow_participants
+          field: participant_role_filter
+          relationship: reverse__workflow_participants__moderated_entity
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value:
+            author: author
+            editor: editor
+            reviewer: reviewer
+          group: 1
+          exposed: false
+          expose:
+            operator_id: participant_role_filter_op
+            label: 'Participant role filter'
+            description: ''
+            use_operator: false
+            operator: participant_role_filter_op
+            identifier: participant_role_filter
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              customer: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: workflow_participants
+          plugin_id: participant_role_filter
+        participant_role_filter_1:
+          id: participant_role_filter_1
+          table: workflow_participants
+          field: participant_role_filter
+          relationship: reverse__workflow_participants__moderated_entity
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value:
+            author: author
+            editor: editor
+            reviewer: reviewer
+          group: 1
+          exposed: true
+          expose:
+            operator_id: participant_role_filter_1_op
+            label: 'My role'
+            description: ''
+            use_operator: false
+            operator: participant_role_filter_1_op
+            identifier: participant_role_filter_1
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              customer: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: workflow_participants
+          plugin_id: participant_role_filter
+      sorts:
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+      title: 'My Workflow'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: 'Content moderation state'
+          required: false
+          entity_type: node
+          plugin_id: standard
+        reverse__workflow_participants__moderated_entity:
+          id: reverse__workflow_participants__moderated_entity
+          table: node_field_data
+          field: reverse__workflow_participants__moderated_entity
+          relationship: none
+          group_type: group
+          admin_label: 'Reverse reference to Moderated entity base field on Workflow participants'
+          required: false
+          entity_type: node
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  my_workflow_page:
+    display_plugin: page
+    id: my_workflow_page
+    display_title: 'My workflow'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/my-workflow
+      menu:
+        type: tab
+        title: 'My workflow'
+        description: 'Content a user has access to that is ready for moderation'
+        expanded: false
+        parent: system.admin_content
+        weight: 0
+        context: '0'
+        menu_name: admin
+      display_description: 'Content a user has access to that is ready for moderation'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/workflow_participants.settings.yml
+++ b/config/sync/workflow_participants.settings.yml
@@ -1,8 +1,8 @@
-enable_notifications: true
+enable_notifications: false
 participant_message:
   subject: 'You have been added as workflow participant to [node:title]'
   body:
-    value: "Greetings [user:name],\n\n You have been added as a workflow participant to [node:title].\n\n[node:url:absolute]"
+    value: "Greetings [user:name],\r\n\r\n You have been added as a workflow participant to [node:title].\r\n\r\n[node:url:absolute]"
     format: plain_text
 _core:
   default_config_hash: zCEGhLVXu2XnolDD4D7fIQqry_eMgwoaUBcsE5C7uho

--- a/config/sync/workflow_participants.settings.yml
+++ b/config/sync/workflow_participants.settings.yml
@@ -1,0 +1,8 @@
+enable_notifications: true
+participant_message:
+  subject: 'You have been added as workflow participant to [node:title]'
+  body:
+    value: "Greetings [user:name],\n\n You have been added as a workflow participant to [node:title].\n\n[node:url:absolute]"
+    format: plain_text
+_core:
+  default_config_hash: zCEGhLVXu2XnolDD4D7fIQqry_eMgwoaUBcsE5C7uho

--- a/docroot/modules/custom/va_gov_notifications/README.md
+++ b/docroot/modules/custom/va_gov_notifications/README.md
@@ -1,0 +1,27 @@
+# VA Notifications
+
+## VA.gov Notifications
+This module sends email alerts to users who have been added to node workflow participants forms.
+Alerts are only sent if a workflow state change has occurred, and this is triggered by node save.
+
+### Workflow Participants form
+An alter has been added to remove the `Editors` fieldset - it is redundant,
+as workflow participants module doesn't pull from va roles to autopopulate fields,
+and doesn't assign any extra perms to users entered in `Editors` or `Reviewers` fields.
+This form can be found on these paths: `node/{NID}/workflow-participants`
+Once a user is added to this form, any time a workflow state has changed, an email
+will be sent to them on node save.
+Once a user is removed from the workflow participants form, they will no longer receive emails when workflow state changes.
+
+### Email data
+```Content title: Make an appointment
+Link: http://va.gov/pittsburgh-health-care/make-an-appointment
+Status Change From: review
+Status Change To: draft
+Log Message: This is a thing.
+Change made by: some.user
+Time changed: 2019-08-04 11:59:04
+```
+
+### Error Reporting
+Email send errors will be reported to Recent Log Messages (`/admin/reports/dblog`)

--- a/docroot/modules/custom/va_gov_notifications/src/WorkflowChangeEmail.php
+++ b/docroot/modules/custom/va_gov_notifications/src/WorkflowChangeEmail.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\va_gov_notifications;
+
+use Drupal\Core\Render\Markup;
+
+/**
+ * For sending workflow status change emails.
+ */
+class WorkflowChangeEmail {
+
+  /**
+   * Creates and sends workflow change email.
+   *
+   * @param array $mail_load
+   *   Contains node, recipient and revision author data for creating email.
+   *   Sample array:
+   *   $mail_load => [
+   *    'users' => [
+   *        356 => [
+   *          'email' => 'test@gmail.com',
+   *          'name' => 'sample.user',
+   *          'lang' => en,
+   *          'time' => 2019-08-04 11:46:11,
+   *        ],
+   *     ],
+   *    'node_title' => 'Make an appointment'
+   *    'original_workflow_state' => 'review'
+   *    'new_workflow_state' => 'approved_by_reviewer'
+   *    'url' => 'http://va.gov/pittsburgh-health-care/make-an-appointment'
+   *    'log_message' => 'Some sample message',
+   *    'change_author' => [
+   *        'name' => 'don.quixote',
+   *        'email' => '123@gmail.com',
+   *        'uid' => 350,
+   *     ],
+   *   ].
+   */
+  public function sendEmail(array $mail_load) {
+    $mailManager = \Drupal::service('plugin.manager.mail');
+    $module = 'va_gov_notifications';
+    // Defined in va_gov_notifications_mail.
+    $key = 'workflow_status_change';
+
+    // The email subject.
+    $params['title'] = t(
+      ':title | Status Changed', [
+        ':title' => $mail_load['node_title'],
+      ]
+    );
+    // Start building email body with content item title.
+    $html = t(
+      'Content title: :title :break',
+      [
+        ':title' => $mail_load['node_title'],
+        ':break' => "\r\n",
+      ]);
+    // Link to the above title.
+    $html .= t(
+      'Link: :url :break',
+      [
+        ':url' => $mail_load['url'],
+        ':break' => "\r\n",
+      ]);
+    // Previous workflow status.
+    $html .= t(
+      'Status Change From: :from :break',
+      [
+        ':from' => $mail_load['original_workflow_state'],
+        ':break' => "\r\n",
+      ]);
+    // Current workflow status.
+    $html .= t(
+      'Status Change To: :to :break',
+      [
+        ':to' => $mail_load['new_workflow_state'],
+        ':break' => "\r\n",
+      ]);
+    // If log message, include it.
+    if (!empty($mail_load['log_message'])) {
+      $html .= t(
+        'Log Message: :message :break', [
+          ':message' => $mail_load['log_message'],
+          ':break' => "\r\n",
+        ]
+      );
+    }
+    // The name of the user who revised the node.
+    $html .= t(
+      'Change made by: :name :break', [
+        ':name' => $mail_load['change_author']['name'],
+        ':break' => "\r\n",
+      ]
+    );
+    // Now loop through workflow participants.
+    foreach ($mail_load['users'] as $mail) {
+      // Get their language for appropriate translation.
+      $langcode = $mail['lang'];
+      $to = $mail['email'];
+      // Don't filter out the timestamp formatting.
+      $html .= t(
+        'Time changed: @time :break', [
+          '@time' => $mail['time'],
+          ':break' => "\r\n",
+        ]
+      );
+      // Run through Markup so that node link can be created in email.
+      $params['message'] = Markup::create($html);
+      $send = TRUE;
+      // Put it all together.
+      $result = $mailManager->mail($module, $key, $to, $langcode, $params, NULL, $send);
+
+      // Log issues.
+      if ($result['result'] !== TRUE) {
+        $message = t('There was a problem sending your email notification to @email.', ['@email' => $to]);
+        drupal_set_message($message, 'error');
+        \Drupal::logger('mail-log')->error($message);
+        return;
+      }
+      // Display success.
+      $message = t('An email notification has been sent to @email', ['@email' => $to]);
+      drupal_set_message($message);
+      \Drupal::logger('mail-log')->notice($message);
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_notifications/va_gov_notifications.info.yml
+++ b/docroot/modules/custom/va_gov_notifications/va_gov_notifications.info.yml
@@ -1,0 +1,7 @@
+name: 'Va.gov Notifications'
+type: module
+description: 'Sends emails to workflow participants on node change.'
+core: 8.x
+package: 'Custom'
+dependencies:
+  - workflow_participants

--- a/docroot/modules/custom/va_gov_notifications/va_gov_notifications.module
+++ b/docroot/modules/custom/va_gov_notifications/va_gov_notifications.module
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @file
+ * Contains va_gov_notifications.module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\Entity\User;
+use Drupal\node\NodeInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\va_gov_notifications\WorkflowChangeEmail;
+
+/**
+ * Implements hook_help().
+ */
+function va_gov_notifications_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the va_gov_notifications module.
+    case 'help.page.va_gov_notifications':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Sends emails to workflow participants on node change.') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function va_gov_notifications_form_workflow_participants_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Editors and reviewers aren't restricted in functionality
+  // by workflow_participants module, so having both is confusing.
+  unset($form['editors']);
+}
+
+/**
+ * Implements hook_mail().
+ */
+function va_gov_notifications_mail($key, &$message, $params) {
+  // This allows us to translate to users selected lalnguage.
+  $options = [
+    'langcode' => $message['langcode'],
+  ];
+  switch ($key) {
+    // Define our email type.
+    case 'workflow_status_change':
+      // Base formatting.
+      $message['from'] = \Drupal::config('system.site')->get('mail');
+      $message['subject'] = t('@title', ['@title' => $params['title']], $options);
+      $message['body'][] = Html::escape($params['message']);
+      break;
+  }
+}
+
+/**
+ * Implements hook_entity_presave().
+ */
+function va_gov_notifications_entity_presave(EntityInterface $entity) {
+  // Make sure it's a node.
+  if ($entity instanceof NodeInterface) {
+
+    // Make sure we have an original for revision comparison.
+    if (!empty($entity->original)) {
+      // Check if workflow state has changed.
+      $original_workflow_state_raw = $entity->original->get('moderation_state')->getValue();
+      $original_workflow_state = reset($original_workflow_state_raw);
+      $new_workflow_state_raw = $entity->get('moderation_state')->getValue();
+      $new_workflow_state = reset($new_workflow_state_raw);
+      if ($new_workflow_state['value'] !== $original_workflow_state['value']) {
+
+        // Check if there are workflow participants.
+        $participants = \Drupal::entityTypeManager()->getStorage('workflow_participants')->loadForModeratedEntity($entity);
+        // Editors field is removed via alter above, but let's leave the check
+        // in place just to be safe / for future functionality revisions.
+        $editors = $participants->editors->getValue();
+        $reviewers = $participants->reviewers->getValue();
+
+        // Put all of our users into one array for multiple load op.
+        $all_participants = array_merge($editors, $reviewers);
+        $uids = array_column($all_participants, 'target_id');
+        $mail = [];
+        if (!empty($uids)) {
+          $users = User::loadMultiple($uids);
+          foreach ($users as $user) {
+
+            // Get our emails, names, and language.
+            if (!empty($user->get('mail')->value)) {
+              $date = new DateTime('now', new DateTimeZone($user->getTimeZone()));
+              $mail['users'][$user->id()]['email'] = $user->get('mail')->value;
+              $mail['users'][$user->id()]['name'] = $user->get('name')->value;
+              $mail['users'][$user->id()]['lang'] = $user->getPreferredLangcode();
+              $mail['users'][$user->id()]['time'] = $date->format('Y-m-d H:i:s');
+            }
+          }
+
+          // Build info about the workflow change for our email.
+          $change_author = $entity->getRevisionUser();
+          $mail['node_title'] = $entity->get('title')->value;
+          $mail['original_workflow_state'] = $original_workflow_state['value'];
+          $mail['new_workflow_state'] = $new_workflow_state['value'];
+          $mail['url'] = \Drupal::request()->getSchemeAndHttpHost() . \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $entity->id());
+          $mail['log_message'] = $entity->get('revision_log')->value;
+          $mail['change_author'] = [
+            'name' => $change_author->get('name')->value,
+            'email' => $change_author->get('mail')->value,
+            'uid' => $change_author->id(),
+          ];
+
+          // Pass it to our send class.
+          $mail_sender = new WorkflowChangeEmail();
+          $mail_sender->sendEmail($mail);
+        }
+      }
+    }
+  }
+}

--- a/patches/workflowParticipantsUncaughtType.patch
+++ b/patches/workflowParticipantsUncaughtType.patch
@@ -1,0 +1,18 @@
+diff --git a/src/Access/LatestVersionCheck.php b/src/Access/LatestVersionCheck.php
+index 9bc5497..83e33ce 100644
+--- a/src/Access/LatestVersionCheck.php
++++ b/src/Access/LatestVersionCheck.php
+@@ -9,11 +9,12 @@ use Drupal\Core\Routing\Access\AccessInterface;
+ use Drupal\Core\Routing\RouteMatchInterface;
+ use Drupal\Core\Session\AccountInterface;
+ use Symfony\Component\Routing\Route;
++use Drupal\content_moderation\Access\LatestRevisionCheck;
+
+ /**
+  * Allow access to the latest version tab for editors and reviewers.
+  */
+-class LatestVersionCheck implements AccessInterface {
++class LatestVersionCheck extends LatestRevisionCheck implements AccessInterface {
+
+   /**
+    * The content moderation latest version access service.


### PR DESCRIPTION
## What this does
Adds `Workflow participants` tab and form to nodes for assigning users that will track workflow changes.
Sends email alerts to users who have been added to node workflow participants forms.
Alerts are only sent if a workflow state change has occurred, and this is triggered by node save.

## Testing Performed
 - Visual
 - Xdebug Profiling
 - Email sending via SMTP (locally)
 - Full functionality test performed on testing instance: http://internal-test-vagovcms-3879-1510337173.us-gov-west-1.elb.amazonaws.com/ 

## Screenshots
![workflow-form](https://user-images.githubusercontent.com/2404547/62426469-43898d00-b6b3-11e9-9ad4-8ac8d1206d12.png)
![confirmation](https://user-images.githubusercontent.com/2404547/62426470-471d1400-b6b3-11e9-9c61-a397686dd78e.png)
![email](https://user-images.githubusercontent.com/2404547/62426472-48e6d780-b6b3-11e9-9444-ae21cd681119.png)

## Definition of done
 - Workflow participants form appears here: `node/{NID}/workflow-participants`
 - Adding a user and saving is successful.
 - Changing a workflow status sends workflow participant an email like the one in the screenshot above.

## To test
 - As an admin, edit the email of the account you are using for testing to an email account you check.
 - As an admin, add the above account to any published node workflow participant form, here:  `node/{NID}/workflow-participants`
 - As an admin, change the workflow state of the above node, and save.
 - Visually verify that you receive an email that is similar in appearance to the screenshot, above.
