### PR TITLE
VAGOV-5683: Only load .env if it exists.

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -1,9 +1,7 @@
 <?php
 use DevShop\Behat\DrupalExtension\Context\DevShopDrupalContext;
 use Behat\Behat\Context\SnippetAcceptingContext;
-use Dotenv\Dotenv;
 
-$autoloader = require_once dirname(dirname(dirname(dirname(__DIR__)))) . '/docroot/autoload.php';
 /**
  * Defines application features from the specific context.
  */
@@ -16,19 +14,6 @@ class FeatureContext extends DevShopDrupalContext implements SnippetAcceptingCon
    * context constructor through behat.yml.
    */
   public function __construct() {
-
-    // The .env file is only used in CMS-CI and if a developer wants to override
-    // any environment variables.
-
-    // Add any Lando-specific and team-wide variables to .env.lando.
-
-    // Load the .env file from the root of the project, if there is one.
-    $dotenv_file = dirname(dirname(dirname(dirname(__DIR__)))) . '/.env';
-    if (file_exists($dotenv_file)) {
-      $dotenv = new Dotenv(dirname(dirname(dirname(dirname(__DIR__)))));
-      $dotenv->load();
-    }
-
     parent::__construct();
   }
 }

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -16,9 +16,19 @@ class FeatureContext extends DevShopDrupalContext implements SnippetAcceptingCon
    * context constructor through behat.yml.
    */
   public function __construct() {
-    $dotenv = new Dotenv(dirname(dirname(dirname(dirname(__DIR__)))));
-    $dotenv->load();
-    parent::__construct();
 
+    // The .env file is only used in CMS-CI and if a developer wants to override
+    // any environment variables.
+
+    // Add any Lando-specific and team-wide variables to .env.lando.
+
+    // Load the .env file from the root of the project, if there is one.
+    $dotenv_file = dirname(dirname(dirname(dirname(__DIR__)))) . '/.env';
+    if (file_exists($dotenv_file)) {
+      $dotenv = new Dotenv(dirname(dirname(dirname(dirname(__DIR__)))));
+      $dotenv->load();
+    }
+
+    parent::__construct();
   }
 }


### PR DESCRIPTION
`.env` file is no longer in the repo or automatically copied. 

I left the DotEnv stuff in behat's `FeatureContext.php` accidentally: it is no longer needed, I think.

CI will decide if it's true.

@swirtSJW @ElijahLynn can you test on lando from a truly fresh clone?

`rm -rf * .env && git reset --hard && lando rebuild && lando start && lando test` will:

1 .wipe all files except what is in git. (vendor, .env, everything).
2. rebuild lando containers from new environment files and lando.yml config.
3. restart lando containers, including composer install.
4. Run `composer yaml-tests` (alias `lando test`)