### PR TITLE
VACMS-836: Specify VACMS instead of VAGOV for branch naming.

### DIFF
--- a/hooks/git/pre-commit
+++ b/hooks/git/pre-commit
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Regular expression to validate that the branch name starts with Jira story ID, e.g. VAGOV-000-
-commit_regex='(VAGOV-[0-9]+)'
+commit_regex='(VACMS-[0-9]+)'
 branch_name=$(git rev-parse --abbrev-ref HEAD)
-error_msg="Aborting commit. Your branch must start start with a VAGOV-* Jira issue number format, e.g. 'VAGOV-123 or VAGOV-123-issue-name. Use \`git branch --move <VAGOV-000-new-name>\` to rename."
+error_msg="Aborting commit. Your branch must start start with a VACMS-* Github issue number format, e.g. 'VACMS-123 or VACMS-123-issue-name. Use \`git branch --move <VACMS-000-new-name>\` to rename."
 
 if ! grep --ignore-case --quiet --extended-regexp "${commit_regex}" <<< "${branch_name}"; then
     echo "${error_msg}" >&2


### PR DESCRIPTION
Don't merge this yet! I think we should merge this sometime next week when we officially make the change to github for issues.