### PR TITLE
VACMS-0: Generate fully qualified local domain link with lando drush uli

### DIFF
--- a/drush/drushrc.local.php
+++ b/drush/drushrc.local.php
@@ -1,0 +1,8 @@
+<?php
+
+$env_type = getenv('CMS_ENVIRONMENT_TYPE');
+
+// Set base url for lando environment.
+if (isset($env_type) && $env_type === 'lando') {
+  $options['uri'] = 'https://va-gov-cms.lndo.site';
+}

--- a/drush/drushrc.php
+++ b/drush/drushrc.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * If there is a local drushrc file, then include it.
+ */
+
+$local_drushrc = __DIR__ . "/drushrc.local.php";
+
+if (file_exists($local_drushrc)) {
+  include $local_drushrc;
+}


### PR DESCRIPTION
# Description

Added drusrc.php and drushrc.local.php files in order to set base url to be used in `lando drush uli`. 

## Testing done

Local environment cli

## QA steps

- [x] `lando start`
- [x] `hub pr checkout 1286`
- [x] `lando composer install`
- [x] `./scripts/sync-db.sh`
- [x] `lando drush uli`
- [x] confirm that link produced has fully qualified local url that looks like this  https://va-gov-cms.lndo.site/user/reset/1/1584743285/t0BJ2qaqH4-8C4BYQkBbfznyL78feUkiPqgtJEDI4Po/login  instead of http://default/user/reset/1/1584743273/79DCWiGJqA7eyFFmxN6G9h1JeC8UKiAbSVmD1oAQxNQ/login

