### PR TITLE
VACMS-1189: Do not render Preview btn for banner alerts

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -88,10 +88,11 @@ function va_gov_build_trigger_preprocess_page(&$variables) {
     $path = \Drupal::request()->getpathInfo();
     $arg = explode('/', $path);
     $exclusion_types = [
-      'outreach_asset',
-      'support_service',
-      'regional_health_care_service_des',
+      'full_width_banner_alert',
       'health_care_local_health_service',
+      'outreach_asset',
+      'regional_health_care_service_des',
+      'support_service',
     ];
     // Make sure we aren't on the node form or an excluded type.
     $route_name = \Drupal::routeMatch()->getRouteName();

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -85,7 +85,6 @@ function va_gov_build_trigger_preprocess_page(&$variables) {
   $node = \Drupal::routeMatch()->getParameter('node');
   if ($node instanceof NodeInterface) {
     // It's a node.
-    $path = \Drupal::request()->getpathInfo();
     $exclusion_types = [
       'full_width_banner_alert',
       'health_care_local_health_service',

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -86,7 +86,6 @@ function va_gov_build_trigger_preprocess_page(&$variables) {
   if ($node instanceof NodeInterface) {
     // It's a node.
     $path = \Drupal::request()->getpathInfo();
-    $arg = explode('/', $path);
     $exclusion_types = [
       'full_width_banner_alert',
       'health_care_local_health_service',


### PR DESCRIPTION
## Description

See #1189 . 

## Testing done

Visual + code review

## QA steps

- [ ] visit /help-limit-the-spread-of-covid-19-and-other-illnesses 
- [ ] confirm there is no "Preview" button on the banner node view page

