### PR TITLE
VAGOV-6020: Footer Menu Feature Flag II

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -3,5 +3,6 @@ features:
   feature_single_value_field_link: FEATURE_SINGLE_VALUE_FIELD_LINK
   feature_header_megamenu: FEATURE_HEADER_MEGAMENU
   feature_image_style_23: FEATURE_IMAGE_STYLE_23
+  feature_footer_menu: FEATURE_FOOTER_MENU
 _core:
   default_config_hash: daCVJgiGNXHoQmWA2-cvaQEapbq7AGlBQtopOWTqqlw


### PR DESCRIPTION
**Description**
This PR adds a footer menu feature flag to the CMS. There is no implementation of this on the front-end yet. We are merely preparing the back-end for the front-end implementation.