### PR TITLE
Revert "Disable automatic STAGING deploys temporarily"

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -51,23 +51,22 @@ pipeline {
         ] , wait: false
       }
     }
-// Commenting out temporarily for User Testing on STAGING. This should be reenabled around Tuesday Dec. 10th, 2019.
-//
-//    stage('Deploy to staging') {
-//      when {
-//        expression {
-//          !shouldBail()
-//        }
-//      }
-//      steps {
-//        build job: "deploys/cms-vagov-staging", parameters: [
-//          stringParam(name: 'app', value: 'cms'),
-//          booleanParam(name: 'notify_slack', value: true),
-//          stringParam(name: 'ref', value: commit),
-//          booleanParam(name: 'migration_status', value: false)
-//        ] , wait: false
-//      }
-//    }
+
+    stage('Deploy to staging') {
+      when {
+        expression {
+          !shouldBail()
+        }
+      }
+      steps {
+        build job: "deploys/cms-vagov-staging", parameters: [
+          stringParam(name: 'app', value: 'cms'),
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: commit),
+          booleanParam(name: 'migration_status', value: false)
+        ] , wait: false
+      }
+    }
   }
   post {
     always {


### PR DESCRIPTION
Reverts department-of-veterans-affairs/va.gov-cms#754

We are clear to re-enable CD to STAGING now. 