### PR TITLE
VAGOV-4871: Header Feature Flag

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -23,5 +23,6 @@ features:
   feature_all_hub_side_navs: FEATURE_ALL_HUB_SIDE_NAVS
   feature_single_value_field_link: FEATURE_SINGLE_VALUE_FIELD_LINK
   feature_field_media_in_library: FEATURE_FIELD_MEDIA_IN_LIBRARY
+  feature_header: FEATURE_HEADER
 _core:
   default_config_hash: daCVJgiGNXHoQmWA2-cvaQEapbq7AGlBQtopOWTqqlw

--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -23,6 +23,6 @@ features:
   feature_all_hub_side_navs: FEATURE_ALL_HUB_SIDE_NAVS
   feature_single_value_field_link: FEATURE_SINGLE_VALUE_FIELD_LINK
   feature_field_media_in_library: FEATURE_FIELD_MEDIA_IN_LIBRARY
-  feature_header: FEATURE_HEADER
+  feature_header_megamenu: FEATURE_HEADER_MEGAMENU
 _core:
   default_config_hash: daCVJgiGNXHoQmWA2-cvaQEapbq7AGlBQtopOWTqqlw


### PR DESCRIPTION
• Adds a new feature flag for development of the Drupal-powered megamenu.

This flag should allow us to turn the Drupal-powered header "on" and "off" as needed. 