### PR TITLE
VACMS-939: Updating wysiwyg text format to fix tag output.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -460,7 +460,8 @@ function _va_gov_backend_sync_wysiwyg_fields(EntityInterface $entity) {
   // Match the new intro field with the old intro field.
   if ($entity->hasField('field_intro_text_limited_html')) {
     $intro_text_field_data = $entity->field_intro_text->value;
-    $entity->set('field_intro_text_limited_html', $intro_text_field_data);
+    $entity->field_intro_text_limited_html->value = $intro_text_field_data;
+    $entity->field_intro_text_limited_html->format = 'rich_text_limited';
   }
 }
 

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -270,3 +270,45 @@ function va_gov_db_update_8009(&$sandbox) {
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
 
 }
+
+/**
+ * Set field_intro_text_limited_html field to new wysiwyg type.
+ */
+function va_gov_db_update_8010(&$sandbox) {
+  // Grab our nodes and set the count.
+  if (empty($sandbox['total'])) {
+    $sandbox['nids_process'] = array_flip(\Drupal::entityQuery('node')
+      ->condition('type', 'page')
+      ->execute());
+    $sandbox['total'] = count($sandbox['nids_process']);
+    $sandbox['current'] = 1;
+  }
+
+  // Run through a batch of 25.
+  $i = 0;
+  $nids = '';
+  foreach ($sandbox['nids_process'] as $nid => $revision) {
+    if ($i > 25) {
+      break;
+    }
+
+    $node = Node::load($nid);
+    $node->save();
+    unset($sandbox['nids_process'][$nid]);
+    $i++;
+
+    $nids .= $nid . ', ';
+    $sandbox['current']++;
+  }
+
+  // Tell drupal we processed some nodes.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'Page nodes %current nodes saved to populate the html intro field. Nodes processed: %nids', [
+      '%current' => $sandbox['current'],
+      '%nids' => $nids,
+    ]);
+
+  // Determine when to stop batching.
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+}


### PR DESCRIPTION
## Description
See #939 - oriignal update hook didn't set text format for new wysiwyg field, resulting in tags being encoded in output. This pr sets text format for new field, and prevents this from happening.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/78921573-191e7980-7a63-11ea-85a1-6ef480feb7eb.png)

## QA steps
 - [ ] Visit `education/about-gi-bill-benefits/montgomery-active-duty` and visually verify that intro text is not wrapped in visible <p> tags.