### PR TITLE
VACMS-1163: Updating new field with old field data in update hook.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -400,14 +400,16 @@ function va_gov_backend_pathauto_alias_alter(&$alias, array &$context) {
 
 /**
  * Implements hook_entity_presave().
+ *
+ * @todo: Remove node page wysiwyg sync after VACMS-1163 is on prod.
  */
 function va_gov_backend_entity_presave(EntityInterface $entity) {
   $bundle_types = ['event', 'news_story', 'press_release', 'outreach_asset'];
 
   if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $bundle_types)) {
-    _va_gov_backend_sync_office_listing_fields($entity);
     _va_gov_backend_feature_bump($entity);
   }
+
   if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'page') {
     _va_gov_backend_sync_wysiwyg_fields($entity);
   }
@@ -445,65 +447,6 @@ function _va_gov_backend_feature_bump(EntityInterface $entity) {
         $node->save();
       }
     }
-  }
-}
-
-/**
- * Sync field_listing with field_office.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   Entity.
- *
- * @todo: Use this function in hook_update_n() - VACMS-1239 Phase 2.
- */
-function _va_gov_backend_sync_office_listing_fields(EntityInterface $entity) {
-  $entity_listing_mapping = [
-    'news_story' => 'story_listing',
-    'press_release' => 'press_releases_listing',
-    'outreach_asset' => 'publication_listing',
-  ];
-
-  // Deduct field_listing value from field_office.
-  // Assuming that there's only one Listing node for each office+content type.
-  // ^ confirmed in current DB.
-  $office = $entity->hasField('field_office') ? $entity->get('field_office')->target_id : NULL;
-
-  $entity_ref = $office ? Drupal::entityTypeManager()->getStorage('node')->load($office) : NULL;
-
-  switch ($entity->bundle()) {
-    case 'event':
-      // Check if the entity reference is an event_listing.
-      if ($entity_ref && $entity_ref->bundle() === 'event_listing') {
-        // Store reference in field_listing.
-        $entity->set('field_listing', NULL);
-        $entity->field_listing[] = ['target_id' => $office];
-      }
-      else {
-        // Find event_listing by office or health_care_region_page id.
-        $result = Drupal::entityQuery('node')
-          ->condition('type', 'event_listing')
-          ->condition('field_office', $office)
-          ->execute();
-
-        _va_gov_backend_set_field_listing_value($entity, $entity_listing_mapping, reset($result));
-      }
-      break;
-
-    // Story; News release; Publication.
-    case 'news_story':
-    case 'press_release':
-    case 'outreach_asset':
-      // Check if the entity reference is an office or health_care_region_page.
-      if ($entity_ref && in_array($entity_ref->bundle(), ['office', 'health_care_region_page'])) {
-        // Find *_listing node by office or health_care_region_page id.
-        $result = Drupal::entityQuery('node')
-          ->condition('type', $entity_listing_mapping[$entity->bundle()])
-          ->condition('field_office', $office)
-          ->execute();
-
-        _va_gov_backend_set_field_listing_value($entity, $entity_listing_mapping, reset($result));
-      }
-      break;
   }
 }
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -404,9 +404,12 @@ function va_gov_backend_pathauto_alias_alter(&$alias, array &$context) {
 function va_gov_backend_entity_presave(EntityInterface $entity) {
   $bundle_types = ['event', 'news_story', 'press_release', 'outreach_asset'];
 
-  if ($entity->getEntityTypeId() == 'node' && in_array($entity->bundle(), $bundle_types)) {
+  if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $bundle_types)) {
     _va_gov_backend_sync_office_listing_fields($entity);
     _va_gov_backend_feature_bump($entity);
+  }
+  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'page') {
+    _va_gov_backend_sync_wysiwyg_fields($entity);
   }
 }
 
@@ -501,6 +504,22 @@ function _va_gov_backend_sync_office_listing_fields(EntityInterface $entity) {
         _va_gov_backend_set_field_listing_value($entity, $entity_listing_mapping, reset($result));
       }
       break;
