### PR TITLE
VACMS-1546: Fix URL aliases for events news stories and press releases.

### DIFF
--- a/config/sync/pathauto.pattern.event.yml
+++ b/config/sync/pathauto.pattern.event.yml
@@ -7,16 +7,16 @@ dependencies:
 id: event
 label: Event
 type: 'canonical_entities:node'
-pattern: '[node:field_office:entity:url:path]/events/[node:title]'
+pattern: '[node:field_listing:entity:field_office:entity:url:path]/events/[node:title]'
 selection_criteria:
-  6be7c8c6-0f8f-4c97-95a6-efb77d336633:
+  66413759-adac-4742-8740-349da68f9d0a:
     id: node_type
     bundles:
       event: event
     negate: false
     context_mapping:
       node: node
-    uuid: 6be7c8c6-0f8f-4c97-95a6-efb77d336633
+    uuid: 66413759-adac-4742-8740-349da68f9d0a
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/config/sync/pathauto.pattern.news_story.yml
+++ b/config/sync/pathauto.pattern.news_story.yml
@@ -7,16 +7,16 @@ dependencies:
 id: news_story
 label: Story
 type: 'canonical_entities:node'
-pattern: '[node:field_office:entity:url:path]/stories/[node:title]'
+pattern: '[node:field_listing:entity:field_office:entity:url:path]/stories/[node:title]'
 selection_criteria:
-  17fd564a-497f-4b38-a619-8fbc653e9cfa:
+  a1e1f7f4-4eec-4273-b4ed-cb528c29027d:
     id: node_type
     bundles:
       news_story: news_story
     negate: false
     context_mapping:
       node: node
-    uuid: 17fd564a-497f-4b38-a619-8fbc653e9cfa
+    uuid: a1e1f7f4-4eec-4273-b4ed-cb528c29027d
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/config/sync/pathauto.pattern.press_releases.yml
+++ b/config/sync/pathauto.pattern.press_releases.yml
@@ -7,16 +7,16 @@ dependencies:
 id: press_releases
 label: 'News release'
 type: 'canonical_entities:node'
-pattern: '[node:field_office:entity:url:path]/news-releases/[node:title]'
+pattern: '[node:field_listing:entity:field_office:entity:url:path]/news-releases/[node:title]'
 selection_criteria:
-  d04ce04f-778c-4dd4-846e-0f5947fab4a6:
+  0109524b-4447-436e-b70b-7238dc4a25ce:
     id: node_type
     bundles:
       press_release: press_release
     negate: false
     context_mapping:
       node: node
-    uuid: d04ce04f-778c-4dd4-846e-0f5947fab4a6
+    uuid: 0109524b-4447-436e-b70b-7238dc4a25ce
 selection_logic: and
 weight: -2
 relationships: {  }


### PR DESCRIPTION
## Description

See #1546. 

## Testing done
Manual

## Screenshots


## QA steps

As user ryan.stubblebine@va.gov with content_publisher role
1. Create a story, event, and news release
1. Assign all to Pittsburgh (owner and listing)
1. URLs should all start with /pittsburgh-health-care


