### PR TITLE
VAGOV-6252 Add GovDelivery banner alert processing. Part 1

### DIFF
--- a/.lando/xdebug/php.ini
+++ b/.lando/xdebug/php.ini
@@ -8,5 +8,5 @@ xdebug.collect_params = 0
 xdebug.remote_enable = 1
 xdebug.remote_autostart = 1
 xdebug.remote_host = ${LANDO_HOST_IP}
-; xdebug.remote_connect_back = 1
+xdebug.remote_connect_back = 1
 xdebug.remote_log = /tmp/xdebug.log

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/fast_404": "^1.0@alpha",
         "drupal/feature_toggle": "^1.2",
         "drupal/field_group": "dev-3.x#b245b85f99c48221edf5fb60344dfe53737ae0f9",
+        "drupal/govdelivery_bulletins": "1.x-dev",
         "drupal/graphql": "^3.0",
         "drupal/graphql_metatag": "1.x-dev",
         "drupal/health_check": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac2be6fcd4632f3a7e33a7a00ce2fa76",
+    "content-hash": "4cc49c8ea5b28e341df7da4e2baf3ae4",
     "packages": [
         {
             "name": "acquia/headless_lightning",
@@ -2009,16 +2009,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "c15dcd24b756f9e52ea7c3ae8227354f3628f11a"
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/c15dcd24b756f9e52ea7c3ae8227354f3628f11a",
-                "reference": "c15dcd24b756f9e52ea7c3ae8227354f3628f11a",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/382e7f4db9a12dc6c19431743a2b096041bcdd62",
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62",
                 "shasum": ""
             },
             "require": {
@@ -2085,10 +2085,9 @@
                 "memcached",
                 "php",
                 "redis",
-                "riak",
                 "xcache"
             ],
-            "time": "2019-11-11T10:31:52+00:00"
+            "time": "2019-11-29T15:36:20+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -3188,7 +3187,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.6",
-                    "datestamp": "1519041484",
+                    "datestamp": "1566763981",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5596,7 +5595,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1521730685",
+                    "datestamp": "1569251888",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5757,8 +5756,8 @@
                     "dev-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.0-rc1+15-dev",
-                    "datestamp": "1570894385",
+                    "version": "8.x-3.0-beta1+54-dev",
+                    "datestamp": "1553812381",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -5801,6 +5800,52 @@
                 "source": "https://git.drupalcode.org/project/field_group"
             },
             "time": "2019-05-23T21:31:25+00:00"
+        },
+        {
+            "name": "drupal/govdelivery_bulletins",
+            "version": "dev-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/govdelivery_bulletins.git",
+                "reference": "cdde79b062941b11a9906352684b7aaea6cf6e4a"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.x-dev",
+                    "datestamp": "1575604384",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Elijah Lynn",
+                    "homepage": "https://www.drupal.org/user/353190"
+                },
+                {
+                    "name": "swirt",
+                    "homepage": "https://www.drupal.org/user/138230"
+                }
+            ],
+            "description": "Provides service and queue for sending bulletins using GovDelivery Bulletins API.",
+            "homepage": "https://www.drupal.org/project/govdelivery_bulletins",
+            "support": {
+                "source": "https://git.drupalcode.org/project/govdelivery_bulletins"
+            },
+            "time": "2019-12-06T05:49:34+00:00"
         },
         {
             "name": "drupal/graphql",
@@ -7307,7 +7352,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.2",
-                    "datestamp": "1496237343",
+                    "datestamp": "1568908385",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8206,7 +8251,7 @@
                     "datestamp": "1543085281",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -8218,6 +8263,10 @@
                 {
                     "name": "Stéphane Le Merre",
                     "homepage": "https://www.drupal.org/u/oulalahakabu"
+                },
+                {
+                    "name": "adriancid",
+                    "homepage": "https://www.drupal.org/user/1962106"
                 }
             ],
             "description": "This module allows to manage node's revisions store : according to settings, revisions are automaticaly deleted.",
@@ -10638,7 +10687,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1528707485",
+                    "datestamp": "1566880085",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -11606,14 +11655,14 @@
             "authors": [
                 {
                     "name": "Nicholas Humfrey",
-                    "role": "Developer",
                     "email": "njh@aelius.com",
-                    "homepage": "http://www.aelius.com/njh/"
+                    "homepage": "http://www.aelius.com/njh/",
+                    "role": "Developer"
                 },
                 {
                     "name": "Alexey Zakhlestin",
-                    "role": "Developer",
-                    "email": "indeyets@gmail.com"
+                    "email": "indeyets@gmail.com",
+                    "role": "Developer"
                 }
             ],
             "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
@@ -11881,8 +11930,8 @@
             "authors": [
                 {
                     "name": "Michele Locati",
-                    "role": "Developer",
-                    "email": "mlocati@gmail.com"
+                    "email": "mlocati@gmail.com",
+                    "role": "Developer"
                 }
             ],
             "description": "gettext languages with plural rules",
@@ -12223,13 +12272,13 @@
             "authors": [
                 {
                     "name": "Justin Bishop",
-                    "role": "Developer",
-                    "email": "jubishop@gmail.com"
+                    "email": "jubishop@gmail.com",
+                    "role": "Developer"
                 },
                 {
                     "name": "Anthon Pang",
-                    "role": "Fork Maintainer",
-                    "email": "apang@softwaredevelopment.ca"
+                    "email": "apang@softwaredevelopment.ca",
+                    "role": "Fork Maintainer"
                 }
             ],
             "description": "PHP WebDriver for Selenium 2",
@@ -12652,9 +12701,9 @@
             "authors": [
                 {
                     "name": "Colin O'Dell",
-                    "role": "Lead Developer",
                     "email": "colinodell@gmail.com",
-                    "homepage": "https://www.colinodell.com"
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
                 }
             ],
             "description": "Markdown parser for PHP based on the CommonMark spec",
