### PR TITLE
VAGOV-6182: Improve editorial experience for VAMC health services.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.inline_entity_form.yml
@@ -1,0 +1,67 @@
+uuid: bb008cdc-9edb-487f-b0f7-083bc51f0bc5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.node.inline_entity_form
+    - field.field.node.health_care_local_health_service.field_administration
+    - field.field.node.health_care_local_health_service.field_body
+    - field.field.node.health_care_local_health_service.field_facility_location
+    - field.field.node.health_care_local_health_service.field_regional_health_service
+    - node.type.health_care_local_health_service
+  module:
+    - field_group
+    - text
+third_party_settings:
+  field_group:
+    group_governance:
+      children: {  }
+      parent_name: ''
+      weight: 4
+      format_type: details_sidebar
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: 1
+        required_fields: 1
+        weight: '0'
+      label: Governance
+      region: hidden
+id: node.health_care_local_health_service.inline_entity_form
+targetEntityType: node
+bundle: health_care_local_health_service
+mode: inline_entity_form
+content:
+  field_administration:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_body:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_facility_location:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+hidden:
+  created: true
+  field_regional_health_service: true
+  moderation_state: true
+  path: true
+  promote: true
+  revision_log: true
+  status: true
+  sticky: true
+  title: true
+  uid: true
+  url_redirects: true

--- a/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
+++ b/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_form_mode.node.inline_entity_form
     - field.field.node.regional_health_care_service_des.field_administration
     - field.field.node.regional_health_care_service_des.field_body
     - field.field.node.regional_health_care_service_des.field_local_health_care_service_
@@ -11,7 +12,7 @@ dependencies:
     - node.type.regional_health_care_service_des
   module:
     - field_group
-    - path
+    - ief_table_view_mode
     - text
 third_party_settings:
   field_group:
@@ -20,7 +21,7 @@ third_party_settings:
         - field_region_page
         - field_administration
       parent_name: ''
-      weight: 10
+      weight: 3
       format_type: details_sidebar
       format_settings:
         open: '1'
@@ -35,7 +36,7 @@ third_party_settings:
         - revision_log
         - moderation_state
       parent_name: ''
-      weight: 11
+      weight: 12
       format_type: fieldset
       format_settings:
         id: ''
@@ -50,12 +51,6 @@ targetEntityType: node
 bundle: regional_health_care_service_des
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 9
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_administration:
     weight: 2
     settings: {  }
@@ -63,7 +58,7 @@ content:
     type: options_select
     region: content
   field_body:
-    weight: 2
+    weight: 1
     settings:
       rows: 5
       placeholder: ''
@@ -71,10 +66,20 @@ content:
     type: text_textarea
     region: content
   field_local_health_care_service_:
-    weight: 3
-    settings: {  }
+    weight: 2
+    settings:
+      form_mode: inline_entity_form
+      label_singular: ''
+      label_plural: ''
+      collapsible: true
+      allow_new: true
+      allow_existing: true
+      match_operator: CONTAINS
+      allow_duplicate: true
+      override_labels: false
+      collapsed: false
     third_party_settings: {  }
-    type: options_select
+    type: inline_entity_form_complex_table_view_mode
     region: content
   field_region_page:
     weight: 1
@@ -88,40 +93,14 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
-  path:
-    type: path
-    weight: 6
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    weight: 8
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 4
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    weight: 7
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  url_redirects:
-    weight: 5
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
+  created: true
   moderation_state: true
+  path: true
+  promote: true
   revision_log: true
+  status: true
+  sticky: true
   title: true
   uid: true
+  url_redirects: true

--- a/config/sync/core.entity_form_display.node.regional_health_care_service_des.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.regional_health_care_service_des.inline_entity_form.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.field.node.regional_health_care_service_des.field_service_name_and_descripti
     - node.type.regional_health_care_service_des
   module:
-    - content_moderation
     - inline_entity_form
     - text
 id: node.regional_health_care_service_des.inline_entity_form
@@ -49,16 +48,11 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
-  moderation_state:
-    type: moderation_state_default
-    weight: 4
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   created: true
   field_administration: true
   field_region_page: true
+  moderation_state: true
   path: true
   promote: true
   revision_log: true

--- a/config/sync/core.entity_view_display.node.health_care_local_health_service.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_health_service.ief_table.yml
@@ -1,8 +1,9 @@
-uuid: 0a2f9c1d-b5a5-484e-9fea-7c25c9c3f0f6
+uuid: 3cff84ce-1b07-4be7-838c-8c2ea605581f
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.ief_table
     - field.field.node.health_care_local_health_service.field_administration
     - field.field.node.health_care_local_health_service.field_body
     - field.field.node.health_care_local_health_service.field_facility_location
@@ -11,21 +12,21 @@ dependencies:
   module:
     - text
     - user
-id: node.health_care_local_health_service.default
+id: node.health_care_local_health_service.ief_table
 targetEntityType: node
 bundle: health_care_local_health_service
-mode: default
+mode: ief_table
 content:
   field_body:
     weight: 1
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   field_facility_location:
     weight: 0
-    label: above
+    label: hidden
     settings:
       link: true
     third_party_settings: {  }
@@ -35,5 +36,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_regional_health_service: true
+  label: true
   links: true
   search_api_excerpt: true
+  status: true

--- a/config/sync/field.field.node.regional_health_care_service_des.field_body.yml
+++ b/config/sync/field.field.node.regional_health_care_service_des.field_body.yml
@@ -11,7 +11,7 @@ id: node.regional_health_care_service_des.field_body
 field_name: field_body
 entity_type: node
 bundle: regional_health_care_service_des
-label: 'Regional description of service'
+label: 'VAMC system description of service'
 description: ''
 required: false
 translatable: true

--- a/config/sync/field.field.node.regional_health_care_service_des.field_local_health_care_service_.yml
+++ b/config/sync/field.field.node.regional_health_care_service_des.field_local_health_care_service_.yml
@@ -11,7 +11,7 @@ field_name: field_local_health_care_service_
 entity_type: node
 bundle: regional_health_care_service_des
 label: 'Facility-specific descriptions of this service'
-description: 'This will get automatically updated when you <a href="/node/add/health_care_local_health_service">create a local health service offering.'
+description: ''
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.regional_health_care_service_des.field_region_page.yml
+++ b/config/sync/field.field.node.regional_health_care_service_des.field_region_page.yml
@@ -10,7 +10,7 @@ id: node.regional_health_care_service_des.field_region_page
 field_name: field_region_page
 entity_type: node
 bundle: regional_health_care_service_des
-label: 'Region page'
+label: 'VAMC system'
 description: ''
 required: true
 translatable: true

--- a/config/sync/node.type.health_care_local_health_service.yml
+++ b/config/sync/node.type.health_care_local_health_service.yml
@@ -7,17 +7,8 @@ dependencies:
     - node_title_help_text
 third_party_settings:
   menu_ui:
-    available_menus:
-      - va-altoona-health-care
-      - va-butler-health-care
-      - va-coatesville-health-care
-      - va-erie-health-care
-      - va-lebanon
-      - va-philadelphia-health-care
-      - pittsburgh-health-care
-      - va-wilkes-barre-health-care
-      - va-wilmington-health-care
-    parent: 'pittsburgh-health-care:'
+    available_menus: {  }
+    parent: ''
   node_title_help_text:
     title_help: ''
 name: 'VAMC facility health service'

--- a/config/sync/node.type.regional_health_care_service_des.yml
+++ b/config/sync/node.type.regional_health_care_service_des.yml
@@ -14,7 +14,7 @@ third_party_settings:
 name: 'VAMC system health service'
 type: regional_health_care_service_des
 description: 'A description of a health service specific to a VAMC system.'
-help: "<ol><li><a href=\"/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview\">Ensure the health service exists in the VHA health services taxonomy</a></li>\r\n<li>Add a VAMC health service, and link it to the VAMC by filling out this form.</li>\r\n<li>Add <a href=\"/node/add/health_care_local_health_service\">a VAMC facility health service</a> and point it to a VAMC health service.</li></ol>"
+help: "<ol><li><a href=\"/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview\">Ensure the health service exists in the VHA health services taxonomy</a></li>\r\n<li>Add a VAMC health service, and link it to the VAMC by filling out this form.</li>\r\n<li>Add as many VAMC facility health services as there are facilities that provide this service, using this form.</li></ol>"
 new_revision: true
 preview_mode: 0
 display_submitted: false

--- a/config/sync/node.type.regional_health_care_service_des.yml
+++ b/config/sync/node.type.regional_health_care_service_des.yml
@@ -7,17 +7,8 @@ dependencies:
     - node_title_help_text
 third_party_settings:
   menu_ui:
-    available_menus:
-      - va-altoona-health-care
-      - va-butler-health-care
-      - va-coatesville-health-care
-      - va-erie-health-care
-      - va-lebanon
-      - va-philadelphia-health-care
-      - pittsburgh-health-care
-      - va-wilkes-barre-health-care
-      - va-wilmington-health-care
-    parent: 'pittsburgh-health-care:'
+    available_menus: {  }
+    parent: ''
   node_title_help_text:
     title_help: ''
 name: 'VAMC system health service'

--- a/tests/behat/drupal-spec-tool/content_model.feature
+++ b/tests/behat/drupal-spec-tool/content_model.feature
@@ -4,7 +4,7 @@ Feature: Content model
   As a content editor
   I want to have content entity types that reflect my content model.
 
-  @dst @content_type                                                                                                                                                                      
+  @dst @content_type
      Scenario: Bundles
        Then exactly the following content entity type bundles should exist
        | Name | Machine name | Type | Description |
@@ -57,193 +57,193 @@ Feature: Content model
 | Type of Redirect | type_of_redirect | Vocabulary |  |
 | VHA health service taxonomy | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |
 
-  @dst @field_type                                                                                                                                                                      
+  @dst @field_type
      Scenario: Fields
        Then exactly the following fields should exist
