### PR TITLE
VACMS-1319 Change entity browser to media_library on block:promo.

### DIFF
--- a/config/sync/core.entity_form_display.block_content.promo.default.yml
+++ b/config/sync/core.entity_form_display.block_content.promo.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - block_content.type.promo
-    - entity_browser.browser.media
     - field.field.block_content.promo.field_image
     - field.field.block_content.promo.field_instructions
     - field.field.block_content.promo.field_owner
@@ -12,9 +11,9 @@ dependencies:
     - workflows.workflow.editorial
   module:
     - content_moderation
-    - entity_browser
     - hide_revision_field
     - markup
+    - media_library
     - paragraphs
 id: block_content.promo.default
 targetEntityType: block_content
@@ -22,18 +21,11 @@ bundle: promo
 mode: default
 content:
   field_image:
-    type: entity_browser_entity_reference
+    type: media_library_widget
     weight: 4
     region: content
     settings:
-      entity_browser: media
-      field_widget_display: label
-      field_widget_edit: true
-      field_widget_remove: true
-      selection_mode: selection_append
-      field_widget_replace: false
-      open: false
-      field_widget_display_settings: {  }
+      media_types: {  }
     third_party_settings: {  }
   field_instructions:
     weight: 2

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -221,7 +221,7 @@ Feature: Content model fields
 | Custom block type | Alert | Scope | field_node_reference | Entity reference |  | Unlimited | Autocomplete |  |
 | Custom block type | Alert | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
 | Custom block type | Alert | Reusability | field_reusability | List (text) | Required | 1 | -- Disabled -- |  |
-| Custom block type | Promo | Image | field_image | Entity reference | Required | 1 | Entity browser |  |
+| Custom block type | Promo | Image | field_image | Entity reference | Required | 1 | Media library |  |
 | Custom block type | Promo | Instructions | field_instructions | Markup |  | 1 | Markup |  |
 | Custom block type | Promo | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
 | Custom block type | Promo | Link | field_promo_link | Entity reference revisions |  | 1 | Paragraphs Classic |  |


### PR DESCRIPTION
## Description

See #1319. 




## QA steps

As user _uid_ with _user_role_
1. Go to /block/add/promo
2. Click on "Add media" button
![image](https://user-images.githubusercontent.com/5752113/77461076-669ab580-6dd8-11ea-8ce8-c82656d098af.png)
- [x] Validate The media library should appear with options to choose existing media
- [x] Validate also have option to upload new image.


## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
