### PR TITLE
VACMS-1378 export field listing display

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -165,7 +165,7 @@ content:
     type: text_textarea
     region: content
   field_address:
-    weight: 16
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: address_default
@@ -199,7 +199,7 @@ content:
     type: string_textfield
     region: content
   field_event_cost:
-    weight: 33
+    weight: 32
     settings:
       size: 60
       placeholder: ''
@@ -246,6 +246,12 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  field_listing:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_location_humanreadable:
     weight: 15
     settings:
@@ -336,7 +342,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_listing: true
   promote: true
   status: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.news_story.default.yml
+++ b/config/sync/core.entity_form_display.node.news_story.default.yml
@@ -30,7 +30,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -101,7 +101,7 @@ third_party_settings:
       children:
         - title
         - field_author
-        - field_office
+        - field_listing
       parent_name: ''
       weight: 0
       format_type: fieldset
@@ -119,7 +119,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -147,7 +147,7 @@ content:
     type: boolean_checkbox
     region: content
   field_full_story:
-    weight: 4
+    weight: 17
     settings:
       rows: 5
       placeholder: ''
@@ -155,7 +155,7 @@ content:
     type: text_textarea
     region: content
   field_image_caption:
-    weight: 15
+    weight: 16
     settings:
       rows: 5
       placeholder: ''
@@ -168,7 +168,7 @@ content:
     type: string_textarea_with_counter
     region: content
   field_intro_text:
-    weight: 2
+    weight: 16
     settings:
       rows: 5
       placeholder: ''
@@ -180,6 +180,12 @@ content:
     third_party_settings: {  }
     type: string_textarea_with_counter
     region: content
+  field_listing:
+    type: options_select
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media:
     type: media_library_widget
     weight: 14
@@ -188,7 +194,7 @@ content:
     region: content
     third_party_settings: {  }
   field_meta_tags:
-    weight: 9
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
@@ -207,7 +213,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -239,7 +245,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 6
     settings:
       match_operator: CONTAINS
       size: 60
@@ -248,12 +254,11 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_listing: true
   promote: true
   status: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.outreach_asset.default.yml
+++ b/config/sync/core.entity_form_display.node.outreach_asset.default.yml
@@ -69,7 +69,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -94,11 +94,17 @@ content:
     type: string_textfield
     region: content
   field_format:
-    weight: 8
+    weight: 9
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
+  field_listing:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media:
     type: media_library_widget
     weight: 10
@@ -120,7 +126,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -128,7 +134,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 3
+    weight: 4
     region: content
     third_party_settings: {  }
   revision_log:
@@ -147,14 +153,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 8
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 4
+    weight: 5
     region: content
     third_party_settings: {  }
   title:
@@ -176,9 +182,8 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden:
-  field_listing: true
+hidden: {  }

--- a/config/sync/core.entity_form_display.node.press_release.default.yml
+++ b/config/sync/core.entity_form_display.node.press_release.default.yml
@@ -74,9 +74,9 @@ third_party_settings:
     group_basic_info:
       children:
         - title
+        - field_listing
         - field_address
         - field_press_release_contact
-        - field_office
         - field_release_date
       parent_name: ''
       weight: 0
@@ -100,7 +100,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_address:
-    weight: 2
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: address_default
@@ -124,6 +124,12 @@ content:
     third_party_settings: {  }
     type: string_textarea_with_counter
     region: content
+  field_listing:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_meta_tags:
     weight: 10
     settings: {  }
@@ -138,7 +144,7 @@ content:
     region: content
     third_party_settings: {  }
   field_press_release_contact:
-    weight: 3
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60
@@ -163,7 +169,7 @@ content:
     type: text_textarea
     region: content
   field_release_date:
-    weight: 6
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -222,7 +228,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_listing: true
   promote: true
   status: true
   sticky: true

--- a/config/sync/node_revisions_autoclean.settings.yml
+++ b/config/sync/node_revisions_autoclean.settings.yml
@@ -26,10 +26,10 @@ node:
   publication_listing: 0
   press_releases_listing: 0
   leadership_listing: 0
-  vba_facility: '50'
-  nca_facility: '0'
-  veterans_center: '0'
-  vet_center: '0'
+  vba_facility: 50
+  nca_facility: 0
+  veterans_center: 0
+  vet_center: 0
 interval:
   documentation_page: '0'
   event: '0'
@@ -54,7 +54,7 @@ interval:
   publication_listing: '0'
   press_releases_listing: '0'
   leadership_listing: '0'
-  vba_facility: 0
-  nca_facility: 0
-  veterans_center: 0
-  vet_center: 0
+  vba_facility: '0'
+  nca_facility: '0'
+  veterans_center: '0'
+  vet_center: '0'

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -64,7 +64,7 @@ Feature: Content model fields
 | Content type | Event | Location type | field_location_type | List (text) |  | 1 | Select list |  |
 | Content type | Event | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Content type | Event | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Event | Event listing | field_listing | Entity reference | Required | 1 | -- Disabled -- |  |
+| Content type | Event | Event listing | field_listing | Entity reference | Required | 1 | Select list |  |
 | Content type | Event | Order | field_order | List (integer) |  | 1 | Select list |  |
 | Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Linkit |  |
 | Content type | Event listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
@@ -82,7 +82,7 @@ Feature: Content model fields
 | Content type | News release | Media assets | field_press_release_downloads | Entity reference |  | Unlimited | Media library |  |
 | Content type | News release | Full text of the Press Release | field_press_release_fulltext | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | News release | Release date | field_release_date | Date |  | 1 | Date and time |  |
-| Content type | News release | News releases listing | field_listing | Entity reference | Required | 1 | -- Disabled -- | Translatable |
+| Content type | News release | News releases listing | field_listing | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Office | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Office | Body | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Office | Meta description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
@@ -94,7 +94,7 @@ Feature: Content model fields
 | Content type | Publication | Format | field_format | List (text) | Required | 1 | Select list |  |
 | Content type | Publication | File or video | field_media | Entity reference |  | 1 | Media library |  |
 | Content type | Publication | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-| Content type | Publication | Publication listing | field_listing | Entity reference | Required | 1 | -- Disabled -- | Translatable |
+| Content type | Publication | Publication listing | field_listing | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Publication listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Publication listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Publication listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
@@ -124,7 +124,7 @@ Feature: Content model fields
 | Content type | Story | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Content type | Story | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Story | Order | field_order | List (integer) |  | 1 | Select list | Translatable |
-| Content type | Story | Story listing | field_listing | Entity reference | Required | 1 | -- Disabled -- | Translatable |
+| Content type | Story | Story listing | field_listing | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Support Service | Link | field_link | Link |  | 1 | Link |  |
 | Content type | Support Service | Related office | field_office | Entity reference | Required | 1 | Select list | Translatable |


### PR DESCRIPTION
## Description

See #1378 . 


## QA steps

As an admin
1. vist the following pages:

/admin/structure/types/manage/outreach_asset/form-display
- [x] validate that Publication Listing is visible near the top of the form and is a select list.

/admin/structure/types/manage/event/form-display
- [x] validate that Event Listing is visible near the top of the form and is a select list.

/admin/structure/types/manage/press_release/form-display
- [x] validate that News releases listing is visible near the top of the form and is a select list.

/admin/structure/types/manage/news_story/form-display
- [x] validate that Story listing is visible near the top of the form and is a select list.



## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