-       | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable | 
-| Content type | Benefits detail page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Benefits detail page | Alert | field_alert | Entity reference |  | 1 | Select list |  | 
-| Content type | Benefits detail page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL |  | 
-| Content type | Benefits detail page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter |  | 
-| Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  | 
-| Content type | Benefits detail page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  | 
-| Content type | Benefits detail page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form |  | 
-| Content type | Benefits detail page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  | 
-| Content type | Benefits detail page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  | 
-| Content type | Benefits detail page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | Date and time |  | 
-| Content type | Benefits detail page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  | 
-| Content type | Benefits hub landing page | Owner | field_administration | Entity reference | Required | 1 | Select list |  | 
-| Content type | Benefits hub landing page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable | 
-| Content type | Benefits hub landing page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Benefits hub landing page | Home page hub label | field_home_page_hub_label | Text (plain) |  | 1 | Textfield |  | 
-| Content type | Benefits hub landing page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable | 
-| Content type | Benefits hub landing page | Links for non-veterans | field_links | Link |  | Unlimited | Linkit |  | 
-| Content type | Benefits hub landing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Benefits hub landing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Benefits hub landing page | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable | 
-| Content type | Benefits hub landing page | Plain language Certified Date | field_plainlanguage_date | Date |  | 1 | Date and time | Translatable | 
-| Content type | Benefits hub landing page | Promo | field_promo | Entity reference |  | 1 | Select list |  | 
-| Content type | Benefits hub landing page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable | 
-| Content type | Benefits hub landing page | Spokes | field_spokes | Entity reference revisions | Required | 4 | Paragraphs EXPERIMENTAL |  | 
-| Content type | Benefits hub landing page | Support Services | field_support_services | Entity reference |  | Unlimited | Inline entity form - Complex |  | 
-| Content type | Benefits hub landing page | Teaser text | field_teaser_text | Text (plain) |  | 1 | Textfield with counter |  | 
-| Content type | Benefits hub landing page | Hub Icon | field_title_icon | List (text) |  | 1 | Select list |  | 
-| Content type | Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Detail Page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable | 
-| Content type | Detail Page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable | 
-| Content type | Detail Page | Summary | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Detail Page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable | 
-| Content type | Detail Page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Content type | Detail Page | Downloads | field_media | Entity reference |  | 1 | Entity browser | Translatable | 
-| Content type | Detail Page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Detail Page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Detail Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable | 
-| Content type | Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox |  | 
-| Content type | Documentation page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser Classic | Translatable | 
-| Content type | Event | Additional information about registration | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | Event | Address | field_address | Address |  | 1 | Address |  | 
-| Content type | Event | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Event | Full event description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | Event | Date and time | field_date | Date range |  | 1 | Date and time range |  | 
-| Content type | Event | A brief (ideally one sentence) summary of the event | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
-| Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  | 
-| Content type | Event | URL Link Label | field_event_cta | List (text) |  | 1 | Select list |  | 
-| Content type | Event | Registration required | field_event_registrationrequired | Boolean |  | 1 | Single on/off checkbox |  | 
-| Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  | 
-| Content type | Event | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox | Translatable | 
-| Content type | Event | URL of an external page or registration link for this event | field_link | Link |  | 1 | Link | Translatable | 
-| Content type | Event | A human-readable label for the event location. | field_location_humanreadable | Text (plain) |  | 1 | Textfield |  | 
-| Content type | Event | Location type | field_location_type | List (text) |  | 1 | Select list |  | 
-| Content type | Event | Image | field_media | Entity reference |  | 1 | Media library | Translatable | 
-| Content type | Event | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Event | Event listing | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Event | Order | field_order | List (integer) |  | 1 | Select list |  | 
-| Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Linkit |  | 
-| Content type | Event listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Event listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Event listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable | 
-| Content type | Event listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Event listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Event listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | News release | Location | field_address | Address | Required | 1 | Address | Translatable | 
-| Content type | News release | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | News release | Introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Content type | News release | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | News release | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | News release | PDF of Press Release | field_pdf_version | Entity reference |  | 1 | Media library |  | 
-| Content type | News release | Media Contact(s) | field_press_release_contact | Entity reference |  | Unlimited | Autocomplete | Translatable | 
-| Content type | News release | Media assets | field_press_release_downloads | Entity reference |  | Unlimited | Media library |  | 
-| Content type | News release | Full text of the Press Release | field_press_release_fulltext | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  | 
-| Content type | News release | Release date | field_release_date | Date |  | 1 | Date and time |  | 
-| Content type | Office | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Office | Body | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable | 
-| Content type | Office | Description | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
-| Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Office | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Publication | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Publication | Related Benefits | field_benefits | List (text) |  | 1 | Select list |  | 
-| Content type | Publication | A brief (ideally one sentence) summary of this asset | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
-| Content type | Publication | Format | field_format | List (text) | Required | 1 | Select list |  | 
-| Content type | Publication | File or video | field_media | Entity reference |  | 1 | Media library |  | 
-| Content type | Publication | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Publication | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Publication listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Publication listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Publication listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable | 
-| Content type | Publication listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Publication listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | Publication listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Staff profile | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Staff profile | Bio | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable | 
-| Content type | Staff profile | Complete Biography | field_complete_biography | File |  | 1 | File |  | 
-| Content type | Staff profile | Job Title | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
-| Content type | Staff profile | Email address | field_email_address | Email |  | 1 | Email |  | 
-| Content type | Staff profile | Introduction | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Content type | Staff profile | Last name | field_last_name | Text (plain) |  | 1 | Textfield |  | 
-| Content type | Staff profile | Photo | field_media | Entity reference |  | 1 | Media library | Translatable | 
-| Content type | Staff profile | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Staff profile | First name | field_name_first | Text (plain) |  | 1 | Textfield |  | 
-| Content type | Staff profile | Related office or health care region | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Staff profile | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number | Translatable | 
-| Content type | Staff profile | High-resolution photo should be available for download by site visitors | field_photo_allow_hires_download | Boolean |  | 1 | Single on/off checkbox |  | 
-| Content type | Staff profile | Suffix | field_suffix | Text (plain) |  | 1 | Textfield |  | 
-| Content type | Story | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Story | Author byline | field_author | Entity reference |  | 1 | Autocomplete |  | 
-| Content type | Story | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox |  | 
-| Content type | Story | Full text of Story | field_full_story | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | Story | Image caption | field_image_caption | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  | 
-| Content type | Story | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Content type | Story | Image | field_media | Entity reference |  | 1 | Media library | Translatable | 
-| Content type | Story | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | Story | Related office or health care region | field_office | Entity reference | Required | 1 | Select list |  | 
-| Content type | Story | Order | field_order | List (integer) |  | 1 | Select list | Translatable | 
-| Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Support Service | Link | field_link | Link |  | 1 | Link |  | 
-| Content type | Support Service | Related office | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | Support Service | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable | 
-| Content type | Support Service | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number |  | 
-| Content type | VAMC facility | Address | field_address | Address |  | 1 | Address | Translatable | 
-| Content type | VAMC facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC facility | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | VAMC facility | Email Subscription | field_email_subscription | Link |  | 1 | Linkit | Translatable | 
-| Content type | VAMC facility | Facebook | field_facebook | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC facility | Classification | field_facility_classification | List (text) |  | 1 | Select list |  | 
-| Content type | VAMC facility | Hours | field_facility_hours  | Table Field |  | 1 | Table Field |  | 
-| Content type | VAMC facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield |  | 
-| Content type | VAMC facility | Flickr | field_flickr | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC facility | Instagram | field_instagram | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC facility | Intro text | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Content type | VAMC facility | Local health care service offerings | field_local_health_care_service_ | Entity reference |  | Unlimited | -- Disabled -- | Translatable | 
-| Content type | VAMC facility | Location services | field_location_services | Entity reference revisions |  | Unlimited | Paragraphs Classic |  | 
-| Content type | VAMC facility | Main location | field_main_location | Boolean |  | 1 | Single on/off checkbox |  | 
-| Content type | VAMC facility | Image | field_media | Entity reference |  | 1 | Media library | Translatable | 
-| Content type | VAMC facility | Mental Health Phone | field_mental_health_phone | Telephone number |  | 1 | Telephone number |  | 
-| Content type | VAMC facility | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | VAMC facility | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | VAMC facility | Nickname for this facility | field_nickname_for_this_facility | Text (plain) | Required | 1 | Textfield |  | 
-| Content type | VAMC facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list |  | 
-| Content type | VAMC facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | VAMC facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable | 
-| Content type | VAMC facility | Region page | field_region_page | Entity reference | Required | 1 | Select list |  | 
-| Content type | VAMC facility | Twitter | field_twitter | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC facility health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC facility health service | Facility description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable | 
-| Content type | VAMC facility health service | Facility | field_facility_location | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC facility health service | VAMC system health service | field_regional_health_service | Entity reference | Required | 1 | Select list |  | 
-| Content type | VAMC system | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC system | Appointments can be scheduled and viewed online | field_appointments_online | Boolean |  | 1 | Single on/off checkbox |  | 
-| Content type | VAMC system | Health services intro text | field_clinical_health_care_servi | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | VAMC system | Regional Health Service Offerings. | field_clinical_health_services | Entity reference |  | Unlimited | Select list |  | 
-| Content type | VAMC system | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | VAMC system | Email Subscription | field_email_subscription | Link |  | 1 | -- Disabled -- | Translatable | 
-| Content type | VAMC system | URL for signing up for email news and announcements | field_email_subscription_links | Link |  | 1 | -- Disabled -- |  | 
-| Content type | VAMC system | Facebook | field_facebook | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC system | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic |  | 
-| Content type | VAMC system | Flickr | field_flickr | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC system | Instagram | field_instagram | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC system | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Content type | VAMC system | Events page intro text | field_intro_text_events_page | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  | 
-| Content type | VAMC system | Leadership page intro text | field_intro_text_leadership | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | VAMC system | Community stories intro text | field_intro_text_news_stories | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  | 
-| Content type | VAMC system | Press releases intro text | field_intro_text_press_releases | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | VAMC system | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete |  | 
-| Content type | VAMC system | Emergency updates email list  | field_link_facility_emerg_list | Link |  | 1 | Link |  | 
-| Content type | VAMC system | News and announcements email list | field_link_facility_news_list | Link |  | 1 | Link |  | 
-| Content type | VAMC system | Email lists | field_links | Link |  | Unlimited | -- Disabled -- | Translatable | 
-| Content type | VAMC system | Our Locations intro text | field_locations_intro_blurb | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  | 
-| Content type | VAMC system | Banner image | field_media | Entity reference |  | 1 | Media library | Translatable | 
-| Content type | VAMC system | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
-| Content type | VAMC system | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Content type | VAMC system | Short name | field_nickname_for_this_facility | Text (plain) |  | 1 | Textfield | Translatable | 
-| Content type | VAMC system | Operating status | field_operating_status | Link |  | 1 | Linkit |  | 
-| Content type | VAMC system | Other VA Locations | field_other_va_locations | Text (plain) |  | Unlimited | Textfield |  | 
-| Content type | VAMC system | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  | 
-| Content type | VAMC system | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable | 
-| Content type | VAMC system | URL for signing up for emergency email alerts | field_sign_up_for_emergency_emai | Link |  | 1 | -- Disabled -- |  | 
-| Content type | VAMC system | Twitter | field_twitter | Link |  | 1 | Link | Translatable | 
-| Content type | VAMC system banner alert with situation updates | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC system banner alert with situation updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  | 
+       | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
+| Content type | Benefits detail page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Benefits detail page | Alert | field_alert | Entity reference |  | 1 | Select list |  |
+| Content type | Benefits detail page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL |  |
+| Content type | Benefits detail page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter |  |
+| Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
+| Content type | Benefits detail page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  |
+| Content type | Benefits detail page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form |  |
+| Content type | Benefits detail page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  |
+| Content type | Benefits detail page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  |
+| Content type | Benefits detail page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | Date and time |  |
+| Content type | Benefits detail page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
+| Content type | Benefits hub landing page | Owner | field_administration | Entity reference | Required | 1 | Select list |  |
+| Content type | Benefits hub landing page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable |
+| Content type | Benefits hub landing page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Benefits hub landing page | Home page hub label | field_home_page_hub_label | Text (plain) |  | 1 | Textfield |  |
+| Content type | Benefits hub landing page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Benefits hub landing page | Links for non-veterans | field_links | Link |  | Unlimited | Linkit |  |
+| Content type | Benefits hub landing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Benefits hub landing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Benefits hub landing page | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
+| Content type | Benefits hub landing page | Plain language Certified Date | field_plainlanguage_date | Date |  | 1 | Date and time | Translatable |
+| Content type | Benefits hub landing page | Promo | field_promo | Entity reference |  | 1 | Select list |  |
+| Content type | Benefits hub landing page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
+| Content type | Benefits hub landing page | Spokes | field_spokes | Entity reference revisions | Required | 4 | Paragraphs EXPERIMENTAL |  |
+| Content type | Benefits hub landing page | Support Services | field_support_services | Entity reference |  | Unlimited | Inline entity form - Complex |  |
+| Content type | Benefits hub landing page | Teaser text | field_teaser_text | Text (plain) |  | 1 | Textfield with counter |  |
+| Content type | Benefits hub landing page | Hub Icon | field_title_icon | List (text) |  | 1 | Select list |  |
+| Content type | Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Detail Page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable |
+| Content type | Detail Page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
+| Content type | Detail Page | Summary | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Detail Page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | Detail Page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Detail Page | Downloads | field_media | Entity reference |  | 1 | Entity browser | Translatable |
+| Content type | Detail Page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Detail Page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Detail Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | Documentation page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser Classic | Translatable |
+| Content type | Event | Additional information about registration | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | Event | Address | field_address | Address |  | 1 | Address |  |
+| Content type | Event | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Event | Full event description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | Event | Date and time | field_date | Date range |  | 1 | Date and time range |  |
+| Content type | Event | A brief (ideally one sentence) summary of the event | field_description | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  |
+| Content type | Event | URL Link Label | field_event_cta | List (text) |  | 1 | Select list |  |
+| Content type | Event | Registration required | field_event_registrationrequired | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  |
+| Content type | Event | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Event | URL of an external page or registration link for this event | field_link | Link |  | 1 | Link | Translatable |
+| Content type | Event | A human-readable label for the event location. | field_location_humanreadable | Text (plain) |  | 1 | Textfield |  |
+| Content type | Event | Location type | field_location_type | List (text) |  | 1 | Select list |  |
+| Content type | Event | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
+| Content type | Event | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Event | Event listing | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Event | Order | field_order | List (integer) |  | 1 | Select list |  |
+| Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Linkit |  |
+| Content type | Event listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Event listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Event listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Event listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Event listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Event listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | News release | Location | field_address | Address | Required | 1 | Address | Translatable |
+| Content type | News release | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | News release | Introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | News release | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | News release | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | News release | PDF of Press Release | field_pdf_version | Entity reference |  | 1 | Media library |  |
+| Content type | News release | Media Contact(s) | field_press_release_contact | Entity reference |  | Unlimited | Autocomplete | Translatable |
+| Content type | News release | Media assets | field_press_release_downloads | Entity reference |  | Unlimited | Media library |  |
+| Content type | News release | Full text of the Press Release | field_press_release_fulltext | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
+| Content type | News release | Release date | field_release_date | Date |  | 1 | Date and time |  |
+| Content type | Office | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Office | Body | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | Office | Description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Office | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Publication | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Publication | Related Benefits | field_benefits | List (text) |  | 1 | Select list |  |
+| Content type | Publication | A brief (ideally one sentence) summary of this asset | field_description | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | Publication | Format | field_format | List (text) | Required | 1 | Select list |  |
+| Content type | Publication | File or video | field_media | Entity reference |  | 1 | Media library |  |
+| Content type | Publication | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Publication | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Publication listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Publication listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Publication listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Publication listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Publication listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Publication listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Staff profile | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Staff profile | Bio | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | Staff profile | Complete Biography | field_complete_biography | File |  | 1 | File |  |
+| Content type | Staff profile | Job Title | field_description | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | Staff profile | Email address | field_email_address | Email |  | 1 | Email |  |
+| Content type | Staff profile | Introduction | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Staff profile | Last name | field_last_name | Text (plain) |  | 1 | Textfield |  |
+| Content type | Staff profile | Photo | field_media | Entity reference |  | 1 | Media library | Translatable |
+| Content type | Staff profile | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Staff profile | First name | field_name_first | Text (plain) |  | 1 | Textfield |  |
+| Content type | Staff profile | Related office or health care region | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Staff profile | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number | Translatable |
+| Content type | Staff profile | High-resolution photo should be available for download by site visitors | field_photo_allow_hires_download | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | Staff profile | Suffix | field_suffix | Text (plain) |  | 1 | Textfield |  |
+| Content type | Story | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Story | Author byline | field_author | Entity reference |  | 1 | Autocomplete |  |
+| Content type | Story | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | Story | Full text of Story | field_full_story | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | Story | Image caption | field_image_caption | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
+| Content type | Story | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Story | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
+| Content type | Story | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | Story | Related office or health care region | field_office | Entity reference | Required | 1 | Select list |  |
+| Content type | Story | Order | field_order | List (integer) |  | 1 | Select list | Translatable |
+| Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Support Service | Link | field_link | Link |  | 1 | Link |  |
+| Content type | Support Service | Related office | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Support Service | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
+| Content type | Support Service | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number |  |
+| Content type | VAMC facility | Address | field_address | Address |  | 1 | Address | Translatable |
+| Content type | VAMC facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC facility | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | VAMC facility | Email Subscription | field_email_subscription | Link |  | 1 | Linkit | Translatable |
+| Content type | VAMC facility | Facebook | field_facebook | Link |  | 1 | Link | Translatable |
+| Content type | VAMC facility | Classification | field_facility_classification | List (text) |  | 1 | Select list |  |
+| Content type | VAMC facility | Hours | field_facility_hours  | Table Field |  | 1 | Table Field |  |
+| Content type | VAMC facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield |  |
+| Content type | VAMC facility | Flickr | field_flickr | Link |  | 1 | Link | Translatable |
+| Content type | VAMC facility | Instagram | field_instagram | Link |  | 1 | Link | Translatable |
+| Content type | VAMC facility | Intro text | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | VAMC facility | Local health care service offerings | field_local_health_care_service_ | Entity reference |  | Unlimited | -- Disabled -- | Translatable |
+| Content type | VAMC facility | Location services | field_location_services | Entity reference revisions |  | Unlimited | Paragraphs Classic |  |
+| Content type | VAMC facility | Main location | field_main_location | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | VAMC facility | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
+| Content type | VAMC facility | Mental Health Phone | field_mental_health_phone | Telephone number |  | 1 | Telephone number |  |
+| Content type | VAMC facility | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | VAMC facility | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | VAMC facility | Nickname for this facility | field_nickname_for_this_facility | Text (plain) | Required | 1 | Textfield |  |
+| Content type | VAMC facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list |  |
+| Content type | VAMC facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | VAMC facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
+| Content type | VAMC facility | Region page | field_region_page | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC facility | Twitter | field_twitter | Link |  | 1 | Link | Translatable |
+| Content type | VAMC facility health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC facility health service | Facility description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | VAMC facility health service | Facility | field_facility_location | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC facility health service | VAMC system health service | field_regional_health_service | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC system | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC system | Appointments can be scheduled and viewed online | field_appointments_online | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | VAMC system | Health services intro text | field_clinical_health_care_servi | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | VAMC system | Regional Health Service Offerings. | field_clinical_health_services | Entity reference |  | Unlimited | Select list |  |
+| Content type | VAMC system | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | VAMC system | Email Subscription | field_email_subscription | Link |  | 1 | -- Disabled -- | Translatable |
+| Content type | VAMC system | URL for signing up for email news and announcements | field_email_subscription_links | Link |  | 1 | -- Disabled -- |  |
+| Content type | VAMC system | Facebook | field_facebook | Link |  | 1 | Link | Translatable |
+| Content type | VAMC system | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic |  |
+| Content type | VAMC system | Flickr | field_flickr | Link |  | 1 | Link | Translatable |
+| Content type | VAMC system | Instagram | field_instagram | Link |  | 1 | Link | Translatable |
+| Content type | VAMC system | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | VAMC system | Events page intro text | field_intro_text_events_page | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
+| Content type | VAMC system | Leadership page intro text | field_intro_text_leadership | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | VAMC system | Community stories intro text | field_intro_text_news_stories | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
+| Content type | VAMC system | Press releases intro text | field_intro_text_press_releases | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | VAMC system | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete |  |
+| Content type | VAMC system | Emergency updates email list  | field_link_facility_emerg_list | Link |  | 1 | Link |  |
+| Content type | VAMC system | News and announcements email list | field_link_facility_news_list | Link |  | 1 | Link |  |
+| Content type | VAMC system | Email lists | field_links | Link |  | Unlimited | -- Disabled -- | Translatable |
+| Content type | VAMC system | Our Locations intro text | field_locations_intro_blurb | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
+| Content type | VAMC system | Banner image | field_media | Entity reference |  | 1 | Media library | Translatable |
+| Content type | VAMC system | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+| Content type | VAMC system | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | VAMC system | Short name | field_nickname_for_this_facility | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | VAMC system | Operating status | field_operating_status | Link |  | 1 | Linkit |  |
+| Content type | VAMC system | Other VA Locations | field_other_va_locations | Text (plain) |  | Unlimited | Textfield |  |
+| Content type | VAMC system | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
+| Content type | VAMC system | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | VAMC system | URL for signing up for emergency email alerts | field_sign_up_for_emergency_emai | Link |  | 1 | -- Disabled -- |  |
+| Content type | VAMC system | Twitter | field_twitter | Link |  | 1 | Link | Translatable |
+| Content type | VAMC system banner alert with situation updates | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC system banner alert with situation updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Subscribe to email updates" link? | field_alert_email_updates_button | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Find other VA facilities near you" link? | field_alert_find_facilities_cta | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Inherited by subpages | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  |
@@ -256,101 +256,101 @@ Feature: Content model
 | Content type | VAMC system banner alert with situation updates | Situation updates | field_situation_updates | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
 | Content type | VAMC system health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC system health service | VAMC system description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
