### PR TITLE
VAGOV-6236

### DIFF
--- a/config/sync/views.view.health_service_offerings.yml
+++ b/config/sync/views.view.health_service_offerings.yml
@@ -259,7 +259,7 @@ display:
           exposed: true
           expose:
             operator_id: title_op
-            label: Title
+            label: 'Filter by VAMC system'
             description: ''
             use_operator: false
             operator: title_op

--- a/config/sync/views.view.health_service_offerings.yml
+++ b/config/sync/views.view.health_service_offerings.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_region_page
     - node.type.regional_health_care_service_des
   module:
     - content_moderation
@@ -245,6 +246,56 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: field_region_page
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              vamc_content_creator: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
       sorts:
         field_regional_health_service_target_id:
           id: field_regional_health_service_target_id
@@ -295,6 +346,15 @@ display:
           required: false
           entity_type: node
           plugin_id: entity_reverse
+        field_region_page:
+          id: field_region_page
+          table: node__field_region_page
+          field: field_region_page
+          relationship: none
+          group_type: group
+          admin_label: 'field_region_page: Content'
+          required: false
+          plugin_id: standard
       arguments: {  }
       display_extenders: {  }
     cache_metadata:
@@ -302,6 +362,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -314,6 +375,69 @@ display:
     display_options:
       display_extenders: {  }
       fields:
+        field_region_page:
+          id: field_region_page
+          table: node__field_region_page
+          field: field_region_page
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Region page'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         name:
           id: name
           table: taxonomy_term_field_data
@@ -321,7 +445,7 @@ display:
           relationship: field_service_name_and_descripti
           group_type: group
           admin_label: ''
-          label: 'National health service taxonomy'
+          label: 'VHA HQ Health Service Taxonomy'
           exclude: false
           alter:
             alter_text: false
@@ -440,11 +564,11 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'Regional offering'
+          label: 'VAMC System Health Service Description'
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ title }} at {{ field_region_page }}'
             make_link: false
             path: ''
             absolute: false
@@ -621,7 +745,7 @@ display:
           relationship: reverse__node__field_regional_health_service
           group_type: group
           admin_label: ''
-          label: 'Local facility offering'
+          label: 'VAMC Facility Health Service Description'
           exclude: false
           alter:
             alter_text: false
@@ -803,7 +927,9 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_region_page'

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -66,7 +66,7 @@ function va_gov_backend_form_views_exposed_form_alter(&$form, FormStateInterface
   $form['title']['#multiple'] = FALSE;
 
   // Specify the empty option for our select list.
-  $form['title']['#empty_option'] = t('VAMC');
+  $form['title']['#empty_option'] = t('Filter by VAMC system');
 
   // Add the $options from above to our select list.
   $form['title']['#options'] = $options;

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -66,7 +66,7 @@ function va_gov_backend_form_views_exposed_form_alter(&$form, FormStateInterface
   $form['title']['#multiple'] = FALSE;
 
   // Specify the empty option for our select list.
-  $form['title']['#empty_option'] = t('Filter by VAMC system');
+  $form['title']['#empty_option'] = t('VAMC');
 
   // Add the $options from above to our select list.
   $form['title']['#options'] = $options;

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -32,10 +32,52 @@ function va_gov_backend_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
+ * Implements hook_form_FORMID_alter().
+ */
+function va_gov_backend_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form['#id'] !== 'views-exposed-form-health-service-offerings-page-1') {
+    return FALSE;
+  }
+  // Query nodes.
+  $storage = Drupal::getContainer()->get('entity_type.manager')->getStorage('node');
+  $nids = $storage->getQuery();
+
+  // Gather vamc nodes and sort by title.
+  $nids = $nids->condition('type', 'health_care_region_page')
+    ->sort('title')
+    ->execute();
+
+  // If there are no nodes, move on.
+  if (!$nids) {
+    return FALSE;
+  }
+
+  // Start building out the options for our select list.
+  $options = [];
+  $nodes = $storage->loadMultiple($nids);
+
+  // Push titles into select list.
+  foreach ($nodes as $node) {
+    $options[$node->getTitle()] = $node->getTitle();
+  }
+
+  // Start building out our replacement form element.
+  $form['title']['#type'] = 'select';
+  $form['title']['#multiple'] = FALSE;
+
+  // Specify the empty option for our select list.
+  $form['title']['#empty_option'] = t('VAMC');
+
+  // Add the $options from above to our select list.
+  $form['title']['#options'] = $options;
+  unset($form['title']['#size']);
+
+}
+
+/**
  * Implements hook_form_alter().
  */
 function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-
   if ($form_id === 'redirect_redirect_edit_form' || $form_id === 'redirect_redirect_form') {
     $value = 'prefix';
     if ($form_id === 'redirect_redirect_edit_form') {

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -35,9 +35,20 @@ function va_gov_backend_help($route_name, RouteMatchInterface $route_match) {
  * Implements hook_form_FORMID_alter().
  */
 function va_gov_backend_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if ($form['#id'] !== 'views-exposed-form-health-service-offerings-page-1') {
-    return FALSE;
+
+  if ($form['#id'] === 'views-exposed-form-health-service-offerings-service-offerings-dash') {
+    // Change our textfield to a dropdown displaying all VAMC systems.
+    _va_gov_backend_add_vamc_regions_select($form);
   }
+}
+
+/**
+ * AChange text input to select list of VAMC systems.
+ *
+ * @param array $form
+ *   The exposed widget form array.
+ */
+function _va_gov_backend_add_vamc_regions_select(array &$form) {
   // Query nodes.
   $storage = Drupal::getContainer()->get('entity_type.manager')->getStorage('node');
   $nids = $storage->getQuery();
@@ -71,7 +82,6 @@ function va_gov_backend_form_views_exposed_form_alter(&$form, FormStateInterface
   // Add the $options from above to our select list.
   $form['title']['#options'] = $options;
   unset($form['title']['#size']);
-
 }
 
 /**


### PR DESCRIPTION
## What this does
 - Changes table header text, appends system name to services in column 2, and adds a vamc system filter dropdown to view found, here: `health-service-offerings`

## QA
 - Visit `health-service-offerings` as admin.
 - Visually verify that headers match screenshot
 - Visually verify that column 2 items are appended with system name (e.g. `Addiction and substance abuse treatment at VA Altoona health care`)
 - Go to `node/324/edit` and change VAMC system to VA Altoona health care
 - Go back to `health-service-offerings` and filter by VA Altoona health care
 - Visually verify that node 324 appears in filtered results.

## Screenshot
![image](https://user-images.githubusercontent.com/2404547/72846788-42ebaf80-3c6f-11ea-82be-90fec418cf16.png)
