### PR TITLE
VAGOV-6017: Replace legacy support email with new.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
@@ -168,7 +168,7 @@ class BuildTriggerForm extends FormBase {
     }
     catch (RequestException $exception) {
       Drupal::messenger()
-        ->addMessage(t('Site rebuild request has failed for :url with an Exception, check log for more information. If this is the PROD environment please notify in #cms-engineering Slack and please email cms-admin@va.gov immediately with the error message you see here.', [':url' => $jenkins_build_job_url]), 'error');
+        ->addMessage(t('Site rebuild request has failed for :url with an Exception, check log for more information. If this is the PROD environment please notify in #cms-engineering Slack and please email vacmssupport@va.gov immediately with the error message you see here.', [':url' => $jenkins_build_job_url]), 'error');
       watchdog_exception('va_gov_build_trigger', $exception);
 
     }

--- a/docroot/modules/custom/va_gov_login/va_gov_login.module
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.module
@@ -13,7 +13,7 @@ use Drupal\Component\Render\FormattableMarkup;
  */
 function va_gov_login_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == "user_login_form") {
-    $form['pass']["#description"] = FieldFilteredMarkup::create(t('Enter the password that accompanies your username, if you have an issue with your password please email the @helpdesk.', ['@helpdesk' => new FormattableMarkup('<a href="mailto:cms-admin@va.gov">helpdesk</a>', [])]));
+    $form['pass']["#description"] = FieldFilteredMarkup::create(t('Enter the password that accompanies your username, if you have an issue with your password please email the @helpdesk.', ['@helpdesk' => new FormattableMarkup('<a href="mailto:vacmssupport@va.gov">helpdesk</a>', [])]));
   }
 }
 

--- a/simplesamlphp-1.17.2/config/config.php
+++ b/simplesamlphp-1.17.2/config/config.php
@@ -73,7 +73,7 @@ $config = [
      * also as the technical contact in generated metadata.
      */
     'technicalcontact_name' => 'VA.gov Administrator',
-    'technicalcontact_email' => 'cms-admin@va.gov',
+    'technicalcontact_email' => 'vacmssupport@va.gov',
 
     /*
      * The envelope from address for outgoing emails.


### PR DESCRIPTION
## What this does
 - Replaces all instances of `cms-admin@va.gov` with `vacmssupport@va.gov`

## QA
 - Search codebase for `cms-admin@va.gov` - should return no results