-| Content type | VAMC system health service | Facility-specific descriptions of this service | field_local_health_care_service_ | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  | 
-| Content type | VAMC system health service | VAMC system | field_region_page | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC system health service | Service name and description | field_service_name_and_descripti | Entity reference | Required | 1 | Select list |  | 
-| Content type | VAMC system operating status | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC system operating status | Banner alert and situation updates | field_banner_alert | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  | 
-| Content type | VAMC system operating status | Update individual facility statuses | field_facility_operating_status | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  | 
-| Content type | VAMC system operating status | Links | field_links | Link |  | Unlimited | Link | Translatable | 
-| Content type | VAMC system operating status | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable | 
-| Content type | VAMC system operating status | VAMC system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
-| Content type | VAMC system operating status | Emergency information | field_operating_status_emerg_inf | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  | 
-| Custom block type | Alert | Alert body | field_alert_content | Entity reference revisions | Required | 1 | Paragraphs Classic |  | 
-| Custom block type | Alert | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  | 
-| Custom block type | Alert | Persistence (for dismissable alerts only) | field_alert_frequency | List (text) | Required | 1 | Select list |  | 
-| Custom block type | Alert | Alert title | field_alert_title | Text (plain) | Required | 1 | Textfield |  | 
-| Custom block type | Alert | Alert Type | field_alert_type | List (text) | Required | 1 | Select list |  | 
-| Custom block type | Alert | Banner or in-page alert? | field_is_this_a_header_alert_ | List (text) |  | 1 | Select list |  | 
-| Custom block type | Alert | Scope | field_node_reference | Entity reference |  | Unlimited | Autocomplete |  | 
-| Custom block type | Alert | Owner | field_owner | Entity reference | Required | 1 | Select list |  | 
-| Custom block type | Alert | Reusability | field_reusability | List (text) | Required | 1 | -- Disabled -- |  | 
-| Custom block type | Promo | Image | field_image | Entity reference | Required | 1 | Entity browser |  | 
-| Custom block type | Promo | Instructions | field_instructions | Markup |  | 1 | Markup |  | 
-| Custom block type | Promo | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable | 
-| Custom block type | Promo | Link | field_promo_link | Entity reference revisions |  | 1 | Paragraphs Classic |  | 
-| Media type | Document | Document | field_document | File | Required | 1 | File |  | 
-| Media type | Document | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable | 
-| Media type | Document | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup |  | 
-| Media type | Document | Owner | field_owner | Entity reference | Required | 1 | Select list |  | 
-| Media type | Image | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- |  | 
-| Media type | Image | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable | 
-| Media type | Image | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable | 
-| Media type | Image | Image | image | Image | Required | 1 | ImageWidget crop |  | 
-| Media type | Video | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable | 
-| Media type | Video | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable | 
-| Media type | Video | Video URL | field_media_video_embed_field | Video Embed | Required | 1 | Video Textfield | Translatable | 
-| Media type | Video | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable | 
-| Paragraph type | Accordion group | Add border around items | field_collapsible_panel_bordered | Boolean |  | 1 | -- Disabled -- |  | 
-| Paragraph type | Accordion group | Start expanded | field_collapsible_panel_expand | Boolean |  | 1 | -- Disabled -- |  | 
-| Paragraph type | Accordion group | Allow more than one item to expand at a time | field_collapsible_panel_multi | Boolean |  | 1 | -- Disabled -- |  | 
-| Paragraph type | Accordion group | Accordion Items | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable | 
-| Paragraph type | Accordion Item | Title | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Paragraph type | Accordion Item | Content block(s) | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs Classic | Translatable | 
-| Paragraph type | Accordion Item | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Paragraph type | Additional information | Instructions for obtaining more information in Spanish | field_text_expander | Text (plain) |  | 1 | Textfield with counter | Translatable | 
-| Paragraph type | Additional information | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Paragraph type | Address | Address | field_address | Address |  | 1 | Address |  | 
-| Paragraph type | Alert | Reusable alert | field_alert_block_reference | Entity reference |  | 1 | Select list |  | 
-| Paragraph type | Alert | Alert Heading | field_alert_heading | Text (plain) |  | 1 | Textfield with counter |  | 
-| Paragraph type | Alert | Alert Type | field_alert_type | List (text) |  | 1 | Select list |  | 
-| Paragraph type | Alert | Alert content | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable | 
-| Paragraph type | Embedded image | Allow clicks on this image to open it in new tab | field_allow_clicks_on_this_image | Boolean |  | 1 | Single on/off checkbox |  | 
-| Paragraph type | Embedded image | Markup | field_markup | Markup |  | 1 | Markup |  | 
-| Paragraph type | Embedded image | Select an image | field_media | Entity reference |  | 1 | Media library |  | 
-| Paragraph type | Expandable Text | Text Expander | field_text_expander | Text (plain) | Required | 1 | Textfield with counter |  | 
-| Paragraph type | Expandable Text | Full Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Paragraph type | Link teaser | Link | field_link | Link |  | 1 | Linkit |  | 
-| Paragraph type | Link teaser | Link summary | field_link_summary | Text (plain) |  | 1 | Textfield with counter |  | 
-| Paragraph type | Link to file or video | Markup | field_markup | Markup |  | 1 | Markup | Translatable | 
-| Paragraph type | Link to file or video | Link to a file or video | field_media | Entity reference | Required | 1 | Media library | Translatable | 
-| Paragraph type | Link to file or video | Link text | field_title | Text (plain) | Required | 1 | Textfield | Translatable | 
-| Paragraph type | List of link teasers | Title | field_title | Text (plain) |  | 1 | Textfield | Translatable | 
-| Paragraph type | List of link teasers | Link teasers | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable | 
-| Paragraph type | Number callout | Short phrase with a number, or time element | field_short_phrase_with_a_number | Text (plain) | Required | 1 | Textfield with counter |  | 
-| Paragraph type | Number callout | Additional information | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Paragraph type | Process list | Steps | field_steps | Text (formatted, long) | Required | Unlimited | Text area (multiple rows) |  | 
-| Paragraph type | Q&A | Answer | field_answer | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  | 
-| Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  | 
-| Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  | 
-| Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  | 
-| Paragraph type | Q&A Section | Section Header | field_section_header | Text (plain) |  | 1 | Textfield |  | 
-| Paragraph type | Q&A Section | Section Intro | field_section_intro | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
-| Paragraph type | React Widget | Display default link as button | field_button_format | Boolean |  | 1 | Single on/off checkbox |  | 
-| Paragraph type | React Widget | Call To Action Widget | field_cta_widget | Boolean |  | 1 | Single on/off checkbox |  | 
-| Paragraph type | React Widget | Default Link | field_default_link | Link |  | 1 | Linkit |  | 
-| Paragraph type | React Widget | Error Message | field_error_message | Text (formatted) |  | 1 | Text field |  | 
-| Paragraph type | React Widget | Loading Message | field_loading_message | Text (plain) |  | 1 | Textfield |  | 
-| Paragraph type | React Widget | Timeout | field_timeout | Number (integer) |  | 1 | Number field |  | 
-| Paragraph type | React Widget | Widget Type | field_widget_type | Text (plain) | Required | 1 | Textfield |  | 
-| Paragraph type | Situation update | Date and time | field_date_and_time | Date | Required | 1 | Date and time |  | 
-| Paragraph type | Situation update | Send email to subscribers via GovDelivery? | field_send_email_to_subscribers | Boolean |  | 1 | Single on/off checkbox |  | 
-| Paragraph type | Situation update | Update | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable | 
-| Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Select list |  | 
-| Paragraph type | Table | Table | field_table | Table Field | Required | 1 | Table Field |  | 
-| Paragraph type | VAMC facility service (non-healthcare service) | Service name | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
-| Paragraph type | VAMC facility service (non-healthcare service) | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Paragraph type | WYSIWYG | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
-| Vocabulary | Sections | Acronym | field_acronym | Text (plain) |  | 1 | Textfield |  | 
-| Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  | 
-| Vocabulary | Sections | Link text | field_email_updates_link_text | Text (plain) |  | 1 | Textfield |  | 
-| Vocabulary | Sections | URL | field_email_updates_url | Text (plain) |  | 1 | Textfield |  | 
-| Vocabulary | Sections | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
-| Vocabulary | Sections | Link | field_link | Link |  | 1 | Linkit |  | 
-| Vocabulary | Sections | Metatags | field_metatags | Meta tags |  | 1 | Advanced meta tags form |  | 
-| Vocabulary | Sections | Social media links | field_social_media_links | Social Media Links Field  |  | 1 | List with all available platforms |  | 
-| Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  | 
-| Vocabulary | VHA health service taxonomy | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  | 
-| Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) |  | 1 | Textfield |  | 
-| Vocabulary | VHA health service taxonomy | Owner | field_owner | Entity reference | Required | 1 | Select list |  | 
-| Vocabulary | VHA health service taxonomy | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  | 
+| Content type | VAMC system health service | Facility-specific descriptions of this service | field_local_health_care_service_ | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
+| Content type | VAMC system health service | VAMC system | field_region_page | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC system health service | Service name and description | field_service_name_and_descripti | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC system operating status | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC system operating status | Banner alert and situation updates | field_banner_alert | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
+| Content type | VAMC system operating status | Update individual facility statuses | field_facility_operating_status | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
+| Content type | VAMC system operating status | Links | field_links | Link |  | Unlimited | Link | Translatable |
+| Content type | VAMC system operating status | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
+| Content type | VAMC system operating status | VAMC system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC system operating status | Emergency information | field_operating_status_emerg_inf | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
+| Custom block type | Alert | Alert body | field_alert_content | Entity reference revisions | Required | 1 | Paragraphs Classic |  |
+| Custom block type | Alert | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  |
+| Custom block type | Alert | Persistence (for dismissable alerts only) | field_alert_frequency | List (text) | Required | 1 | Select list |  |
+| Custom block type | Alert | Alert title | field_alert_title | Text (plain) | Required | 1 | Textfield |  |
+| Custom block type | Alert | Alert Type | field_alert_type | List (text) | Required | 1 | Select list |  |
+| Custom block type | Alert | Banner or in-page alert? | field_is_this_a_header_alert_ | List (text) |  | 1 | Select list |  |
+| Custom block type | Alert | Scope | field_node_reference | Entity reference |  | Unlimited | Autocomplete |  |
+| Custom block type | Alert | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
+| Custom block type | Alert | Reusability | field_reusability | List (text) | Required | 1 | -- Disabled -- |  |
+| Custom block type | Promo | Image | field_image | Entity reference | Required | 1 | Entity browser |  |
+| Custom block type | Promo | Instructions | field_instructions | Markup |  | 1 | Markup |  |
+| Custom block type | Promo | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
+| Custom block type | Promo | Link | field_promo_link | Entity reference revisions |  | 1 | Paragraphs Classic |  |
+| Media type | Document | Document | field_document | File | Required | 1 | File |  |
+| Media type | Document | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable |
+| Media type | Document | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup |  |
+| Media type | Document | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
+| Media type | Image | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- |  |
+| Media type | Image | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable |
+| Media type | Image | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
+| Media type | Image | Image | image | Image | Required | 1 | ImageWidget crop |  |
+| Media type | Video | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable |
+| Media type | Video | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable |
+| Media type | Video | Video URL | field_media_video_embed_field | Video Embed | Required | 1 | Video Textfield | Translatable |
+| Media type | Video | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
+| Paragraph type | Accordion group | Add border around items | field_collapsible_panel_bordered | Boolean |  | 1 | -- Disabled -- |  |
+| Paragraph type | Accordion group | Start expanded | field_collapsible_panel_expand | Boolean |  | 1 | -- Disabled -- |  |
+| Paragraph type | Accordion group | Allow more than one item to expand at a time | field_collapsible_panel_multi | Boolean |  | 1 | -- Disabled -- |  |
+| Paragraph type | Accordion group | Accordion Items | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable |
+| Paragraph type | Accordion Item | Title | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Paragraph type | Accordion Item | Content block(s) | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs Classic | Translatable |
+| Paragraph type | Accordion Item | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Paragraph type | Additional information | Instructions for obtaining more information in Spanish | field_text_expander | Text (plain) |  | 1 | Textfield with counter | Translatable |
+| Paragraph type | Additional information | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Paragraph type | Address | Address | field_address | Address |  | 1 | Address |  |
+| Paragraph type | Alert | Reusable alert | field_alert_block_reference | Entity reference |  | 1 | Select list |  |
+| Paragraph type | Alert | Alert Heading | field_alert_heading | Text (plain) |  | 1 | Textfield with counter |  |
+| Paragraph type | Alert | Alert Type | field_alert_type | List (text) |  | 1 | Select list |  |
+| Paragraph type | Alert | Alert content | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable |
+| Paragraph type | Embedded image | Allow clicks on this image to open it in new tab | field_allow_clicks_on_this_image | Boolean |  | 1 | Single on/off checkbox |  |
+| Paragraph type | Embedded image | Markup | field_markup | Markup |  | 1 | Markup |  |
+| Paragraph type | Embedded image | Select an image | field_media | Entity reference |  | 1 | Media library |  |
+| Paragraph type | Expandable Text | Text Expander | field_text_expander | Text (plain) | Required | 1 | Textfield with counter |  |
+| Paragraph type | Expandable Text | Full Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Paragraph type | Link teaser | Link | field_link | Link |  | 1 | Linkit |  |
+| Paragraph type | Link teaser | Link summary | field_link_summary | Text (plain) |  | 1 | Textfield with counter |  |
+| Paragraph type | Link to file or video | Markup | field_markup | Markup |  | 1 | Markup | Translatable |
+| Paragraph type | Link to file or video | Link to a file or video | field_media | Entity reference | Required | 1 | Media library | Translatable |
+| Paragraph type | Link to file or video | Link text | field_title | Text (plain) | Required | 1 | Textfield | Translatable |
+| Paragraph type | List of link teasers | Title | field_title | Text (plain) |  | 1 | Textfield | Translatable |
+| Paragraph type | List of link teasers | Link teasers | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable |
+| Paragraph type | Number callout | Short phrase with a number, or time element | field_short_phrase_with_a_number | Text (plain) | Required | 1 | Textfield with counter |  |
+| Paragraph type | Number callout | Additional information | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Paragraph type | Process list | Steps | field_steps | Text (formatted, long) | Required | Unlimited | Text area (multiple rows) |  |
+| Paragraph type | Q&A | Answer | field_answer | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  |
+| Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  |
+| Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  |
+| Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  |
+| Paragraph type | Q&A Section | Section Header | field_section_header | Text (plain) |  | 1 | Textfield |  |
+| Paragraph type | Q&A Section | Section Intro | field_section_intro | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Paragraph type | React Widget | Display default link as button | field_button_format | Boolean |  | 1 | Single on/off checkbox |  |
+| Paragraph type | React Widget | Call To Action Widget | field_cta_widget | Boolean |  | 1 | Single on/off checkbox |  |
+| Paragraph type | React Widget | Default Link | field_default_link | Link |  | 1 | Linkit |  |
+| Paragraph type | React Widget | Error Message | field_error_message | Text (formatted) |  | 1 | Text field |  |
+| Paragraph type | React Widget | Loading Message | field_loading_message | Text (plain) |  | 1 | Textfield |  |
+| Paragraph type | React Widget | Timeout | field_timeout | Number (integer) |  | 1 | Number field |  |
+| Paragraph type | React Widget | Widget Type | field_widget_type | Text (plain) | Required | 1 | Textfield |  |
+| Paragraph type | Situation update | Date and time | field_date_and_time | Date | Required | 1 | Date and time |  |
+| Paragraph type | Situation update | Send email to subscribers via GovDelivery? | field_send_email_to_subscribers | Boolean |  | 1 | Single on/off checkbox |  |
+| Paragraph type | Situation update | Update | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Select list |  |
+| Paragraph type | Table | Table | field_table | Table Field | Required | 1 | Table Field |  |
+| Paragraph type | VAMC facility service (non-healthcare service) | Service name | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Paragraph type | VAMC facility service (non-healthcare service) | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Paragraph type | WYSIWYG | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Vocabulary | Sections | Acronym | field_acronym | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | Sections | Link text | field_email_updates_link_text | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | Sections | URL | field_email_updates_url | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | Sections | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Vocabulary | Sections | Link | field_link | Link |  | 1 | Linkit |  |
+| Vocabulary | Sections | Metatags | field_metatags | Meta tags |  | 1 | Advanced meta tags form |  |
+| Vocabulary | Sections | Social media links | field_social_media_links | Social Media Links Field  |  | 1 | List with all available platforms |  |
+| Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VHA health service taxonomy | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VHA health service taxonomy | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
+| Vocabulary | VHA health service taxonomy | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |

