### PR TITLE
VACMS-000: Removing table field drag and drop patch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -248,8 +248,7 @@
                 "Bypass password requirement for password change if logged in with sso.": "https://www.drupal.org/files/issues/2018-05-01/simplesamlphp_auth-change-password-access-2968598-2.patch"
             },
             "drupal/tablefield": {
-                "0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch",
-                "Make tables draggable": "https://www.drupal.org/files/issues/2019-04-25/tablefield-tabledrag_support-3040358-4-D8.patch"
+                "0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch"
             },
             "drupal/textfield_counter": {
                 "Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -9858,8 +9858,7 @@
                     }
                 },
                 "patches_applied": {
-                    "0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch",
-                    "Make tables draggable": "https://www.drupal.org/files/issues/2019-04-25/tablefield-tabledrag_support-3040358-4-D8.patch"
+                    "0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",


### PR DESCRIPTION
## Description
Drag and drop patch applied to tablefield module isn't being rendered properly in frontend build. This pr removes this patch.
 - Expected: dragging and dropping rows in tablefield found on `node/767/edit` will render in new order here: `life-insurance/options-eligibility/sgli/`
 - Actual: new ordering is not respected, and additional column representing each row's weight is generated

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/75286531-b0e34380-57e6-11ea-9c67-531a0263d0b0.png)


## QA steps
 - As an admin, go to `node/767/edit` and visually verify that you cannot drag table rows.
 - Save node, build front end, visually verify that weight column does not appear.