### PR TITLE
VACMS-1409: All auth users should be able to see /taxonomy/term/tid.

### DIFF
--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -4,12 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_administration
-    - user.role.administrator
-    - user.role.admnistrator_users
-    - user.role.content_editor
-    - user.role.content_publisher
-    - user.role.content_reviewer
-    - user.role.redirect_administrator
+    - user.role.authenticated
     - views.view.child_terms
     - workflows.workflow.editorial
   module:
@@ -48,12 +43,7 @@ display:
         type: role
         options:
           role:
-            content_editor: content_editor
-            content_reviewer: content_reviewer
-            content_publisher: content_publisher
-            admnistrator_users: admnistrator_users
-            administrator: administrator
-            redirect_administrator: redirect_administrator
+            authenticated: authenticated
       cache:
         type: none
         options: {  }


### PR DESCRIPTION
## Description

See #1409. 

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
