### PR TITLE
VAGOV-6375: Enabling vamc menus on detail content type.

### DIFF
--- a/config/sync/node.type.health_care_region_detail_page.yml
+++ b/config/sync/node.type.health_care_region_detail_page.yml
@@ -9,7 +9,15 @@ third_party_settings:
   menu_ui:
     available_menus:
       - outreach-and-events
+      - va-altoona-health-care
+      - va-butler-health-care
+      - va-coatesville-health-care
+      - va-erie-health-care
+      - va-lebanon
+      - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-wilkes-barre-health-care
+      - va-wilmington-health-care
     parent: 'pittsburgh-health-care:'
   node_title_help_text:
     title_help: 'This appears as the h1 to visitors of the page. <a href="https://design.va.gov/content-style-guide/page-titles-and-section-titles" target="_blank">Use sentence case</a>. '


### PR DESCRIPTION
## What this does
 - Enables all VAMC system menus on detail pages

## How to test
 - Go to `admin/structure/types/manage/health_care_region_detail_page` click the menu tab and visually verify that all VAMC systems are checked (in addition to outreach menu).

## Screenshot
![image](https://user-images.githubusercontent.com/2404547/71845114-9669d500-3095-11ea-9dd1-12d658d620f4.png)
