### PR TITLE
VACMS-980 Unset deploy pending flag on failure.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
@@ -48,9 +48,10 @@ class BuildTriggerForm extends FormBase {
       ]),
     ];
 
-    // Save pending state.
+    // Get pending state.
     $config = \Drupal::service('config.factory')->getEditable('va_gov.build');
     if ($config->get('web.build.pending', 0)) {
+      // A build is pending so set a display.
       $form['tip']['#prefix'] = '<em>';
       $form['tip']['#markup'] = t('A site rebuild is queued.');
       $form['tip']['#suffix'] = '</em>';

--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
@@ -99,6 +99,7 @@ class BuildFrontend {
       else {
         // This has failed due to bad devshop setting.
         $message = t('VA Web Rebuild & Deploy has NOT been queued because @method returned no id.', ['@method' => "\DevShopTaskApiClient::create('vabuild')"]);
+        $this->setPendingState(0);
         $this->messenger->addError($message);
         $this->logger->error($message);
       }
@@ -191,6 +192,7 @@ class BuildFrontend {
         $message = t('Site rebuild request has failed for :url with an Exception, check log for more information. If this is the PROD environment please notify in #cms-engineering Slack and please email vacmssupport@va.gov immediately with the error message you see here.', [':url' => $jenkins_build_job_url]);
         $this->messenger->addError($message);
         $this->logger->error($message);
+        $this->setPendingState(0);
         watchdog_exception('va_gov_build_trigger', $exception);
       }
     }
@@ -199,6 +201,7 @@ class BuildFrontend {
       $message = t('You cannot trigger a build in this environment. Only the DEV, STAGING and PROD environments support triggering builds.');
       $this->messenger->addWarning($message);
       $this->logger->warning($message);
+      $this->setPendingState(0);
       return FALSE;
     }
   }


### PR DESCRIPTION
## Description

Related to issue #980 

When a frontend build is triggered and the request fails on the drupal side, drupal should unset the build pending flag.

## QA steps
Can't easily reproduce failure.

## Definition of Done
- [-] Product release notes 
- [-] Documentation has been updated, if applicable
- [-] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
