### PR TITLE
VACMS-1025 Uninstall health_check module.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -57,7 +57,6 @@ module:
   graphql: 0
   graphql_core: 0
   graphql_metatag: 0
-  health_check: 0
   health_check_url: 0
   help: 0
   history: 0

--- a/config/sync/health_check_url.settings.yml
+++ b/config/sync/health_check_url.settings.yml
@@ -1,4 +1,4 @@
-type: stringWithDateTimestamp
+type: timestamp
 string: UP
 endpoint: /health
 maintainence_access: true

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -133,3 +133,15 @@ function va_gov_db_update_8004(&$sandbox) {
 
   return $messages;
 }
+
+/**
+ * Uninstall health_check.
+ */
+function va_gov_db_update_8005(&$sandbox) {
+  $unistall_modules = [
+    'health_check',
+  ];
+  $messages = _va_gov_db_uninstall_modules($unistall_modules);
+
+  return $messages;
+}


### PR DESCRIPTION
## Description

See #1025 
## Testing done


## Screenshots


## QA steps

1. As admin enable maintenance mode at /admin/config/development/maintenance
1. In an incognito window with your browser network inspector open, visit /health
1. Then validate Acceptance Criteria from issue
- [ ] The network response code is 200
- [ ] The page shows only a unix timestamp


## Definition of Done
- [-] Product release notes 
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
