### PR TITLE
VACMS-1009 Update node_link_report for improved UX

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "drupal/migrate_source_csv": "^2.2",
         "drupal/migrate_tools": "^4.0",
         "drupal/migration_tools": "^2.1",
-        "drupal/node_link_report": "^1.9",
+        "drupal/node_link_report": "^1.10",
         "drupal/node_revisions_autoclean": "^1.0@beta",
         "drupal/node_title_help_text": "^1.0",
         "drupal/override_node_options": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "drupal/migrate_source_csv": "^2.2",
         "drupal/migrate_tools": "^4.0",
         "drupal/migration_tools": "^2.1",
-        "drupal/node_link_report": "^1.8",
+        "drupal/node_link_report": "^1.9",
         "drupal/node_revisions_autoclean": "^1.0@beta",
         "drupal/node_title_help_text": "^1.0",
         "drupal/override_node_options": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "456acbba7bd53d70304781c1444d7b9c",
+    "content-hash": "ca41fde56d2bfad3af0a569cd41b86a0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7776,17 +7776,17 @@
         },
         {
             "name": "drupal/node_link_report",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/node_link_report.git",
-                "reference": "8.x-1.9"
+                "reference": "8.x-1.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.9.zip",
-                "reference": "8.x-1.9",
-                "shasum": "1217fea6947637a7bc63699d6b7d80a558fa5d3d"
+                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.10.zip",
+                "reference": "8.x-1.10",
+                "shasum": "34d327bd055f619a2ed0dbfda485f6ee682923d7"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -7797,8 +7797,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.9",
-                    "datestamp": "1582766587",
+                    "version": "8.x-1.10",
+                    "datestamp": "1582815892",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce3f96e21af2d984de513a757c4af642",
+    "content-hash": "456acbba7bd53d70304781c1444d7b9c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7776,17 +7776,17 @@
         },
         {
             "name": "drupal/node_link_report",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/node_link_report.git",
-                "reference": "8.x-1.8"
+                "reference": "8.x-1.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.8.zip",
-                "reference": "8.x-1.8",
-                "shasum": "8a88ab6a48f3dda70abb8ca0e8428e5687c47100"
+                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.9.zip",
+                "reference": "8.x-1.9",
+                "shasum": "1217fea6947637a7bc63699d6b7d80a558fa5d3d"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -7797,8 +7797,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.8",
-                    "datestamp": "1582224868",
+                    "version": "8.x-1.9",
+                    "datestamp": "1582766587",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca41fde56d2bfad3af0a569cd41b86a0",
+    "content-hash": "ec149464ed797c34671eb67dcb4505b5",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -7,5 +7,5 @@ additional_domains_as_internal: www.va.gov
 domains_to_skip: "charlesajudge.com\r\nwww.instagram.com\r\nwww.linkedin.com\r\nwww.redroof.com\r\nwww.youtube.com\r\n"
 enable_reporting_skipped_links: 1
 user_agent: 'VA.gov CMS link checker'
-path_patterns_to_skip: "/block/*\r\nmedia/*/edit\r\n/node/*/edit\r\n/user/*\r\n"
+path_patterns_to_skip: "/block/*\r\nmedia/*/edit\r\n/node/*/edit\r\n/user/*\r\n/section/*\r\n"
 decoupled_frontend: 'https://www.va.gov'


### PR DESCRIPTION
## Description

See #1009 . 

This brings with it an update to node_link_report focusing on UX improvements to the display of the reports
https://www.drupal.org/project/node_link_report/releases/8.x-1.9

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Visit random content, 
   http://pr1085.ci.cms.va.gov/lebanon-health-care
   http://pr1085.ci.cms.va.gov/pittsburgh-health-care/research/safety-security/human-research
   http://pr1085.ci.cms.va.gov/health-care
- [ ] you should see the node link report sections are now collapsed and can be expanded to see the links covered by the various reports (broken, redirected...) 
- [ ] THe headings of each report should show the count for the number of items found in that section.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
