### PR TITLE
VACMS-1541: Post API hook_cron

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8955,7 +8955,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "0967ac2ed7782ced2361437f780646e9e4f0f4e4"
+                "reference": "d0b10c233b108cbf5c3f9a031cb59f216aa05afa"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8967,7 +8967,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1586793938",
+                    "datestamp": "1587071982",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8989,7 +8989,7 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/post_api"
             },
-            "time": "2020-04-15T20:01:09+00:00"
+            "time": "2020-04-20T23:02:23+00:00"
         },
         {
             "name": "drupal/redirect",


### PR DESCRIPTION
## Description

See #1541 . 
https://git.drupalcode.org/project/post_api/-/commit/d0b10c233b108cbf5c3f9a031cb59f216aa05afa 

## Testing done
Manual

## QA steps

As user 1
**test queue items failure**
1. remove any api creds from settings.php
1. add some items to queue by updating some facility nodes
1. `lando drush cron`
    - [ ] Confirm you see log message `Post API: failure to process queued items. Total items in queue: X.` 
    - [ ] Confirm all queued items remained in queue
1. add sandbox creds to settings.php
1. `lando drush cr`
1. `lando drush cron`
    - [ ] Confirm you see log message `Post API: processed X out of X queued items.` 
    - [ ] Confirm all queued items are released from queue

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
