### PR TITLE
VAGOV-4960: Adding content api user redirect view.

### DIFF
--- a/config/sync/views.view.redirect.yml
+++ b/config/sync/views.view.redirect.yml
@@ -2,6 +2,11 @@ uuid: 461421d8-e68d-49ad-be21-d3dcedc6dae0
 langcode: en
 status: true
 dependencies:
+  config:
+    - system.menu.admin
+    - user.role.administrator
+    - user.role.content_api_consumer
+    - user.role.redirect_administrator
   module:
     - link
     - redirect
@@ -597,4 +602,187 @@ display:
         - user.permissions
       cacheable: false
       max-age: 0
+      tags: {  }
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: 'Non admin Page'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: redirects-list
+      display_description: ''
+      fields:
+        redirect_source__path:
+          id: redirect_source__path
+          table: redirect
+          field: redirect_source__path
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: From
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: path
+          type: redirect_source
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: field
+        redirect_redirect__uri:
+          id: redirect_redirect__uri
+          table: redirect
+          field: redirect_redirect__uri
+          entity_type: redirect
+          entity_field: redirect_redirect
+          plugin_id: field
+        status_code:
+          id: status_code
+          table: redirect
+          field: status_code
+          entity_type: redirect
+          entity_field: status_code
+          plugin_id: field
+        language:
+          id: language
+          table: redirect
+          field: language
+          entity_type: redirect
+          entity_field: language
+          plugin_id: field
+        created:
+          id: created
+          table: redirect
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: fallback
+          custom_date_format: ''
+          timezone: ''
+          entity_type: redirect
+          entity_field: created
+          plugin_id: date
+      defaults:
+        fields: false
+        access: false
+      access:
+        type: role
+        options:
+          role:
+            content_api_consumer: content_api_consumer
+            administrator: administrator
+            redirect_administrator: redirect_administrator
+      menu:
+        type: normal
+        title: 'Redirect list'
+        description: 'Shows redirects'
+        expanded: false
+        parent: system.admin_content
+        weight: 0
+        context: '1'
+        menu_name: admin
+      tab_options:
+        type: tab
+        title: 'Redirect Listing'
+        description: ''
+        weight: 0
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.roles
+      cacheable: false
+      max-age: -1
       tags: {  }


### PR DESCRIPTION
## What this does

- Adds redirect view identical to admin redirect view for content api user role, sans editing options

## Screenshot
![page](https://user-images.githubusercontent.com/2404547/63192066-20a69380-c038-11e9-8a17-92fe8b65eb3b.png)

## QA

- As a user who has content api user role, go to `admin/config/search/redirect` - you should see an access denied message
- As a user who has content api user role, go to `redirects-list` - you should a list of redirects, sans editing and bulk operations options
- Visually verify that `Redirect List` appears under `Content` in admin menu.