### PR TITLE
VAGOV-000 Ignore samlsessiondb.sq3 for all users on composer install hook.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -252,6 +252,7 @@
             "cp -r 'simplesamlphp-1.17.2/metadata/' 'docroot/vendor/simplesamlphp/simplesamlphp/'",
             "echo 'Removing deleted .git/hooks/commit-msg file, no longer used.'",
             "rm -f .git/hooks/commit-msg",
+            "git update-index --skip-worktree samlsessiondb.sq3",
             "@va:web:install"
         ],
         "post-update-cmd": [


### PR DESCRIPTION
This keeps samlsessiondb.sq3 from always showing up in git status. 