### PR TITLE
VACMS-1207 Add patch for site_alert 508.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -261,6 +261,7 @@
             },
             "drupal/site_alert": {
                 "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-add_drush_commands-3118800-6.patch",
+                "Add aria https://www.drupal.org/project/site_alert/issues/3120303": "https://www.drupal.org/files/issues/2020-03-17/site_alert-add-508-aria-3120303-3.patch",
                 "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-support_drush8_commands-3118800-7.patch"
             },
             "drupal/tablefield": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ed19e8466c3dcf645dce67d1908636d",
+    "content-hash": "79cfccc06764568761cfced3e990e0f2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9797,6 +9797,7 @@
                 },
                 "patches_applied": {
                     "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-add_drush_commands-3118800-6.patch",
+                    "Add aria https://www.drupal.org/project/site_alert/issues/3120303": "https://www.drupal.org/files/issues/2020-03-17/site_alert-add-508-aria-3120303-3.patch",
                     "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-support_drush8_commands-3118800-7.patch"
                 }
             },


### PR DESCRIPTION
## Description

See #1207 

Adds the patch from https://www.drupal.org/project/site_alert/issues/3120303 to make the output 508 accessible.


## Screenshots
Populated with site_alerts
![image](https://user-images.githubusercontent.com/5752113/76882156-a00b7800-6850-11ea-8f49-eed633706402.png)
Empty block (no active site alerts)
![image](https://user-images.githubusercontent.com/5752113/76882458-0f816780-6851-11ea-9a44-a43fd092b852.png)

## QA steps

Login as any user other than anon
1. Go to any page in the cms,  admin or otherwise.
1. Then inspect the area just above the h1. 
- [x] validate that the div id = block_sitealert contains a div with the class of site-alert with an attribute of `aria-live="polite"`
![image](https://user-images.githubusercontent.com/5752113/76882943-bebe3e80-6851-11ea-9d17-2b2575a7c090.png)
 - [x] Go to D.o issue and set to RTBC https://www.drupal.org/project/site_alert/issues/3120303



