### PR TITLE
VACMS-1273: Entity browser for alert block, and improved view display.

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.alert_blocks
     - field.field.node.page.field_administration
     - field.field.node.page.field_alert
     - field.field.node.page.field_content_block
@@ -15,9 +16,11 @@ dependencies:
     - field.field.node.page.field_plainlanguage_date
     - field.field.node.page.field_related_links
     - node.type.page
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - datetime
+    - entity_browser
     - field_group
     - hide_revision_field
     - metatag
@@ -119,9 +122,18 @@ content:
     region: content
   field_alert:
     weight: 3
-    settings: {  }
+    settings:
+      entity_browser: alert_blocks
+      field_widget_display: rendered_entity
+      field_widget_display_settings:
+        view_mode: default
+      field_widget_edit: true
+      field_widget_remove: true
+      open: true
+      selection_mode: selection_append
+      field_widget_replace: false
     third_party_settings: {  }
-    type: options_select
+    type: entity_browser_entity_reference
     region: content
   field_content_block:
     type: paragraphs_browser

--- a/config/sync/core.entity_form_display.paragraph.alert.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.alert.default.yml
@@ -3,12 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.alert_blocks
     - field.field.paragraph.alert.field_alert_block_reference
     - field.field.paragraph.alert.field_alert_heading
     - field.field.paragraph.alert.field_alert_type
     - field.field.paragraph.alert.field_va_paragraphs
     - paragraphs.paragraphs_type.alert
   module:
+    - entity_browser
     - field_group
     - paragraphs
     - textfield_counter
@@ -49,9 +51,18 @@ mode: default
 content:
   field_alert_block_reference:
     weight: 1
-    settings: {  }
+    settings:
+      entity_browser: alert_blocks
+      field_widget_display: rendered_entity
+      field_widget_display_settings:
+        view_mode: default
+      field_widget_edit: true
+      field_widget_remove: true
+      open: true
+      selection_mode: selection_append
+      field_widget_replace: false
     third_party_settings: {  }
-    type: options_select
+    type: entity_browser_entity_reference
     region: content
   field_alert_heading:
     weight: 4

--- a/config/sync/core.entity_view_display.block_content.alert.default.yml
+++ b/config/sync/core.entity_view_display.block_content.alert.default.yml
@@ -24,25 +24,15 @@ content:
   field_alert_content:
     type: entity_reference_revisions_entity_view
     weight: 2
-    label: hidden
+    label: above
     settings:
       view_mode: preview
       link: ''
     third_party_settings: {  }
     region: content
-  field_alert_dismissable:
-    weight: 8
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: boolean
-    region: content
   field_alert_title:
     weight: 1
-    label: hidden
+    label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -50,34 +40,24 @@ content:
     region: content
   field_alert_type:
     weight: 0
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: list_default
-    region: content
-  field_is_this_a_header_alert_:
-    weight: 7
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_owner:
-    weight: 3
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
     type: entity_reference_label
+    weight: 3
     region: content
-  field_reusability:
-    weight: 4
-    label: hidden
-    settings: {  }
+    label: above
+    settings:
+      link: false
     third_party_settings: {  }
-    type: list_default
-    region: content
 hidden:
   content_moderation_control: true
+  field_alert_dismissable: true
   field_alert_frequency: true
+  field_is_this_a_header_alert_: true
   field_node_reference: true
+  field_reusability: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -50,9 +50,10 @@ content:
     weight: 3
     label: above
     settings:
-      link: true
+      view_mode: default
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
     region: content
   field_content_block:
     type: entity_reference_revisions_entity_view

--- a/config/sync/entity_browser.browser.alert_blocks.yml
+++ b/config/sync/entity_browser.browser.alert_blocks.yml
@@ -1,0 +1,31 @@
+uuid: 4dc64ddc-e016-4197-a6f6-5e434eea67db
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.custom_block_entity_browsers
+  module:
+    - views
+name: alert_blocks
+label: 'Alert blocks'
+display: modal
+display_configuration:
+  width: ''
+  height: ''
+  link_text: 'Place alert'
+  auto_open: false
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: single
+widget_selector_configuration: {  }
+widgets:
+  03832723-7601-4ed8-82e3-09617277e3bb:
+    settings:
+      view: custom_block_entity_browsers
+      view_display: entity_browser_1
+      submit_text: 'Select alert'
+      auto_select: false
+    uuid: 03832723-7601-4ed8-82e3-09617277e3bb
+    weight: 1
+    label: ''
+    id: view

