### PR TITLE
VAGOV-6296: Don't add Home link to breadcrumb.

### DIFF
--- a/config/sync/menu_breadcrumb.settings.yml
+++ b/config/sync/menu_breadcrumb.settings.yml
@@ -5,7 +5,7 @@ current_page_as_link: false
 append_member_page: false
 member_page_as_link: false
 remove_home: false
-add_home: true
+add_home: false
 home_as_site_name: false
 exclude_empty_url: false
 menu_breadcrumb_menus:
@@ -59,9 +59,49 @@ menu_breadcrumb_menus:
     weight: -1
     taxattach: 0
     langhandle: 0
+  va-wilkes-barre-health-care:
+    weight: 0
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-erie-health-care:
+    weight: 0
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-wilmington-health-care:
+    weight: 0
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
   careers-employment-benefits:
     enabled: 1
     weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-philadelphia-health-care:
+    weight: 0
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-lebanon:
+    weight: 0
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-altoona-health-care:
+    weight: 0
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-butler-health-care:
+    weight: 0
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-coatesville-health-care:
+    weight: 0
+    enabled: 0
     taxattach: 0
     langhandle: 0
   footer-bottom-rail:
@@ -109,12 +149,12 @@ menu_breadcrumb_menus:
     enabled: 0
     taxattach: 0
     langhandle: 0
-  homepage-top-tasks-blocks:
+  account:
     weight: 10
     enabled: 0
     taxattach: 0
     langhandle: 0
-  account:
+  homepage-top-tasks-blocks:
     weight: 10
     enabled: 0
     taxattach: 0


### PR DESCRIPTION
QA:
* Go to /admin/content
* Open a few random nodes of various types and click Preview.
* None should have the "Home" breadcrumb 