### PR TITLE
VACMS-1273: Adding form widget and display setting for alert.

### DIFF
--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.node.inline_entity_form
+    - entity_browser.browser.alert_blocks
     - field.field.node.landing_page.field_administration
     - field.field.node.landing_page.field_alert
     - field.field.node.landing_page.field_description
@@ -21,9 +22,11 @@ dependencies:
     - field.field.node.landing_page.field_teaser_text
     - field.field.node.landing_page.field_title_icon
     - node.type.landing_page
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - datetime
+    - entity_browser
     - field_group
     - hide_revision_field
     - inline_entity_form
@@ -164,9 +167,18 @@ content:
     region: content
   field_alert:
     weight: 2
-    settings: {  }
+    settings:
+      entity_browser: alert_blocks
+      field_widget_display: rendered_entity
+      field_widget_display_settings:
+        view_mode: default
+      field_widget_edit: true
+      field_widget_remove: true
+      open: true
+      selection_mode: selection_append
+      field_widget_replace: false
     third_party_settings: {  }
-    type: options_select
+    type: entity_browser_entity_reference
     region: content
   field_description:
     weight: 6
@@ -289,6 +301,7 @@ content:
       override_labels: false
       collapsible: false
       allow_duplicate: false
+      revision: false
     third_party_settings: {  }
     type: inline_entity_form_complex
     region: content

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -110,9 +110,10 @@ content:
     weight: 5
     label: above
     settings:
-      link: true
+      view_mode: default
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
     region: content
   field_description:
     type: string

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -20,7 +20,7 @@ Feature: Content model fields
 | Content type | Benefits detail page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | Date and time |  |
 | Content type | Benefits detail page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Benefits hub landing page | Owner | field_administration | Entity reference | Required | 1 | Select list |  |
-| Content type | Benefits hub landing page | Alert | field_alert | Entity reference |  | 1 | Select list | Translatable |
+| Content type | Benefits hub landing page | Alert | field_alert | Entity reference |  | 1 | Entity browser | Translatable |
 | Content type | Benefits hub landing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Benefits hub landing page | Home page hub label | field_home_page_hub_label | Text (plain) |  | 1 | Textfield |  |
 | Content type | Benefits hub landing page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |


### PR DESCRIPTION
## Description

This is a follow up to #1274, in which i missed one field instance. 

## Testing done

Validated on /health-care and the edit screen for /health-care.

## Screenshots

![VA_Health_Care___Veterans_Affairs_and_Edit_Benefits_hub_landing_page_VA_health_care___VA_gov_CMS_and_vagov____workspace_vagov__-_____tests_behat_drupal-spec-tool_content_model_fields_feature](https://user-images.githubusercontent.com/643678/77501015-126df080-6e2d-11ea-9eb2-41a34969b258.jpg)

## QA steps

As randi.hecht@va.gov
- [ ] Go to /health-care, see that the alert is displayed as a rendered entity instead of a link. 
- [ ] Edit the node and see that the alert field uses a functioning entity browser.


## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
