### PR TITLE
VACMS-1533: va_gov_post_api bypass_data_check setting.

### DIFF
--- a/config/sync/va_gov_post_api.settings.yml
+++ b/config/sync/va_gov_post_api.settings.yml
@@ -1,0 +1,1 @@
+bypass_data_check: 0

--- a/docroot/modules/custom/va_gov_post_api/config/install/va_gov_post_api.settings.yml
+++ b/docroot/modules/custom/va_gov_post_api/config/install/va_gov_post_api.settings.yml
@@ -1,0 +1,1 @@
+bypass_data_check: 0

--- a/docroot/modules/custom/va_gov_post_api/src/Form/VaGovPostApiSettingsForm.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Form/VaGovPostApiSettingsForm.php
@@ -31,7 +31,7 @@ class VaGovPostApiSettingsForm extends FormBase {
     $form['bypass_data_check'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Bypass data comparison'),
-      '#description' => $this->t('If checked, all created and saved nodes will be queued for syncing bypassing a requirement for updated data.'),
+      '#description' => $this->t('If checked, all saved nodes will be queued for syncing bypassing a requirement for updated data.'),
       '#default_value' => $config->get('bypass_data_check'),
     ];
 

--- a/docroot/modules/custom/va_gov_post_api/src/Form/VaGovPostApiSettingsForm.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Form/VaGovPostApiSettingsForm.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\va_gov_post_api\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class VaGovPostApiSettingsForm.
+ */
+class VaGovPostApiSettingsForm extends FormBase {
+
+  /**
+   * Class constructor.
+   */
+  public function __construct() {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'va_gov_post_api_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('va_gov_post_api.settings');
+
+    $form['bypass_data_check'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Bypass data comparison'),
+      '#description' => $this->t('If checked, all created and saved nodes will be queued for syncing bypassing a requirement for updated data.'),
+      '#default_value' => $config->get('bypass_data_check'),
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save'),
+      '#weight' => '20',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = self::configFactory()->getEditable('va_gov_post_api.settings');
+    $config
+      ->set('bypass_data_check', $form_state->getValue('bypass_data_check'))
+      ->save();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.links.menu.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.links.menu.yml
@@ -1,0 +1,5 @@
+va_gov_post_api.admin_settings:
+  title: VA.gov Post API Settings
+  description: 'VA.gov Post API settings.'
+  route_name: va_gov_post_api.admin_settings
+  parent: post_api.admin_home

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -89,6 +89,19 @@ function _post_api_get_facility_payload(EntityInterface $entity) {
   $operating_status = $entity->field_operating_status_facility->value;
   $additional_info = $entity->field_operating_status_more_info->value;
 
+  $config = \Drupal::config('va_gov_post_api.settings');
+
+  // If bypass_data_check setting is enabled, do not check for data change,
+  // return the payload for the item immediately.
+  if ($config->get('bypass_data_check')) {
+    return [
+      'operating_status' => [
+        'code' => strtoupper($operating_status),
+        'additional_info' => $additional_info,
+      ],
+    ];
+  }
+
   if (isset($entity->original) && $entity->original instanceof EntityInterface) {
     // Entity is updated.
     $original_operating_status = $entity->original->field_operating_status_facility->value;

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.routing.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.routing.yml
@@ -1,0 +1,9 @@
+va_gov_post_api.admin_settings:
+  path: '/admin/config/va-gov-post-api/config'
+  defaults:
+    _form: '\Drupal\va_gov_post_api\Form\VaGovPostApiSettingsForm'
+    _title: 'VA.gov Post API Settings'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE


### PR DESCRIPTION
## Description

See #1533. 

- adds settings form for `va_gov_post_api` module
- adds menu item within Post Api menu "VA.gov Post API Settings"
- adds `bypass_data_check` flag; when checked, updated data comparison is bypassed an item payload is immediately returned + entity queued for syncing

## Testing done

Manual 

## Screenshots

<img width="970" alt="Screen Shot 2020-04-20 at 12 06 01 PM" src="https://user-images.githubusercontent.com/16477724/79784359-5a364980-82ff-11ea-9bc5-08e7f21eb3b1.png">

## QA steps

As user 1
- [ ] visit Configuration > Web Services > Post API > VA.gov Post API Settings , while confirming this menu item exists
- [ ] check the "Bypass" checkbox. Save form
- [ ] edit any facility and save without adding / updating data. Confirm this facility is queued at /admin/config/post-api/queue
- [ ] disable the "Bypass" settings. Save form.
- [ ] edit any facility and save without adding / updating data. Confirm this facility is NOT queued at /admin/config/post-api/queue

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
