### PR TITLE
VAGOV-5333 Facility API

### DIFF
--- a/docroot/modules/custom/va_gov_consumers/src/FacilityConsumer.php
+++ b/docroot/modules/custom/va_gov_consumers/src/FacilityConsumer.php
@@ -19,15 +19,16 @@ class FacilityConsumer {
    */
   public function contentRender($facility_id) {
     $data = '';
-
-    if (!empty(getenv('CMS_FACILITY_API_KEY'))) {
+    $cms_facility_api_key = getenv('CMS_FACILITY_API_KEY');
+    $cms_facility_api_url = getenv('CMS_FACILITY_API_URL');
+    if ((!empty($cms_facility_api_key)) && (!empty($cms_facility_api_url))) {
       $client = new Client();
       // Make sure we get a good response before heavy lifting.
       try {
-        $data_source = getenv('CMS_FACILITY_API_URL') . '/services/va_facilities/v0/facilities/' . $facility_id;
+        $data_source = $cms_facility_api_url . '/services/va_facilities/v0/facilities/' . $facility_id;
         $response = $client->get($data_source, [
           'headers' => [
-            'apikey' => getenv('CMS_FACILITY_API_KEY'),
+            'apikey' => $cms_facility_api_key,
           ],
         ]);
 

--- a/docroot/modules/custom/va_gov_consumers/src/FacilityConsumer.php
+++ b/docroot/modules/custom/va_gov_consumers/src/FacilityConsumer.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\va_gov_consumers;
 
+use Drupal\Component\Serialization\Json;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception as GuzzleException;
 
@@ -17,19 +18,31 @@ class FacilityConsumer {
    *   The facility id.
    */
   public function contentRender($facility_id) {
+    $data = '';
 
-    $data = FALSE;
-    $client = new Client();
-    // Make sure we get a good response before heavy lifting.
-    try {
-      // @TODO  Restore the logic here when the env-API call is finalized.
-    }
-    // Record any trouble to watchdog.
-    catch (GuzzleException $e) {
-      watchdog_exception('Facility_content', $e->getMessage());
-    }
+    if (!empty(getenv('CMS_FACILITY_API_KEY'))) {
+      $client = new Client();
+      // Make sure we get a good response before heavy lifting.
+      try {
+        $data_source = getenv('CMS_FACILITY_API_URL') . '/services/va_facilities/v0/facilities/' . $facility_id;
+        $response = $client->get($data_source, [
+          'headers' => [
+            'apikey' => getenv('CMS_FACILITY_API_KEY'),
+          ],
+        ]);
 
+        if ($response->getStatusCode() === 200) {
+          $data = Json::decode($response->getBody());
+        }
+
+      }
+      // Record any trouble to watchdog.
+      catch (GuzzleException $e) {
+        watchdog_exception('Facility_content', $e->getMessage());
+      }
+    }
     return $data;
+
   }
 
 }

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -50,15 +50,6 @@ function va_gov_consumers_entity_presave(EntityInterface $entity) {
       if (empty($entity->title)) {
         $entity->title = 'TBD';
       }
-      if (empty($entity->field_address['address_line1'])) {
-        $entity->field_address = [
-          'country_code' => 'US',
-          'address_line1' => 'TBD',
-          'locality' => 'Sarasota',
-          'administrative_area' => 'FL',
-          'postal_code' => '34243',
-        ];
-      }
       if (!empty($facility_id)) {
         $vast = new FacilityConsumer();
         $reset_facility_id = reset($facility_id);
@@ -90,7 +81,10 @@ function va_gov_consumers_entity_presave(EntityInterface $entity) {
           $entity->field_facility_hours = $days_array;
         }
         else {
-          drupal_set_message(t('Facility API response is empty. CMS_FACILITY_API_KEY environment variable may not be set.'), 'warning');
+          $message = t('Facility API response for Facility ID :facility_id is empty. CMS_FACILITY_API_KEY environment variable may not be set.',
+          [':facility_id' => $facility_id['value']]);
+          \Drupal::logger('va_gov_consumers')->notice($message);
+          drupal_set_message($message, 'warning');
         }
       }
       break;

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -46,6 +46,19 @@ function va_gov_consumers_entity_presave(EntityInterface $entity) {
       $facility_id_raw = $entity->get('field_facility_locator_api_id')->getValue();
       $facility_id = !empty($facility_id_raw) ? reset($facility_id_raw) : '';
 
+      // Make sure we have something to prevent empty field errors.
+      if (empty($entity->title)) {
+        $entity->title = 'TBD';
+      }
+      if (empty($entity->field_address['address_line1'])) {
+        $entity->field_address = [
+          'country_code' => 'US',
+          'address_line1' => 'TBD',
+          'locality' => 'Sarasota',
+          'administrative_area' => 'FL',
+          'postal_code' => '34243',
+        ];
+      }
       if (!empty($facility_id)) {
         $vast = new FacilityConsumer();
         $reset_facility_id = reset($facility_id);
@@ -75,6 +88,9 @@ function va_gov_consumers_entity_presave(EntityInterface $entity) {
             $i++;
           }
           $entity->field_facility_hours = $days_array;
+        }
+        else {
+          drupal_set_message(t('Facility API response is empty. CMS_FACILITY_API_KEY environment variable may not be set.'), 'warning');
         }
       }
       break;


### PR DESCRIPTION
## What this does
 - Adds facility api consumer class

## How this differs from last attempt
 - Takes into account new prod api key (set as env var on prod)
  -- Prod has unique key, all other environments use the original dev key (per api team instruction)
 - Env var has same naming convention in all environments, so no env switch necessary in code.