### PR TITLE
VAGOV-5690: Globally load environment variables.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,9 +4,6 @@ config:
   webroot: docroot
   php: "7.2"
 
-env_file:
-  - .env.lando
-
 events:
   post-db-import:
     # @TODO: Change to `composer yaml-tests va/deploy` once the "filter argument" feature is in place.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     },
     "require": {
         "acquia/headless_lightning": "^1.4.0-beta2",
-        "bangpound/composer-dotenv": "^1.0@dev",
         "cweagans/composer-patches": "^1.6.0",
         "devshop/behat-drupal-extension": "dev-master",
         "drupal-composer/drupal-scaffold": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,10 @@
         "psr-4": {
             "Traits\\": "tests/traits",
             "CustomDrupal\\": "tests/behat/Drupal"
-        }
+        },
+        "files": [
+            "scripts/composer/EnvironmentHandler.php"
+        ]
     },
     "repositories": {
         "va-gov-web":   {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03148b50d517bca881ee17adb04ff30e",
+    "content-hash": "af36b8e2d068b92e0512b3d3c9fe2141",
     "packages": [
         {
             "name": "acquia/headless_lightning",
@@ -201,43 +201,6 @@
                 "stack"
             ],
             "time": "2017-12-20T14:37:45+00:00"
-        },
-        {
-            "name": "bangpound/composer-dotenv",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bangpound/composer-dotenv.git",
-                "reference": "00952f0bdac65442819220ea999c57f1753a9bc1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bangpound/composer-dotenv/zipball/00952f0bdac65442819220ea999c57f1753a9bc1",
-                "reference": "00952f0bdac65442819220ea999c57f1753a9bc1",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0",
-                "vlucas/phpdotenv": "~2.0"
-            },
-            "require-dev": {
-                "composer/composer": "~1.0@dev"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Bangpound\\Composer\\DotenvPlugin",
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Bangpound\\Composer\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "description": "Load environment variables from `.env` when Composer runs",
-            "time": "2016-08-21T23:23:28+00:00"
         },
         {
             "name": "behat/behat",
@@ -10725,7 +10688,7 @@
                     }
                 },
                 "patches_applied": {
-                    "Fix uncaught type error by extending class.": "patches/workflowParticipantsUncaughtType.patch"
+                    "Fix revision uncaught type error by extending class.": "https://www.drupal.org/files/issues/2019-08-16/workflow_participants-revision-error-3075426-1.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -11294,8 +11257,8 @@
             "authors": [
                 {
                     "name": "Michele Locati",
-                    "role": "Developer",
-                    "email": "mlocati@gmail.com"
+                    "email": "mlocati@gmail.com",
+                    "role": "Developer"
                 }
             ],
             "description": "gettext languages with plural rules",
@@ -11636,13 +11599,13 @@
             "authors": [
                 {
                     "name": "Justin Bishop",
-                    "role": "Developer",
-                    "email": "jubishop@gmail.com"
+                    "email": "jubishop@gmail.com",
+                    "role": "Developer"
                 },
                 {
                     "name": "Anthon Pang",
-                    "role": "Fork Maintainer",
-                    "email": "apang@softwaredevelopment.ca"
+                    "email": "apang@softwaredevelopment.ca",
+                    "role": "Fork Maintainer"
                 }
             ],
             "description": "PHP WebDriver for Selenium 2",
@@ -12064,9 +12027,9 @@
             "authors": [
                 {
                     "name": "Colin O'Dell",
-                    "role": "Lead Developer",
                     "email": "colinodell@gmail.com",
-                    "homepage": "https://www.colinodell.com"
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
                 }
             ],
             "description": "Markdown parser for PHP based on the CommonMark spec",
@@ -12367,9 +12330,9 @@
             "authors": [
                 {
                     "name": "Michel Fortin",
-                    "role": "Developer",
                     "email": "michel.fortin@michelf.ca",
-                    "homepage": "https://michelf.ca/"
+                    "homepage": "https://michelf.ca/",
+                    "role": "Developer"
                 },
                 {
                     "name": "John Gruber",
@@ -12771,18 +12734,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -18414,7 +18377,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "bangpound/composer-dotenv": 20,
         "devshop/behat-drupal-extension": 20,
         "drupal/auto_entitylabel": 10,
         "drupal/cer": 15,

--- a/composer.lock
+++ b/composer.lock
@@ -3524,6 +3524,10 @@
                 {
                     "name": "e0ipso",
                     "homepage": "https://www.drupal.org/user/550110"
+                },
+                {
+                    "name": "eojthebrave",
+                    "homepage": "https://www.drupal.org/user/79230"
                 }
             ],
             "description": "Declare all the consumers of your API",
@@ -4910,6 +4914,10 @@
                 {
                     "name": "cs_shadow",
                     "homepage": "https://www.drupal.org/user/2828287"
+                },
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
                     "name": "phenaproxima",
@@ -7351,7 +7359,7 @@
                 },
                 "drupal": {
                     "version": "8.x-4.1",
-                    "datestamp": "1546879080",
+                    "datestamp": "1565213885",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8288,7 +8296,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.8",
-                    "datestamp": "1553618281",
+                    "datestamp": "1565881389",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8487,7 +8495,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta1",
-                    "datestamp": "1485452283",
+                    "datestamp": "1565535787",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8505,6 +8513,10 @@
                 {
                     "name": "gabrielu",
                     "homepage": "https://www.drupal.org/user/279352"
+                },
+                {
+                    "name": "otrolopezmas",
+                    "homepage": "https://www.drupal.org/user/3516204"
                 },
                 {
                     "name": "plopesc",
@@ -11203,9 +11215,9 @@
             "authors": [
                 {
                     "name": "Oscar Otero",
+                    "role": "Developer",
                     "email": "oom@oscarotero.com",
-                    "homepage": "http://oscarotero.com",
-                    "role": "Developer"
+                    "homepage": "http://oscarotero.com"
                 }
             ],
             "description": "PHP gettext manager",
@@ -11257,8 +11269,8 @@
             "authors": [
                 {
                     "name": "Michele Locati",
-                    "email": "mlocati@gmail.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "mlocati@gmail.com"
                 }
             ],
             "description": "gettext languages with plural rules",
@@ -11599,13 +11611,13 @@
             "authors": [
                 {
                     "name": "Justin Bishop",
-                    "email": "jubishop@gmail.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "jubishop@gmail.com"
                 },
                 {
                     "name": "Anthon Pang",
-                    "email": "apang@softwaredevelopment.ca",
-                    "role": "Fork Maintainer"
+                    "role": "Fork Maintainer",
+                    "email": "apang@softwaredevelopment.ca"
                 }
             ],
             "description": "PHP WebDriver for Selenium 2",
@@ -11961,8 +11973,8 @@
             "authors": [
                 {
                     "name": "Luís Otávio Cobucci Oblonczyk",
-                    "email": "lcobucci@gmail.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "lcobucci@gmail.com"
                 }
             ],
             "description": "A simple library to work with JSON Web Token and JSON Web Signature",
@@ -12027,9 +12039,9 @@
             "authors": [
                 {
                     "name": "Colin O'Dell",
+                    "role": "Lead Developer",
                     "email": "colinodell@gmail.com",
-                    "homepage": "https://www.colinodell.com",
-                    "role": "Lead Developer"
+                    "homepage": "https://www.colinodell.com"
                 }
             ],
             "description": "Markdown parser for PHP based on the CommonMark spec",
@@ -12330,9 +12342,9 @@
             "authors": [
                 {
                     "name": "Michel Fortin",
+                    "role": "Developer",
                     "email": "michel.fortin@michelf.ca",
-                    "homepage": "https://michelf.ca/",
-                    "role": "Developer"
+                    "homepage": "https://michelf.ca/"
                 },
                 {
                     "name": "John Gruber",
@@ -12734,18 +12746,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -17154,8 +17166,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
@@ -17337,7 +17349,7 @@
                 "reference": "origin/VAGOV-2937-unity"
             },
             "type": "library",
-            "time": "2019-08-21T02:02:58+00:00"
+            "time": "2019-07-31T14:06:28+00:00"
         },
         {
             "name": "vardot/blazy",

--- a/scripts/composer/EnvironmentHandler.php
+++ b/scripts/composer/EnvironmentHandler.php
@@ -24,25 +24,29 @@ class EnvironmentHandler {
 
     try {
 
-      // If LANDO Server variable already exists, load lando env file and make sure DRUPAL_ADDRESS is present.
+      // If LANDO Server variable exists, load lando env file.
       if (!empty($_SERVER['LANDO']) && $_SERVER['LANDO'] == 'ON') {
-        $dotenv = new Dotenv($env_file_dir, EnvironmentHandler::landoEnvironmentFile);
 
-        // Make DRUPAL_ADDRESS and BEHAT_PARAMS required on LANDO only because developers need to see this.
-        $dotenv->overload();
-
-        $dotenv->required('DRUPAL_ADDRESS')->notEmpty();
-        $dotenv->required('BEHAT_PARAMS')->notEmpty();
-
+        // Load .env file if it exists, otherise use .env.lando.
+        if (file_exists($env_file_dir . '/.env')) {
+          $dotenv = new Dotenv($env_file_dir);
+        }
+        else {
+          $dotenv = new Dotenv($env_file_dir, EnvironmentHandler::landoEnvironmentFile);
+        }
       }
 
-      // Otherise, use default (.env) if it exists.
-      // If no .env of .env.lando, don't load  variables to avoid error.
+      // If NOT in LANDO, and .env file exists, load it.
       elseif (file_exists($env_file_dir . '/.env')) {
         $dotenv = new Dotenv($env_file_dir);
-        $dotenv->overload();
       }
 
+      // If dotenv files exist, load it and make vars required.
+      if (isset($dotenv)) {
+        $dotenv->overload();
+        $dotenv->required('DRUPAL_ADDRESS')->notEmpty();
+        $dotenv->required('BEHAT_PARAMS')->notEmpty();
+      }
     }
     catch (\Dotenv\Exception\ValidationException $exception) {
 

--- a/scripts/composer/EnvironmentHandler.php
+++ b/scripts/composer/EnvironmentHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace VA\Composer;
+
+use Acquia\Lightning\Composer\Package;
+use Dotenv\Dotenv;
+use Dotenv\Exception\ValidationException;
+
+EnvironmentHandler::load();
+
+/**
+ * Sets environment variables from .env or .env.lando files.
+ */
+class EnvironmentHandler {
+
+  const landoEnvironmentFile = '.env.lando';
+
+  /**
+   * Loads .env files if they exist.
+   */
+  static function load() {
+
+    $env_file_dir = dirname(dirname(__DIR__));
+
+    try {
+
+      // If LANDO Server variable already exists, load lando env file and make sure DRUPAL_ADDRESS is present.
+      if (!empty($_SERVER['LANDO']) && $_SERVER['LANDO'] == 'ON') {
+        $dotenv = new Dotenv($env_file_dir, EnvironmentHandler::landoEnvironmentFile);
+
+        // Make DRUPAL_ADDRESS and BEHAT_PARAMS required on LANDO only because developers need to see this.
+        $dotenv->overload();
+
+        $dotenv->required('DRUPAL_ADDRESS')->notEmpty();
+        $dotenv->required('BEHAT_PARAMS')->notEmpty();
+
+      }
+
+      // Otherise, use default (.env) if it exists.
+      // If no .env of .env.lando, don't load  variables to avoid error.
+      elseif (file_exists($env_file_dir . '/.env')) {
+        $dotenv = new Dotenv($env_file_dir);
+        $dotenv->overload();
+      }
+
+    }
+    catch (\Dotenv\Exception\ValidationException $exception) {
+
+      throw $exception;
+    }
+  }
+}
+
+

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -28,8 +28,16 @@ default:
       javascript_session: "selenium2"
       selenium2: ~
       files_path: "%paths.base%/media"
+
+# DO NOT UNCOMMENT: Set with BEHAT_PARAMS. @see .env
+#      base_url: localhost
+
     Drupal\DrupalExtension:
       blackbox: ~
       api_driver: "drupal"
-      drupal:
-        drupal_root: ../../docroot
+
+# DO NOT UNCOMMENT: Set with BEHAT_PARAMS. @see .env
+#      drupal:
+#        drupal_root: ../../docroot
+#      drush:
+#        alias: 'local'


### PR DESCRIPTION
Adds EnvironmentHandler.php file that has simple logic for setting .env vars.

1. If `.env` exists, load it.
2. If $_SERVER['LANDO'], load `.env.lando`.
3. If env file was found, make DRUPAL_ADDRESS and BEHAT_PARAMS required.

Now, all PHP that uses the main autoloader should have the proper environment variables set, FORCED from `.env` or `.env.lando` file.

