### PR TITLE
VAGOV-4870: Home Page Top Tasks Menu Links

### DIFF
--- a/config/sync/entityqueue.entity_queue.home_page_hub_list.yml
+++ b/config/sync/entityqueue.entity_queue.home_page_hub_list.yml
@@ -20,6 +20,6 @@ entity_settings:
     auto_create_bundle: ''
 queue_settings:
   min_size: 0
-  max_size: 0
+  max_size: 11
   act_as_queue: false
   reverse_in_admin: false


### PR DESCRIPTION
*Description*
Contains additional config for the home page full-hub-list entity queue. This config limits the number of hubs added to 11 in order to avoid potentially breaking the home page layout. 

*Testing*

- Navigate to admin/structure/entityqueue/home_page_hub_list?destination=/admin/structure/entityqueue.
- Click **Queue settings**.
- Confirm the max is 11.

<img width="1386" alt="Screen Shot 2019-08-15 at 11 41 26 AM" src="https://user-images.githubusercontent.com/1181665/63106813-ac91c000-bf51-11e9-8b91-3c8ca3ac7983.png">
