### PR TITLE
VAGOV-6107 - Load services.yml in CI environments too.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -64,7 +64,7 @@ $settings['update_free_access'] = FALSE;
 /**
  * Load services definition file.
  */
-$settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
+$settings['container_yamls'][] = $app_root . '/' . $site_path . '/../default/services.yml';
 
 /**
  * The default list of directories that will be ignored by Drupal's file API.


### PR DESCRIPTION
sms: protocol was being stripped from wysiwyg content areas and it looked like a cache issue but was just that the `filter_protocols:` key in services.yml that had `sms` as a whitelisted protocol, wasn't being loaded.

This may affect other things in CI, but mostly for the better as the services.yml wasn't being loaded all this time.