--- a/tests/behat/drupal-spec-tool/content_model.feature
+++ b/tests/behat/drupal-spec-tool/content_model.feature
@@ -4,7 +4,7 @@ Feature: Content model
   As a content editor
   I want to have content entity types that reflect my content model.
 
-  @dst @content_type
+  @dst @content_type                                                                                                                                                                      
      Scenario: Bundles
        Then exactly the following content entity type bundles should exist
        | Name | Machine name | Type | Description |
@@ -57,300 +57,300 @@ Feature: Content model
 | Type of Redirect | type_of_redirect | Vocabulary |  |
 | VHA health service taxonomy | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |
 
-  @dst @field_type
+  @dst @field_type                                                                                                                                                                      
      Scenario: Fields
        Then exactly the following fields should exist
-       | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
-| Content type | Benefits detail page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Benefits detail page | Alert | field_alert | Entity reference |  | 1 | Select list |  |
-| Content type | Benefits detail page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL |  |
-| Content type | Benefits detail page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter |  |
-| Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
-| Content type | Benefits detail page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  |
-| Content type | Benefits detail page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form |  |
-| Content type | Benefits detail page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  |
-| Content type | Benefits detail page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  |
-| Content type | Benefits detail page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | Date and time |  |
-| Content type | Benefits detail page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
-| Content type | Benefits hub landing page | Owner | field_administration | Entity reference | Required | 1 | Select list |  |
-| Content type | Benefits hub landing page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable |
-| Content type | Benefits hub landing page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Benefits hub landing page | Home page hub label | field_home_page_hub_label | Text (plain) |  | 1 | Textfield |  |
-| Content type | Benefits hub landing page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
-| Content type | Benefits hub landing page | Links for non-veterans | field_links | Link |  | Unlimited | Linkit |  |
-| Content type | Benefits hub landing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Benefits hub landing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Benefits hub landing page | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
-| Content type | Benefits hub landing page | Plain language Certified Date | field_plainlanguage_date | Date |  | 1 | Date and time | Translatable |
-| Content type | Benefits hub landing page | Promo | field_promo | Entity reference |  | 1 | Select list |  |
-| Content type | Benefits hub landing page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | Benefits hub landing page | Spokes | field_spokes | Entity reference revisions | Required | 4 | Paragraphs EXPERIMENTAL |  |
-| Content type | Benefits hub landing page | Support Services | field_support_services | Entity reference |  | Unlimited | Inline entity form - Complex |  |
-| Content type | Benefits hub landing page | Teaser text | field_teaser_text | Text (plain) |  | 1 | Textfield with counter |  |
-| Content type | Benefits hub landing page | Hub Icon | field_title_icon | List (text) |  | 1 | Select list |  |
-| Content type | Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Detail Page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable |
-| Content type | Detail Page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
-| Content type | Detail Page | Summary | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Detail Page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable |
-| Content type | Detail Page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Detail Page | Downloads | field_media | Entity reference |  | 1 | Entity browser | Translatable |
-| Content type | Detail Page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Detail Page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Detail Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
-| Content type | Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | Documentation page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser Classic | Translatable |
-| Content type | Event | Additional information about registration | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | Event | Address | field_address | Address |  | 1 | Address |  |
-| Content type | Event | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Event | Full event description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | Event | Date and time | field_date | Date range |  | 1 | Date and time range |  |
-| Content type | Event | A brief (ideally one sentence) summary of the event | field_description | Text (plain) |  | 1 | Textfield | Translatable |
-| Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  |
-| Content type | Event | URL Link Label | field_event_cta | List (text) |  | 1 | Select list |  |
-| Content type | Event | Registration required | field_event_registrationrequired | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  |
-| Content type | Event | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | Event | URL of an external page or registration link for this event | field_link | Link |  | 1 | Link | Translatable |
-| Content type | Event | A human-readable label for the event location. | field_location_humanreadable | Text (plain) |  | 1 | Textfield |  |
-| Content type | Event | Location type | field_location_type | List (text) |  | 1 | Select list |  |
-| Content type | Event | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
-| Content type | Event | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Event | Event listing | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Event | Order | field_order | List (integer) |  | 1 | Select list |  |
-| Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Linkit |  |
-| Content type | Event listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Event listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Event listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
-| Content type | Event listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Event listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Event listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | News release | Location | field_address | Address | Required | 1 | Address | Translatable |
-| Content type | News release | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | News release | Introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | News release | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | News release | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | News release | PDF of Press Release | field_pdf_version | Entity reference |  | 1 | Media library |  |
-| Content type | News release | Media Contact(s) | field_press_release_contact | Entity reference |  | Unlimited | Autocomplete | Translatable |
-| Content type | News release | Media assets | field_press_release_downloads | Entity reference |  | Unlimited | Media library |  |
-| Content type | News release | Full text of the Press Release | field_press_release_fulltext | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
-| Content type | News release | Release date | field_release_date | Date |  | 1 | Date and time |  |
-| Content type | Office | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Office | Body | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
-| Content type | Office | Description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
-| Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Office | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Publication | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Publication | Related Benefits | field_benefits | List (text) |  | 1 | Select list |  |
-| Content type | Publication | A brief (ideally one sentence) summary of this asset | field_description | Text (plain) |  | 1 | Textfield | Translatable |
-| Content type | Publication | Format | field_format | List (text) | Required | 1 | Select list |  |
-| Content type | Publication | File or video | field_media | Entity reference |  | 1 | Media library |  |
-| Content type | Publication | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Publication | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Publication listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Publication listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Publication listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
-| Content type | Publication listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Publication listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Publication listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Staff profile | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Staff profile | Bio | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
-| Content type | Staff profile | Complete Biography | field_complete_biography | File |  | 1 | File |  |
-| Content type | Staff profile | Job Title | field_description | Text (plain) |  | 1 | Textfield | Translatable |
-| Content type | Staff profile | Email address | field_email_address | Email |  | 1 | Email |  |
-| Content type | Staff profile | Introduction | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Staff profile | Last name | field_last_name | Text (plain) |  | 1 | Textfield |  |
-| Content type | Staff profile | Photo | field_media | Entity reference |  | 1 | Media library | Translatable |
-| Content type | Staff profile | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Staff profile | First name | field_name_first | Text (plain) |  | 1 | Textfield |  |
-| Content type | Staff profile | Related office or health care region | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Staff profile | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number | Translatable |
-| Content type | Staff profile | High-resolution photo should be available for download by site visitors | field_photo_allow_hires_download | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | Staff profile | Suffix | field_suffix | Text (plain) |  | 1 | Textfield |  |
-| Content type | Story | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Story | Author byline | field_author | Entity reference |  | 1 | Autocomplete |  |
-| Content type | Story | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | Story | Full text of Story | field_full_story | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | Story | Image caption | field_image_caption | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
-| Content type | Story | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Story | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
-| Content type | Story | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Story | Related office or health care region | field_office | Entity reference | Required | 1 | Select list |  |
-| Content type | Story | Order | field_order | List (integer) |  | 1 | Select list | Translatable |
-| Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Support Service | Link | field_link | Link |  | 1 | Link |  |
-| Content type | Support Service | Related office | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Support Service | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
-| Content type | Support Service | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number |  |
-| Content type | VAMC facility | Address | field_address | Address |  | 1 | Address | Translatable |
-| Content type | VAMC facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC facility | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC facility | Email Subscription | field_email_subscription | Link |  | 1 | Linkit | Translatable |
-| Content type | VAMC facility | Facebook | field_facebook | Link |  | 1 | Link | Translatable |
-| Content type | VAMC facility | Classification | field_facility_classification | List (text) |  | 1 | Select list |  |
-| Content type | VAMC facility | Hours | field_facility_hours  | Table Field |  | 1 | Table Field |  |
-| Content type | VAMC facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield |  |
-| Content type | VAMC facility | Flickr | field_flickr | Link |  | 1 | Link | Translatable |
-| Content type | VAMC facility | Instagram | field_instagram | Link |  | 1 | Link | Translatable |
-| Content type | VAMC facility | Intro text | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | VAMC facility | Local health care service offerings | field_local_health_care_service_ | Entity reference |  | Unlimited | -- Disabled -- | Translatable |
-| Content type | VAMC facility | Location services | field_location_services | Entity reference revisions |  | Unlimited | Paragraphs Classic |  |
-| Content type | VAMC facility | Main location | field_main_location | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | VAMC facility | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
-| Content type | VAMC facility | Mental Health Phone | field_mental_health_phone | Telephone number |  | 1 | Telephone number |  |
-| Content type | VAMC facility | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | VAMC facility | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC facility | Nickname for this facility | field_nickname_for_this_facility | Text (plain) | Required | 1 | Textfield |  |
-| Content type | VAMC facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list |  |
-| Content type | VAMC facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | VAMC facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
-| Content type | VAMC facility | Region page | field_region_page | Entity reference | Required | 1 | Select list |  |
-| Content type | VAMC facility | Twitter | field_twitter | Link |  | 1 | Link | Translatable |
-| Content type | VAMC facility health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC facility health service | Facility description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
-| Content type | VAMC facility health service | Facility | field_facility_location | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC facility health service | VAMC system health service | field_regional_health_service | Entity reference | Required | 1 | Select list |  |
-| Content type | VAMC system | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC system | Appointments can be scheduled and viewed online | field_appointments_online | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | VAMC system | Health services intro text | field_clinical_health_care_servi | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | VAMC system | Regional Health Service Offerings. | field_clinical_health_services | Entity reference |  | Unlimited | Select list |  |
-| Content type | VAMC system | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC system | Email Subscription | field_email_subscription | Link |  | 1 | -- Disabled -- | Translatable |
-| Content type | VAMC system | URL for signing up for email news and announcements | field_email_subscription_links | Link |  | 1 | -- Disabled -- |  |
-| Content type | VAMC system | Facebook | field_facebook | Link |  | 1 | Link | Translatable |
-| Content type | VAMC system | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic |  |
-| Content type | VAMC system | Flickr | field_flickr | Link |  | 1 | Link | Translatable |
-| Content type | VAMC system | Instagram | field_instagram | Link |  | 1 | Link | Translatable |
-| Content type | VAMC system | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | VAMC system | Events page intro text | field_intro_text_events_page | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
-| Content type | VAMC system | Leadership page intro text | field_intro_text_leadership | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | VAMC system | Community stories intro text | field_intro_text_news_stories | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
-| Content type | VAMC system | Press releases intro text | field_intro_text_press_releases | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | VAMC system | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete |  |
-| Content type | VAMC system | Emergency updates email list  | field_link_facility_emerg_list | Link |  | 1 | Link |  |
-| Content type | VAMC system | News and announcements email list | field_link_facility_news_list | Link |  | 1 | Link |  |
-| Content type | VAMC system | Email lists | field_links | Link |  | Unlimited | -- Disabled -- | Translatable |
-| Content type | VAMC system | Our Locations intro text | field_locations_intro_blurb | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
-| Content type | VAMC system | Banner image | field_media | Entity reference |  | 1 | Media library | Translatable |
-| Content type | VAMC system | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | VAMC system | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC system | Short name | field_nickname_for_this_facility | Text (plain) |  | 1 | Textfield | Translatable |
-| Content type | VAMC system | Operating status | field_operating_status | Link |  | 1 | Linkit |  |
-| Content type | VAMC system | Other VA Locations | field_other_va_locations | Text (plain) |  | Unlimited | Textfield |  |
-| Content type | VAMC system | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
-| Content type | VAMC system | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
-| Content type | VAMC system | URL for signing up for emergency email alerts | field_sign_up_for_emergency_emai | Link |  | 1 | -- Disabled -- |  |
-| Content type | VAMC system | Twitter | field_twitter | Link |  | 1 | Link | Translatable |
-| Content type | VAMC system banner alert with situation updates | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC system banner alert with situation updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  |
+       | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable | 
+| Content type | Benefits detail page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Benefits detail page | Alert | field_alert | Entity reference |  | 1 | Select list |  | 
+| Content type | Benefits detail page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL |  | 
+| Content type | Benefits detail page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter |  | 
+| Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  | 
+| Content type | Benefits detail page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  | 
+| Content type | Benefits detail page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form |  | 
+| Content type | Benefits detail page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  | 
+| Content type | Benefits detail page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  | 
+| Content type | Benefits detail page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | Date and time |  | 
+| Content type | Benefits detail page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  | 
+| Content type | Benefits hub landing page | Owner | field_administration | Entity reference | Required | 1 | Select list |  | 
+| Content type | Benefits hub landing page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable | 
+| Content type | Benefits hub landing page | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Benefits hub landing page | Home page hub label | field_home_page_hub_label | Text (plain) |  | 1 | Textfield |  | 
+| Content type | Benefits hub landing page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable | 
+| Content type | Benefits hub landing page | Links for non-veterans | field_links | Link |  | Unlimited | Linkit |  | 
+| Content type | Benefits hub landing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Benefits hub landing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Benefits hub landing page | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable | 
+| Content type | Benefits hub landing page | Plain language Certified Date | field_plainlanguage_date | Date |  | 1 | Date and time | Translatable | 
+| Content type | Benefits hub landing page | Promo | field_promo | Entity reference |  | 1 | Select list |  | 
+| Content type | Benefits hub landing page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable | 
+| Content type | Benefits hub landing page | Spokes | field_spokes | Entity reference revisions | Required | 4 | Paragraphs EXPERIMENTAL |  | 
+| Content type | Benefits hub landing page | Support Services | field_support_services | Entity reference |  | Unlimited | Inline entity form - Complex |  | 
+| Content type | Benefits hub landing page | Teaser text | field_teaser_text | Text (plain) |  | 1 | Textfield with counter |  | 
+| Content type | Benefits hub landing page | Hub Icon | field_title_icon | List (text) |  | 1 | Select list |  | 
+| Content type | Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Detail Page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable | 
+| Content type | Detail Page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable | 
+| Content type | Detail Page | Summary | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Detail Page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable | 
+| Content type | Detail Page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Content type | Detail Page | Downloads | field_media | Entity reference |  | 1 | Entity browser | Translatable | 
+| Content type | Detail Page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Detail Page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Detail Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable | 
+| Content type | Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox |  | 
+| Content type | Documentation page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser Classic | Translatable | 
+| Content type | Event | Additional information about registration | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | Event | Address | field_address | Address |  | 1 | Address |  | 
+| Content type | Event | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Event | Full event description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | Event | Date and time | field_date | Date range |  | 1 | Date and time range |  | 
+| Content type | Event | A brief (ideally one sentence) summary of the event | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
+| Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  | 
+| Content type | Event | URL Link Label | field_event_cta | List (text) |  | 1 | Select list |  | 
+| Content type | Event | Registration required | field_event_registrationrequired | Boolean |  | 1 | Single on/off checkbox |  | 
+| Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  | 
+| Content type | Event | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox | Translatable | 
+| Content type | Event | URL of an external page or registration link for this event | field_link | Link |  | 1 | Link | Translatable | 
+| Content type | Event | A human-readable label for the event location. | field_location_humanreadable | Text (plain) |  | 1 | Textfield |  | 
+| Content type | Event | Location type | field_location_type | List (text) |  | 1 | Select list |  | 
+| Content type | Event | Image | field_media | Entity reference |  | 1 | Media library | Translatable | 
+| Content type | Event | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Event | Event listing | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Event | Order | field_order | List (integer) |  | 1 | Select list |  | 
+| Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Linkit |  | 
+| Content type | Event listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Event listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Event listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable | 
+| Content type | Event listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Event listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Event listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | News release | Location | field_address | Address | Required | 1 | Address | Translatable | 
+| Content type | News release | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | News release | Introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Content type | News release | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | News release | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | News release | PDF of Press Release | field_pdf_version | Entity reference |  | 1 | Media library |  | 
+| Content type | News release | Media Contact(s) | field_press_release_contact | Entity reference |  | Unlimited | Autocomplete | Translatable | 
+| Content type | News release | Media assets | field_press_release_downloads | Entity reference |  | Unlimited | Media library |  | 
+| Content type | News release | Full text of the Press Release | field_press_release_fulltext | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  | 
+| Content type | News release | Release date | field_release_date | Date |  | 1 | Date and time |  | 
+| Content type | Office | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Office | Body | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable | 
+| Content type | Office | Description | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
+| Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Office | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Publication | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Publication | Related Benefits | field_benefits | List (text) |  | 1 | Select list |  | 
+| Content type | Publication | A brief (ideally one sentence) summary of this asset | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
+| Content type | Publication | Format | field_format | List (text) | Required | 1 | Select list |  | 
+| Content type | Publication | File or video | field_media | Entity reference |  | 1 | Media library |  | 
+| Content type | Publication | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Publication | Healthcare system or related office | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Publication listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Publication listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Publication listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable | 
+| Content type | Publication listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Publication listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | Publication listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Staff profile | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Staff profile | Bio | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable | 
+| Content type | Staff profile | Complete Biography | field_complete_biography | File |  | 1 | File |  | 
+| Content type | Staff profile | Job Title | field_description | Text (plain) |  | 1 | Textfield | Translatable | 
+| Content type | Staff profile | Email address | field_email_address | Email |  | 1 | Email |  | 
+| Content type | Staff profile | Introduction | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Content type | Staff profile | Last name | field_last_name | Text (plain) |  | 1 | Textfield |  | 
+| Content type | Staff profile | Photo | field_media | Entity reference |  | 1 | Media library | Translatable | 
+| Content type | Staff profile | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Staff profile | First name | field_name_first | Text (plain) |  | 1 | Textfield |  | 
+| Content type | Staff profile | Related office or health care region | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Staff profile | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number | Translatable | 
+| Content type | Staff profile | High-resolution photo should be available for download by site visitors | field_photo_allow_hires_download | Boolean |  | 1 | Single on/off checkbox |  | 
+| Content type | Staff profile | Suffix | field_suffix | Text (plain) |  | 1 | Textfield |  | 
+| Content type | Story | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Story | Author byline | field_author | Entity reference |  | 1 | Autocomplete |  | 
+| Content type | Story | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox |  | 
+| Content type | Story | Full text of Story | field_full_story | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | Story | Image caption | field_image_caption | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  | 
+| Content type | Story | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Content type | Story | Image | field_media | Entity reference |  | 1 | Media library | Translatable | 
+| Content type | Story | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | Story | Related office or health care region | field_office | Entity reference | Required | 1 | Select list |  | 
+| Content type | Story | Order | field_order | List (integer) |  | 1 | Select list | Translatable | 
+| Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Support Service | Link | field_link | Link |  | 1 | Link |  | 
+| Content type | Support Service | Related office | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | Support Service | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable | 
+| Content type | Support Service | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number |  | 
+| Content type | VAMC facility | Address | field_address | Address |  | 1 | Address | Translatable | 
+| Content type | VAMC facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC facility | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | VAMC facility | Email Subscription | field_email_subscription | Link |  | 1 | Linkit | Translatable | 
+| Content type | VAMC facility | Facebook | field_facebook | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC facility | Classification | field_facility_classification | List (text) |  | 1 | Select list |  | 
+| Content type | VAMC facility | Hours | field_facility_hours  | Table Field |  | 1 | Table Field |  | 
+| Content type | VAMC facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield |  | 
+| Content type | VAMC facility | Flickr | field_flickr | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC facility | Instagram | field_instagram | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC facility | Intro text | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Content type | VAMC facility | Local health care service offerings | field_local_health_care_service_ | Entity reference |  | Unlimited | -- Disabled -- | Translatable | 
+| Content type | VAMC facility | Location services | field_location_services | Entity reference revisions |  | Unlimited | Paragraphs Classic |  | 
+| Content type | VAMC facility | Main location | field_main_location | Boolean |  | 1 | Single on/off checkbox |  | 
+| Content type | VAMC facility | Image | field_media | Entity reference |  | 1 | Media library | Translatable | 
+| Content type | VAMC facility | Mental Health Phone | field_mental_health_phone | Telephone number |  | 1 | Telephone number |  | 
+| Content type | VAMC facility | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | VAMC facility | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | VAMC facility | Nickname for this facility | field_nickname_for_this_facility | Text (plain) | Required | 1 | Textfield |  | 
+| Content type | VAMC facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list |  | 
+| Content type | VAMC facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | VAMC facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable | 
+| Content type | VAMC facility | Region page | field_region_page | Entity reference | Required | 1 | Select list |  | 
+| Content type | VAMC facility | Twitter | field_twitter | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC facility health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC facility health service | Facility description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable | 
+| Content type | VAMC facility health service | Facility | field_facility_location | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC facility health service | VAMC system health service | field_regional_health_service | Entity reference | Required | 1 | Select list |  | 
+| Content type | VAMC system | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC system | Appointments can be scheduled and viewed online | field_appointments_online | Boolean |  | 1 | Single on/off checkbox |  | 
+| Content type | VAMC system | Health services intro text | field_clinical_health_care_servi | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | VAMC system | Regional Health Service Offerings. | field_clinical_health_services | Entity reference |  | Unlimited | Select list |  | 
+| Content type | VAMC system | Description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | VAMC system | Email Subscription | field_email_subscription | Link |  | 1 | -- Disabled -- | Translatable | 
+| Content type | VAMC system | URL for signing up for email news and announcements | field_email_subscription_links | Link |  | 1 | -- Disabled -- |  | 
+| Content type | VAMC system | Facebook | field_facebook | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC system | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic |  | 
+| Content type | VAMC system | Flickr | field_flickr | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC system | Instagram | field_instagram | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC system | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Content type | VAMC system | Events page intro text | field_intro_text_events_page | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  | 
+| Content type | VAMC system | Leadership page intro text | field_intro_text_leadership | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | VAMC system | Community stories intro text | field_intro_text_news_stories | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  | 
+| Content type | VAMC system | Press releases intro text | field_intro_text_press_releases | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | VAMC system | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete |  | 
+| Content type | VAMC system | Emergency updates email list  | field_link_facility_emerg_list | Link |  | 1 | Link |  | 
+| Content type | VAMC system | News and announcements email list | field_link_facility_news_list | Link |  | 1 | Link |  | 
+| Content type | VAMC system | Email lists | field_links | Link |  | Unlimited | -- Disabled -- | Translatable | 
+| Content type | VAMC system | Our Locations intro text | field_locations_intro_blurb | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  | 
+| Content type | VAMC system | Banner image | field_media | Entity reference |  | 1 | Media library | Translatable | 
+| Content type | VAMC system | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable | 
+| Content type | VAMC system | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Content type | VAMC system | Short name | field_nickname_for_this_facility | Text (plain) |  | 1 | Textfield | Translatable | 
+| Content type | VAMC system | Operating status | field_operating_status | Link |  | 1 | Linkit |  | 
+| Content type | VAMC system | Other VA Locations | field_other_va_locations | Text (plain) |  | Unlimited | Textfield |  | 
+| Content type | VAMC system | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  | 
+| Content type | VAMC system | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable | 
+| Content type | VAMC system | URL for signing up for emergency email alerts | field_sign_up_for_emergency_emai | Link |  | 1 | -- Disabled -- |  | 
+| Content type | VAMC system | Twitter | field_twitter | Link |  | 1 | Link | Translatable | 
+| Content type | VAMC system banner alert with situation updates | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC system banner alert with situation updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  | 
 | Content type | VAMC system banner alert with situation updates | Display "Subscribe to email updates" link? | field_alert_email_updates_button | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Find other VA facilities near you" link? | field_alert_find_facilities_cta | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | VAMC system banner alert with situation updates | Inherited by subpages | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | VAMC system banner alert with situation updates | Inherited by subpages | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  | 
 | Content type | VAMC system banner alert with situation updates | Display "Get updates on affected services and facilities" link | field_alert_operating_status_cta | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | VAMC system banner alert with situation updates | Alert type | field_alert_type | List (text) | Required | 1 | Select list |  |
