### PR TITLE
VACMS-1047: term owner

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - taxonomy.vocabulary.health_care_service_taxonomy
   module:
     - field_group
+    - hide_revision_field
     - path
     - text
 third_party_settings:
@@ -19,7 +20,7 @@ third_party_settings:
       children:
         - field_owner
       parent_name: ''
-      weight: 7
+      weight: 9
       format_type: details_sidebar
       format_settings:
         weight: '0'
@@ -28,7 +29,7 @@ third_party_settings:
         classes: ''
         open: 0
       label: Governance
-      region: content
+      region: hidden
 id: taxonomy_term.health_care_service_taxonomy.default
 targetEntityType: taxonomy_term
 bundle: health_care_service_taxonomy
@@ -66,12 +67,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  field_owner:
-    weight: 7
-    settings: {  }
-    third_party_settings: {  }
-    type: options_select
-    region: content
   field_vha_healthservice_stopcode:
     weight: 2
     settings:
@@ -95,7 +90,7 @@ content:
     third_party_settings: {  }
   revision_log_message:
     type: hide_revision_field_log_widget
-    weight: 80
+    weight: 7
     region: content
     settings:
       show: true
@@ -109,7 +104,8 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 100
+    weight: 8
     region: content
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_owner: true

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -24,7 +24,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_also_known_as:
-    weight: 2
+    weight: 1
     label: above
     settings:
       link_to_entity: false
@@ -32,7 +32,7 @@ content:
     type: string
     region: content
   field_commonly_treated_condition:
-    weight: 3
+    weight: 2
     label: above
     settings:
       link_to_entity: false
@@ -40,23 +40,15 @@ content:
     type: string
     region: content
   field_health_service_api_id:
-    weight: 4
+    weight: 3
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
     region: content
-  field_owner:
-    weight: 1
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_vha_healthservice_stopcode:
-    weight: 5
+    weight: 4
     label: above
     settings:
       thousand_separator: ''
@@ -65,4 +57,5 @@ content:
     type: number_integer
     region: content
 hidden:
+  field_owner: true
   search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_owner.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_owner.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.storage.taxonomy_term.field_owner
     - taxonomy.vocabulary.administration
     - taxonomy.vocabulary.health_care_service_taxonomy
+  content:
+    - 'taxonomy_term:administration:0e30e74c-76b9-4c25-aa12-745086f02e37'
 id: taxonomy_term.health_care_service_taxonomy.field_owner
 field_name: field_owner
 entity_type: taxonomy_term
@@ -14,7 +16,9 @@ label: Owner
 description: 'The VA office or program that owns this content.'
 required: true
 translatable: false
-default_value: {  }
+default_value:
+  -
+    target_uuid: 0e30e74c-76b9-4c25-aa12-745086f02e37
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.install
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.install
@@ -183,3 +183,46 @@ function va_gov_backend_update_8003() {
     ]);
   }
 }