@@ -12713,9 +12762,9 @@
             "authors": [
                 {
                     "name": "Phil Bennett",
-                    "role": "Developer",
                     "email": "philipobenito@gmail.com",
-                    "homepage": "http://www.philipobenito.com"
+                    "homepage": "http://www.philipobenito.com",
+                    "role": "Developer"
                 }
             ],
             "description": "A fast and intuitive dependency injection container.",
@@ -13012,9 +13061,9 @@
             "authors": [
                 {
                     "name": "Michel Fortin",
-                    "role": "Developer",
                     "email": "michel.fortin@michelf.ca",
-                    "homepage": "https://michelf.ca/"
+                    "homepage": "https://michelf.ca/",
+                    "role": "Developer"
                 },
                 {
                     "name": "John Gruber",
@@ -13416,18 +13465,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -13463,18 +13512,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Library for handling version information and constraints",
@@ -14213,8 +14262,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -14261,8 +14310,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -14303,8 +14352,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Simple template engine.",
@@ -14352,8 +14401,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -14483,8 +14532,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -15583,8 +15632,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
@@ -16103,7 +16152,7 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
@@ -16223,16 +16272,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "17b154f932c5874cdbda6d05796b6490eec9f9f7"
+                "reference": "1ee23b3b659b06c622f2bd2492a229e416eb4586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/17b154f932c5874cdbda6d05796b6490eec9f9f7",
-                "reference": "17b154f932c5874cdbda6d05796b6490eec9f9f7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1ee23b3b659b06c622f2bd2492a229e416eb4586",
+                "reference": "1ee23b3b659b06c622f2bd2492a229e416eb4586",
                 "shasum": ""
             },
             "require": {
@@ -16291,7 +16340,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-13T07:12:39+00:00"
+            "time": "2019-12-01T10:04:45+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -16348,16 +16397,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "5ea9c3e01989a86ceaa0283f21234b12deadf5e2"
+                "reference": "b8600a1d7d20b0e80906398bb1f50612fa074a8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5ea9c3e01989a86ceaa0283f21234b12deadf5e2",
-                "reference": "5ea9c3e01989a86ceaa0283f21234b12deadf5e2",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b8600a1d7d20b0e80906398bb1f50612fa074a8e",
+                "reference": "b8600a1d7d20b0e80906398bb1f50612fa074a8e",
                 "shasum": ""
             },
             "require": {
@@ -16368,12 +16417,12 @@
                 "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "symfony/http-kernel": "~3.4|~4.0"
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -16400,20 +16449,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-28T17:07:32+00:00"
+            "time": "2019-11-28T13:33:56+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "0ea4d39ca82409a25a43b61ce828048a90000920"
+                "reference": "0d201916bfb3af939fec3c0c8815ea16c60ac1a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0ea4d39ca82409a25a43b61ce828048a90000920",
-                "reference": "0ea4d39ca82409a25a43b61ce828048a90000920",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0d201916bfb3af939fec3c0c8815ea16c60ac1a2",
+                "reference": "0d201916bfb3af939fec3c0c8815ea16c60ac1a2",
                 "shasum": ""
             },
             "require": {
@@ -16471,7 +16520,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-08T16:18:30+00:00"
+            "time": "2019-12-01T08:33:36+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -16536,7 +16585,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -16698,16 +16747,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9e4b3ac8fa3348b4811674d23de32d201de225ce"
+                "reference": "d2d0cfe8e319d9df44c4cca570710fcf221d4593"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9e4b3ac8fa3348b4811674d23de32d201de225ce",
-                "reference": "9e4b3ac8fa3348b4811674d23de32d201de225ce",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/d2d0cfe8e319d9df44c4cca570710fcf221d4593",
+                "reference": "d2d0cfe8e319d9df44c4cca570710fcf221d4593",
                 "shasum": ""
             },
             "require": {
@@ -16748,20 +16797,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-11T12:53:10+00:00"
+            "time": "2019-11-28T12:52:59+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "e1764b3de00ec5636dd03d02fd44bcb1147d70d9"
+                "reference": "c42c8339acb28cfff0fb1786948db4d23d609ff7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e1764b3de00ec5636dd03d02fd44bcb1147d70d9",
-                "reference": "e1764b3de00ec5636dd03d02fd44bcb1147d70d9",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c42c8339acb28cfff0fb1786948db4d23d609ff7",
+                "reference": "c42c8339acb28cfff0fb1786948db4d23d609ff7",
                 "shasum": ""
             },
             "require": {
@@ -16838,7 +16887,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-13T08:44:50+00:00"
+            "time": "2019-12-01T13:50:37+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -16961,16 +17010,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -16982,7 +17031,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -17015,20 +17064,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "685968b11e61a347c18bf25db32effa478be610f"
+                "reference": "a019efccc03f1a335af6b4f20c30f5ea8060be36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/685968b11e61a347c18bf25db32effa478be610f",
-                "reference": "685968b11e61a347c18bf25db32effa478be610f",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/a019efccc03f1a335af6b4f20c30f5ea8060be36",
+                "reference": "a019efccc03f1a335af6b4f20c30f5ea8060be36",
                 "shasum": ""
             },
             "require": {
@@ -17040,7 +17089,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -17074,20 +17123,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
                 "shasum": ""
             },
             "require": {
@@ -17099,7 +17148,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -17133,20 +17182,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T14:18:11+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "0e3b212e96a51338639d8ce175c046d7729c3403"
+                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/0e3b212e96a51338639d8ce175c046d7729c3403",
-                "reference": "0e3b212e96a51338639d8ce175c046d7729c3403",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
+                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
                 "shasum": ""
             },
             "require": {
@@ -17156,7 +17205,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -17189,20 +17238,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "54b4c428a0054e254223797d2713c31e08610831"
+                "reference": "af23c7bb26a73b850840823662dda371484926c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/54b4c428a0054e254223797d2713c31e08610831",
-                "reference": "54b4c428a0054e254223797d2713c31e08610831",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/af23c7bb26a73b850840823662dda371484926c4",
+                "reference": "af23c7bb26a73b850840823662dda371484926c4",
                 "shasum": ""
             },
             "require": {
@@ -17212,7 +17261,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -17248,20 +17297,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "4317de1386717b4c22caed7725350a8887ab205c"
+                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/4317de1386717b4c22caed7725350a8887ab205c",
-                "reference": "4317de1386717b4c22caed7725350a8887ab205c",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/964a67f293b66b95883a5ed918a65354fcd2258f",
+                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f",
                 "shasum": ""
             },
             "require": {
@@ -17270,7 +17319,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -17300,20 +17349,20 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c19da50bc3e8fa7d60628fdb4ab5d67de534cf3e"
+                "reference": "9a4545c01e1e4f473492bd52b71e574dcc401ca2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c19da50bc3e8fa7d60628fdb4ab5d67de534cf3e",
-                "reference": "c19da50bc3e8fa7d60628fdb4ab5d67de534cf3e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/9a4545c01e1e4f473492bd52b71e574dcc401ca2",
+                "reference": "9a4545c01e1e4f473492bd52b71e574dcc401ca2",
                 "shasum": ""
             },
             "require": {
@@ -17349,7 +17398,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-24T15:33:53+00:00"
+            "time": "2019-11-28T10:05:51+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -17418,16 +17467,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "afc10b9c6b5196e0fecbc3bd373c7b4482e5b6b5"
+                "reference": "b689ccd48e234ea404806d94b07eeb45f9f6f06a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/afc10b9c6b5196e0fecbc3bd373c7b4482e5b6b5",
-                "reference": "afc10b9c6b5196e0fecbc3bd373c7b4482e5b6b5",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/b689ccd48e234ea404806d94b07eeb45f9f6f06a",
+                "reference": "b689ccd48e234ea404806d94b07eeb45f9f6f06a",
                 "shasum": ""
             },
             "require": {
@@ -17490,20 +17539,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-11-08T17:25:00+00:00"
+            "time": "2019-12-01T08:33:36+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "9d14f7ff2c585a8a9f6f980253066285ddc2f675"
+                "reference": "05a1125ff3fdd10a68a2857a5d1d4a1ceb93ba42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/9d14f7ff2c585a8a9f6f980253066285ddc2f675",
-                "reference": "9d14f7ff2c585a8a9f6f980253066285ddc2f675",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/05a1125ff3fdd10a68a2857a5d1d4a1ceb93ba42",
+                "reference": "05a1125ff3fdd10a68a2857a5d1d4a1ceb93ba42",
                 "shasum": ""
             },
             "require": {
@@ -17569,20 +17618,20 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-12T17:51:12+00:00"
+            "time": "2019-11-25T16:36:22+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "2031c895bc97ac1787d418d90bd1ed7d299f2772"
+                "reference": "0be25347c4a8695d9423fe897f4c774f46e97b51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/2031c895bc97ac1787d418d90bd1ed7d299f2772",
-                "reference": "2031c895bc97ac1787d418d90bd1ed7d299f2772",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/0be25347c4a8695d9423fe897f4c774f46e97b51",
+                "reference": "0be25347c4a8695d9423fe897f4c774f46e97b51",
                 "shasum": ""
             },
             "require": {
@@ -17639,20 +17688,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-30T12:43:22+00:00"
+            "time": "2019-11-23T20:30:33+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "b11f45742c5c9a228cedc46b70c6317780a1ac80"
+                "reference": "55e329a518baa3b169b7d278620ae2cd76005188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/b11f45742c5c9a228cedc46b70c6317780a1ac80",
-                "reference": "b11f45742c5c9a228cedc46b70c6317780a1ac80",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/55e329a518baa3b169b7d278620ae2cd76005188",
+                "reference": "55e329a518baa3b169b7d278620ae2cd76005188",
                 "shasum": ""
             },
             "require": {
@@ -17725,7 +17774,7 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-05T22:03:38+00:00"
+            "time": "2019-11-29T19:07:18+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -17798,7 +17847,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.35",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -17944,8 +17993,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
@@ -18050,19 +18099,19 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "role": "Lead Developer",
                     "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org"
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Armin Ronacher",
-                    "role": "Project Founder",
-                    "email": "armin.ronacher@active-4.com"
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
                 },
                 {
                     "name": "Twig Team",
-                    "role": "Contributors",
-                    "homepage": "https://twig.symfony.com/contributors"
+                    "homepage": "https://twig.symfony.com/contributors",
+                    "role": "Contributors"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",
@@ -18800,8 +18849,8 @@
             "authors": [
                 {
                     "name": "Acquia Engineering",
-                    "role": "Maintainer",
-                    "homepage": "https://www.acquia.com"
+                    "homepage": "https://www.acquia.com",
+                    "role": "Maintainer"
                 }
             ],
             "description": "A tool for specifying Drupal architecture details and generating automated tests for them",
@@ -19034,13 +19083,13 @@
             "authors": [
                 {
                     "name": "Maciej Łebkowski",
-                    "role": "Contributor",
-                    "email": "m.lebkowski@gmail.com"
+                    "email": "m.lebkowski@gmail.com",
+                    "role": "Contributor"
                 },
                 {
                     "name": "Markus Poerschke",
-                    "role": "Developer",
-                    "email": "markus@eluceo.de"
+                    "email": "markus@eluceo.de",
+                    "role": "Developer"
                 }
             ],
             "description": "The eluceo/iCal package offers a abstraction layer for creating iCalendars. You can easily create iCal files by using PHP object instead of typing your *.ics file by hand. The output will follow RFC 2445 as best as possible.",
@@ -19202,6 +19251,7 @@
         "drupal/entityqueue": 10,
         "drupal/fast_404": 15,
         "drupal/field_group": 20,
+        "drupal/govdelivery_bulletins": 20,
         "drupal/graphql_metatag": 20,
         "drupal/image_style_warmer": 10,
         "drupal/linkit": 20,

--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -41,6 +41,7 @@ third_party_settings:
       region: content
     group_edi:
       children:
+        - status
         - moderation_state
         - revision_log
       parent_name: ''
@@ -236,13 +237,17 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 3
+    weight: 7
     settings: {  }
     region: content
     third_party_settings: {  }
   revision_log:
     type: hide_revision_field_log_widget
+<<<<<<< HEAD
     weight: 5
+=======
+    weight: 8
+>>>>>>> VAGOV-6252 Update full_width_banner_alert form.
     region: content
     settings:
       show: true
@@ -251,6 +256,13 @@ content:
       allow_user_settings: true
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -265,7 +277,6 @@ hidden:
   field_banner_alert_computdvalues: true
   path: true
   promote: true
-  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -57,7 +57,7 @@ third_party_settings:
     group_alert_display_and_behavior:
       children: {  }
       parent_name: ''
-      weight: 15
+      weight: 13
       format_type: details
       format_settings:
         id: ''
@@ -118,14 +118,14 @@ third_party_settings:
       children:
         - field_banner_alert_situationinfo
       parent_name: ''
-      weight: 14
-      format_type: fieldset
+      weight: 3
+      format_type: details
       format_settings:
         description: 'For "static" situation information that is additional to any situation updates.'
+        open: true
         id: ''
         classes: ''
         required_fields: false
-        open: false
       label: 'Situation information'
       region: content
     group_calls_to_action:

--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -56,7 +56,7 @@ third_party_settings:
     group_alert_display_and_behavior:
       children: {  }
       parent_name: ''
-      weight: 14
+      weight: 15
       format_type: details
       format_settings:
         id: ''
@@ -117,8 +117,8 @@ third_party_settings:
       children:
         - field_banner_alert_situationinfo
       parent_name: ''
-      weight: 3
-      format_type: details
+      weight: 14
+      format_type: fieldset
       format_settings:
         description: 'For "static" situation information that is additional to any situation updates.'
         id: ''
@@ -188,7 +188,7 @@ content:
     type: options_select
     region: content
   field_banner_alert_situationinfo:
-    weight: 5
+    weight: 3
     settings:
       rows: 5
       placeholder: ''

--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -243,11 +243,7 @@ content:
     third_party_settings: {  }
   revision_log:
     type: hide_revision_field_log_widget
-<<<<<<< HEAD
-    weight: 5
-=======
     weight: 8
->>>>>>> VAGOV-6252 Update full_width_banner_alert form.
     region: content
     settings:
       show: true

--- a/config/sync/core.entity_form_display.paragraph.situation_update.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.situation_update.default.yml
@@ -36,12 +36,6 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  status:
-    type: boolean_checkbox
-    weight: 3
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
 hidden:
   created: true
+  status: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -53,6 +53,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  govdelivery_bulletins: 0
   graphql: 0
   graphql_core: 0
   graphql_metatag: 0
@@ -157,6 +158,7 @@ module:
   va_gov_consumers: 0
   va_gov_db: 0
   va_gov_flags: 0
+  va_gov_govdelivery: 0
   va_gov_graphql: 0
   va_gov_login: 0
   va_gov_migrate: 0

--- a/config/sync/govdelivery_bulletins.settings.yml
+++ b/config/sync/govdelivery_bulletins.settings.yml
@@ -1,0 +1,3 @@
+api_queue_trigger_enabled: 1
+enable_bulletin_queuing: 1
+enable_bulletin_queue_sends_to_govdelivery: 0

--- a/config/sync/lightning_core.versions.yml
+++ b/config/sync/lightning_core.versions.yml
@@ -63,6 +63,7 @@ field_group: 0.0.0
 field_ui: 8.6.2
 file: 8.6.2
 filter: 8.6.2
+govdelivery_bulletins: 0.0.0
 graphql: 3.0.0-rc2
 graphql_core: 3.0.0-rc2
 graphql_metatag: 0.0.0
@@ -203,6 +204,7 @@ va_gov_bulk: 0.0.0
 va_gov_consumers: '1'
 va_gov_db: 0.0.0
 va_gov_flags: 0.0.0
+va_gov_govdelivery: 0.0.0
 va_gov_graphql: 0.0.0
 va_gov_login: 0.0.0
 va_gov_migrate: 0.0.0

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -9,6 +9,7 @@ label: 'Anonymous user'
 weight: -10
 is_admin: false
 permissions:
+  - 'access bulletin queue trigger api'
   - 'access content'
   - 'access site-wide contact form'
   - 'view media'

--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -8,7 +8,6 @@ dependencies:
     - node.type.documentation_page
     - node.type.event
     - node.type.event_listing
-    - node.type.full_width_banner_alert
     - node.type.health_care_local_facility
     - node.type.health_care_local_health_service
     - node.type.health_care_region_detail_page
@@ -114,7 +113,6 @@ type_settings:
       - documentation_page
       - event
       - event_listing
-      - full_width_banner_alert
       - health_care_local_facility
       - health_care_local_health_service
       - health_care_region_detail_page

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -5,7 +5,6 @@
  * Contains va_gov_backend.module.
  */
 
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Field\WidgetBase;
@@ -206,53 +205,4 @@ function va_gov_backend_rebuild() {
   }
 
   \Drupal::state()->set("environment_indicator.current_release", $indicator);
-}
-
-/**
- * Implements hook_entity_presave().
- */
-function va_gov_backend_entity_presave(EntityInterface $entity) {
-  // Build computed field array on banner alert nodes.
-  _va_gov_backend_build_alert_computed_field_data($entity);
-}
-
-/**
- * Populates computed field on banner alert nodes.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   The node object.
- */
-function _va_gov_backend_build_alert_computed_field_data(EntityInterface $entity) {
-  // Make sure it's a node.
-  if ($entity instanceof NodeInterface && $entity->bundle() === 'full_width_banner_alert') {
-
-    // This is where we get our Operating status node id's.
-    $vamcs_op_status_ids = $entity->get('field_banner_alert_vamcs')->getValue();
-    foreach ($vamcs_op_status_ids as $key => $vamcs_op_status_id) {
-      $vamcs_op_status_ids[$key] = !empty($vamcs_op_status_id['target_id']) ? $vamcs_op_status_id['target_id'] : '';
-    }
-    // Get a node storage object.
-    $node_storage = \Drupal::entityManager()->getStorage('node');
-
-    $vamc_office_values = [];
-    $computed_return = [];
-    $vamc_op_nodes = $node_storage->loadMultiple($vamcs_op_status_ids);
-
-    // Get out op status page paths.
-    foreach ($vamc_op_nodes as $key => $vamc_op_node) {
-      $computed_return[$key]['vamc_op_status_path'] = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $vamc_op_node->id());
-      $vamc_office_values[] = $vamc_op_node->get('field_office')->getString();
-    }
-
-    // Grab what we need from our vamcs.
-    $vamc_system_nodes = $node_storage->loadMultiple($vamc_office_values);
-    foreach ($vamc_system_nodes as $key => $vamc_system_node) {
-      $computed_return[$key]['vamc_topic_id'] = !empty($vamc_system_node->get('field_govdelivery_id_emerg')->getString()) ? $vamc_system_node->get('field_govdelivery_id_emerg')->getString() : '';
-      $computed_return[$key]['vamc_title'] = $vamc_system_node->getTitle();
-      $computed_return[$key]['vamc_path'] = $vamc_system_node->toUrl()->toString();
-    }
-    // Convert to string for field storage.
-    $storage = json_encode($computed_return);
-    $entity->field_banner_alert_computdvalues->setValue(['value' => $storage]);
-  }
 }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -88,12 +88,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
       [':date1' => $date1, ':date2' => $date2]);
     }
   }
