### PR TITLE
VAGOV-5984 Update header menu promo reference

### DIFF
--- a/config/sync/core.entity_form_display.block_content.promo.default.yml
+++ b/config/sync/core.entity_form_display.block_content.promo.default.yml
@@ -47,7 +47,7 @@ content:
       title_plural: Links
       edit_mode: open
       add_mode: select
-      form_display_mode: default
+      form_display_mode: promo_link_teaser
       default_paragraph_type: link_teaser
     third_party_settings: {  }
     region: content

--- a/config/sync/core.entity_form_display.paragraph.link_teaser.promo_link_teaser.yml
+++ b/config/sync/core.entity_form_display.paragraph.link_teaser.promo_link_teaser.yml
@@ -1,0 +1,44 @@
+uuid: 579b187b-3114-4c05-9d2b-4cc2e3cfbb26
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.paragraph.promo_link_teaser
+    - field.field.paragraph.link_teaser.field_link
+    - field.field.paragraph.link_teaser.field_link_summary
+    - paragraphs.paragraphs_type.link_teaser
+  module:
+    - linkit
+    - textfield_counter
+id: paragraph.link_teaser.promo_link_teaser
+targetEntityType: paragraph
+bundle: link_teaser
+mode: promo_link_teaser
+content:
+  field_link:
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      linkit_profile: default
+    third_party_settings: {  }
+    type: linkit
+    region: content
+  field_link_summary:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+      maxlength: 110
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Characters Used: <span class="current_count">@current_length</span><br />Characters Remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
+    third_party_settings: {  }
+    type: string_textfield_with_counter
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/config/sync/core.entity_form_mode.paragraph.promo_link_teaser.yml
+++ b/config/sync/core.entity_form_mode.paragraph.promo_link_teaser.yml
@@ -1,0 +1,14 @@
+uuid: 54057969-99be-4214-8ef0-d3244959a6d4
+langcode: en
+status: true
+dependencies:
+  module:
+    - lightning_core
+    - paragraphs
+third_party_settings:
+  lightning_core:
+    description: ''
+id: paragraph.promo_link_teaser
+label: 'Promo Link Teaser'
+targetEntityType: paragraph
+cache: true

--- a/config/sync/field.field.menu_link_content.header-megamenu.field_promo_reference.yml
+++ b/config/sync/field.field.menu_link_content.header-megamenu.field_promo_reference.yml
@@ -3,19 +3,26 @@ langcode: en
 status: true
 dependencies:
   config:
+    - block_content.type.promo
     - field.storage.menu_link_content.field_promo_reference
     - system.menu.header-megamenu
 id: menu_link_content.header-megamenu.field_promo_reference
 field_name: field_promo_reference
 entity_type: menu_link_content
 bundle: header-megamenu
-label: 'Promo for About VA dropdown'
-description: 'Promo that appears when hovering on  About VA on larger screens. (The only menu item where this has an effect is the About VA menu item)'
+label: 'Related Promo'
+description: 'Promo block that appears in benefit hub sections or in the About VA menu tab.'
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:block_content'
-  handler_settings: {  }
+  handler_settings:
+    target_bundles:
+      promo: promo
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
 field_type: entity_reference

--- a/config/sync/field.field.paragraph.link_teaser.field_link_summary.yml
+++ b/config/sync/field.field.paragraph.link_teaser.field_link_summary.yml
@@ -10,7 +10,7 @@ field_name: field_link_summary
 entity_type: paragraph
 bundle: link_teaser
 label: 'Link summary'
-description: 'A short description of the link, less than 110 characters if this promo needs to appear in the header megamenu.'
+description: 'A short description of the link, less than 500 characters.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.link_teaser.field_link_summary.yml
+++ b/config/sync/field.field.paragraph.link_teaser.field_link_summary.yml
@@ -10,7 +10,7 @@ field_name: field_link_summary
 entity_type: paragraph
 bundle: link_teaser
 label: 'Link summary'
-description: 'A short description of the link, less than 500 characters.'
+description: 'A short description of the link, less than 110 characters if this promo needs to appear in the header megamenu.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
This code does the following:

- Updates the label and help text for field_promo_reference on the header megamenu so that it also applies to benefit hub promos.
- Adds a new form display for the link teaser paragraph type.
- Applies that new form display to promo blocks.