+
+/**
+ * Update the Owner for terms in health_care_service_taxonomy vocab.
+ */
+function va_gov_backend_update_8004() {
+  $updated = 0;
+  $skipped = 0;
+
+  // "National health care service descriptions" term ID.
+  $tid = 46;
+
+  $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+  $terms = $storage->loadByProperties(['vid' => 'health_care_service_taxonomy']);
+
+  foreach ($terms as $term) {
+    // Check if owner is already set to term tid 46.
+    $owner = intval($term->field_owner->target_id);
+    if ($owner !== $tid) {
+      $term->set('field_owner', NULL);
+      $term->field_owner[] = ['target_id' => $tid];
+      try {
+        $saved = $term->save();
+        $updated = (is_int($saved) && $saved > 0) ? $updated + 1 : $updated;
+        Drupal::logger('va_gov_backend')->log(LogLevel::INFO, 'VHA health service taxonomy: Updated owner for term "%term_name".', [
+          '%term_name' => $term->label(),
+        ]);
+      }
+      catch (\Exception $e) {
+        $skipped = (is_int($saved) && $saved <= 0) ? $skipped + 1 : $skipped;
+        Drupal::logger('va_gov_backend')->log(LogLevel::ERROR, 'VHA health service taxonomy: Error updating owner for term "%term_name". Do it manually. Error message: %error_message.', [
+          '%term_name' => $term->label(),
+          '%error_message' => $e->getMessage(),
+        ]);
+      }
+    }
+  }
+
+  Drupal::logger('va_gov_backend')->log(LogLevel::INFO, 'VHA health service taxonomy: Successfully updated an owner for %updated out of %count terms. Failed to update %skipped out of %count terms.', [
+    '%count' => count($terms),
+    '%updated' => $updated,
+    '%skipped' => $skipped,
+  ]);
+}

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.install
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.install
@@ -189,7 +189,7 @@ function va_gov_backend_update_8003() {
  */
 function va_gov_backend_update_8004() {
   $updated = 0;
-  $skipped = 0;
+  $failed = 0;
 
   // "National health care service descriptions" term ID.
   $tid = 46;
@@ -211,7 +211,7 @@ function va_gov_backend_update_8004() {
         ]);
       }
       catch (\Exception $e) {
-        $skipped = (is_int($saved) && $saved <= 0) ? $skipped + 1 : $skipped;
+        $failed = (is_int($saved) && $saved <= 0) ? $failed + 1 : $failed;
         Drupal::logger('va_gov_backend')->log(LogLevel::ERROR, 'VHA health service taxonomy: Error updating owner for term "%term_name". Do it manually. Error message: %error_message.', [
           '%term_name' => $term->label(),
           '%error_message' => $e->getMessage(),
@@ -220,9 +220,9 @@ function va_gov_backend_update_8004() {
     }
   }
 
-  Drupal::logger('va_gov_backend')->log(LogLevel::INFO, 'VHA health service taxonomy: Successfully updated an owner for %updated out of %count terms. Failed to update %skipped out of %count terms.', [
+  Drupal::logger('va_gov_backend')->log(LogLevel::INFO, 'VHA health service taxonomy: Successfully updated an owner for %updated out of %count terms. Failed to update %failed out of %count terms.', [
     '%count' => count($terms),
     '%updated' => $updated,
-    '%skipped' => $skipped,
+    '%failed' => $failed,
   ]);
 }

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -298,7 +298,7 @@ Feature: Content model fields
 | Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VHA health service taxonomy | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
+| Vocabulary | VHA health service taxonomy | Owner | field_owner | Entity reference | Required | 1 | -- Disabled -- |  |
 | Vocabulary | VHA health service taxonomy | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |
 | Content type | VAMC system banner alert with situation updates | Only show on VAMC System page & Operating status page | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system | GovDelivery ID for Emergency updates email | field_govdelivery_id_emerg | Text (plain) | Required | 1 | Textfield |  |


### PR DESCRIPTION
## Description

See #1047 . 

- Sets default value for field_owner to "National health care service descriptions (46)" for all terms within `VHA health service taxonomy` vocabulary
- Disables field_owner on taxonomy term form display and taxonomy term view page
- Adds hook_update that standardizes field_owner value for all terms within the vocabulary by setting it to "National health care service descriptions (46)"

## Testing done

Visual + code.
[PR env link](http://pr1331a.ci.cms.va.gov/admin/reports/dblog?type%5B%5D=va_gov_backend)

## QA steps

1. `lando drush updb -y`, then check dblog for the number of terms updated. You should see the following summary message - `VHA health service taxonomy: Successfully updated an owner for 6 out of 95 terms. Failed to update 0 out of 95 terms.` . Logs in PR env http://pr1331a.ci.cms.va.gov/admin/reports/dblog?type%5B%5D=va_gov_backend
1. Login as user 1 and create a new term in `VHA health service taxonomy` vocabulary
1. Confirm field "Owner" is not visible in the term edit form
1. visit `/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview/form-display` and move Governance field group from disabled to enable and save the config
1. Edit new term you created and confirm that Owner field is already populated with term reference to "National health care service descriptions (46)"