-| Content type | VAMC system banner alert with situation updates | Situation information | field_banner_alert_situationinfo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | VAMC system banner alert with situation updates | VA Medical Centers | field_banner_alert_vamcs | Entity reference | Required | Unlimited | Check boxes/radio buttons |  |
-| Content type | VAMC system banner alert with situation updates | Alert body | field_body | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
-| Content type | VAMC system banner alert with situation updates | Send email to subscribers via GovDelivery? | field_operating_status_sendemail | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | VAMC system banner alert with situation updates | Situation updates | field_situation_updates | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
-| Content type | VAMC system health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC system health service | Regional description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
-| Content type | VAMC system health service | Facility-specific descriptions of this service | field_local_health_care_service_ | Entity reference |  | Unlimited | Select list |  |
-| Content type | VAMC system health service | Region page | field_region_page | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC system health service | Service name and description | field_service_name_and_descripti | Entity reference | Required | 1 | Select list |  |
-| Content type | VAMC system operating status | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC system operating status | Banner alert and situation updates | field_banner_alert | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
-| Content type | VAMC system operating status | Update individual facility statuses | field_facility_operating_status | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
-| Content type | VAMC system operating status | Links | field_links | Link |  | Unlimited | Link | Translatable |
-| Content type | VAMC system operating status | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
-| Content type | VAMC system operating status | VAMC system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VAMC system operating status | Emergency information | field_operating_status_emerg_inf | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
-| Custom block type | Alert | Alert body | field_alert_content | Entity reference revisions | Required | 1 | Paragraphs Classic |  |
-| Custom block type | Alert | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  |
-| Custom block type | Alert | Persistence (for dismissable alerts only) | field_alert_frequency | List (text) | Required | 1 | Select list |  |
-| Custom block type | Alert | Alert title | field_alert_title | Text (plain) | Required | 1 | Textfield |  |
-| Custom block type | Alert | Alert Type | field_alert_type | List (text) | Required | 1 | Select list |  |
-| Custom block type | Alert | Banner or in-page alert? | field_is_this_a_header_alert_ | List (text) |  | 1 | Select list |  |
-| Custom block type | Alert | Scope | field_node_reference | Entity reference |  | Unlimited | Autocomplete |  |
-| Custom block type | Alert | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
-| Custom block type | Alert | Reusability | field_reusability | List (text) | Required | 1 | -- Disabled -- |  |
-| Custom block type | Promo | Image | field_image | Entity reference | Required | 1 | Entity browser |  |
-| Custom block type | Promo | Instructions | field_instructions | Markup |  | 1 | Markup |  |
-| Custom block type | Promo | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
-| Custom block type | Promo | Link | field_promo_link | Entity reference revisions |  | 1 | Paragraphs Classic |  |
-| Media type | Document | Document | field_document | File | Required | 1 | File |  |
-| Media type | Document | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable |
-| Media type | Document | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup |  |
-| Media type | Document | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
-| Media type | Image | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- |  |
-| Media type | Image | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable |
-| Media type | Image | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
-| Media type | Image | Image | image | Image | Required | 1 | ImageWidget crop |  |
-| Media type | Video | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable |
-| Media type | Video | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable |
-| Media type | Video | Video URL | field_media_video_embed_field | Video Embed | Required | 1 | Video Textfield | Translatable |
-| Media type | Video | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
-| Paragraph type | Accordion group | Add border around items | field_collapsible_panel_bordered | Boolean |  | 1 | -- Disabled -- |  |
-| Paragraph type | Accordion group | Start expanded | field_collapsible_panel_expand | Boolean |  | 1 | -- Disabled -- |  |
-| Paragraph type | Accordion group | Allow more than one item to expand at a time | field_collapsible_panel_multi | Boolean |  | 1 | -- Disabled -- |  |
-| Paragraph type | Accordion group | Accordion Items | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable |
-| Paragraph type | Accordion Item | Title | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Paragraph type | Accordion Item | Content block(s) | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs Classic | Translatable |
-| Paragraph type | Accordion Item | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Paragraph type | Additional information | Instructions for obtaining more information in Spanish | field_text_expander | Text (plain) |  | 1 | Textfield with counter | Translatable |
-| Paragraph type | Additional information | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Paragraph type | Address | Address | field_address | Address |  | 1 | Address |  |
-| Paragraph type | Alert | Reusable alert | field_alert_block_reference | Entity reference |  | 1 | Select list |  |
-| Paragraph type | Alert | Alert Heading | field_alert_heading | Text (plain) |  | 1 | Textfield with counter |  |
-| Paragraph type | Alert | Alert Type | field_alert_type | List (text) |  | 1 | Select list |  |
-| Paragraph type | Alert | Alert content | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable |
-| Paragraph type | Embedded image | Allow clicks on this image to open it in new tab | field_allow_clicks_on_this_image | Boolean |  | 1 | Single on/off checkbox |  |
-| Paragraph type | Embedded image | Markup | field_markup | Markup |  | 1 | Markup |  |
-| Paragraph type | Embedded image | Select an image | field_media | Entity reference |  | 1 | Media library |  |
-| Paragraph type | Expandable Text | Text Expander | field_text_expander | Text (plain) | Required | 1 | Textfield with counter |  |
-| Paragraph type | Expandable Text | Full Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Paragraph type | Link teaser | Link | field_link | Link |  | 1 | Linkit |  |
-| Paragraph type | Link teaser | Link summary | field_link_summary | Text (plain) |  | 1 | Textfield with counter |  |
-| Paragraph type | Link to file or video | Markup | field_markup | Markup |  | 1 | Markup | Translatable |
-| Paragraph type | Link to file or video | Link to a file or video | field_media | Entity reference | Required | 1 | Media library | Translatable |
-| Paragraph type | Link to file or video | Link text | field_title | Text (plain) | Required | 1 | Textfield | Translatable |
-| Paragraph type | List of link teasers | Title | field_title | Text (plain) |  | 1 | Textfield | Translatable |
-| Paragraph type | List of link teasers | Link teasers | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable |
-| Paragraph type | Number callout | Short phrase with a number, or time element | field_short_phrase_with_a_number | Text (plain) | Required | 1 | Textfield with counter |  |
-| Paragraph type | Number callout | Additional information | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Paragraph type | Process list | Steps | field_steps | Text (formatted, long) | Required | Unlimited | Text area (multiple rows) |  |
-| Paragraph type | Q&A | Answer | field_answer | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  |
-| Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  |
-| Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  |
-| Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  |
-| Paragraph type | Q&A Section | Section Header | field_section_header | Text (plain) |  | 1 | Textfield |  |
-| Paragraph type | Q&A Section | Section Intro | field_section_intro | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
-| Paragraph type | React Widget | Display default link as button | field_button_format | Boolean |  | 1 | Single on/off checkbox |  |
-| Paragraph type | React Widget | Call To Action Widget | field_cta_widget | Boolean |  | 1 | Single on/off checkbox |  |
-| Paragraph type | React Widget | Default Link | field_default_link | Link |  | 1 | Linkit |  |
-| Paragraph type | React Widget | Error Message | field_error_message | Text (formatted) |  | 1 | Text field |  |
-| Paragraph type | React Widget | Loading Message | field_loading_message | Text (plain) |  | 1 | Textfield |  |
-| Paragraph type | React Widget | Timeout | field_timeout | Number (integer) |  | 1 | Number field |  |
-| Paragraph type | React Widget | Widget Type | field_widget_type | Text (plain) | Required | 1 | Textfield |  |
-| Paragraph type | Situation update | Date and time | field_date_and_time | Date | Required | 1 | Date and time |  |
-| Paragraph type | Situation update | Send email to subscribers via GovDelivery? | field_send_email_to_subscribers | Boolean |  | 1 | Single on/off checkbox |  |
-| Paragraph type | Situation update | Update | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
-| Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Select list |  |
-| Paragraph type | Table | Table | field_table | Table Field | Required | 1 | Table Field |  |
-| Paragraph type | VAMC facility service (non-healthcare service) | Service name | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Paragraph type | VAMC facility service (non-healthcare service) | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Paragraph type | WYSIWYG | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Vocabulary | Sections | Acronym | field_acronym | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | Sections | Link text | field_email_updates_link_text | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | Sections | URL | field_email_updates_url | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | Sections | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
-| Vocabulary | Sections | Link | field_link | Link |  | 1 | Linkit |  |
-| Vocabulary | Sections | Metatags | field_metatags | Meta tags |  | 1 | Advanced meta tags form |  |
-| Vocabulary | Sections | Social media links | field_social_media_links | Social Media Links Field  |  | 1 | List with all available platforms |  |
-| Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VHA health service taxonomy | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VHA health service taxonomy | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
-| Vocabulary | VHA health service taxonomy | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |
+| Content type | VAMC system banner alert with situation updates | Alert type | field_alert_type | List (text) | Required | 1 | Select list |  | 
+| Content type | VAMC system banner alert with situation updates | Situation information | field_banner_alert_situationinfo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
+| Content type | VAMC system banner alert with situation updates | VA Medical Centers | field_banner_alert_vamcs | Entity reference | Required | Unlimited | Check boxes/radio buttons |  | 
+| Content type | VAMC system banner alert with situation updates | Alert body | field_body | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable | 
+| Content type | VAMC system banner alert with situation updates | Send email to subscribers via GovDelivery? | field_operating_status_sendemail | Boolean |  | 1 | Single on/off checkbox | Translatable | 
+| Content type | VAMC system banner alert with situation updates | Situation updates | field_situation_updates | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  | 
+| Content type | VAMC system health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC system health service | VAMC system description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | VAMC system health service | Facility-specific descriptions of this service | field_local_health_care_service_ | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  | 
+| Content type | VAMC system health service | VAMC system | field_region_page | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC system health service | Service name and description | field_service_name_and_descripti | Entity reference | Required | 1 | Select list |  | 
+| Content type | VAMC system operating status | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC system operating status | Banner alert and situation updates | field_banner_alert | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  | 
+| Content type | VAMC system operating status | Update individual facility statuses | field_facility_operating_status | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  | 
+| Content type | VAMC system operating status | Links | field_links | Link |  | Unlimited | Link | Translatable | 
+| Content type | VAMC system operating status | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable | 
+| Content type | VAMC system operating status | VAMC system | field_office | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC system operating status | Emergency information | field_operating_status_emerg_inf | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  | 
+| Custom block type | Alert | Alert body | field_alert_content | Entity reference revisions | Required | 1 | Paragraphs Classic |  | 
+| Custom block type | Alert | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  | 
+| Custom block type | Alert | Persistence (for dismissable alerts only) | field_alert_frequency | List (text) | Required | 1 | Select list |  | 
+| Custom block type | Alert | Alert title | field_alert_title | Text (plain) | Required | 1 | Textfield |  | 
+| Custom block type | Alert | Alert Type | field_alert_type | List (text) | Required | 1 | Select list |  | 
+| Custom block type | Alert | Banner or in-page alert? | field_is_this_a_header_alert_ | List (text) |  | 1 | Select list |  | 
+| Custom block type | Alert | Scope | field_node_reference | Entity reference |  | Unlimited | Autocomplete |  | 
+| Custom block type | Alert | Owner | field_owner | Entity reference | Required | 1 | Select list |  | 
+| Custom block type | Alert | Reusability | field_reusability | List (text) | Required | 1 | -- Disabled -- |  | 
+| Custom block type | Promo | Image | field_image | Entity reference | Required | 1 | Entity browser |  | 
+| Custom block type | Promo | Instructions | field_instructions | Markup |  | 1 | Markup |  | 
+| Custom block type | Promo | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable | 
+| Custom block type | Promo | Link | field_promo_link | Entity reference revisions |  | 1 | Paragraphs Classic |  | 
+| Media type | Document | Document | field_document | File | Required | 1 | File |  | 
+| Media type | Document | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable | 
+| Media type | Document | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup |  | 
+| Media type | Document | Owner | field_owner | Entity reference | Required | 1 | Select list |  | 
+| Media type | Image | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- |  | 
+| Media type | Image | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable | 
+| Media type | Image | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable | 
+| Media type | Image | Image | image | Image | Required | 1 | ImageWidget crop |  | 
+| Media type | Video | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable | 
+| Media type | Video | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable | 
+| Media type | Video | Video URL | field_media_video_embed_field | Video Embed | Required | 1 | Video Textfield | Translatable | 
+| Media type | Video | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable | 
+| Paragraph type | Accordion group | Add border around items | field_collapsible_panel_bordered | Boolean |  | 1 | -- Disabled -- |  | 
+| Paragraph type | Accordion group | Start expanded | field_collapsible_panel_expand | Boolean |  | 1 | -- Disabled -- |  | 
+| Paragraph type | Accordion group | Allow more than one item to expand at a time | field_collapsible_panel_multi | Boolean |  | 1 | -- Disabled -- |  | 
+| Paragraph type | Accordion group | Accordion Items | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable | 
+| Paragraph type | Accordion Item | Title | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Paragraph type | Accordion Item | Content block(s) | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs Classic | Translatable | 
+| Paragraph type | Accordion Item | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Paragraph type | Additional information | Instructions for obtaining more information in Spanish | field_text_expander | Text (plain) |  | 1 | Textfield with counter | Translatable | 
+| Paragraph type | Additional information | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Paragraph type | Address | Address | field_address | Address |  | 1 | Address |  | 
+| Paragraph type | Alert | Reusable alert | field_alert_block_reference | Entity reference |  | 1 | Select list |  | 
+| Paragraph type | Alert | Alert Heading | field_alert_heading | Text (plain) |  | 1 | Textfield with counter |  | 
+| Paragraph type | Alert | Alert Type | field_alert_type | List (text) |  | 1 | Select list |  | 
+| Paragraph type | Alert | Alert content | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable | 
+| Paragraph type | Embedded image | Allow clicks on this image to open it in new tab | field_allow_clicks_on_this_image | Boolean |  | 1 | Single on/off checkbox |  | 
+| Paragraph type | Embedded image | Markup | field_markup | Markup |  | 1 | Markup |  | 
+| Paragraph type | Embedded image | Select an image | field_media | Entity reference |  | 1 | Media library |  | 
+| Paragraph type | Expandable Text | Text Expander | field_text_expander | Text (plain) | Required | 1 | Textfield with counter |  | 
+| Paragraph type | Expandable Text | Full Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Paragraph type | Link teaser | Link | field_link | Link |  | 1 | Linkit |  | 
+| Paragraph type | Link teaser | Link summary | field_link_summary | Text (plain) |  | 1 | Textfield with counter |  | 
+| Paragraph type | Link to file or video | Markup | field_markup | Markup |  | 1 | Markup | Translatable | 
+| Paragraph type | Link to file or video | Link to a file or video | field_media | Entity reference | Required | 1 | Media library | Translatable | 
+| Paragraph type | Link to file or video | Link text | field_title | Text (plain) | Required | 1 | Textfield | Translatable | 
+| Paragraph type | List of link teasers | Title | field_title | Text (plain) |  | 1 | Textfield | Translatable | 
+| Paragraph type | List of link teasers | Link teasers | field_va_paragraphs | Entity reference revisions | Required | Unlimited | Paragraphs Classic | Translatable | 
+| Paragraph type | Number callout | Short phrase with a number, or time element | field_short_phrase_with_a_number | Text (plain) | Required | 1 | Textfield with counter |  | 
+| Paragraph type | Number callout | Additional information | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Paragraph type | Process list | Steps | field_steps | Text (formatted, long) | Required | Unlimited | Text area (multiple rows) |  | 
+| Paragraph type | Q&A | Answer | field_answer | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  | 
+| Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  | 
+| Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  | 
+| Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  | 
+| Paragraph type | Q&A Section | Section Header | field_section_header | Text (plain) |  | 1 | Textfield |  | 
+| Paragraph type | Q&A Section | Section Intro | field_section_intro | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
+| Paragraph type | React Widget | Display default link as button | field_button_format | Boolean |  | 1 | Single on/off checkbox |  | 
+| Paragraph type | React Widget | Call To Action Widget | field_cta_widget | Boolean |  | 1 | Single on/off checkbox |  | 
+| Paragraph type | React Widget | Default Link | field_default_link | Link |  | 1 | Linkit |  | 
+| Paragraph type | React Widget | Error Message | field_error_message | Text (formatted) |  | 1 | Text field |  | 
+| Paragraph type | React Widget | Loading Message | field_loading_message | Text (plain) |  | 1 | Textfield |  | 
+| Paragraph type | React Widget | Timeout | field_timeout | Number (integer) |  | 1 | Number field |  | 
+| Paragraph type | React Widget | Widget Type | field_widget_type | Text (plain) | Required | 1 | Textfield |  | 
+| Paragraph type | Situation update | Date and time | field_date_and_time | Date | Required | 1 | Date and time |  | 
+| Paragraph type | Situation update | Send email to subscribers via GovDelivery? | field_send_email_to_subscribers | Boolean |  | 1 | Single on/off checkbox |  | 
+| Paragraph type | Situation update | Update | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable | 
+| Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Select list |  | 
+| Paragraph type | Table | Table | field_table | Table Field | Required | 1 | Table Field |  | 
+| Paragraph type | VAMC facility service (non-healthcare service) | Service name | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable | 
+| Paragraph type | VAMC facility service (non-healthcare service) | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Paragraph type | WYSIWYG | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable | 
+| Vocabulary | Sections | Acronym | field_acronym | Text (plain) |  | 1 | Textfield |  | 
+| Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  | 
+| Vocabulary | Sections | Link text | field_email_updates_link_text | Text (plain) |  | 1 | Textfield |  | 
+| Vocabulary | Sections | URL | field_email_updates_url | Text (plain) |  | 1 | Textfield |  | 
+| Vocabulary | Sections | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) |  | 
+| Vocabulary | Sections | Link | field_link | Link |  | 1 | Linkit |  | 
+| Vocabulary | Sections | Metatags | field_metatags | Meta tags |  | 1 | Advanced meta tags form |  | 
+| Vocabulary | Sections | Social media links | field_social_media_links | Social Media Links Field  |  | 1 | List with all available platforms |  | 
+| Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  | 
+| Vocabulary | VHA health service taxonomy | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  | 
+| Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) |  | 1 | Textfield |  | 
+| Vocabulary | VHA health service taxonomy | Owner | field_owner | Entity reference | Required | 1 | Select list |  | 
+| Vocabulary | VHA health service taxonomy | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  | 

