### PR TITLE
VACMS-988 Remove redundant behat vaweb build.

### DIFF
--- a/tests/behat/features/decoupled.feature
+++ b/tests/behat/features/decoupled.feature
@@ -10,18 +10,6 @@ Feature: The VA Website is generated inside the Drupal CMS code.
     Then I should see "Access and manage your VA benefits and health care" in the "h1.homepage-heading" element
     Then print current URL
 
-  @unpublished_content @frontend
-  Scenario: Unpublish health-care and confirm it is not in build
-      """
-      Necessary to run the build twice in this file to toggle
-      node from unpublished to published in static build
-      """
-    When I am logged in as a user with the "administrator" role
-    Given I set the node with title "VA health care" to "unpublished"
-    When I run "cd .. && composer va:web:build"
-    And I am on "/static/health-care"
-    Then the response status code should be 403
-
   @errors @cms_in_static @frontend
   Scenario: Log in, edit, publish, unpublish, and save nodes and see changes in the CMS and the front end website. Confirm cms menu items are in static site build.
     When I am logged in as a user with the "administrator" role
@@ -31,7 +19,8 @@ Feature: The VA Website is generated inside the Drupal CMS code.
     And I fill in "Page title" with "VA blind and low vision rehabilitation services - EDITED"
     And I press "Save"
     Then I should see "Benefits detail page VA blind and low vision rehabilitation services - EDITED has been updated."
-    Then I set the node with title "VA health care" to "published"
+    Then I set the node with title "VA blind and low vision rehabilitation services - EDITED" to "published"
+    Then I set the node with title "VA health care" to "unpublished"
     Then print current URL
     When I run "cd .. && composer va:web:build"
     And I am at "/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services"
@@ -39,5 +28,5 @@ Feature: The VA Website is generated inside the Drupal CMS code.
     And I am at "/static/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services"
     Then I should see "VA blind and low vision rehabilitation services - EDITED"
     Then print current URL
-    Given I am at "/static/health-care"
-    Then the response status code should be 200
+    And I am on "/static/health-care"
+    Then the response status code should be 403


### PR DESCRIPTION
## Description

See #988  

## Testing done

The tests run and pass



## QA steps
- [x] The tests run and pass 


## Definition of Done
- [-] Product release notes 
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
