### PR TITLE
VAGOVTEAM-8188: Removing nickname field from cms form and view.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -61,7 +61,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       parent_name: ''
       weight: 9
       format_type: fieldset
@@ -101,7 +100,6 @@ third_party_settings:
       region: content
     group_title_and_summary:
       children:
-        - field_nickname_for_this_facility
         - field_intro_text
         - field_media
       parent_name: ''
@@ -330,14 +328,6 @@ content:
     third_party_settings: {  }
     type: string_textfield_with_counter
     region: content
-  field_nickname_for_this_facility:
-    weight: 4
-    settings:
-      size: 120
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_operating_status_facility:
     weight: 5
     settings: {  }
@@ -402,6 +392,7 @@ content:
 hidden:
   created: true
   field_local_health_care_service_: true
+  field_nickname_for_this_facility: true
   promote: true
   status: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -63,7 +63,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       parent_name: ''
       weight: 13
       format_type: fieldset
@@ -185,7 +184,6 @@ third_party_settings:
       children:
         - title
         - field_vamc_system_official_name
-        - field_nickname_for_this_facility
         - field_intro_text
       parent_name: ''
       weight: 0
@@ -451,14 +449,6 @@ content:
     third_party_settings: {  }
     type: string_textfield_with_counter
     region: content
-  field_nickname_for_this_facility:
-    weight: 3
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_operating_status:
     weight: 37
     settings:
@@ -563,6 +553,7 @@ hidden:
   field_link_facility_emerg_list: true
   field_link_facility_news_list: true
   field_links: true
+  field_nickname_for_this_facility: true
   field_sign_up_for_emergency_emai: true
   promote: true
   sticky: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -45,7 +45,7 @@ third_party_settings:
         - field_meta_title
         - field_description
       parent_name: ''
-      weight: 2
+      weight: 1
       format_type: fieldset
       format_settings:
         id: ''
@@ -64,7 +64,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_address:
-    weight: 7
+    weight: 6
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -72,7 +72,7 @@ content:
     region: content
   field_administration:
     type: entity_reference_rss_category
-    weight: 22
+    weight: 21
     region: content
     label: above
     settings: {  }
@@ -86,7 +86,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   field_email_subscription:
-    weight: 15
+    weight: 14
     label: above
     settings:
       trim_length: 80
@@ -98,7 +98,7 @@ content:
     type: link
     region: content
   field_facebook:
-    weight: 11
+    weight: 10
     label: above
     settings:
       trim_length: 80
@@ -110,14 +110,14 @@ content:
     type: link
     region: content
   field_facility_classification:
-    weight: 20
+    weight: 19
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_facility_hours:
-    weight: 18
+    weight: 17
     label: above
     settings:
       row_header: 1
@@ -126,7 +126,7 @@ content:
     type: tablefield
     region: content
   field_facility_locator_api_id:
-    weight: 5
+    weight: 4
     label: above
     settings:
       link_to_entity: false
@@ -134,7 +134,7 @@ content:
     type: string
     region: content
   field_flickr:
-    weight: 12
+    weight: 11
     label: above
     settings:
       trim_length: 80
@@ -146,7 +146,7 @@ content:
     type: link
     region: content
   field_instagram:
-    weight: 13
+    weight: 12
     label: above
     settings:
       trim_length: 80
@@ -158,14 +158,14 @@ content:
     type: link
     region: content
   field_intro_text:
-    weight: 3
+    weight: 2
     label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
     region: content
   field_local_health_care_service_:
-    weight: 9
+    weight: 8
     label: above
     settings:
       link: true
@@ -174,7 +174,7 @@ content:
     region: content
   field_location_services:
     type: entity_reference_revisions_entity_view
-    weight: 10
+    weight: 9
     label: above
     settings:
       view_mode: default
@@ -182,7 +182,7 @@ content:
     third_party_settings: {  }
     region: content
   field_main_location:
-    weight: 6
+    weight: 5
     label: above
     settings:
       format: default
@@ -192,7 +192,7 @@ content:
     type: boolean
     region: content
   field_media:
-    weight: 4
+    weight: 3
     label: above
     settings:
       link: true
@@ -200,7 +200,7 @@ content:
     type: entity_reference_label
     region: content
   field_mental_health_phone:
-    weight: 19
+    weight: 18
     label: above
     settings:
       title: ''
@@ -215,30 +215,22 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-  field_nickname_for_this_facility:
-    weight: 1
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
   field_operating_status_facility:
-    weight: 16
+    weight: 15
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_operating_status_more_info:
-    weight: 17
+    weight: 16
     label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
     region: content
   field_phone_number:
-    weight: 8
+    weight: 7
     label: above
     settings:
       title: ''
@@ -247,14 +239,14 @@ content:
     region: content
   field_region_page:
     type: entity_reference_label
-    weight: 21
+    weight: 20
     region: content
     label: above
     settings:
       link: true
     third_party_settings: {  }
   field_twitter:
-    weight: 14
+    weight: 13
     label: above
     settings:
       trim_length: 80
@@ -267,5 +259,6 @@ content:
     region: content
 hidden:
   field_meta_tags: true
+  field_nickname_for_this_facility: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
@@ -57,7 +57,7 @@ third_party_settings:
       children:
         - field_intro_text
         - field_media
-        - field_nickname_for_this_facility
+        - field_vamc_system_official_name
         - field_other_va_locations
         - field_leadership
         - field_appointments_online
@@ -92,11 +92,6 @@ third_party_settings:
       region: content
     group_social_media_and_links:
       children:
-        - field_links
-        - field_sign_up_for_emergency_emai
-        - field_email_subscription_links
-        - field_link_facility_emerg_list
-        - field_link_facility_news_list
         - field_operating_status
         - field_facebook
         - field_flickr
