### PR TITLE
VACMS-980 Add logging to build trigger if devshop config is not in place.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
@@ -96,6 +96,12 @@ class BuildFrontend {
         // Save pending state.
         $this->setPendingState(1);
       }
+      else {
+        // This has failed due to bad devshop setting.
+        $message = t('VA Web Rebuild & Deploy has NOT been queued because @method returned no id.', ['@method' => "\DevShopTaskApiClient::create('vabuild')"]);
+        $this->messenger->addError($message);
+        $this->logger->error($message);
+      }
     }
     elseif ($this->getEnvironment() === 'lando') {
       // This is a local dev environment.


### PR DESCRIPTION

## Description

See #980. 

## Testing done
Tested locally with manipulating values to make it act like devshop.  
Devshop is currently in a "working" state so this can not be fully tested, but does not warrant wiping devshop to fully test.

## Screenshots




## Definition of Done
- [-] Product release notes 
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
