### PR TITLE
VACMS-1081: Set visual_inline as default diff view.

### DIFF
--- a/config/sync/diff.settings.yml
+++ b/config/sync/diff.settings.yml
@@ -4,13 +4,13 @@ general_settings:
   context_lines_trailing: 2
   revision_pager_limit: 50
   layout_plugins:
-    split_fields:
+    visual_inline:
       enabled: true
       weight: -50
-    unified_fields:
+    split_fields:
       enabled: true
       weight: -49
-    visual_inline:
+    unified_fields:
       enabled: true
       weight: -48
   visual_inline_theme: default


### PR DESCRIPTION
## Description

See #1081 . 

## QA steps

1. log in and visit /node/35/revisions and click "Compare selected revisions"
- [ ] confirm that default diff layout is "Visual inline"

##