### PR TITLE
VAGOV-6289: Updating config to include govid fields on facility.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -13,6 +13,8 @@ dependencies:
     - field.field.node.health_care_region_page.field_facebook
     - field.field.node.health_care_region_page.field_featured_content_healthser
     - field.field.node.health_care_region_page.field_flickr
+    - field.field.node.health_care_region_page.field_govdelivery_id_emerg
+    - field.field.node.health_care_region_page.field_govdelivery_id_news
     - field.field.node.health_care_region_page.field_instagram
     - field.field.node.health_care_region_page.field_intro_text
     - field.field.node.health_care_region_page.field_intro_text_events_page
@@ -53,7 +55,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 16
+      weight: 15
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -68,7 +70,7 @@ third_party_settings:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 17
+      weight: 16
       format_type: fieldset
       format_settings:
         id: ''
@@ -82,7 +84,7 @@ third_party_settings:
         - field_locations_intro_blurb
         - field_other_va_locations
       parent_name: ''
-      weight: 10
+      weight: 9
       format_type: details
       format_settings:
         description: "<p>To add locations to the \"Our Locations\" page, <a href=\"/node/add/health_care_local_facility\">create a facility listing</a> for each one.This section also allows you to add other content to the \"Our Locations\" page.</p>\r\n\r\n\r\n"
@@ -98,7 +100,7 @@ third_party_settings:
         - field_clinical_health_care_servi
         - field_clinical_health_services
       parent_name: ''
-      weight: 12
+      weight: 11
       format_type: details
       format_settings:
         description: 'This content will appear on the Health Services page, (eg va.gov/pittsburgh-health-care/health-services). '
@@ -113,7 +115,7 @@ third_party_settings:
         - group_online_appointments
         - field_related_links
       parent_name: ''
-      weight: 15
+      weight: 14
       format_type: details
       format_settings:
         id: ''
@@ -142,7 +144,7 @@ third_party_settings:
         - field_intro_text_press_releases
         - field_press_release_blurb
       parent_name: ''
-      weight: 14
+      weight: 13
       format_type: details
       format_settings:
         required_fields: true
@@ -154,11 +156,10 @@ third_party_settings:
     group_get_updates_from_us:
       children:
         - field_operating_status
-        - field_link_facility_emerg_list
-        - field_link_facility_news_list
+        - group_govdelivery_email_lists
         - group_s
       parent_name: ''
-      weight: 11
+      weight: 10
       format_type: details
       format_settings:
         description: 'This will populate the "Get updates" from us block on the health care system page and its facility pages. '
@@ -175,7 +176,7 @@ third_party_settings:
         - field_instagram
         - field_flickr
       parent_name: group_get_updates_from_us
-      weight: 29
+      weight: 39
       format_type: fieldset
       format_settings:
         id: ''
@@ -207,7 +208,7 @@ third_party_settings:
         - field_intro_text_leadership
         - field_leadership
       parent_name: ''
-      weight: 13
+      weight: 12
       format_type: details
       format_settings:
         id: ''
@@ -230,6 +231,20 @@ third_party_settings:
         required_fields: true
       label: 'Featured content'
       region: content
+    group_govdelivery_email_lists:
+      children:
+        - field_govdelivery_id_emerg
+        - field_govdelivery_id_news
+      parent_name: group_get_updates_from_us
+      weight: 38
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: 'For each of these fields, the topic_id that’s found at the end of the URL used to subscribe to GovDelivery emails. For example, if the URL is https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id=1234, enter “1234”.'
+        required_fields: true
+      label: 'GovDelivery email lists'
+      region: content
 id: node.health_care_region_page.default
 targetEntityType: node
 bundle: health_care_region_page
@@ -237,12 +252,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 4
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_administration:
-    weight: 11
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -292,7 +307,7 @@ content:
     region: content
   field_featured_content_healthser:
     type: entity_reference_paragraphs
-    weight: 30
+    weight: 15
     settings:
       title: 'Featured content'
       title_plural: 'Featured content'
