### PR TITLE
VAGOV-938: Adding entity_clone patch to prevent child node ref recursion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -204,6 +204,9 @@
                 "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",
                 "Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch"
             },
+            "drupal/entity_clone": {
+                "Cloning child references to nodes has potential to cause memory resource issues": "https://www.drupal.org/files/issues/2020-02-10/entity_clone-child-node-system-drain-3112577-1.patch"
+            },
             "drupal/field_group": {
                 "Allow to position the group in the advanced (sidebar) column": "https://www.drupal.org/files/issues/2018-07-26/2652642-59.patch",
                 "Incompatibility with inline entity form": "https://www.drupal.org/files/issues/2018-10-30/field_group-inline_entity_form_compatibility-2986704-3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26febc39c6f13fecb1bf52829fbdcff2",
+    "content-hash": "005b432ac00e1b45964ce4be5c489263",
     "packages": [
         {
             "name": "acquia/headless_lightning",
@@ -5299,6 +5299,9 @@
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Cloning child references to nodes has potential to cause memory resource issues": "https://www.drupal.org/files/issues/2020-02-10/entity_clone-child-node-system-drain-3112577-1.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",


### PR DESCRIPTION
## Description
Fixes #938 :
Prevents recursive references to child nodes when cloning content. This behavior is not needed for VA, and results in time outs.

## Testing done
Visual / manual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/74196462-47323980-4c2b-11ea-9ba0-a1d8935667dd.png)

## QA steps

As user with any role
- [ ] Go to `node/296/edit` and click the clone tab
- [ ] Visually verify the site doesn't error or time out
- [ ] Select as many items as you like, then complete the cloning operation, confirming it was successful
- [ ] Repeat the above steps for nodes 285, 290, and 738

## Definition of Done
- [ ] Entity cloning just works
