### PR TITLE
VAGOV-5133 Unhide password reset tab, email sending works now.

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -1,7 +1,7 @@
 uuid: 45814d2f-3e31-4878-aa12-733ea60ff326
-name: 'Veterans Affairs'
+name: 'VA.gov CMS'
 mail: vacmssupport@va.gov
-slogan: 'VA.gov CMS'
+slogan: 'Department of Veterans Affairs'' Content Management System (CMS)'
 page:
   403: /user/login
   404: ''

--- a/docroot/modules/custom/va_gov_login/va_gov_login.module
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.module
@@ -18,15 +18,6 @@ function va_gov_login_form_alter(&$form, &$form_state, $form_id) {
 }
 
 /**
- * Implements hook_local_tasks_alter().
- */
-function va_gov_login_menu_local_tasks_alter(&$data, $route_name) {
-  if ($route_name == 'user.login') {
-    $data['tabs'][0]['user.pass']['#access'] = FALSE;
-  }
-}
-
-/**
  * Implements hook_simplesamlphp_auth_existing_user().
  *
  * @see hook_simplesamlphp_auth_existing_user()

--- a/tests/behat/features/user.feature
+++ b/tests/behat/features/user.feature
@@ -1,9 +1,9 @@
-Feature: The VA Website is accesible to users.
+Feature: The VA Website is accessible to users.
 
 @api @errors @user
   Scenario: The homepage is the log in form and the site title is as intended.
     Given I am on the homepage
     Then I should see "Log in"
-    And I should see "Veterans Affairs" in the "title" element
+    And I should see "VA.gov CMS" in the "title" element
     And I should see "Login with PIV or other Smartcard." in the "#edit-simplesamlphp-auth-login-link" element
     Then print current URL


### PR DESCRIPTION
VAGOV-5133

To test on BRD environments (CI doesn't work just yet) you must set the users email to something, as they are all empty by default on DEV/STAGING due to DB sanitization. PROD should work out of the box now.

The sitename in this PR changes it from "Veterans Affairs" to "VA.gov CMS". 