### PR TITLE
VAGOV-6167: Adding new links fields to VAMC.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -20,6 +20,8 @@ dependencies:
     - field.field.node.health_care_region_page.field_intro_text_news_stories
     - field.field.node.health_care_region_page.field_intro_text_press_releases
     - field.field.node.health_care_region_page.field_leadership
+    - field.field.node.health_care_region_page.field_link_facility_emerg_list
+    - field.field.node.health_care_region_page.field_link_facility_news_list
     - field.field.node.health_care_region_page.field_links
     - field.field.node.health_care_region_page.field_locations_intro_blurb
     - field.field.node.health_care_region_page.field_media
@@ -80,7 +82,7 @@ third_party_settings:
         - field_locations_intro_blurb
         - field_other_va_locations
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details
       format_settings:
         description: "<p>To add locations to the \"Our Locations\" page, <a href=\"/node/add/health_care_local_facility\">create a facility listing</a> for each one.This section also allows you to add other content to the \"Our Locations\" page.</p>\r\n\r\n\r\n"
@@ -151,11 +153,12 @@ third_party_settings:
       region: content
     group_get_updates_from_us:
       children:
-        - field_links
         - field_operating_status
+        - field_link_facility_emerg_list
+        - field_link_facility_news_list
         - group_s
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: details
       format_settings:
         description: 'This will populate the "Get updates" from us block on the health care system page and its facility pages. '
@@ -172,7 +175,7 @@ third_party_settings:
         - field_instagram
         - field_flickr
       parent_name: group_get_updates_from_us
-      weight: 27
+      weight: 29
       format_type: fieldset
       format_settings:
         id: ''
@@ -234,7 +237,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -260,13 +263,13 @@ content:
     type: text_textarea
     region: content
   field_clinical_health_services:
-    weight: 31
+    weight: 32
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_description:
-    weight: 4
+    weight: 5
     settings:
       size: 60
       placeholder: ''
@@ -316,7 +319,7 @@ content:
     type: link_default
     region: content
   field_intro_text:
-    weight: 5
+    weight: 6
     settings:
       rows: 5
       placeholder: ''
@@ -329,7 +332,7 @@ content:
     type: string_textarea_with_counter
     region: content
   field_intro_text_events_page:
-    weight: 24
+    weight: 23
     settings:
       rows: 5
       placeholder: ''
@@ -379,14 +382,21 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-  field_links:
-    weight: 25
+  field_link_facility_emerg_list:
+    weight: 27
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
     third_party_settings: {  }
-    type: linkit
+    type: link_default
+    region: content
+  field_link_facility_news_list:
+    weight: 28
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
     region: content
   field_locations_intro_blurb:
     weight: 10
@@ -423,7 +433,7 @@ content:
     type: string_textfield_with_counter
     region: content
   field_nickname_for_this_facility:
-    weight: 3
+    weight: 4
     settings:
       size: 60
       placeholder: ''
@@ -461,7 +471,7 @@ content:
     type: text_textarea_with_counter
     region: content
   field_related_links:
-    weight: 21
+    weight: 22
     settings:
       title: Link
       title_plural: Links
@@ -495,7 +505,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -503,7 +513,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 4
+    weight: 5
     region: content
     third_party_settings: {  }
   revision_log:
@@ -522,14 +532,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 5
+    weight: 6
     region: content
     third_party_settings: {  }
   title:
@@ -548,7 +558,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 3
     settings:
       match_operator: CONTAINS
       size: 60
@@ -556,11 +566,12 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   field_email_subscription: true
   field_email_subscription_links: true
+  field_links: true
   field_sign_up_for_emergency_emai: true

--- a/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
@@ -20,6 +20,8 @@ dependencies:
     - field.field.node.health_care_region_page.field_intro_text_news_stories
     - field.field.node.health_care_region_page.field_intro_text_press_releases
     - field.field.node.health_care_region_page.field_leadership
+    - field.field.node.health_care_region_page.field_link_facility_emerg_list
+    - field.field.node.health_care_region_page.field_link_facility_news_list
     - field.field.node.health_care_region_page.field_links
     - field.field.node.health_care_region_page.field_locations_intro_blurb
     - field.field.node.health_care_region_page.field_media
