### PR TITLE
VACMS-1572: Fixing update hook to set text format for benefits field.

### DIFF
--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -266,6 +266,9 @@ function va_gov_db_update_8015(&$sandbox) {
     $node->setNewRevision(TRUE);
     // Set revision author to uid 1317.
     $node->setRevisionAuthorId(1317);
+    $node->setChangedTime(time());
+    $node->setRevisionCreationTime(time());
+    $node->setOwnerId(1317);
     // Set revision log message.
     $node->setRevisionLogMessage('Automated move of text from intro_text to intro_text_limited_html');
     $node->save();
@@ -287,6 +290,11 @@ function va_gov_db_update_8015(&$sandbox) {
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
   // Log the all finsished notice.
   if ($sandbox['#finished'] == 1) {
-    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'RE-saving all page nodes completed by va_gov_db_update_8012.');
+    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'RE-saving all %count page nodes completed by va_gov_db_update_8015.', [
+      '%count' => $sandbox['total'],
+    ]);
+    return "Process complete.";
   }
+
+return "Processing page nodes...";
 }

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -242,9 +242,9 @@ function va_gov_db_update_8011(&$sandbox) {
 }
 
 /**
- * Set field_intro_text_limited_html field to new wysiwyg type.
+ * Move field_intro_text to field_intro_text_limited_html wysiwyg field.
  */