@@ -131,7 +126,7 @@ content:
     type: entity_reference_label
     region: content
   field_appointments_online:
-    weight: 9
+    weight: 10
     label: above
     settings:
       format: default
@@ -148,7 +143,7 @@ content:
     type: text_default
     region: content
   field_clinical_health_services:
-    weight: 10
+    weight: 11
     label: above
     settings:
       link: true
@@ -197,7 +192,7 @@ content:
     type: link
     region: content
   field_govdelivery_id_emerg:
-    weight: 26
+    weight: 6
     label: above
     settings:
       link_to_entity: false
@@ -205,7 +200,7 @@ content:
     type: string
     region: content
   field_govdelivery_id_news:
-    weight: 27
+    weight: 7
     label: above
     settings:
       link_to_entity: false
@@ -232,35 +227,35 @@ content:
     type: basic_string
     region: content
   field_intro_text_events_page:
-    weight: 8
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: text_default
-    region: content
-  field_intro_text_leadership:
-    weight: 5
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: basic_string
-    region: content
-  field_intro_text_news_stories:
     weight: 9
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
-  field_intro_text_press_releases:
+  field_intro_text_leadership:
     weight: 6
     label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
     region: content
+  field_intro_text_news_stories:
+    weight: 10
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_intro_text_press_releases:
+    weight: 7
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
   field_leadership:
-    weight: 8
+    weight: 9
     label: above
     settings:
       link: true
@@ -290,14 +285,6 @@ content:
     third_party_settings: {  }
     type: string
     region: content
-  field_nickname_for_this_facility:
-    weight: 6
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
   field_operating_status:
     weight: 11
     label: above
@@ -311,7 +298,7 @@ content:
     type: link
     region: content
   field_other_va_locations:
-    weight: 7
+    weight: 8
     label: above
     settings:
       link_to_entity: false
@@ -319,7 +306,7 @@ content:
     type: string
     region: content
   field_press_release_blurb:
-    weight: 7
+    weight: 8
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -347,7 +334,7 @@ content:
     type: link
     region: content
   field_vamc_system_official_name:
-    weight: 28
+    weight: 6
     label: above
     settings:
       link_to_entity: false
@@ -356,5 +343,6 @@ content:
     region: content
 hidden:
   field_meta_tags: true
+  field_nickname_for_this_facility: true
   links: true
   search_api_excerpt: true

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -13,13 +13,13 @@ Feature: Content model fields
 | Content type | Benefits detail page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL |  |
 | Content type | Benefits detail page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits detail page | Featured content | field_featured_content | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
-| Content type | Benefits detail page | Intro text | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  |
 | Content type | Benefits detail page | Intro text | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | -- Disabled -- |  |
 | Content type | Benefits detail page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form |  |
 | Content type | Benefits detail page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits detail page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  |
 | Content type | Benefits detail page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | Date and time |  |
 | Content type | Benefits detail page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
+| Content type | Benefits detail page | Intro text | field_intro_text  | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  |
 | Content type | Benefits hub landing page | Owner | field_administration | Entity reference | Required | 1 | Select list |  |
 | Content type | Benefits hub landing page | Alert | field_alert | Entity reference |  | 1 | Entity browser | Translatable |
 | Content type | Benefits hub landing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
@@ -149,12 +149,12 @@ Feature: Content model fields
 | Content type | VAMC facility | Mental Health Phone | field_mental_health_phone | Telephone number |  | 1 | Telephone number |  |
 | Content type | VAMC facility | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | VAMC facility | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC facility | Nickname for this facility | field_nickname_for_this_facility | Text (plain) | Required | 1 | Textfield |  |
 | Content type | VAMC facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list |  |
 | Content type | VAMC facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | VAMC facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | VAMC facility | Region page | field_region_page | Entity reference | Required | 1 | Select list |  |
 | Content type | VAMC facility | Twitter | field_twitter | Link |  | 1 | Link | Translatable |
+| Content type | VAMC facility | Nickname for this facility | field_nickname_for_this_facility | Text (plain) | Required | 1 | -- Disabled -- |  |
 | Content type | VAMC facility health service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC facility health service | Facility description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC facility health service | Facility | field_facility_location | Entity reference | Required | 1 | Select list | Translatable |
@@ -178,13 +178,13 @@ Feature: Content model fields
 | Content type | VAMC system | Banner image | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Content type | VAMC system | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | VAMC system | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC system | VAMC system short name | field_nickname_for_this_facility | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | VAMC system | VAMC system official name | field_vamc_system_official_name | Text (plain) |  | 1 | Textfield |  |
 | Content type | VAMC system | Operating status | field_operating_status | Link |  | 1 | Linkit |  |
 | Content type | VAMC system | Other VA Locations | field_other_va_locations | Text (plain) |  | Unlimited | Textfield |  |
 | Content type | VAMC system | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC system | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | VAMC system | Twitter | field_twitter | Link |  | 1 | Link | Translatable |
+| Content type | VAMC system | VAMC system short name | field_nickname_for_this_facility | Text (plain) |  | 1 | -- Disabled -- | Translatable |
 | Content type | VAMC system banner alert with situation updates | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC system banner alert with situation updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC system banner alert with situation updates | Display "Subscribe to email updates" link? | field_alert_email_updates_button | Boolean |  | 1 | Single on/off checkbox |  |


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-team/issues/8188

## Testing done
 - Build cms and then vets-website locally - build success

## Screenshots
N/A

## QA steps
 - As an admin, visit `http://va-gov-cms.lndo.site/admin/structure/types/manage/health_care_region_page/form-display` and `http://va-gov-cms.lndo.site/admin/structure/types/manage/health_care_local_facility/form-display`, visually verifying `field_nickname_for_this_facility` is disabled