### PR TITLE
VACMS-1144: Change intro text field on listings to optional.

### DIFF
--- a/config/sync/field.field.node.event_listing.field_intro_text.yml
+++ b/config/sync/field.field.node.event_listing.field_intro_text.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: event_listing
 label: 'Intro text'
 description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.health_services_listing.field_intro_text.yml
+++ b/config/sync/field.field.node.health_services_listing.field_intro_text.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: health_services_listing
 label: 'Intro text'
 description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.leadership_listing.field_intro_text.yml
+++ b/config/sync/field.field.node.leadership_listing.field_intro_text.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: leadership_listing
 label: 'Intro text'
 description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.locations_listing.field_intro_text.yml
+++ b/config/sync/field.field.node.locations_listing.field_intro_text.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: locations_listing
 label: 'Intro text'
 description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.press_releases_listing.field_intro_text.yml
+++ b/config/sync/field.field.node.press_releases_listing.field_intro_text.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: press_releases_listing
 label: 'Intro text'
 description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.publication_listing.field_intro_text.yml
+++ b/config/sync/field.field.node.publication_listing.field_intro_text.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: publication_listing
 label: 'Intro text'
 description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. '
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.story_listing.field_intro_text.yml
+++ b/config/sync/field.field.node.story_listing.field_intro_text.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: story_listing
 label: 'Intro text'
 description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -70,7 +70,7 @@ Feature: Content model fields
 | Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Linkit |  |
 | Content type | Event listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Event listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Event listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Event listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Event listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Event listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Event listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
@@ -100,7 +100,7 @@ Feature: Content model fields
 | Content type | Publication | Publication listing | field_listing | Entity reference | Required | 1 | -- Disabled -- | Translatable |
 | Content type | Publication listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Publication listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Publication listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Publication listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Publication listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Publication listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Publication listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
@@ -304,35 +304,36 @@ Feature: Content model fields
 | Content type | VAMC system | GovDelivery ID for Emergency updates email | field_govdelivery_id_emerg | Text (plain) | Required | 1 | Textfield |  |
 | Content type | VAMC system | GovDelivery ID for News and Announcements | field_govdelivery_id_news | Text (plain) | Required | 1 | Textfield |  |
 | Content type | Health services listing | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic | Translatable |
-| Content type | Health services listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Health services listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Health services listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Health services listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Health services listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Health services listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Health services listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Locations listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Locations listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Locations listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Locations listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Locations listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Locations listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Locations listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | News releases listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | News releases listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | News releases listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | News releases listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | News releases listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | News releases listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | News releases listing | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | News releases listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Story listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Story listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Story listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Story listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Story listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Story listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Story listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Leadership listing | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
+| Content type | Leadership listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Leadership listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Leadership listing | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Leadership listing | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Leadership listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Leadership listing | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Leadership listing | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete | Translatable |
+


### PR DESCRIPTION
## Description
See #1144 

## Testing done
Visual

## QA steps
As an admin, visit
 - `/admin/structure/types/manage/story_listing/fields/node.story_listing.field_intro_text`
 - `/admin/structure/types/manage/publication_listing/fields/node.publication_listing.field_intro_text`
 - `/admin/structure/types/manage/story_listing/fields/node.story_listing.field_intro_text`
 - `/admin/structure/types/manage/press_releases_listing/fields/node.press_releases_listing.field_intro_text`
 - `/admin/structure/types/manage/locations_listing/fields/node.locations_listing.field_intro_text`
 - `/admin/structure/types/manage/leadership_listing/fields/node.leadership_listing.field_intro_text`
 - `/admin/structure/types/manage/health_services_listing/fields/node.health_services_listing.field_intro_text`
 - `/admin/structure/types/manage/event_listing/fields/node.event_listing.field_intro_text`
and visually verify that field_into_text is not required