### PR TITLE
VACMS-1548: Fix cache cid for field_listing values storage.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_backend/src/Service/UserPermsService.php
@@ -78,6 +78,12 @@ class UserPermsService {
       if (in_array($target, $form) && !empty($form[$target]['widget']['#options'])) {
         $cid = 'userpermservice-dropdown-access-' . $target . '-' . $user_id;
 
+        if ($target === 'field_listing') {
+          // Add form id to cid for field_listing, since lists for various
+          // content type are different.
+          $cid = 'userpermservice-dropdown-access-' . $form['#form_id'] . '-' . $target . '-' . $user_id;
+        }
+
         $cached_data = \Drupal::cache()->get($cid);
         // If we have a cache, return it.
         if (!empty($cached_data)) {


### PR DESCRIPTION
## Description

See #1548. 

## Testing done
Manual

## Screenshots


## QA steps

**Note: this fixes caching issue for field_listing value storage. Permissions for some entities still need to be addressed.**

- [x] As louis.scavnicky@va.gov (content_admin) , go to:
   - [x] /node/add/event - confirm you see all available Event Listings in field_listing
   - [x] /node/add/press_release - confirm you see all available Press Release Listings in field_listing
   - [x] node/add/news_story  - confirm you see all available Story Listings in field_listing
   - [x] /node/add/outreach_asset -  confirm you see Outreach listing in field_listing
- [x] @ryan.stubblebine@va.gov (content_publisher), go to:
   - [x] /node/add/event - confirm you see on Pittsburgh Events in field_listing
   - [x] /node/add/press_release - confirm you see all available Press Release Listings in field_listing **(note: exposure of all options to publishers is a temporary fix)**
   - [x] node/add/news_story  - confirm you see all available Story Listings in field_listing **(note: exposure of all options to publishers is a temporary fix)**
   - [x] /node/add/outreach_asset -  confirm you see no options in field_listing

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