--- a/config/sync/user.role.content_admin.yml
+++ b/config/sync/user.role.content_admin.yml
@@ -13,8 +13,10 @@ weight: -1
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access alert_blocks entity browser pages'
   - 'access files overview'
   - 'access image_browser entity browser pages'
+  - 'access media entity browser pages'
   - 'access media overview'
   - 'access media_browser entity browser pages'
   - 'access toolbar'

--- a/config/sync/user.role.content_creator_benefits_hubs.yml
+++ b/config/sync/user.role.content_creator_benefits_hubs.yml
@@ -12,7 +12,9 @@ label: 'Content creator - Benefits hubs'
 weight: -6
 is_admin: null
 permissions:
+  - 'access alert_blocks entity browser pages'
   - 'access files overview'
+  - 'access media entity browser pages'
   - 'clone block entity'
   - 'clone block_content entity'
   - 'clone field_config entity'

--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -13,9 +13,11 @@ weight: -4
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access alert_blocks entity browser pages'
   - 'access content overview'
   - 'access files overview'
   - 'access image_browser entity browser pages'
+  - 'access media entity browser pages'
   - 'access media overview'
   - 'access media_browser entity browser pages'
   - 'access shortcuts'

--- a/config/sync/user.role.content_publisher.yml
+++ b/config/sync/user.role.content_publisher.yml
@@ -13,9 +13,11 @@ weight: -2
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access alert_blocks entity browser pages'
   - 'access content overview'
   - 'access files overview'
   - 'access image_browser entity browser pages'
+  - 'access media entity browser pages'
   - 'access media overview'
   - 'access media_browser entity browser pages'
   - 'access shortcuts'

--- a/config/sync/user.role.content_reviewer.yml
+++ b/config/sync/user.role.content_reviewer.yml
@@ -13,9 +13,11 @@ weight: -3
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access alert_blocks entity browser pages'
   - 'access content overview'
   - 'access files overview'
   - 'access image_browser entity browser pages'
+  - 'access media entity browser pages'
   - 'access media overview'
   - 'access media_browser entity browser pages'
   - 'access shortcuts'

--- a/config/sync/user.role.vamc_content_creator.yml
+++ b/config/sync/user.role.vamc_content_creator.yml
@@ -12,7 +12,9 @@ label: 'Content creator - VAMC'
 weight: -5
 is_admin: null
 permissions:
+  - 'access alert_blocks entity browser pages'
   - 'access files overview'
+  - 'access media entity browser pages'
   - 'clone block entity'
   - 'clone block_content entity'
   - 'clone field_config entity'

