### PR TITLE
VAGOV-5346: Removing artifacts referencing removed file.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.libraries.yml
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.libraries.yml
@@ -1,6 +1,0 @@
-preview_button:
-  version: 1.x
-  js:
-    js/script.js: {}
-  dependencies:
-    - core/jquery

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -80,10 +80,3 @@ function va_gov_build_trigger_preprocess_page(&$variables) {
     }
   }
 }
-
-/**
- * Implements hook_page_attachments().
- */
-function va_gov_build_trigger_page_attachments(array &$attachments) {
-  $attachments['#attached']['library'][] = 'va_gov_build_trigger/preview_button';
-}


### PR DESCRIPTION
## What this does
Removes references to js file in va_gov_build_trigger module (was previously removed).

## To test
 - [ ] In testing enviroment, clear logs: `admin/reports/dblog`
 - [ ] Navigate multiple site pages
 - [ ] Revisit `admin/reports/dblog`, confirm `Warning: file_get_contents(modules/custom/va_gov_build_trigger/js/script.js): failed to open stream:  No such file or directory` does not appear