### PR TITLE
VAGOV-6156: Disable access to web.config because of Nessus scan.

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -7,6 +7,12 @@
 # /static assets are built using the `composer va:web:build` command.
 # See https://stackoverflow.com/questions/595005/redirect-requests-only-if-the-file-is-not-found
 
+# Block web.config because of Nessus scan
+# @see https://va-gov.atlassian.net/browse/VAGOV-6156
+<Files "web.config">
+  Require all denied
+</Files>
+
 # If requested file or directory exists, skip the next rule.
 RewriteCond %{DOCUMENT_ROOT}/$1 -f [OR]
 RewriteCond %{DOCUMENT_ROOT}/$1 -d


### PR DESCRIPTION
VAGOV-6156

![image](https://user-images.githubusercontent.com/1504756/67128311-25aacf00-f1b0-11e9-9395-adeca7080cd8.png)