+  }
+}
+
+/**
+ * Sync field_intro_text with field_intro_text_limited_html.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity.
+ *
+ * @todo: Use this function in hook_update_n() - VACMS-939 Phase 2.
+ */
+function _va_gov_backend_sync_wysiwyg_fields(EntityInterface $entity) {
+  // Match the new intro field with the old intro field.
+  if ($entity->hasField('field_intro_text_limited_html')) {
+    $intro_text_field_data = $entity->field_intro_text->value;
+    $entity->set('field_intro_text_limited_html', $intro_text_field_data);
   }
 }
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -512,8 +512,6 @@ function _va_gov_backend_sync_office_listing_fields(EntityInterface $entity) {
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   Entity.
- *
- * @todo: Use this function in hook_update_n() - VACMS-939 Phase 2.
  */
 function _va_gov_backend_sync_wysiwyg_fields(EntityInterface $entity) {
   // Match the new intro field with the old intro field.

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Utility\UpdateException;
 use Drupal\node\Entity\Node;
+use Psr\Log\LogLevel;
 
 /**
  * Uninstalls requested modules.
@@ -226,4 +227,49 @@ function va_gov_db_update_8008() {
       'moderation_state' => 'draft',
     ])
     ->execute();
+}
+
+/**
+ * Save benefits page to migrate old intro text data to new intro text field.
+ */
+function va_gov_db_update_8009(&$sandbox) {
+  // Grab our nodes and set the count.
+  if (empty($sandbox['total'])) {
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', 'page')
+      ->execute();
+    $sandbox['total'] = count($nids);
+    $sandbox['current'] = 0;
+  }
+
+  // Batch 25 at a time. Low number, but we have less than 300.
+  $nodes_per_batch = 25;
+
+  // Establish our place in the process.
+  $nids = \Drupal::entityQuery('node')
+    ->condition('type', 'page')
+    ->range($sandbox['current'], $sandbox['current'] + $nodes_per_batch)
+    ->execute();
+
+  // Save the nodes to update fields, and count where we are.
+  foreach ($nids as $nid) {
+    $node = Node::load($nid);
+    $node->save();
+    $sandbox['current']++;
+  }
+
+  // Tell drupal we processed some nodes.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, '%current nodes processed', [
+      '%current' => $sandbox['current'],
+    ]);
+
+  // Determine when to stop batching.
+  if ($sandbox['total'] === 0) {
+    $sandbox['#finished'] = 1;
+  }
+  else {
+    $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  }
+
 }

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -260,16 +260,11 @@ function va_gov_db_update_8009(&$sandbox) {
 
   // Tell drupal we processed some nodes.
   Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, '%current nodes processed', [
+    ->log(LogLevel::INFO, 'Page nodes %current nodes saved to populate the html intro field', [
       '%current' => $sandbox['current'],
     ]);
 
   // Determine when to stop batching.
-  if ($sandbox['total'] === 0) {
-    $sandbox['#finished'] = 1;
-  }
-  else {
-    $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
-  }
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
 
 }

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -235,33 +235,35 @@ function va_gov_db_update_8008() {
 function va_gov_db_update_8009(&$sandbox) {
   // Grab our nodes and set the count.
   if (empty($sandbox['total'])) {
-    $nids = \Drupal::entityQuery('node')
+    $sandbox['nids_process'] = array_flip(\Drupal::entityQuery('node')
       ->condition('type', 'page')
-      ->execute();
-    $sandbox['total'] = count($nids);
-    $sandbox['current'] = 0;
+      ->execute());
+    $sandbox['total'] = count($sandbox['nids_process']);
+    $sandbox['current'] = 1;
   }
 
-  // Batch 25 at a time. Low number, but we have less than 300.
-  $nodes_per_batch = 25;
+  // Run through a batch of 25.
+  $i = 0;
+  $nids = '';
+  foreach ($sandbox['nids_process'] as $nid => $revision) {
+    if ($i > 25) {
+      break;
+    }
 
-  // Establish our place in the process.
-  $nids = \Drupal::entityQuery('node')
-    ->condition('type', 'page')
-    ->range($sandbox['current'], $sandbox['current'] + $nodes_per_batch)
-    ->execute();
-
-  // Save the nodes to update fields, and count where we are.
-  foreach ($nids as $nid) {
     $node = Node::load($nid);
     $node->save();
+    unset($sandbox['nids_process'][$nid]);
+    $i++;
+
+    $nids .= $nid . ', ';
     $sandbox['current']++;
   }
 
   // Tell drupal we processed some nodes.
   Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, 'Page nodes %current nodes saved to populate the html intro field', [
+    ->log(LogLevel::INFO, 'Page nodes %current nodes saved to populate the html intro field. Nodes processed: %nids', [
       '%current' => $sandbox['current'],
+      '%nids' => $nids,
     ]);
 
   // Determine when to stop batching.

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -14,7 +14,7 @@ Feature: Content model fields
 | Content type | Benefits detail page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
 | Content type | Benefits detail page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  |
-| Content type | Benefits detail page | Intro text | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | -- Disabled -- |  |
+| Content type | Benefits detail page | Intro text | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | Benefits detail page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form |  |
 | Content type | Benefits detail page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits detail page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  |
@@ -345,3 +345,4 @@ Feature: Content model fields
 | Content type | Vet Center | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
 | Content type | Vet Center | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -14,7 +14,7 @@ Feature: Content model fields
 | Content type | Benefits detail page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
 | Content type | Benefits detail page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  |
-| Content type | Benefits detail page | Intro text | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
+| Content type | Benefits detail page | Intro text | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | -- Disabled -- |  |
 | Content type | Benefits detail page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form |  |
 | Content type | Benefits detail page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits detail page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  |


### PR DESCRIPTION
## Description
See #1163 

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/78591494-8044ef80-7811-11ea-8ac5-0565bdd2f7fe.png)

![image](https://user-images.githubusercontent.com/2404547/78591507-85a23a00-7811-11ea-8084-a347df1e57ed.png)

## QA steps
 - [ ] As an admin, go to `/admin/structure/types/manage/page/form-display` and move disabled `Intro text` field to bottom of enabled list and save
- [ ] Go to `node/3014/edit` and visually verify that wysiwyg field appears at bottom of page, and is populated with content
