### PR TITLE
VAGOV-5690: Adding custom vars to .env.

### DIFF
--- a/.env
+++ b/.env
@@ -17,5 +17,5 @@ PROVISION_PROCESS_OUTPUT=direct
 # DO NOT use environment variable insertion here. Other systems may load this in a different order.
 # @TODO: I could just have been tired: This used to use single quotes: that would prevent $VAR substitution from working at all.
 # Looks like lando includes the " as the string!
-BEHAT_PARAMS={"extensions":{"Behat\\MinkExtension":{"base_url":"http://va-gov-cms.lndo.site"},"Drupal\\DrupalExtension":{"drush":{"root":"/app/docroot","alias":"@none"},"drupal":{"drupal_root":"/app/docroot"}}}}
+BEHAT_PARAMS={"extensions":{"Behat\\MinkExtension":{"base_url":"http://va-gov-cms.lndo.site"},"Drupal\\DrupalExtension":{"drush":{"root":"/app/docroot","alias":"@self"},"drupal":{"drupal_root":"/app/docroot"}}}}
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,3 @@ node_modules/
 /docroot/sites/all/drush/drushrc.php
 
 !/docroot/sites/default/settings.php
-
-# Ignore environment specific file
-.env

--- a/.lando.yml
+++ b/.lando.yml
@@ -5,7 +5,7 @@ config:
   php: "7.2"
 
 env_file:
-  - .env.lando
+  - .env
 
 events:
   post-db-import:

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -31,5 +31,3 @@ default:
     Drupal\DrupalExtension:
       blackbox: ~
       api_driver: "drupal"
-      drupal:
-        drupal_root: ../../docroot


### PR DESCRIPTION
Removes env.lando as it isn't detected by lando.
Replaces with .env, and allows for removing behat settings
in behat.yml.