### PR TITLE
VACMS-844 Update node_link_report to reduce false failures.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "drupal/migrate_source_csv": "^2.2",
         "drupal/migrate_tools": "^4.0",
         "drupal/migration_tools": "^2.1",
-        "drupal/node_link_report": "^1.7",
+        "drupal/node_link_report": "^1.8",
         "drupal/node_revisions_autoclean": "^1.0@beta",
         "drupal/node_title_help_text": "^1.0",
         "drupal/override_node_options": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "drupal/migrate_source_csv": "^2.2",
         "drupal/migrate_tools": "^4.0",
         "drupal/migration_tools": "^2.1",
-        "drupal/node_link_report": "^1.0",
+        "drupal/node_link_report": "^1.7",
         "drupal/node_revisions_autoclean": "^1.0@beta",
         "drupal/node_title_help_text": "^1.0",
         "drupal/override_node_options": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -7776,17 +7776,17 @@
         },
         {
             "name": "drupal/node_link_report",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/node_link_report.git",
-                "reference": "8.x-1.6"
+                "reference": "8.x-1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.6.zip",
-                "reference": "8.x-1.6",
-                "shasum": "b90975e370d4ae0da3f1dbec667b8af49776a960"
+                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.7.zip",
+                "reference": "8.x-1.7",
+                "shasum": "f276f55d5429bdd4d800c0bdaed9bbb11771b6a7"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -7797,8 +7797,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.6",
-                    "datestamp": "1579124583",
+                    "version": "8.x-1.7",
+                    "datestamp": "1582154211",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -7776,17 +7776,17 @@
         },
         {
             "name": "drupal/node_link_report",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/node_link_report.git",
-                "reference": "8.x-1.7"
+                "reference": "8.x-1.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.7.zip",
-                "reference": "8.x-1.7",
-                "shasum": "f276f55d5429bdd4d800c0bdaed9bbb11771b6a7"
+                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.8.zip",
+                "reference": "8.x-1.8",
+                "shasum": "8a88ab6a48f3dda70abb8ca0e8428e5687c47100"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -7797,8 +7797,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.7",
-                    "datestamp": "1582154211",
+                    "version": "8.x-1.8",
+                    "datestamp": "1582224868",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -4,6 +4,8 @@ display_on_node_view: node_view
 display_on_node_edit: node_edit
 display_on_node_preview: node_preview
 additional_domains_as_internal: www.va.gov
-domains_to_skip: ''
+domains_to_skip: "charlesajudge.com\r\nwww.instagram.com\r\nwww.linkedin.com\r\nwww.redroof.com\r\nwww.youtube.com\r\n"
 enable_reporting_skipped_links: 1
 user_agent: 'VA.gov CMS link checker'
+path_patterns_to_skip: "/block/*\r\nmedia/*/edit\r\n/node/*/edit\r\n/user/*\r\n"
+decoupled_frontend: 'https://www.va.gov'


### PR DESCRIPTION
## Description

See #844 and $856 

## Testing done
Examine the following pages which had notoriously high numbers of falsely reported broken links.
/health-care/how-to-apply
/health-care/after-you-apply
/education/transfer-post-9-11-gi-bill-benefits
/pittsburgh-health-care/staff-profiles/brenda-shaffer
/outreach-and-events/events/events-10
/pittsburgh-health-care/stories/stroke-survivortime-is-brain
/pittsburgh-health-care/research/safety-security/animal-research
/disability/va-claim-exam
/disability

## Screenshots


## QA steps

As as an admin or content admin (the only roles who can see the node link report) visit the following pages and validate there are no fake broken links.
- [x] /health-care/how-to-apply
- [x] /health-care/after-you-apply
- [x] /education/transfer-post-9-11-gi-bill-benefits
- [x] /pittsburgh-health-care/staff-profiles/brenda-shaffer
- [x] /outreach-and-events/events/events-10
- [x] /pittsburgh-health-care/stories/stroke-survivortime-is-brain
- [x] /pittsburgh-health-care/research/safety-security/animal-research
- [x] /disability/va-claim-exam
- [x] /disability

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
