### PR TITLE
VAGOV-6277 Fix "Warning: in_array() expects parameter 2 to be array, string given in va_gov_build_trigger_form_alter() (line 30 of modules/custom/va_gov_build_trigger/va_gov_build_trigger.module)."

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -27,7 +27,7 @@ function va_gov_node_update(NodeInterface $node) {
  */
 function va_gov_build_trigger_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
-  if (in_array('node_form', $form['#theme'])) {
+  if (in_array('node_form', (array) $form['#theme'])) {
 
     $form['actions']['preview'] = [
       '#type' => 'submit',


### PR DESCRIPTION
Fixes:

> Warning: in_array() expects parameter 2 to be array, string given in va_gov_build_trigger_form_alter() (line 30 of modules/custom/va_gov_build_trigger/va_gov_build_trigger.module).

On config forms this is just a string but node forms it is an array. Just casted it to an `(array)`. 