-  if ($form_id === 'node_full_width_banner_alert_edit_form') {
-    // Hide send email field because this form will only send an email once.
-    // @todo Consider disabling it instead of hiding it. And/or:
-    // @todo Check node revisions and disable this field if node has ever been published.
-    $form['field_operating_status_sendemail']['#attributes']['class'] = 'hidden';
-  }
+
   if ($form_id === 'node_vamc_operating_status_and_alerts_edit_form') {
     // Hide field_office for existing operating statuses: they won't be moved.
     // @todo Consider disabling it instead of hiding it.

--- a/docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
+++ b/docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Drupal\va_gov_govdelivery\Service;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Class for processing facility status to GovDelivery Bulletin.
+ */
+class ProcessStatusBulletin {
+
+  private $node;
+  private $situationUpdate = NULL;
+
+  private $sendType;
+
+  /**
+   * ProcessStatusBulletin constructor.
+   */
+  public function __construct() {
+
+  }
+
+  /**
+   * Triggers the process for the whole thing.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node object.
+   */
+  public function processNode(NodeInterface $node) {
+    $this->node = $node;
+    $this->setSendType();
+    $this->published = $node->status;
+    if ($this->sendType === 'status alert') {
+      $queue_id = "{$node->get('nid')->value}-alert";
+      // Pull the data from the alert fields.
+      $body = $node->get('field_body')->getString();
+      $type = $node->get("field_alert_type")->getString();
+      $header = $node->get("fieldName")->getString();
+      $footer = $node->get("fieldName")->getString();
+      $subject = $node->get('title')->getString();
+      // @TODO  get the time the alert was saved.
+    }
+    elseif ($this->sendType === 'situation update') {
+      // Might be multiples, use this to dedupe so that only the last one goes.
+      $queue_id = "{$node->get('nid')->value}-update";
+      // Pull the data from the situation update fields $this->situationUpdate.
+      $time = $this->situationUpdate->get('field_date_and_time')->value;
+      $body = $this->situationUpdate->get('field_wysiwyg')->value;
+      $type = $node->get("field_alert_type")->getString();
+      $header = '';
+      $footer = '';
+      $subject = "{$node->get('title')->getString()} - Situation Update";
+    }
+
+    if (!empty($this->sendType)) {
+      $vmacs_data = reset($node->get('field_banner_alert_computdvalues')->getValue());
+      $vmacs = !empty($vmacs_data['value']) ? json_decode($vmacs_data['value']) : [];
+
+      // Loop through the VMACs since each title will be VAMC specific.
+      foreach ($vmacs as $vmac) {
+        $vamc_title = $vmac->vamc_title;
+        $vamc_path = $vmac->vamc_path;
+        $vamc_op_status_path = $vmac->vamc_op_status_path;
+        // Add the item to queue.
+        \Drupal::service('govdelivery_bulletins.add_bulletin_to_queue')
+          ->setFlag('dedupe', TRUE)
+          ->setQueueUid($queue_id)
+          // @TODO run body through a twig template.
+          ->setBody($body)
+          ->setFooter($footer)
+          ->setFromAddress('us@example.org')
+          ->setGovDeliveryID('some_unique_id')
+          ->setHeader($header)
+          // @TODO make subject VMAC specific.
+          ->setSubject("{$type}: {$vmac->vamc_title} {$subject}")
+          // ->setSMSBody('Some text SMS text.')
+          ->addTopic($vmac->vamc_topic_id)
+          ->setXmlBool('click_tracking', FALSE)
+          ->setXmlBool('open_tracking', FALSE)
+          ->setXmlBool('publish_rss', FALSE)
+          ->setXmlBool('share_content_enabled', TRUE)
+          ->setXmlBool('urgent', FALSE)
+          ->addToQueue();
+      }
+    }
+  }
+
+  /**
+   * Set the value of sendType.  Will only be set if something should be sent.
+   */
+  private function setSendType() {
+    $sendType = FALSE;
+    // If field_operating_status_sendemail is checked AND it is the first save
+    // (no original) then it is a status alert.
+    $original = $this->node->original;
+    $published = $this->node->isPublished();
+
+    $first_save = (empty($this->node->original)) ? TRUE : FALSE;
+    $send_status_email = $this->node->get('field_operating_status_sendemail')->value;
+    $first_save_published = ($first_save && $published);
+    $just_updated_to_published = (!$first_save && $published && !$this->node->original->isPublished());
+
+    if ($send_status_email) {
+      // The node is set to send email.
+      if ($first_save_published || $just_updated_to_published) {
+        // This is the first that the node has been published, should be queued
+        // as a status update.
+        $sendType = 'status alert';
+      }
+      else {
+        // Look for a new situation update that needs to be sent.
+        // Grab the last situation update from the array of updates.
+        // Risk: Assumes only the last one might need to be sent.
+        $situationUpdatesList = $this->node->get('field_situation_updates')->referencedEntities();
+        $situationUpdatesLast = end($situationUpdatesList);
+
+        $situation_update_send = (!empty($situationUpdatesLast)) ? $situationUpdatesLast->get('field_send_email_to_subscribers')->value : FALSE;
+        if ($situation_update_send) {
+          // This should be sent or was already sent.
+          $situation_update_id = (!empty($situationUpdatesLast)) ? $situationUpdatesLast->get('id')->value : FALSE;
+          // Need to see if the original situation update is not a match.
+          // If it is NOT a match, this needs to be sent.
+          $situationUpdatesListOriginal = $this->node->original->get('field_situation_updates')->referencedEntities();
+          $situationUpdatesLastOriginal = end($situationUpdatesListOriginal);
+          $situation_update_id_original = (!empty($situationUpdatesLastOriginal)) ? $situationUpdatesLastOriginal->get('id')->value : FALSE;
+          if ($situation_update_id !== $situation_update_id_original) {
+            // This is a new situation update that needs to be sent.
+            $this->situationUpdate = $situationUpdatesLast;
+            $sendType = 'situation update';
+          }
+        }
+
+      }
+    }
+
+    $this->sendType = $sendType;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
+++ b/docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
@@ -36,8 +36,8 @@ class ProcessStatusBulletin {
       // Pull the data from the alert fields.
       $body = $node->get('field_body')->getString();
       $type = $node->get("field_alert_type")->getString();
-      $header = $node->get("fieldName")->getString();
-      $footer = $node->get("fieldName")->getString();
+      $header = '';
+      $footer = '';
       $subject = $node->get('title')->getString();
       // @TODO  get the time the alert was saved.
     }
@@ -54,8 +54,10 @@ class ProcessStatusBulletin {
     }
 
     if (!empty($this->sendType)) {
-      $vmacs_data = reset($node->get('field_banner_alert_computdvalues')->getValue());
-      $vmacs = !empty($vmacs_data['value']) ? json_decode($vmacs_data['value']) : [];
+
+      $vmacs_data = $node->get('field_banner_alert_computdvalues')->getValue();
+      $vmacs_datum = reset($vmacs_data);
+      $vmacs = !empty($vmacs_datum['value']) ? json_decode($vmacs_datum['value']) : [];
 
       // Loop through the VMACs since each title will be VAMC specific.
       foreach ($vmacs as $vmac) {

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.info.yml
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.info.yml
@@ -4,4 +4,4 @@ package: 'Custom'
 type: module
 core: 8.x
 dependencies:
-  - gov_delivery_bulletins:gov_delivery_bulletins
+  - govdelivery_bulletins:govdelivery_bulletins

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.info.yml
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.info.yml
@@ -1,0 +1,7 @@
+name: VA GovDelivery
+description: Provides customization to send bulletins through GovDelivery.
+package: 'Custom'
+type: module
+core: 8.x
+dependencies:
+  - gov_delivery_bulletins:gov_delivery_bulletins

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
@@ -5,31 +5,42 @@
  * Module hooks for va_gov_govdelivery module.
  */
 
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_presave().
  */
-function va_gov_govdelivery_node_presave(EntityInterface $entity) {
+function va_gov_govdelivery_node_presave(NodeInterface $node) {
   // Make sure we are dealing with correct content type.
-  if ($entity->getType() === ' full_width_banner_alert') {
+  if ($node->getType() === ' full_width_banner_alert') {
     // Build computed field array on banner alert nodes.
-    _va_gov_govdelivery_build_alert_computed_field_data($entity);
+    _va_gov_govdelivery_build_alert_computed_field_data($node);
+    _va_gov_add_bulletin_to_queue($node);
   }
+}
+
+/**
+ * Adds an alert or situation update to bulletin queue.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node entity containing the data to add to queue.
+ */
+function _va_gov_add_bulletin_to_queue(NodeInterface $node) {
+
 }
 
 /**
  * Populates computed field on banner alert nodes.
  *
- * @param \Drupal\Core\Entity\EntityInterface $entity
+ * @param \Drupal\node\NodeInterface $node
  *   The node object.
  */
-function _va_gov_govdelivery_build_alert_computed_field_data(EntityInterface $entity) {
+function _va_gov_govdelivery_build_alert_computed_field_data(NodeInterface $node) {
   // Make sure it's a node.
-  if ($entity instanceof NodeInterface && $entity->bundle() === 'full_width_banner_alert') {
+  if ($node instanceof NodeInterface && $node->bundle() === 'full_width_banner_alert') {
 
     // This is where we get our Operating status node id's.
-    $vamcs_op_status_ids = $entity->get('field_banner_alert_vamcs')->getValue();
+    $vamcs_op_status_ids = $node->get('field_banner_alert_vamcs')->getValue();
     foreach ($vamcs_op_status_ids as $key => $vamcs_op_status_id) {
       $vamcs_op_status_ids[$key] = !empty($vamcs_op_status_id['target_id']) ? $vamcs_op_status_id['target_id'] : '';
     }
@@ -55,6 +66,6 @@ function _va_gov_govdelivery_build_alert_computed_field_data(EntityInterface $en
     }
     // Convert to string for field storage.
     $storage = json_encode($computed_return);
-    $entity->field_banner_alert_computdvalues->setValue(['value' => $storage]);
+    $node->field_banner_alert_computdvalues->setValue(['value' => $storage]);
   }
 }

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
@@ -6,27 +6,39 @@
  */
 
 use Drupal\node\NodeInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_presave().
  */
 function va_gov_govdelivery_node_presave(NodeInterface $node) {
   // Make sure we are dealing with correct content type.
-  if ($node->getType() === ' full_width_banner_alert') {
+  $original = $node->original;
+  $original_alert = $original->get('field_alert_type')->value;
+  $new_alert = $node->get('field_alert_type')->value;
+  if ($node->getType() === 'full_width_banner_alert') {
     // Build computed field array on banner alert nodes.
     _va_gov_govdelivery_build_alert_computed_field_data($node);
-    _va_gov_add_bulletin_to_queue($node);
+    $bulletin = \Drupal::service('va_gov_govdelivery.process_status_bulletin')
+      ->processNode($node);
   }
 }
 
 /**
- * Adds an alert or situation update to bulletin queue.
- *
- * @param \Drupal\node\NodeInterface $node
- *   The node entity containing the data to add to queue.
+ * Implements hook_form_alter().
  */
-function _va_gov_add_bulletin_to_queue(NodeInterface $node) {
+function va_gov_govdelivery_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id === 'node_full_width_banner_alert_edit_form') {
+    $node = $form_state->getFormObject()->getEntity();
+    $state = $node->moderation_state->value;
+    if ($state === 'published') {
+      // Disable send email field, this form will only send initial email once.
+      // @todo Check node revisions in addition to current state, disable this
+      // field if it was ever published.
+      $form['field_operating_status_sendemail']['widget']['#disabled'] = TRUE;
+    }
 
+  }
 }
 
 /**
@@ -38,7 +50,6 @@ function _va_gov_add_bulletin_to_queue(NodeInterface $node) {
 function _va_gov_govdelivery_build_alert_computed_field_data(NodeInterface $node) {
   // Make sure it's a node.
   if ($node instanceof NodeInterface && $node->bundle() === 'full_width_banner_alert') {
-
     // This is where we get our Operating status node id's.
     $vamcs_op_status_ids = $node->get('field_banner_alert_vamcs')->getValue();
     foreach ($vamcs_op_status_ids as $key => $vamcs_op_status_id) {

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @file
+ * Module hooks for va_gov_govdelivery module.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function va_gov_govdelivery_node_presave(EntityInterface $entity) {
+  // Make sure we are dealing with correct content type.
+  if ($entity->getType() === ' full_width_banner_alert') {
+    // Build computed field array on banner alert nodes.
+    _va_gov_govdelivery_build_alert_computed_field_data($entity);
+  }
+}
+
+/**
+ * Populates computed field on banner alert nodes.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The node object.
+ */
+function _va_gov_govdelivery_build_alert_computed_field_data(EntityInterface $entity) {
+  // Make sure it's a node.
+  if ($entity instanceof NodeInterface && $entity->bundle() === 'full_width_banner_alert') {
+
+    // This is where we get our Operating status node id's.
+    $vamcs_op_status_ids = $entity->get('field_banner_alert_vamcs')->getValue();
+    foreach ($vamcs_op_status_ids as $key => $vamcs_op_status_id) {
+      $vamcs_op_status_ids[$key] = !empty($vamcs_op_status_id['target_id']) ? $vamcs_op_status_id['target_id'] : '';
+    }
+    // Get a node storage object.
+    $node_storage = \Drupal::entityManager()->getStorage('node');
+
+    $vamc_office_values = [];
+    $computed_return = [];
+    $vamc_op_nodes = $node_storage->loadMultiple($vamcs_op_status_ids);
+
+    // Get out op status page paths.
+    foreach ($vamc_op_nodes as $key => $vamc_op_node) {
+      $computed_return[$key]['vamc_op_status_path'] = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $vamc_op_node->id());
+      $vamc_office_values[] = $vamc_op_node->get('field_office')->getString();
+    }
+
+    // Grab what we need from our vamcs.
+    $vamc_system_nodes = $node_storage->loadMultiple($vamc_office_values);
+    foreach ($vamc_system_nodes as $key => $vamc_system_node) {
+      $computed_return[$key]['vamc_topic_id'] = !empty($vamc_system_node->get('field_govdelivery_id_emerg')->getString()) ? $vamc_system_node->get('field_govdelivery_id_emerg')->getString() : '';
+      $computed_return[$key]['vamc_title'] = $vamc_system_node->getTitle();
+      $computed_return[$key]['vamc_path'] = $vamc_system_node->toUrl()->toString();
+    }
+    // Convert to string for field storage.
+    $storage = json_encode($computed_return);
+    $entity->field_banner_alert_computdvalues->setValue(['value' => $storage]);
+  }
+}

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
@@ -13,9 +13,6 @@ use Drupal\Core\Form\FormStateInterface;
  */
 function va_gov_govdelivery_node_presave(NodeInterface $node) {
   // Make sure we are dealing with correct content type.
-  $original = $node->original;
-  $original_alert = $original->get('field_alert_type')->value;
-  $new_alert = $node->get('field_alert_type')->value;
   if ($node->getType() === 'full_width_banner_alert') {
     // Build computed field array on banner alert nodes.
     _va_gov_govdelivery_build_alert_computed_field_data($node);
@@ -30,14 +27,12 @@ function va_gov_govdelivery_node_presave(NodeInterface $node) {
 function va_gov_govdelivery_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form_id === 'node_full_width_banner_alert_edit_form') {
     $node = $form_state->getFormObject()->getEntity();
-    $state = $node->moderation_state->value;
-    if ($state === 'published') {
+    if ($node->isPublished() || ($node->moderation_state->value === 'published')) {
       // Disable send email field, this form will only send initial email once.
       // @todo Check node revisions in addition to current state, disable this
       // field if it was ever published.
       $form['field_operating_status_sendemail']['widget']['#disabled'] = TRUE;
     }
-
   }
 }
 
@@ -58,18 +53,19 @@ function _va_gov_govdelivery_build_alert_computed_field_data(NodeInterface $node
     // Get a node storage object.
     $node_storage = \Drupal::entityManager()->getStorage('node');
 
-    $vamc_office_values = [];
+    $vamc_office_nids = [];
     $computed_return = [];
     $vamc_op_nodes = $node_storage->loadMultiple($vamcs_op_status_ids);
 
     // Get out op status page paths.
     foreach ($vamc_op_nodes as $key => $vamc_op_node) {
-      $computed_return[$key]['vamc_op_status_path'] = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $vamc_op_node->id());
-      $vamc_office_values[] = $vamc_op_node->get('field_office')->getString();
+      $vamc_office_nid = $vamc_op_node->get('field_office')->getString();
+      $computed_return[$vamc_office_nid]['vamc_op_status_path'] = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $vamc_op_node->id());
+      $vamc_office_nids[] = $vamc_office_nid;
     }
 
     // Grab what we need from our vamcs.
-    $vamc_system_nodes = $node_storage->loadMultiple($vamc_office_values);
+    $vamc_system_nodes = $node_storage->loadMultiple($vamc_office_nids);
     foreach ($vamc_system_nodes as $key => $vamc_system_node) {
       $computed_return[$key]['vamc_topic_id'] = !empty($vamc_system_node->get('field_govdelivery_id_emerg')->getString()) ? $vamc_system_node->get('field_govdelivery_id_emerg')->getString() : '';
       $computed_return[$key]['vamc_title'] = $vamc_system_node->getTitle();

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.services.yml
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.services.yml
@@ -1,0 +1,4 @@
+services:
+  va_gov_govdelivery.process_status_bulletin:
+    class: Drupal\va_gov_govdelivery\Service\ProcessStatusBulletin
+    arguments: []

--- a/tests/phpunit/SecurityRolesPermissionsTest.php
+++ b/tests/phpunit/SecurityRolesPermissionsTest.php
@@ -47,6 +47,7 @@ class SecurityRolesPermissions extends ExistingSiteBase {
       [
         'anonymous',
         [
+          'access bulletin queue trigger api',
           'access content',
           'access site-wide contact form',
           'view media',


### PR DESCRIPTION
This has a lot of items affected and does not fully get the queue working but it does the following:

1. Removes workbench moderation from the full_width_banner_alert content type.
1. Disables the send email checkbox upon node being published
![image](https://user-images.githubusercontent.com/5752113/70368545-e7f62880-1879-11ea-88c4-aff34e934edd.png)

2. Utilizes the  "publish" checkbox 
![image](https://user-images.githubusercontent.com/5752113/70368563-39061c80-187a-11ea-9602-b2219241afc2.png)

3. removes the publish checkbox from situation update paragraph.
![image](https://user-images.githubusercontent.com/5752113/70368556-0a884180-187a-11ea-8645-a7630db398b4.png)

4. Adds the logic to decide when to queue  status alert bulletins and when to queue a situation update bulletin.
5.  Logging of adding items to the queue.
![image](https://user-images.githubusercontent.com/5752113/70368590-94d0a580-187a-11ea-8861-09279ad69835.png)

6. Adds all current features of govdelivery_bulletins (perms, queue adding, configuration killswitches, endpoint triggering)
https://www.drupal.org/project/issues/govdelivery_bulletins?status=7
7. Can visit /api/govdelivery_bulletins/queue?EndTime=1234567899 to get a 200 response if the EndTime timestamp is valid.
**Valid**
![image](https://user-images.githubusercontent.com/5752113/70368633-22ac9080-187b-11ea-8688-8337917c874c.png)

**Not valid**
![image](https://user-images.githubusercontent.com/5752113/70368643-5091d500-187b-11ea-8835-a176f5631712.png)

**Not present**
![image](https://user-images.githubusercontent.com/5752113/70368656-79b26580-187b-11ea-8482-64822934ea51.png)


What is does NOT do.
1 Actually process the queue (no sending, no clearing out of the queue.
https://www.drupal.org/project/issues/govdelivery_bulletins?
2. Formatting content if the email message with twig templates.
3.  automated testing.
