### PR TITLE
VACMS-1359 Use correct Slack channel for PROD deploy failures, add success message.

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -72,8 +72,11 @@ pipeline {
     always {
       cleanWs()
     }
+    success {
+      slackSend(channel: params.slack_channel, color: 'danger', message: "Deployment for ${env.JOB_NAME} succeeded ${env.BUILD_URL}, please visit prod.cms.va.gov to smoke test and leave a checkmark emoji here once done.")
+    }
     failure {
-      slackSend(channel: '#cms-team', color: 'danger', message: "${env.JOB_NAME} failed ${env.BUILD_URL}")
+      slackSend(channel: params.slack_channel, color: 'danger', message: "${env.JOB_NAME} failed ${env.BUILD_URL}")
     }
   }
 }


### PR DESCRIPTION
Also follows up on https://github.com/department-of-veterans-affairs/devops/pull/6654 and https://github.com/department-of-veterans-affairs/devops/pull/6641.