### PR TITLE
VAGOV-5510: Enable Linkit and Pathologic filters on rich text.

### DIFF
--- a/config/sync/editor.editor.rich_text.yml
+++ b/config/sync/editor.editor.rich_text.yml
@@ -42,13 +42,13 @@ settings:
             - Format
             - Styles
   plugins:
+    stylescombo:
+      styles: "p.va-address-block|Address Block\r\na.usa-button|Link button\r\na.usa-button-primary.va-button-primary|Primary link button\r\na.usa-button.usa-button-secondary|Secondary link button\r\n"
     drupallink:
       linkit_enabled: true
       linkit_profile: default
     language:
       language_list: un
-    stylescombo:
-      styles: "p.va-address-block|Address Block\r\na.usa-button|Link button\r\na.usa-button-primary.va-button-primary|Primary link button\r\na.usa-button.usa-button-secondary|Secondary link button\r\n"
 image_upload:
   status: true
   scheme: public

--- a/config/sync/editor.editor.rich_text.yml
+++ b/config/sync/editor.editor.rich_text.yml
@@ -42,13 +42,13 @@ settings:
             - Format
             - Styles
   plugins:
-    stylescombo:
-      styles: "p.va-address-block|Address Block\r\na.usa-button|Link button\r\na.usa-button-primary.va-button-primary|Primary link button\r\na.usa-button.usa-button-secondary|Secondary link button\r\n"
     drupallink:
       linkit_enabled: true
       linkit_profile: default
     language:
       language_list: un
+    stylescombo:
+      styles: "p.va-address-block|Address Block\r\na.usa-button|Link button\r\na.usa-button-primary.va-button-primary|Primary link button\r\na.usa-button.usa-button-secondary|Secondary link button\r\n"
 image_upload:
   status: true
   scheme: public

--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -18,13 +18,13 @@ filters:
     id: filter_align
     provider: filter
     status: false
-    weight: -46
+    weight: -43
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: false
-    weight: -45
+    weight: -42
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
@@ -42,7 +42,7 @@ filters:
     id: entity_embed
     provider: entity_embed
     status: false
-    weight: -47
+    weight: -44
     settings: {  }
   filter_html:
     id: filter_html
@@ -57,48 +57,48 @@ filters:
     id: filter_autop
     provider: filter
     status: false
-    weight: -43
+    weight: -40
     settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -44
+    weight: -41
     settings: {  }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -42
+    weight: -39
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: true
-    weight: -38
+    weight: -47
     settings:
       filter_url_length: 72
   linkit:
     id: linkit
     provider: linkit
     status: true
-    weight: -41
+    weight: -45
     settings:
       title: true
   markdown:
     id: markdown
     provider: markdown
     status: false
-    weight: -40
+    weight: -38
     settings:
       markdown_library: php-markdown
   filter_pathologic:
     id: filter_pathologic
     provider: pathologic
     status: true
-    weight: -39
+    weight: -46
     settings:
-      settings_source: global
+      settings_source: local
       local_settings:
-        protocol_style: full
+        protocol_style: path
         local_paths: ''

--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -5,6 +5,9 @@ dependencies:
   module:
     - editor
     - entity_embed
+    - linkit
+    - markdown
+    - pathologic
 _core:
   default_config_hash: Mc8Hl-Ya14lrbMXaUx7Ybmv-18vtqE4lw2DpgNHPj-s
 name: 'Rich Text'
@@ -15,31 +18,31 @@ filters:
     id: filter_align
     provider: filter
     status: false
-    weight: -48
+    weight: -46
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: false
-    weight: -47
+    weight: -45
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: -46
+    weight: -49
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: true
-    weight: -45
+    weight: -48
     settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: false
-    weight: -49
+    weight: -47
     settings: {  }
   filter_html:
     id: filter_html
@@ -47,7 +50,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <hr> <br> <drupal-entity data-* title alt> <p class="va-address-block"> <a href hreflang class=" usa-button usa-button-primary usa-button-secondary va-button-primary login-required">'
+      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <hr> <br> <drupal-entity data-* title alt> <p class="va-address-block"> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title class=" usa-button usa-button-primary usa-button-secondary va-button-primary login-required">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:
@@ -66,12 +69,36 @@ filters:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -41
+    weight: -42
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: true
-    weight: -42
+    weight: -38
     settings:
       filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -41
+    settings:
+      title: true
+  markdown:
+    id: markdown
+    provider: markdown
+    status: false
+    weight: -40
+    settings:
+      markdown_library: php-markdown
+  filter_pathologic:
+    id: filter_pathologic
+    provider: pathologic
+    status: true
+    weight: -39
+    settings:
+      settings_source: global
+      local_settings:
+        protocol_style: full
+        local_paths: ''


### PR DESCRIPTION
QA: 
* /node/add/page
* Add a wysiwyg content block
* Add a link using the linkit dropdown, by searching for "VA blind and low vision" and picking "VA blind and low vision rehabilitation services"
* Add another link, paste in http://prod.cms.va.gov/health-care to the link dialog
* Fill out required fields with whatever, and hit save
* ~~The first link should appear in the front end as /health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services (not "/node/2")~~ **As discussed, this will show up as /node/2, unless a user enters a link after selecting text**
* The second one should be linked to [whatever test environment].va.gov/health-care  NOT health-care 