-function va_gov_db_update_8012(&$sandbox) {
+function va_gov_db_update_8015(&$sandbox) {
   // Grab our nodes and set the count.
   if (empty($sandbox['total'])) {
     $sandbox['nids_process'] = \Drupal::entityQuery('node')
@@ -262,10 +262,14 @@ function va_gov_db_update_8012(&$sandbox) {
       break;
     }
     $node = Node::load($nid);
-    // Add revision log message here with uid 1317.
-    $node->setRevisionLogMessage('New revision created by uid 1317.');
+    // Make this change a new revision.
+    $node->setNewRevision(TRUE);
+    // Set revision author to uid 1317.
+    $node->setRevisionAuthorId(1317);
+    // Set revision log message.
+    $node->setRevisionLogMessage('Automated move of text from intro_text to intro_text_limited_html');
     $node->save();
-    unset($sandbox['nids_process'][$nid]);
+    unset($sandbox['nids_process'][$revision]);
     $i++;
 
     $nids .= $nid . ', ';
@@ -283,6 +287,6 @@ function va_gov_db_update_8012(&$sandbox) {
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
   // Log the all finsished notice.
   if ($sandbox['#finished'] == 1) {
-    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'Batch operation in va_gov_db_update_8012 completed.');
+    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'RE-saving all page nodes completed by va_gov_db_update_8012.');
   }
 }

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -230,90 +230,6 @@ function va_gov_db_update_8008() {
 }
 
 /**
- * Save benefits page to migrate old intro text data to new intro text field.
- */
-function va_gov_db_update_8009(&$sandbox) {
-  // Grab our nodes and set the count.
-  if (empty($sandbox['total'])) {
-    $sandbox['nids_process'] = array_flip(\Drupal::entityQuery('node')
-      ->condition('type', 'page')
-      ->execute());
-    $sandbox['total'] = count($sandbox['nids_process']);
-    $sandbox['current'] = 1;
-  }
-
-  // Run through a batch of 25.
-  $i = 0;
-  $nids = '';
-  foreach ($sandbox['nids_process'] as $nid => $revision) {
-    if ($i > 25) {
-      break;
-    }
-
-    $node = Node::load($nid);
-    $node->save();
-    unset($sandbox['nids_process'][$nid]);
-    $i++;
-
-    $nids .= $nid . ', ';
-    $sandbox['current']++;
-  }
-
-  // Tell drupal we processed some nodes.
-  Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, 'Page nodes %current nodes saved to populate the html intro field. Nodes processed: %nids', [
-      '%current' => $sandbox['current'],
-      '%nids' => $nids,
-    ]);
-
-  // Determine when to stop batching.
-  $sandbox['finished'] = ($sandbox['current'] / $sandbox['total']);
-
-}
-
-/**
- * Set field_intro_text_limited_html field to new wysiwyg type.
- */
-function va_gov_db_update_8010(&$sandbox) {
-  // Grab our nodes and set the count.
-  if (empty($sandbox['total'])) {
-    $sandbox['nids_process'] = array_flip(\Drupal::entityQuery('node')
-      ->condition('type', 'page')
-      ->execute());
-    $sandbox['total'] = count($sandbox['nids_process']);
-    $sandbox['current'] = 1;
-  }
-
-  // Run through a batch of 25.
-  $i = 0;
-  $nids = '';
-  foreach ($sandbox['nids_process'] as $nid => $revision) {
-    if ($i > 25) {
-      break;
-    }
-
-    $node = Node::load($nid);
-    $node->save();
-    unset($sandbox['nids_process'][$nid]);
-    $i++;
-
-    $nids .= $nid . ', ';
-    $sandbox['current']++;
-  }
-
-  // Tell drupal we processed some nodes.
-  Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, 'Page nodes %current nodes saved to populate the html intro field. Nodes processed: %nids', [
-      '%current' => $sandbox['current'],
-      '%nids' => $nids,
-    ]);
-
-  // Determine when to stop batching.
-  $sandbox['finished'] = ($sandbox['current'] / $sandbox['total']);
-
-}
-
-/**
  * Uninstall hide_revision_field.
  */
 function va_gov_db_update_8011(&$sandbox) {
@@ -323,4 +239,50 @@ function va_gov_db_update_8011(&$sandbox) {
   $messages = _va_gov_db_uninstall_modules($unistall_modules);
 
   return $messages;
+}
+
+/**
+ * Set field_intro_text_limited_html field to new wysiwyg type.
+ */
+function va_gov_db_update_8012(&$sandbox) {
+  // Grab our nodes and set the count.
+  if (empty($sandbox['total'])) {
+    $sandbox['nids_process'] = \Drupal::entityQuery('node')
+      ->condition('type', 'page')
+      ->execute();
+    $sandbox['total'] = count($sandbox['nids_process']);
+    $sandbox['current'] = 0;
+  }
+
+  // Run through a batch of 25.
+  $i = 0;
+  $nids = '';
+  foreach ($sandbox['nids_process'] as $revision => $nid) {
+    if ($i == 25) {
+      break;
+    }
+    $node = Node::load($nid);
+    // Add revision log message here with uid 1317.
+    $node->setRevisionLogMessage('New revision created by uid 1317.');
+    $node->save();
+    unset($sandbox['nids_process'][$nid]);
+    $i++;
+
+    $nids .= $nid . ', ';
+    $sandbox['current']++;
+  }
+
+  // Tell drupal we processed some nodes.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'Page nodes %current nodes saved to populate the html intro field. Nodes processed: %nids', [
+      '%current' => $sandbox['current'],
+      '%nids' => $nids,
+    ]);
+
+  // Determine when to stop batching.
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  // Log the all finsished notice.
+  if ($sandbox['#finished'] == 1) {
+    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'Batch operation in va_gov_db_update_8012 completed.');
+  }
 }


### PR DESCRIPTION
## Description
Fixes batch process to process all nodes when updating text format for `field_intro_text_limited_html`

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/79909886-b8405b00-83eb-11ea-9b60-62d590a885c3.png)
![image](https://user-images.githubusercontent.com/2404547/79909902-bfffff80-83eb-11ea-8559-5b693c6136f9.png)

## QA steps
 - [ ] As an admin on testing instance, visually verify all updates have completed, if not, press the button: `/update.php`
 - [ ] Visit `/admin/reports/dblog` and visually verify that you see `Batch operation in va_gov_db_update_8012 completed.` logged.
 - [ ] Spot check multiple Benefit detail pages, and visually verify on revision page that top item in right sidebar has message `New revision created by uid 1317.
Published`