### PR TITLE
VACMS-1384: Uninstall hide_revision_field contrib.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -179,7 +179,6 @@ module:
   workbench_menu_access: 0
   workflow_participants: 0
   workflows: 0
-  hide_revision_field: 1
   menu_link_content: 1
   pathauto: 1
   disable_node_menu_item: 10

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -312,3 +312,15 @@ function va_gov_db_update_8010(&$sandbox) {
   $sandbox['finished'] = ($sandbox['current'] / $sandbox['total']);
 
 }
+
+/**
+ * Uninstall hide_revision_field.
+ */
+function va_gov_db_update_8011(&$sandbox) {
+  $unistall_modules = [
+    'hide_revision_field',
+  ];
+  $messages = _va_gov_db_uninstall_modules($unistall_modules);
+
+  return $messages;
+}


### PR DESCRIPTION
## Description

See #1384 . 

Uninstalls `hide_revision_field` contrib module.

## QA steps

- [ ] confirm `hide_revision_module` is uninstalled/disabled /admin/modules

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
