### PR TITLE
VAGOV-860: Change fieldset layout.

### DIFF
--- a/docroot/themes/custom/vagovadmin/templates/layout/fieldset.html.twig
+++ b/docroot/themes/custom/vagovadmin/templates/layout/fieldset.html.twig
@@ -1,0 +1,62 @@
+{#
+/**
+ * @file
+ * Theme override for a fieldset element and its children.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the fieldset element.
+ * - errors: (optional) Any errors for this fieldset element, may not be set.
+ * - required: Boolean indicating whether the fieldeset element is required.
+ * - legend: The legend element containing the following properties:
+ *   - title: Title of the fieldset, intended for use as the text of the legend.
+ *   - attributes: HTML attributes to apply to the legend.
+ * - description: The description element containing the following properties:
+ *   - content: The description content of the fieldset.
+ *   - attributes: HTML attributes to apply to the description container.
+ * - children: The rendered child elements of the fieldset.
+ * - prefix: The content to add before the fieldset children.
+ * - suffix: The content to add after the fieldset children.
+ *
+ * @see template_preprocess_fieldset()
+ */
+#}
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+    'js-form-wrapper',
+    'form-wrapper',
+  ]
+%}
+<fieldset{{attributes.addClass(classes)}}>
+	{%
+    set legend_span_classes = [
+      'fieldset-legend',
+      required ? 'js-form-required',
+      required ? 'form-required',
+    ]
+  %}
+	{#  Always wrap fieldset legends in a <span> for CSS positioning. #}
+	<legend{{legend.attributes}}>
+		<span{{legend_span.attributes.addClass(legend_span_classes)}}>{{ legend.title }}</span>
+	</legend>
+	{% if description.content %}
+		<div{{description.attributes.addClass('description')}}>{{ description.content }}</div>
+	{% endif %}
+
+	<div class="fieldset-wrapper">
+		{% if errors %}
+			<div class="form-item--error-message">
+				<strong>{{ errors }}</strong>
+			</div>
+		{% endif %}
+		{% if prefix %}
+			<span class="field-prefix">{{ prefix }}</span>
+		{% endif %}
+		{{ children }}
+		{% if suffix %}
+			<span class="field-suffix">{{ suffix }}</span>
+		{% endif %}
+
+	</div>
+</fieldset>


### PR DESCRIPTION
## What this does
 - Moves fieldset description text from bottom of fieldset to top (just below title / legend on node form).

## QA
 - On content type, add some description text to a fieldset on node form view page
 - Create a new piece of this content type, and confirm the help text appears below title.

## Screenshot
 - `Do some stuff` is the description text
![image](https://user-images.githubusercontent.com/2404547/73782419-10a67b80-4760-11ea-8f32-41c86d9da2da.png)
