### PR TITLE
VACMS-1556: QueueWorker max runtime.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8959,7 +8959,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "330f54ef421b710525fae922117a9450a56c9564"
+                "reference": "ed3f8a9997cc0845b8178b770569decdfb63d448"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8971,7 +8971,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1586980893",
+                    "datestamp": "1587495235",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8993,7 +8993,7 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/post_api"
             },
-            "time": "2020-04-16T21:15:38+00:00"
+            "time": "2020-04-21T18:56:54+00:00"
         },
         {
             "name": "drupal/redirect",

--- a/config/sync/post_api.settings.yml
+++ b/config/sync/post_api.settings.yml
@@ -1,0 +1,1 @@
+queueworker_max_runtime: '60'


### PR DESCRIPTION
## Description

See #1556 . 
https://git.drupalcode.org/project/post_api/commit/ed3f8a9 
## Testing done

<img width="1597" alt="Screen Shot 2020-04-21 at 1 05 27 PM" src="https://user-images.githubusercontent.com/16477724/79903729-d0ef4780-83d0-11ea-8ac0-bbad913f6ead.png">

Queued 7 items.
Enabled xDebug and set breakpoints throughout processQueue() method to ensure I can delay the last item execution until 60 seconds have passed.
Ran queue process manually.
As expected, last item was not processed (no exp date) because it fell outside of the 60 sec runtime limit.

## Screenshots


## QA steps

- make sure you have no real credentials added in settings.php in order to have item fail and go back to queue
- add at 3-5 items to queue
- set runtime settings to something ridiculous like 1 second at /admin/config/post-api/config
- Process queue manually
- check that queue items that were processed have expiration dates set. Locally, 1 seconds allowed for 1 processed item for me. For you mileage can very

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
