### PR TITLE
VACMS-1172 Update node_link_report to get 1.13.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "drupal/migrate_tools": "^4.0",
         "drupal/migration_tools": "^2.1",
         "drupal/module_missing_message_fixer": "^1.1",
-        "drupal/node_link_report": "^1.8",
+        "drupal/node_link_report": "^1.13",
         "drupal/node_revisions_autoclean": "^1.0@beta",
         "drupal/node_title_help_text": "^1.0",
         "drupal/override_node_options": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79cfccc06764568761cfced3e990e0f2",
+    "content-hash": "1287a84e272be33020a2f25de8582181",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -597,7 +597,7 @@
             "version": "v4.1.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:fengyuanchen/cropper.git",
+                "url": "https://github.com/fengyuanchen/cropper.git",
                 "reference": "617d9bdb8688cc4edb3b03bc49a04b83c7facbe7"
             },
             "dist": {
@@ -7885,20 +7885,20 @@
         },
         {
             "name": "drupal/node_link_report",
-            "version": "1.10.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/node_link_report.git",
-                "reference": "8.x-1.10"
+                "reference": "8.x-1.13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.10.zip",
-                "reference": "8.x-1.10",
-                "shasum": "34d327bd055f619a2ed0dbfda485f6ee682923d7"
+                "url": "https://ftp.drupal.org/files/projects/node_link_report-8.x-1.13.zip",
+                "reference": "8.x-1.13",
+                "shasum": "36a7095998832ff8690d38b738842ab5012fa6b3"
             },
             "require": {
-                "drupal/core": "~8.0"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
@@ -7906,8 +7906,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.10",
-                    "datestamp": "1582815892",
+                    "version": "8.x-1.13",
+                    "datestamp": "1585059591",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Description

See #1172 . 

This is a contrib module update which pulls in a fix for sites that reject header only curls.
## QA steps

As an admin visit /health-care/health-needs-conditions/mental-health
- Click the edit tab, then save  (no changes needed) this is just to cause the node link report to be rebuilt.
- [ ] Validate that there are no broken links identified pointing to URLs that actually exist.


