### PR TITLE
VACMS-1282 Add media browser to block promo image.

### DIFF
--- a/config/sync/core.entity_form_display.block_content.promo.default.yml
+++ b/config/sync/core.entity_form_display.block_content.promo.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - block_content.type.promo
+    - entity_browser.browser.media
     - field.field.block_content.promo.field_image
     - field.field.block_content.promo.field_instructions
     - field.field.block_content.promo.field_owner
@@ -25,14 +26,14 @@ content:
     weight: 4
     region: content
     settings:
-      entity_browser: null
-      open: false
+      entity_browser: media
       field_widget_display: label
       field_widget_edit: true
       field_widget_remove: true
-      field_widget_replace: false
-      field_widget_display_settings: {  }
       selection_mode: selection_append
+      field_widget_replace: false
+      open: false
+      field_widget_display_settings: {  }
     third_party_settings: {  }
   field_instructions:
     weight: 2

--- a/config/sync/field.field.block_content.promo.field_image.yml
+++ b/config/sync/field.field.block_content.promo.field_image.yml
@@ -23,6 +23,6 @@ settings:
       image: image
     sort:
       field: _none
-    auto_create: true
+    auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference


### PR DESCRIPTION
## Description

See #1282 
## Testing done


## Screenshots


## QA steps
1. Go to /block/add/promo 
- [ ] validate that you can add an image
- [ ] validate that you can choose a different image

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
