### PR TITLE
VACMS-1314: Adding logic to prioritize last featured item.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -349,6 +349,42 @@ function va_gov_backend_entity_presave(EntityInterface $entity) {
 
   if ($entity->getEntityTypeId() == 'node' && in_array($entity->bundle(), $bundle_types)) {
     _va_gov_backend_sync_office_listing_fields($entity);
+    _va_gov_backend_feature_bump($entity);
+  }
+}
+
+/**
+ * Unfeature other items of same bundle in system.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity.
+ */
+function _va_gov_backend_feature_bump(EntityInterface $entity) {
+  // Check to see if this entity has a featured option.
+  if (!empty($entity->field_featured)) {
+    $status = $entity->field_featured->value;
+    $bundle = $entity->bundle();
+    $target = $entity->field_listing->target_id;
+    // If this is our feature item, start the process.
+    if ($status === 1) {
+      // Look for all of same bundle in system that are also featured.
+      $select = \Drupal::database()->select('node__field_featured', 'nff');
+      $select->join('node__field_listing', 'nfl', 'nfl.entity_id = nff.entity_id');
+      $select->fields('nff', ['entity_id'])
+      // We don't want to operate on current node.
+        ->condition('nff.entity_id', $entity->id(), '!=')
+        ->condition('nff.field_featured_value', 1)
+        ->condition('nfl.field_listing_target_id', $target)
+        ->condition('nff.bundle', $bundle);
+      $results = $select->execute()->fetchAllKeyed();
+      // Better to use entity api than raw db query to get drupal magic.
+      $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple(array_keys($results));
+      foreach ($nodes as $node) {
+        // Set the others to unfeatured.
+        $node->field_featured->value = 0;
+        $node->save();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description
See #1314 
Approach: when an item is feature toggled on, toggle off all other content of same bundle in system.
Disregard 1st/2nd placement select list (it isn't used, and will probably be removed)

## Testing done
Visual

## QA steps
 - [ ] As an admin, sort events by Pittsburgh on content page, and toggle on the feature option for a published item that is not featured, and save.
 - [ ] Next, toggle on the feature option for another event in Pittsburgh, save, and visit the original node you featured, confirming that the feature option is no longer toggle on.
 - [ ] After https://github.com/department-of-veterans-affairs/vets-website/pull/12016 is merged, we will want to check event and story listings to confirm that items featured unset previous featured items, but they remain in the list