### PR TITLE
VAGOV-5991: Restoring field_alert_inheritance_subpages on banner

### DIFF
--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.full_width_banner_alert.field_alert_dismissable
     - field.field.node.full_width_banner_alert.field_alert_email_updates_button
     - field.field.node.full_width_banner_alert.field_alert_find_facilities_cta
+    - field.field.node.full_width_banner_alert.field_alert_inheritance_subpages
     - field.field.node.full_width_banner_alert.field_alert_operating_status_cta
     - field.field.node.full_width_banner_alert.field_alert_type
     - field.field.node.full_width_banner_alert.field_banner_alert_computdvalues
@@ -28,7 +29,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -45,7 +46,7 @@ third_party_settings:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         id: ''
@@ -57,7 +58,7 @@ third_party_settings:
     group_alert_display_and_behavior:
       children: {  }
       parent_name: ''
-      weight: 13
+      weight: 14
       format_type: details
       format_settings:
         id: ''
@@ -88,6 +89,7 @@ third_party_settings:
     group_type:
       children:
         - field_banner_alert_vamcs
+        - field_alert_inheritance_subpages
         - field_operating_status_sendemail
       parent_name: ''
       weight: 0
@@ -104,7 +106,7 @@ third_party_settings:
       children:
         - field_situation_updates
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: details
       format_settings:
         description: ''
@@ -118,7 +120,7 @@ third_party_settings:
       children:
         - field_banner_alert_situationinfo
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: details
       format_settings:
         description: 'For "static" situation information that is additional to any situation updates.'
@@ -175,6 +177,13 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
+  field_alert_inheritance_subpages:
+    weight: 3
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_alert_operating_status_cta:
     weight: 6
     settings:
@@ -211,7 +220,7 @@ content:
     type: text_textarea
     region: content
   field_operating_status_sendemail:
-    weight: 3
+    weight: 4
     settings:
       display_label: true
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_view_display.node.full_width_banner_alert.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.full_width_banner_alert.field_alert_dismissable
     - field.field.node.full_width_banner_alert.field_alert_email_updates_button
     - field.field.node.full_width_banner_alert.field_alert_find_facilities_cta
+    - field.field.node.full_width_banner_alert.field_alert_inheritance_subpages
     - field.field.node.full_width_banner_alert.field_alert_operating_status_cta
     - field.field.node.full_width_banner_alert.field_alert_type
     - field.field.node.full_width_banner_alert.field_banner_alert_computdvalues
@@ -84,6 +85,16 @@ content:
     region: content
   field_alert_find_facilities_cta:
     weight: 9
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_alert_inheritance_subpages:
+    weight: 14
     label: above
     settings:
       format: default

--- a/config/sync/field.field.node.full_width_banner_alert.field_alert_inheritance_subpages.yml
+++ b/config/sync/field.field.node.full_width_banner_alert.field_alert_inheritance_subpages.yml
@@ -1,0 +1,23 @@
+uuid: f0d9c163-e0d8-4a45-9b24-940a34543430
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_alert_inheritance_subpages
+    - node.type.full_width_banner_alert
+id: node.full_width_banner_alert.field_alert_inheritance_subpages
+field_name: field_alert_inheritance_subpages
+entity_type: node
+bundle: full_width_banner_alert
+label: 'Only show on VAMC System Page & Operating Status Page'
+description: 'By checking this box, you will limit the alert display to only the VAMC System Page.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.node.field_alert_inheritance_subpages.yml
+++ b/config/sync/field.storage.node.field_alert_inheritance_subpages.yml
@@ -1,0 +1,18 @@
+uuid: ce167494-4b1a-40b5-b558-72b23f7cd8be
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_alert_inheritance_subpages
+field_name: field_alert_inheritance_subpages
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model.feature
+++ b/tests/behat/drupal-spec-tool/content_model.feature
@@ -249,6 +249,7 @@ Feature: Content model
 | Content type | VAMC system banner alert with situation updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Subscribe to email updates" link? | field_alert_email_updates_button | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Find other VA facilities near you" link? | field_alert_find_facilities_cta | Boolean |  | 1 | Single on/off checkbox |  |
+| Content type | VAMC system banner alert with situation updates | Only show on VAMC System Page & Operating Status Page | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Computed values for alerts | field_banner_alert_computdvalues | Computed (text, long) |  | 1 | -- Disabled -- |  |
 | Content type | VAMC system banner alert with situation updates | Display "Get updates on affected services and facilities" link | field_alert_operating_status_cta | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Alert type | field_alert_type | List (text) | Required | 1 | Select list |  |


### PR DESCRIPTION
## What this does
- Recreates https://github.com/department-of-veterans-affairs/va.gov-cms/pull/721 = adds `Only show on VAMC System Page & Operating Status Page` boolean to banner content type.

## QA
 - [ ] Go to `admin/structure/types/manage/full_width_banner_alert/form-display` and visually verify `Only show on VAMC System Page & Operating Status Page` boolean appears in `Where will this banner appear?` fieldset

## Screenshot
![image](https://user-images.githubusercontent.com/2404547/70472593-5d8e0e80-1a9d-11ea-9e6a-bb99e83ade53.png)