@@ -247,6 +249,30 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  field_link_facility_emerg_list:
+    weight: 27
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_link_facility_news_list:
+    weight: 28
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
   field_links:
     weight: 11
     label: above
@@ -344,3 +370,4 @@ hidden:
   field_meta_tags: true
   field_sign_up_for_emergency_emai: true
   links: true
+  search_api_excerpt: true

--- a/config/sync/field.field.node.health_care_region_page.field_link_facility_emerg_list.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_link_facility_emerg_list.yml
@@ -12,7 +12,7 @@ field_name: field_link_facility_emerg_list
 entity_type: node
 bundle: health_care_region_page
 label: 'Emergency updates email list'
-description: ''
+description: 'A link to a URL (generally, GovDelivery) where people can subscribe to emergency email lists.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_region_page.field_link_facility_emerg_list.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_link_facility_emerg_list.yml
@@ -1,0 +1,23 @@
+uuid: c1caab1c-3477-49e5-bcb8-e238ed1fd814
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_link_facility_emerg_list
+    - node.type.health_care_region_page
+  module:
+    - link
+id: node.health_care_region_page.field_link_facility_emerg_list
+field_name: field_link_facility_emerg_list
+entity_type: node
+bundle: health_care_region_page
+label: 'Emergency updates email list'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.field.node.health_care_region_page.field_link_facility_news_list.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_link_facility_news_list.yml
@@ -1,0 +1,23 @@
+uuid: 33ce365b-e3aa-46d0-bcbc-48a897ca3a14
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_link_facility_news_list
+    - node.type.health_care_region_page
+  module:
+    - link
+id: node.health_care_region_page.field_link_facility_news_list
+field_name: field_link_facility_news_list
+entity_type: node
+bundle: health_care_region_page
+label: 'News and announcements email list'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.field.node.health_care_region_page.field_link_facility_news_list.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_link_facility_news_list.yml
@@ -12,7 +12,7 @@ field_name: field_link_facility_news_list
 entity_type: node
 bundle: health_care_region_page
 label: 'News and announcements email list'
-description: ''
+description: 'A link to a URL (generally, GovDelivery) where people can subscribe to news and announcements.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.storage.node.field_link_facility_emerg_list.yml
+++ b/config/sync/field.storage.node.field_link_facility_emerg_list.yml
@@ -1,0 +1,19 @@
+uuid: ec88ef91-ce7f-4bff-8760-ecd5fe192379
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_link_facility_emerg_list
+field_name: field_link_facility_emerg_list
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_link_facility_news_list.yml
+++ b/config/sync/field.storage.node.field_link_facility_news_list.yml
@@ -1,0 +1,19 @@
+uuid: 3168f049-6480-4f43-9bf4-82586e5a666b
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_link_facility_news_list
+field_name: field_link_facility_news_list
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model.feature
+++ b/tests/behat/drupal-spec-tool/content_model.feature
@@ -188,7 +188,7 @@ Feature: Content model
 | Content type | VAMC system | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | VAMC system | Community stories intro text | field_intro_text_news_stories | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC system | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC system | Email lists | field_links | Link |  | Unlimited | Linkit | Translatable |
+| Content type | VAMC system | Email lists | field_links | Link |  | Unlimited | -- Disabled -- | Translatable |
 | Content type | VAMC system | Email Subscription | field_email_subscription | Link |  | 1 | -- Disabled -- | Translatable |
 | Content type | VAMC system | Events page intro text | field_intro_text_events_page | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC system | Facebook | field_facebook | Link |  | 1 | Link | Translatable |
@@ -351,3 +351,5 @@ Feature: Content model
 | Content type | VAMC facility | Hours | field_facility_hours  | Table Field |  | 1 | Table Field |  |
 | Content type | VAMC facility | Mental Health Phone | field_mental_health_phone | Telephone number |  | 1 | Telephone number |  |
 | Content type | VAMC facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
+| Content type | VAMC system | Emergency updates email list  | field_link_facility_emerg_list | Link |  | 1 | Link |  |
+| Content type | VAMC system | News and announcements email list | field_link_facility_news_list | Link |  | 1 | Link |  |


### PR DESCRIPTION
## What this does
 - Adds two new link fields to VAMC system content type for subscribing to emergency notifications or email lists
 - Moves old email subscription field out of node form