### PR TITLE
VACMS-1120 Make table field not required.

### DIFF
--- a/config/sync/field.field.paragraph.table.field_table.yml
+++ b/config/sync/field.field.paragraph.table.field_table.yml
@@ -13,7 +13,7 @@ entity_type: paragraph
 bundle: table
 label: Table
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/tests/behat/drupal-spec-tool/content_model.feature
+++ b/tests/behat/drupal-spec-tool/content_model.feature
@@ -374,7 +374,7 @@ Feature: Content model
 | Paragraph type | Situation update | Send email to subscribers via GovDelivery? | field_send_email_to_subscribers | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Situation update | Update | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
 | Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Select list |  |
-| Paragraph type | Table | Table | field_table | Table Field | Required | 1 | Table Field |  |
+| Paragraph type | Table | Table | field_table | Table Field |  | 1 | Table Field |  |
 | Paragraph type | VAMC facility service (non-healthcare service) | Service name | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Paragraph type | VAMC facility service (non-healthcare service) | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | WYSIWYG | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |


### PR DESCRIPTION
## Description

See #1120  

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Login with any editorial role
1. Then go to /node/748/edit
1. Edit one of the table paragraphs. 
1.  Delete the content out of one of the cells, make sure you leave no spaces in the cell.
1. Save the node
- [ ] validate that no red errors related to table being empty appear.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