--- a/config/sync/views.view.custom_block_entity_browsers.yml
+++ b/config/sync/views.view.custom_block_entity_browsers.yml
@@ -1,0 +1,796 @@
+uuid: efc57802-8193-4d5e-a4fc-8fc89d2af96e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.alert
+    - field.storage.block_content.field_alert_content
+    - field.storage.block_content.field_alert_title
+    - field.storage.block_content.field_alert_type
+    - field.storage.block_content.field_owner
+    - taxonomy.vocabulary.administration
+  module:
+    - block_content
+    - content_moderation
+    - entity_browser
+    - options
+    - paragraphs
+    - taxonomy
+id: custom_block_entity_browsers
+label: 'Custom block entity browsers'
+module: views
+description: 'For placing on content forms'
+tag: ''
+base_table: block_content_field_data
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            entity_browser_select: entity_browser_select
+            field_alert_title: field_alert_title
+            field_alert_content: field_alert_title
+            field_alert_type: field_alert_type
+            changed: changed
+            moderation_state: moderation_state
+            field_owner: field_owner
+          info:
+            entity_browser_select:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_alert_title:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_alert_content:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_alert_type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            moderation_state:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_owner:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: changed
+          empty_table: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        entity_browser_select:
+          id: entity_browser_select
+          table: block_content
+          field: entity_browser_select
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          use_field_cardinality: true
+          entity_type: block_content
+          plugin_id: entity_browser_select
+        field_alert_title:
+          id: field_alert_title
+          table: block_content__field_alert_title
+          field: field_alert_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Alert title'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h3
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_alert_content:
+          id: field_alert_content
+          table: block_content__field_alert_content
+          field: field_alert_content
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Content
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: paragraph_summary
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_alert_type:
+          id: field_alert_type
+          table: block_content__field_alert_type
+          field: field_alert_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        changed:
+          id: changed
+          table: block_content_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Last updated'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp_ago
+          settings:
+            future_format: '@interval hence'
+            past_format: '@interval ago'
+            granularity: 1
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: block_content
+          entity_field: changed
+          plugin_id: field
+        moderation_state:
+          id: moderation_state
+          table: block_content_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Moderation state'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: content_moderation_state
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: block_content
+          plugin_id: moderation_state_field
+        field_owner:
+          id: field_owner
+          table: block_content__field_owner
+          field: field_owner
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Owner
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        reusable:
+          id: reusable
+          plugin_id: boolean
+          table: block_content_field_data
+          field: reusable
+          value: '1'
+          entity_type: block_content
+          entity_field: reusable
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: block_content_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            alert: alert
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            argument: null
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: block_content
+          entity_field: type
+          plugin_id: bundle
+        field_owner_target_id:
+          id: field_owner_target_id
+          table: block_content__field_owner
+          field: field_owner_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_owner_target_id_op
+            label: Owner
+            description: ''
+            use_operator: false
+            operator: field_owner_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_owner_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              vamc_content_creator: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: administration
+          hierarchy: true
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_alert_type_value:
+          id: field_alert_type_value
+          table: block_content__field_alert_type
+          field: field_alert_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_alert_type_value_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: field_alert_type_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_alert_type_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              vamc_content_creator: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      sorts: {  }
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content: 'You can place any alert block that has been saved by its owner as "reusable". '
+          plugin_id: text_custom
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+      tags:
+        - 'config:field.storage.block_content.field_alert_content'
+        - 'config:field.storage.block_content.field_alert_title'
+        - 'config:field.storage.block_content.field_alert_type'
+        - 'config:field.storage.block_content.field_owner'
+  entity_browser_1:
+    display_plugin: entity_browser
+    id: entity_browser_1
+    display_title: 'Alert block entity browsers'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+      tags:
+        - 'config:field.storage.block_content.field_alert_content'
+        - 'config:field.storage.block_content.field_alert_title'
+        - 'config:field.storage.block_content.field_alert_type'
+        - 'config:field.storage.block_content.field_owner'

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -9,7 +9,7 @@ Feature: Content model fields
        Then exactly the following fields should exist
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Content type | Benefits detail page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Benefits detail page | Alert | field_alert | Entity reference |  | 1 | Select list |  |
+| Content type | Benefits detail page | Alert | field_alert | Entity reference |  | 1 | Entity browser |  |
 | Content type | Benefits detail page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL |  |
 | Content type | Benefits detail page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
@@ -243,7 +243,7 @@ Feature: Content model fields
 | Paragraph type | Additional information | Instructions for obtaining more information in Spanish | field_text_expander | Text (plain) |  | 1 | Textfield with counter | Translatable |
 | Paragraph type | Additional information | Text | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Address | Address | field_address | Address |  | 1 | Address |  |
-| Paragraph type | Alert | Reusable alert | field_alert_block_reference | Entity reference |  | 1 | Select list |  |
+| Paragraph type | Alert | Reusable alert | field_alert_block_reference | Entity reference |  | 1 | Entity browser |  |
 | Paragraph type | Alert | Alert Heading | field_alert_heading | Text (plain) |  | 1 | Textfield with counter |  |
 | Paragraph type | Alert | Alert Type | field_alert_type | List (text) |  | 1 | Select list |  |
 | Paragraph type | Alert | Alert content | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable |

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -15,6 +15,7 @@ Feature: Views
 | Content | content | Content | Enabled | Find and manage content. |
 | Recent content | content_recent | Content | Disabled | Recent content. |
 | Content served from Drupal | content_served_from_drupal | Content | Enabled | An exportable list of all content served from Drupal |
