### PR TITLE
VAGOV-000: Remove patch no longer needed for field_group & paragraphs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -218,9 +218,6 @@
             "drupal/menu_link_content": {
                 "Fix php warning when creating new items": "https://www.drupal.org/files/issues/updateLink-2775665-2.patch"
             },
-            "drupal/paragraphs": {
-                "Fix broken fieldset wrapping.": "https://www.drupal.org/files/issues/2907094_7_field_group_support.patch"
-            },
             "drupal/paragraphs_browser": {
                 "Extend from ParagraphsWidget instead of InlineParagraphsWidget": "https://www.drupal.org/files/issues/2019-01-22/paragraphs_browser-extend-from-ParagraphsWidget-2917656-14_0.patch"
             },


### PR DESCRIPTION
Patched no longer needed with 8.x-1.4 https://www.drupal.org/node/2907094