### PR TITLE
VAGOV-6249 Add deploy permission.

### DIFF
--- a/config/sync/user.role.content_admin.yml
+++ b/config/sync/user.role.content_admin.yml
@@ -68,6 +68,7 @@ permissions:
   - 'use moderation sidebar'
   - 'use text format rich_text'
   - 'use workbench access'
+  - 'va gov deploy content build'
   - 'view all media revisions'
   - 'view any unpublished content'
   - 'view latest version'

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.permissions.yml
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.permissions.yml
@@ -1,0 +1,4 @@
+va gov deploy content build:
+  title: 'VA.gov Deploy Content Build'
+  description: 'Grants access to the build and deploy front end button.'
+  restrict access: FALSE

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.routing.yml
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.routing.yml
@@ -4,7 +4,7 @@ va_gov_build_trigger.build_trigger_form:
     _title: "Build & Deploy Content"
     _form: '\Drupal\va_gov_build_trigger\Form\BuildTriggerForm'
   requirements:
-    _permission: "bypass password policies"
+    _permission: "va gov deploy content build"
 
 va_gov_build_trigger.preview_form:
   defaults:


### PR DESCRIPTION
Adds the permission for deploying content and assigns it to 'admin' and 'content admin'.

## Testing

Login as admin
- [ ] visit /admin/content/deploy  should see deploy button
![image](https://user-images.githubusercontent.com/5752113/69462167-5f8a6a80-0d46-11ea-959c-bd81f41dfd02.png)

- [ ] visit /admin/people/permissions and search for 'deploy'  On that row, only admin and content admin should be checked.
![image](https://user-images.githubusercontent.com/5752113/69462154-53061200-0d46-11ea-9a60-509a5ec743f8.png)


Login as Steve.Tokar2@  (not content  admin )
- [ ] visit /admin/content/deploy  should see access denied
![image](https://user-images.githubusercontent.com/5752113/69462180-67e2a580-0d46-11ea-95b6-ba9a24cd729a.png)

Login as Randi.Hecht@  ( content  admin )
- [ ] visit /admin/content/deploy  should see deploy button
![image](https://user-images.githubusercontent.com/5752113/69462218-716c0d80-0d46-11ea-9c52-641925b0d111.png)
