### PR TITLE
VAGOV-1738: Adding excluded type logic for previews.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -87,9 +87,17 @@ function va_gov_build_trigger_preprocess_page(&$variables) {
     // It's a node.
     $path = \Drupal::request()->getpathInfo();
     $arg = explode('/', $path);
-
-    // Make sure we aren't on the node form.
-    if (empty($arg[1]) || empty($arg[2]) || $arg[1] !== 'node' && !is_numeric($arg[2])) {
+    $exclusion_types = [
+      'outreach_asset',
+      'person_profile',
+      'support_service',
+      'regional_health_care_service_des',
+      'health_care_local_health_service',
+    ];
+    // Make sure we aren't on the node form or an excluded type.
+    if ((empty($arg[1]) || empty($arg[2]) || $arg[1] !== 'node') &&
+     (!is_numeric($arg[2])) &&
+      (!in_array($node->bundle(), $exclusion_types))) {
       // Make sure we aren't on /training-guide.
       $current_uri = \Drupal::request()->getRequestUri();
       if ($current_uri !== '/training-guide') {

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -95,8 +95,8 @@ function va_gov_build_trigger_preprocess_page(&$variables) {
       'health_care_local_health_service',
     ];
     // Make sure we aren't on the node form or an excluded type.
-    if ((empty($arg[1]) || empty($arg[2]) || $arg[1] !== 'node') &&
-     (!is_numeric($arg[2])) &&
+    $route_name = \Drupal::routeMatch()->getRouteName();
+    if (($route_name !== 'entity.node.edit_form') &&
       (!in_array($node->bundle(), $exclusion_types))) {
       // Make sure we aren't on /training-guide.
       $current_uri = \Drupal::request()->getRequestUri();


### PR DESCRIPTION
## What this does
  - Removes "Preview" button from node view page for 5 node types.

## QA
  - Go to `admin/content`
  - Visit the node view page and confirm "Preview" button does not appear for 1 of each type:

1. outreach_asset
2. person_profile
3. support_service
4. regional_health_care_service_des
5. health_care_local_health_service