+| Custom block entity browsers | custom_block_entity_browsers | Custom Block | Enabled | For placing on content forms |
 | Files | files | Files | Enabled | Find and manage files. |
 | Frontpage | frontpage | Content | Enabled | All content promoted to frontpage |
 | Glossary | glossary | Content | Disabled | All content, by letter. |
@@ -68,6 +69,8 @@ Feature: Views
 | Content served from Drupal | Page | page_1 | Page |
 | Content served from Drupal | Data export | data_export_1 | Data export |
 | Content served from Drupal | Master | default | Master |
+| Custom block entity browsers | Alert block entity browsers | entity_browser_1 | Entity browser |
+| Custom block entity browsers | Master                      | default          | Master         |
 | Custom block library | Master | default | Master |
 | Custom block library | Page | page_1 | Page |
 | Files | Master | default | Master |

--- a/tests/phpunit/SecurityRolesPermissionsTest.php
+++ b/tests/phpunit/SecurityRolesPermissionsTest.php
@@ -24,7 +24,7 @@ class SecurityRolesPermissions extends ExistingSiteBase {
 
     if (isset($role)) {
       $permissions = $role->getPermissions();
-      $message = "The permissions for the " . $roleMatch . " do not match the expected permissions: \n '" . implode("',\n '", $permissions) . "'\n";
+      $message = "The permissions for the " . $roleMatch . " do not match the expected permissions.  Make the expected look like this, to get the test passing: \n '" . implode("',\n '", $permissions) . "'\n";
     }
     else {
       $message = 'The ' . $roleMatch . ' role is missing from the system.';
@@ -93,8 +93,10 @@ class SecurityRolesPermissions extends ExistingSiteBase {
         'content_admin',
         [
           'access administration pages',
+          'access alert_blocks entity browser pages',
           'access files overview',
           'access image_browser entity browser pages',
+          'access media entity browser pages',
           'access media overview',
           'access media_browser entity browser pages',
           'access toolbar',
@@ -184,9 +186,11 @@ class SecurityRolesPermissions extends ExistingSiteBase {
         'content_editor',
         [
           'access administration pages',
+          'access alert_blocks entity browser pages',
           'access content overview',
           'access files overview',
           'access image_browser entity browser pages',
+          'access media entity browser pages',
           'access media overview',
           'access media_browser entity browser pages',
           'access shortcuts',
@@ -298,9 +302,11 @@ class SecurityRolesPermissions extends ExistingSiteBase {
         'content_reviewer',
         [
           'access administration pages',
+          'access alert_blocks entity browser pages',
           'access content overview',
           'access files overview',
           'access image_browser entity browser pages',
+          'access media entity browser pages',
           'access media overview',
           'access media_browser entity browser pages',
           'access shortcuts',
@@ -405,9 +411,11 @@ class SecurityRolesPermissions extends ExistingSiteBase {
         'content_publisher',
         [
           'access administration pages',
+          'access alert_blocks entity browser pages',
           'access content overview',
           'access files overview',
           'access image_browser entity browser pages',
+          'access media entity browser pages',
           'access media overview',
           'access media_browser entity browser pages',
           'access shortcuts',


### PR DESCRIPTION
## Description

See #1273 . 

## Testing done

See QA steps below.

## Screenshots

### Editing, before and after

![alert-entity-browser](https://user-images.githubusercontent.com/643678/77032740-af3b1480-697b-11ea-9d94-72a45749b231.gif)



### Proofing

Before

![Coronavirus_FAQs__What_Veterans_Need_To_Know___Veterans_Affairs](https://user-images.githubusercontent.com/643678/77032790-c974f280-697b-11ea-8f21-0d501503cb94.jpg)

After

![Coronavirus_FAQs__What_Veterans_Need_To_Know___Veterans_Affairs](https://user-images.githubusercontent.com/643678/77032717-9894bd80-697b-11ea-9950-02e83f880908.jpg)






## QA steps

As randi.hecht@va.gov 

- [x] From /node/23/edit, i open an alert block browser and filter and choose any alert, in the Alert field above Featured content
- [x] Also on /node/23/edit, i can place an "Alert" content block and use the same widget to find and place an existing alert (or add a non-reusable alert)
- [x] On /node/23, i can see the content of an alert block, instead of just a link to edit it.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