@@ -309,6 +324,22 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  field_govdelivery_id_emerg:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_govdelivery_id_news:
+    weight: 28
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_instagram:
     weight: 16
@@ -332,7 +363,7 @@ content:
     type: string_textarea_with_counter
     region: content
   field_intro_text_events_page:
-    weight: 23
+    weight: 16
     settings:
       rows: 5
       placeholder: ''
@@ -345,7 +376,7 @@ content:
     type: text_textarea_with_counter
     region: content
   field_intro_text_leadership:
-    weight: 24
+    weight: 21
     settings:
       rows: 5
       placeholder: ''
@@ -353,7 +384,7 @@ content:
     type: string_textarea
     region: content
   field_intro_text_news_stories:
-    weight: 22
+    weight: 15
     settings:
       rows: 5
       placeholder: ''
@@ -366,7 +397,7 @@ content:
     type: text_textarea_with_counter
     region: content
   field_intro_text_press_releases:
-    weight: 25
+    weight: 17
     settings:
       rows: 5
       placeholder: ''
@@ -374,29 +405,13 @@ content:
     type: string_textarea
     region: content
   field_leadership:
-    weight: 25
+    weight: 22
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
-    region: content
-  field_link_facility_emerg_list:
-    weight: 27
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
-    type: link_default
-    region: content
-  field_link_facility_news_list:
-    weight: 28
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
-    type: link_default
     region: content
   field_locations_intro_blurb:
     weight: 10
@@ -413,7 +428,7 @@ content:
     region: content
     third_party_settings: {  }
   field_meta_tags:
-    weight: 18
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
@@ -441,7 +456,7 @@ content:
     type: string_textfield
     region: content
   field_operating_status:
-    weight: 26
+    weight: 37
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -458,7 +473,7 @@ content:
     type: string_textfield
     region: content
   field_press_release_blurb:
-    weight: 26
+    weight: 18
     settings:
       rows: 5
       placeholder: ''
@@ -505,7 +520,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -513,12 +528,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 5
+    weight: 4
     region: content
     third_party_settings: {  }
   revision_log:
     type: hide_revision_field_log_widget
-    weight: 9
+    weight: 10
     region: content
     settings:
       show: true
@@ -532,14 +547,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 8
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 5
     region: content
     third_party_settings: {  }
   title:
@@ -558,7 +573,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 3
+    weight: 2
     settings:
       match_operator: CONTAINS
       size: 60
@@ -566,12 +581,14 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 8
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   field_email_subscription: true
   field_email_subscription_links: true
+  field_link_facility_emerg_list: true
+  field_link_facility_news_list: true
   field_links: true
   field_sign_up_for_emergency_emai: true

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -241,7 +241,7 @@ third_party_settings:
       format_settings:
         id: ''
         classes: ''
-        description: 'For each of these fields, the topic_id that’s found at the end of the URL used to subscribe to GovDelivery emails. For example, if the URL is https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id=1234, enter “1234”.'
+        description: 'For each of these fields, the topic_id that is found at the end of the URL used to subscribe to GovDelivery emails. For example, if the URL is https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id=1234, enter “1234”.'
         required_fields: true
       label: 'GovDelivery email lists'
       region: content

--- a/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
@@ -13,6 +13,8 @@ dependencies:
     - field.field.node.health_care_region_page.field_facebook
     - field.field.node.health_care_region_page.field_featured_content_healthser
     - field.field.node.health_care_region_page.field_flickr
+    - field.field.node.health_care_region_page.field_govdelivery_id_emerg
+    - field.field.node.health_care_region_page.field_govdelivery_id_news
     - field.field.node.health_care_region_page.field_instagram
     - field.field.node.health_care_region_page.field_intro_text
     - field.field.node.health_care_region_page.field_intro_text_events_page
@@ -210,6 +212,22 @@ content:
       target: ''
     third_party_settings: {  }
     type: link
