### PR TITLE
VACMS-1023 Add module site_alert and patch to add drush commands.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
         "drupal/role_delegation": "^1.0@alpha",
         "drupal/seckit": "^1.1",
         "drupal/simplesamlphp_auth": "^3.0",
+        "drupal/site_alert": "1.x-dev#7e8a229292ec6cf85cb5e22d8a58afac098c3bd1",
         "drupal/social_media_links": "^2.6",
         "drupal/tablefield": "^2.1",
         "drupal/taxonomy_menu": "^3.4",
@@ -257,6 +258,10 @@
             "drupal/simplesamlphp_auth": {
                 "Don't attempt username sync when user was already matched by username": "https://www.drupal.org/files/issues/2019-08-14/2748731-23.patch",
                 "Bypass password requirement for password change if logged in with sso.": "https://www.drupal.org/files/issues/2018-05-01/simplesamlphp_auth-change-password-access-2968598-2.patch"
+            },
+            "drupal/site_alert": {
+                "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-add_drush_commands-3118800-6.patch",
+                "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-support_drush8_commands-3118800-7.patch"
             },
             "drupal/tablefield": {
                 "0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c7c961884159a3dff63bb91a6692766",
+    "content-hash": "0ed19e8466c3dcf645dce67d1908636d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -612,7 +612,7 @@
             "version": "v5.5.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:enyo/dropzone.git",
+                "url": "https://github.com/enyo/dropzone.git",
                 "reference": "08b9e0a763b54a685404dea523a9c54242fbe1b9"
             },
             "dist": {
@@ -9772,6 +9772,60 @@
             }
         },
         {
+            "name": "drupal/site_alert",
+            "version": "dev-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/site_alert.git",
+                "reference": "7e8a229292ec6cf85cb5e22d8a58afac098c3bd1"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0+13-dev",
+                    "datestamp": "1583740113",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                },
+                "patches_applied": {
+                    "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-add_drush_commands-3118800-6.patch",
+                    "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-support_drush8_commands-3118800-7.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "cecrs",
+                    "homepage": "https://www.drupal.org/user/1876384"
+                },
+                {
+                    "name": "nicola85",
+                    "homepage": "https://www.drupal.org/user/1746956"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/user/382067"
+                }
+            ],
+            "description": "Allows site admins to display a site-wide alert to all users.",
+            "homepage": "https://www.drupal.org/project/site_alert",
+            "support": {
+                "source": "https://git.drupalcode.org/project/site_alert"
+            },
+            "time": "2020-03-09T08:06:36+00:00"
+        },
+        {
             "name": "drupal/social_media_links",
             "version": "2.6.0",
             "source": {
@@ -18904,6 +18958,7 @@
         "drupal/path_redirect_import": 10,
         "drupal/pathologic": 15,
         "drupal/role_delegation": 15,
+        "drupal/site_alert": 20,
         "drupal/tour_ui": 10,
         "drupal/user_history": 15,
         "drupal/uswds": 10,

--- a/config/sync/block.block.sitealert.yml
+++ b/config/sync/block.block.sitealert.yml
@@ -1,0 +1,21 @@
+uuid: 1adab529-776b-4f35-af2b-489439a10793
+langcode: en
+status: true
+dependencies:
+  module:
+    - site_alert
+  theme:
+    - vagovadmin
+id: sitealert
+theme: vagovadmin
+region: header
+weight: -15
+provider: null
+plugin: site_alert_block
+settings:
+  id: site_alert_block
+  label: 'Site Alert'
+  provider: site_alert
+  label_display: '0'
+  timeout: 20
+visibility: {  }

--- a/config/sync/block.block.vagovadmin_page_title.yml
+++ b/config/sync/block.block.vagovadmin_page_title.yml
@@ -9,7 +9,7 @@ _core:
 id: vagovadmin_page_title
 theme: vagovadmin
 region: header
-weight: -30
+weight: -14
 provider: null
 plugin: page_title_block
 settings:

--- a/config/sync/block.block.vagovadmin_primary_local_tasks.yml
+++ b/config/sync/block.block.vagovadmin_primary_local_tasks.yml
@@ -9,7 +9,7 @@ _core:
 id: vagovadmin_primary_local_tasks
 theme: vagovadmin
 region: header
-weight: 0
+weight: -13
 provider: null
 plugin: local_tasks_block
 settings:

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -133,6 +133,7 @@ module:
   simple_oauth: 0
   simple_oauth_extras: 0
   simplesamlphp_auth: 0
+  site_alert: 0
   social_media_links: 0
   social_media_links_field: 0
   system: 0

--- a/config/sync/lightning_core.versions.yml
+++ b/config/sync/lightning_core.versions.yml
@@ -184,6 +184,7 @@ shortcut: 8.6.2
 simple_oauth: 3.10.0
 simple_oauth_extras: 3.10.0
 simplesamlphp_auth: 3.0.0
+site_alert: 0.0.0
 slick: 1.0.0
 slick_entityreference: 1.1.0
 social_media_links: 2.6.0


### PR DESCRIPTION
## Description

See #1023. 

## Testing done
Tested locally

## Screenshots


## QA steps

1.  Go to /admin/config/system/site-alerts and add a new site_alert.  
- [x] validate that the site alert appears at the top of the page.
2.  In  a new tab, edit the site_alert and save it.
   - [x] In the original tab, watch and wait at least 20 seconds to validate that the site alert updates without refreshing the tab

3. Validate Drush commands either by pulling locally or by sshing into CI.
- [x] drush site_alert:create   |  Should error, too few arguments       
- [x] drush site_alert:create "label"  | Should error, too few arguments.
- [x] drush site_alert:create "label" "new message"  | Should respond with "Created site_alert 'label'."
- [x] drush site_alert:create "label" "new message" --severity=high | Should respond with "Created site_alert 'label'."
- [x] drush site_alert:create "label" "new message" --duration=40 | Should respond with "Created site_alert 'label'."
- [x] drush site_alert:delete   |  Should error, Exception: A label is required.
- [x] drush site_alert:delete "label"  |  Should respond with "Deleted 3 site_alerts labelled 'label'."
- [x] drush site_alert:delete "label"  |  Should respond with "Found no site_alerts with label 'label' to delete."

- [x] If tests pass, go to https://www.drupal.org/project/site_alert/issues/3118800 and give a status of Reviewed and Tested by Community.