--- a/tests/behat/drupal-spec-tool/content_model.feature
+++ b/tests/behat/drupal-spec-tool/content_model.feature
@@ -246,15 +246,15 @@ Feature: Content model
 | Content type | VAMC system banner alert with situation updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  | 
 | Content type | VAMC system banner alert with situation updates | Display "Subscribe to email updates" link? | field_alert_email_updates_button | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Find other VA facilities near you" link? | field_alert_find_facilities_cta | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | VAMC system banner alert with situation updates | Inherited by subpages | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  | 
+| Content type | VAMC system banner alert with situation updates | Inherited by subpages | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Get updates on affected services and facilities" link | field_alert_operating_status_cta | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | VAMC system banner alert with situation updates | Alert type | field_alert_type | List (text) | Required | 1 | Select list |  | 
-| Content type | VAMC system banner alert with situation updates | Situation information | field_banner_alert_situationinfo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  | 
-| Content type | VAMC system banner alert with situation updates | VA Medical Centers | field_banner_alert_vamcs | Entity reference | Required | Unlimited | Check boxes/radio buttons |  | 
-| Content type | VAMC system banner alert with situation updates | Alert body | field_body | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable | 
-| Content type | VAMC system banner alert with situation updates | Send email to subscribers via GovDelivery? | field_operating_status_sendemail | Boolean |  | 1 | Single on/off checkbox | Translatable | 
-| Content type | VAMC system banner alert with situation updates | Situation updates | field_situation_updates | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  | 
-| Content type | VAMC system health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable | 
+| Content type | VAMC system banner alert with situation updates | Alert type | field_alert_type | List (text) | Required | 1 | Select list |  |
+| Content type | VAMC system banner alert with situation updates | Situation information | field_banner_alert_situationinfo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | VAMC system banner alert with situation updates | VA Medical Centers | field_banner_alert_vamcs | Entity reference | Required | Unlimited | Check boxes/radio buttons |  |
+| Content type | VAMC system banner alert with situation updates | Alert body | field_body | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | VAMC system banner alert with situation updates | Send email to subscribers via GovDelivery? | field_operating_status_sendemail | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | VAMC system banner alert with situation updates | Situation updates | field_situation_updates | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
+| Content type | VAMC system health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC system health service | VAMC system description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC system health service | Facility-specific descriptions of this service | field_local_health_care_service_ | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  | 
 | Content type | VAMC system health service | VAMC system | field_region_page | Entity reference | Required | 1 | Select list | Translatable | 


### PR DESCRIPTION
QA
- [ ] Create a new VAMC system health service (/node/add/regional_health_care_service_des) for Pittsburgh that doesn't exist at va.gov/pittsburgh-health-care/health-services, such as Rheumataology.  Add Pittsburgh as the owner and VAMC system.
- [ ] Without leaving this form, go ahead and add local facilities to the form, adding Rheumatology descriptions for two facilities, such as Butler and Beaver County
- [ ] Save as draft then go to /admin/content, you should see three nodes that have been created for Rheumatology: Rheumatology at Beaver County, Rheumatology at Belmont, and Rheumatology. 
- [ ] Edit the "child" nodes (Beaver and Belmont). You should see corresponding entity reference pointing "back" at the parent Rheumatology page. 