+    region: content
+  field_govdelivery_id_emerg:
+    weight: 26
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_govdelivery_id_news:
+    weight: 27
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_instagram:
     weight: 14

--- a/config/sync/field.field.node.health_care_region_page.field_govdelivery_id_emerg.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_govdelivery_id_emerg.yml
@@ -1,0 +1,19 @@
+uuid: 3a97b514-a89e-4516-94de-833c07c5c943
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_govdelivery_id_emerg
+    - node.type.health_care_region_page
+id: node.health_care_region_page.field_govdelivery_id_emerg
+field_name: field_govdelivery_id_emerg
+entity_type: node
+bundle: health_care_region_page
+label: 'GovDelivery ID for Emergency updates email'
+description: 'The GovDelivery ID where people can subscribe to emergency email lists.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.health_care_region_page.field_govdelivery_id_news.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_govdelivery_id_news.yml
@@ -1,0 +1,19 @@
+uuid: 4100e5a4-432e-49a3-8f83-ceb32675bebf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_govdelivery_id_news
+    - node.type.health_care_region_page
+id: node.health_care_region_page.field_govdelivery_id_news
+field_name: field_govdelivery_id_news
+entity_type: node
+bundle: health_care_region_page
+label: 'GovDelivery ID for News and Announcements'
+description: 'The GovDelivery ID where people can subscribe to news and announcement email lists.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_govdelivery_id_emerg.yml
+++ b/config/sync/field.storage.node.field_govdelivery_id_emerg.yml
@@ -1,0 +1,21 @@
+uuid: ab032d1b-6117-45be-b1ff-11e9ea57f6c7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_govdelivery_id_emerg
+field_name: field_govdelivery_id_emerg
+entity_type: node
+type: string
+settings:
+  max_length: 10
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_govdelivery_id_news.yml
+++ b/config/sync/field.storage.node.field_govdelivery_id_news.yml
@@ -1,0 +1,21 @@
+uuid: f0431e00-fe97-489c-9b1a-b3b75747198b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_govdelivery_id_news
+field_name: field_govdelivery_id_news
+entity_type: node
+type: string
+settings:
+  max_length: 10
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model.feature
+++ b/tests/behat/drupal-spec-tool/content_model.feature
@@ -228,8 +228,10 @@ Feature: Content model
 | Content type | VAMC system | Community stories intro text | field_intro_text_news_stories | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC system | Press releases intro text | field_intro_text_press_releases | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | VAMC system | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete |  |
-| Content type | VAMC system | Emergency updates email list  | field_link_facility_emerg_list | Link |  | 1 | Link |  |
-| Content type | VAMC system | News and announcements email list | field_link_facility_news_list | Link |  | 1 | Link |  |
+| Content type | VAMC system | Emergency updates email list               | field_link_facility_emerg_list | Link         |          | 1 | -- Disabled -- |  |
+| Content type | VAMC system | News and announcements email list          | field_link_facility_news_list  | Link         |          | 1 | -- Disabled -- |  |
+| Content type | VAMC system | GovDelivery ID for News and Announcements  | field_govdelivery_id_news      | Text (plain) | Required | 1 | Textfield      |  |
+| Content type | VAMC system | GovDelivery ID for Emergency updates email | field_govdelivery_id_emerg     | Text (plain) | Required | 1 | Textfield      |  |
 | Content type | VAMC system | Email lists | field_links | Link |  | Unlimited | -- Disabled -- | Translatable |
 | Content type | VAMC system | Our Locations intro text | field_locations_intro_blurb | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | VAMC system | Banner image | field_media | Entity reference |  | 1 | Media library | Translatable |


### PR DESCRIPTION
## Description
Adding two 10 character text fields to facility type to capture GovDelivery email list ids, and disabling previous 2 full url capture fields.

## QA
Go to `node/318/edit` and visually verify that new fields and fieldset captured in screenshot below are visible.

## Screenshot
![image](https://user-images.githubusercontent.com/2404547/69366638-c20b3a00-0c64-11ea-9cb8-cba1bbd37ce3.png)
