### PR TITLE
update gitignore to allow for custom php config and custom lando

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ node_modules/
 # Ignore accessibility test reports
 /tests/accessibility/axeReport/*.csv
 
+# Ignore local lando config
+.lando.local.yml
+.lando/zzzz-local.ini
+
 # Ignore WEB (vets-website)
 # web
 # @TODO: Installer paths is not working. Leaving symlink for now.


### PR DESCRIPTION
This is how I am overriding my local php settings to get xdebug to work and the db port so I can access consistently from my external db tools.

.lando.local.yml:

```
services:
  appserver:
    config:
      php: ./lando/.zzzz-local.ini
  database:
    portforward: 33242
```

.lanod/zzz-local.ini
```
[PHP]
; File is named zzz-lando-my-custom.ini because Lando renames on copy to /usr/local/etc/php/conf.d/

; Default is 90, this is higher because /graphql requests timeout locally for WEB builds otherwise.
max_execution_time = 190
; Xdebug
xdebug.max_nesting_level = 256
xdebug.show_exception_trace = 0
; Extra custom Xdebug setting for debug to work in VSCode.
xdebug.remote_enable = 1
xdebug.remote_autostart = 1
xdebug.remote_log = /tmp/xdebug.log

xdebug.remote_port=9001
xdebug.collect_assignments=1
xdebug.collect_includes=1
xdebug.collect_vars=1
xdebug.force_display_errors=1
xdebug.force_error_reporting=1
xdebug.collect_params=4
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/1240)
<!-- Reviewable:end -->
