### PR TITLE
VAGOV-5586: Add config for new Home page hub label field

### DIFF
--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.landing_page.field_administration
     - field.field.node.landing_page.field_alert
     - field.field.node.landing_page.field_description
+    - field.field.node.landing_page.field_home_page_hub_label
     - field.field.node.landing_page.field_intro_text
     - field.field.node.landing_page.field_links
     - field.field.node.landing_page.field_meta_tags
@@ -97,6 +98,7 @@ third_party_settings:
       children:
         - field_title_icon
         - title
+        - field_home_page_hub_label
         - field_meta_title
         - field_description
         - field_teaser_text
@@ -155,7 +157,7 @@ content:
     type: options_select
     region: content
   field_description:
-    weight: 5
+    weight: 6
     settings:
       size: 300
       placeholder: ''
@@ -168,8 +170,16 @@ content:
     third_party_settings: {  }
     type: string_textfield_with_counter
     region: content
+  field_home_page_hub_label:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_intro_text:
-    weight: 7
+    weight: 8
     settings:
       rows: 5
       placeholder: ''
@@ -192,7 +202,7 @@ content:
     type: metatag_firehose
     region: content
   field_meta_title:
-    weight: 4
+    weight: 5
     settings:
       size: 70
       placeholder: ''
@@ -271,7 +281,7 @@ content:
     type: inline_entity_form_complex
     region: content
   field_teaser_text:
-    weight: 6
+    weight: 7
     settings:
       size: 200
       placeholder: ''

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.landing_page.field_administration
     - field.field.node.landing_page.field_alert
     - field.field.node.landing_page.field_description
+    - field.field.node.landing_page.field_home_page_hub_label
     - field.field.node.landing_page.field_intro_text
     - field.field.node.landing_page.field_links
     - field.field.node.landing_page.field_meta_tags
@@ -104,6 +105,14 @@ content:
     region: content
   field_description:
     weight: 5
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_home_page_hub_label:
+    weight: 17
     label: above
     settings:
       link_to_entity: false

--- a/config/sync/field.field.node.landing_page.field_home_page_hub_label.yml
+++ b/config/sync/field.field.node.landing_page.field_home_page_hub_label.yml
@@ -1,0 +1,19 @@
+uuid: 83735859-58eb-48c8-b27f-663196728413
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_home_page_hub_label
+    - node.type.landing_page
+id: node.landing_page.field_home_page_hub_label
+field_name: field_home_page_hub_label
+entity_type: node
+bundle: landing_page
+label: 'Home page hub label'
+description: 'This is a general name for this hub. It is used in the full hub list on the home page.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_home_page_hub_label.yml
+++ b/config/sync/field.storage.node.field_home_page_hub_label.yml
@@ -1,0 +1,21 @@
+uuid: 42a493d6-69c8-49cd-ae53-db25d231aad7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_home_page_hub_label
+field_name: field_home_page_hub_label
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
**Description**
Includes config for new field_home_page_hub_label. 

The idea is that these titles...
<img width="1108" alt="home_page_hub_names" src="https://user-images.githubusercontent.com/1181665/63191907-bc83cf80-c037-11e9-8796-2873fe17cad8.png">

... will be fed by this new field: 
<img width="1147" alt="home_page_hub_label" src="https://user-images.githubusercontent.com/1181665/63191933-cb6a8200-c037-11e9-82ad-5abbee366856.png">

**Testing**

- Navigate to benefit hub landing page's field config at admin/structure/types/manage/landing_page/fields.
- Confirm **Home page hub label** is there.