### PR TITLE
VAGOV-877: Adding title to event breadcrumb alias.

### DIFF
--- a/config/sync/pathauto.pattern.event.yml
+++ b/config/sync/pathauto.pattern.event.yml
@@ -7,16 +7,16 @@ dependencies:
 id: event
 label: Events
 type: 'canonical_entities:node'
-pattern: '[node:field_office:entity:url:path]/events'
+pattern: '[node:field_office:entity:url:path]/events/[node:title]'
 selection_criteria:
-  8058b0db-0d30-4662-9931-0804f29a6036:
+  205e1830-7588-486c-95b1-f91f33592e62:
     id: node_type
     bundles:
       event: event
     negate: false
     context_mapping:
       node: node
-    uuid: 8058b0db-0d30-4662-9931-0804f29a6036
+    uuid: 205e1830-7588-486c-95b1-f91f33592e62
 selection_logic: and
 weight: -5
 relationships: {  }


### PR DESCRIPTION
## What this does
 - Adds node title to event type path alias (pattern was copied inadvertently from event_listing type, missing the final node:title token). This fixes broken breadcrumb issue related to drupal not having title string for output.
## QA
 - Add an event to outreach and asset event listing (in Drupal).
 - Rebuild front end
 - Visually verify that event has functional breadcrumb, and doesn't output node id in lieu of node title