### PR TITLE
VACMS-1521: claimItem in the database and memory queues does not use e…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -224,8 +224,8 @@
                 "Content lock causes redirect response preventing migration rollback.": "https://www.drupal.org/files/issues/2018-08-28/2951652-4.patch"
             },
             "drupal/core": {
-                "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",
-                "Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch"
+                "2807629 - Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch",
+                "2893933 - claimItem in the database and memory queues does not use expire correctly": "https://www.drupal.org/files/issues/2020-01-07/2893933-34.patch"
             },
             "drupal/entity_browser": {
                 "Entity display plugin Rendered Entity is missing cache tags/keys": "https://www.drupal.org/files/issues/2020-03-31/rendered-entity-cache-keys-tags-3123876-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -237,6 +237,9 @@
                 "Allow to position the group in the advanced (sidebar) column": "https://www.drupal.org/files/issues/2018-07-26/2652642-59.patch",
                 "Incompatibility with inline entity form": "https://www.drupal.org/files/issues/2018-10-30/field_group-inline_entity_form_compatibility-2986704-3.patch"
             },
+            "drupal/govdelivery_bulletins": {
+                "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch"
+            },
             "drupal/graphql": {
                 "PHP 7.4 Notices (https://github.com/drupal-graphql/graphql/pull/989)": "https://patch-diff.githubusercontent.com/raw/drupal-graphql/graphql/pull/989.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-<<<<<<< HEAD
-    "content-hash": "321ff5fc555fe7aaadfd3c86c3e8754e",
-=======
-    "content-hash": "b823de3fcf7480b7ccabdb71bd863387",
->>>>>>> VACMS-000: Applied patch to govdevelivery_bulletins.
+    "content-hash": "6c730e2a75ea3961b8c90d2bd980f827",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8963,7 +8959,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "0967ac2ed7782ced2361437f780646e9e4f0f4e4"
+                "reference": "330f54ef421b710525fae922117a9450a56c9564"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8975,7 +8971,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1586793938",
+                    "datestamp": "1586980893",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8997,7 +8993,7 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/post_api"
             },
-            "time": "2020-04-15T20:01:09+00:00"
+            "time": "2020-04-16T21:15:38+00:00"
         },
         {
             "name": "drupal/redirect",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
+<<<<<<< HEAD
     "content-hash": "321ff5fc555fe7aaadfd3c86c3e8754e",
+=======
+    "content-hash": "b823de3fcf7480b7ccabdb71bd863387",
+>>>>>>> VACMS-000: Applied patch to govdevelivery_bulletins.
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5699,6 +5703,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63ecc394512ea34dd1ce5bf483ede171",
+    "content-hash": "321ff5fc555fe7aaadfd3c86c3e8754e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4049,9 +4049,10 @@
                     }
                 },
                 "patches_applied": {
-                    "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-11-27/2815221-125.patch",
-                    "Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch",
+                    "2807629 - Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch",
+                    "2893933 - claimItem in the database and memory queues does not use expire correctly": "https://www.drupal.org/files/issues/2020-01-07/2893933-34.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
+                    "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-11-27/2815221-125.patch",
                     "1356276 - Allow profiles to define a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/2019-11-05/1356276-531-8.8.x-4.patch",
                     "2914389 - Allow profiles to exclude dependencies of their parent": "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch"
                 }


### PR DESCRIPTION
…xpire correctly

## Description

This is a follow up to queue item processing, queue item lease expire dates.

## Testing done


## Screenshots


## QA steps

**Problem statement**: in certain circumstances (yet unknown/unreproducible), queue items lease expire timestamps are not cleared on queue item release. If expiration date is cleared, the queue worker will not touch that item ever again.

Expected behavior: if the queue item has expire value set to a timestamp that signifies past data, the queue worker should claim the item during the next processing task and either successfully process it or release back to queue w/ expire timestamp set to `0`.

[Core patch](https://www.drupal.org/project/drupal/issues/2893933#comment-13413895) applied in this PR fixes the problem.

[See Slack thread for context](https://dsva.slack.com/archives/CT4GZBM8F/p1587059574195200)

Also, phpunit tests were originally failing after core patch applied due to `govdelivery_bulletins` `claimItem(0)` which now should only be a positive integer. I already updated post_api to fix the same issue and posted a [patch](https://www.drupal.org/project/govdelivery_bulletins/issues/3128425) for `govdelivery_bulletins` which I applied here. @swirtSJW , if you'd like to create a new release w/ that patch and include version update in this PR - it'd be great.

**To reproduce and test the fix for this issue:**

1. `git checkout master`
1. open va_gov_post_api.module in IDE docroot/modules/custom/va_gov_post_api/va_gov_post_api.module and on **line 65**  change the condition `if (!empty($data['payload']) && $facility_id) {` to `if (!empty($data['payload'])) {`
1. run perms.feature tests `lando behat --tags=perms`, wait until tests are complete
    - [ ] visit https://va-gov-cms.lndo.site/admin/config/post-api/queue  and confirm that 3 out of 4 items have expiration dates that are in the past
    - [ ] Process the queue. Confirm that expire dates left unchanged - this means that _none_ of the items w/ expire dates were processed
1. git checkout this branch
1. `lando composer install`
   - [ ] visit https://va-gov-cms.lndo.site/admin/config/post-api/queue  and confirm that 3 out of 4 items have expiration dates that are in the past
    - [ ] Process the queue. Confirm that expire dates are now set to `0` - this means that _all_ of the items w/ expire dates were processed and released correctly


## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
