### PR TITLE
VACMS-1415: Set char limit for Operating Status - More Info field

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -349,8 +349,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+      maxlength: 300
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Remaining characters: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
-    type: string_textarea
+    type: string_textarea_with_counter
     region: content
   field_phone_number:
     weight: 15

--- a/config/sync/core.entity_form_display.node.nca_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.nca_facility.default.yml
@@ -103,8 +103,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+      maxlength: 300
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Remaining characters: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
-    type: string_textarea
+    type: string_textarea_with_counter
     region: content
   moderation_state:
     type: moderation_state_default

--- a/config/sync/core.entity_form_display.node.vba_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.vba_facility.default.yml
@@ -103,8 +103,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+      maxlength: 300
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Remaining characters: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
-    type: string_textarea
+    type: string_textarea_with_counter
     region: content
   moderation_state:
     type: moderation_state_default

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -103,8 +103,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+      maxlength: 300
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Remaining characters: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
-    type: string_textarea
+    type: string_textarea_with_counter
     region: content
   moderation_state:
     type: moderation_state_default

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -151,7 +151,7 @@ Feature: Content model fields
 | Content type | VAMC facility | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | VAMC facility | Nickname for this facility | field_nickname_for_this_facility | Text (plain) | Required | 1 | Textfield |  |
 | Content type | VAMC facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list |  |
-| Content type | VAMC facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Content type | VAMC facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | VAMC facility | Region page | field_region_page | Entity reference | Required | 1 | Select list |  |
 | Content type | VAMC facility | Twitter | field_twitter | Link |  | 1 | Link | Translatable |
@@ -336,13 +336,12 @@ Feature: Content model fields
 | Content type | VBA facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | VBA facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VBA facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
-| Content type | VBA facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | VBA facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | NCA facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | NCA facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | NCA facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
-| Content type | NCA facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | NCA facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Vet Center | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Vet Center | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
-| Content type | Vet Center | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
-
+| Content type | Vet Center | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |


### PR DESCRIPTION
## Description

See #1415. 

## Testing done

Manual 

## QA steps

As Administrator or Content Admin user:

- [x] add NCA facility `/node/add/nca_facility`, enter more than 300 chars in "Operating Status - More Info" field. Press "Save". Confirm that the form validation prevented node submission and character limit error message is shown under the field.
- [x] add VBA facility `/node/add/vba_facility`, enter more than 300 chars in "Operating Status - More Info" field. Press "Save". Confirm that the form validation prevented node submission and character limit error message is shown under the field.
- [x] add Vet Center facility `/node/add/vet_center`, enter more than 300 chars in "Operating Status - More Info" field. Press "Save". Confirm that the form validation prevented node submission and character limit error message is shown under the field.
- [x] add VAMC facility `/node/add/health_care_local_facility`, enter more than 300 chars in "Operating Status - More Info" field. Press "Save". Confirm that the form validation prevented node submission and character limit error message is shown under the field.
- [x] visit Facility Status tool `/admin/content/facility-status`. Select some facilities. Press "Update Operating Status". Check the checkbox next to "Operating Status - more info" field and fill the textbox w/ more than 300 chars. Press "Apply". Confirm that the form validation prevented submission and character limit error message is shown under the field.


## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
