### PR TITLE
VACMS-1581: post api 201/202 + VACMS-1580: Slack notification fix + VACMS-1553: Slack notification ENV

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8959,7 +8959,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "ed3f8a9997cc0845b8178b770569decdfb63d448"
+                "reference": "4622e86655b42ca2665ea1bb85e431c8e02be8ec"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8971,7 +8971,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1587495235",
+                    "datestamp": "1587495437",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8993,7 +8993,7 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/post_api"
             },
-            "time": "2020-04-21T18:56:54+00:00"
+            "time": "2020-04-22T21:56:03+00:00"
         },
         {
             "name": "drupal/redirect",

--- a/docroot/modules/custom/va_gov_post_api/src/EventSubscriber/QueueItemProcessedEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_post_api/src/EventSubscriber/QueueItemProcessedEventSubscriber.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\va_gov_post_api\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\post_api\Event\QueueItemProcessedEvent;
+use Drupal\slack\Slack;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class QueueItemProcessedEventSubscriber.
+ *
+ * @package Drupal\va_gov_post_api\EventSubscriber
+ */
+class QueueItemProcessedEventSubscriber implements EventSubscriberInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $config;
+
+  /**
+   * Logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $logger;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Slack service.
+   *
+   * @var \Drupal\slack\Slack
+   */
+  protected $slack;
+
+  /**
+   * Creates a new QueueItemProcessedEventSubscriber object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   Config.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger
+   *   Logger.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   Module handler.
+   * @param \Drupal\slack\Slack $slack
+   *   Slack service.
+   */
+  public function __construct(ConfigFactoryInterface $config, LoggerChannelFactoryInterface $logger, ModuleHandlerInterface $moduleHandler, Slack $slack) {
+    $this->config = $config;
+    $this->logger = $logger;
+    $this->moduleHandler = $moduleHandler;
+    $this->slack = $slack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('logger.factory'),
+      $container->get('module_handler'),
+      $container->get('slack.slack_service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      QueueItemProcessedEvent::EVENT_NAME => 'onQueueItemProcessed',
+    ];
+  }
+
+  /**
+   * React to the "queue item processed" event dispatched.
+   *
+   * @param \Drupal\post_api\Event\QueueItemProcessedEvent $event
+   *   Event object.
+   */
+  public function onQueueItemProcessed(QueueItemProcessedEvent $event) {
+    $response_code = $event->getResponseCode();
+    if (in_array($response_code, [201, 202])) {
+      $item_data = $event->getQueueItem();
+      $facility_id = str_replace('facility_status_', '', $item_data['uid']);
+      $message = sprintf('Post API: facility %s doesn\'t exist and was removed from queue. POST response code - %d. ENV: %s.', $facility_id, $response_code, getenv('CMS_ENVIRONMENT_TYPE'));
+
+      $this->logger->get('va_gov_post_api')->info($message);
+
+      if ($this->moduleHandler->moduleExists('slack')) {
+        $slack_config = $this->config->get('slack.settings');
+        if ($slack_config->get('slack_webhook_url')) {
+          $this->slack->sendMessage(':warning: ' . $message);
+        }
+      }
+    }
+
+  }
+
+}

--- a/docroot/modules/custom/va_gov_post_api/src/EventSubscriber/QueueItemProcessedEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_post_api/src/EventSubscriber/QueueItemProcessedEventSubscriber.php
@@ -99,7 +99,7 @@ class QueueItemProcessedEventSubscriber implements EventSubscriberInterface, Con
       $facility_id = str_replace('facility_status_', '', $item_data['uid']);
       $message = sprintf('Post API: facility %s doesn\'t exist and was removed from queue. POST response code - %d. ENV: %s.', $facility_id, $response_code, getenv('CMS_ENVIRONMENT_TYPE'));
 
-      $this->logger->get('va_gov_post_api')->info($message);
+      $this->logger->get('va_gov_post_api')->warning($message);
 
       if ($this->moduleHandler->moduleExists('slack')) {
         $slack_config = $this->config->get('slack.settings');

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
@@ -1,7 +1,12 @@
 services:
-  # Subscriber to the event dispatched on queue processing in post_api.
+  # Subscribers to events dispatched on queue processing in post_api.
   va_gov_post_api.queue_processed_subsriber:
     class: '\Drupal\va_gov_post_api\EventSubscriber\QueueProcessedEventSubscriber'
+    arguments: ['@config.factory', '@logger.factory', '@module_handler', '@slack.slack_service']
+    tags:
+      - { name: 'event_subscriber' }
+  va_gov_post_api.queue_item_processed_subsriber:
+    class: '\Drupal\va_gov_post_api\EventSubscriber\QueueItemProcessedEventSubscriber'
     arguments: ['@config.factory', '@logger.factory', '@module_handler', '@slack.slack_service']
     tags:
       - { name: 'event_subscriber' }


### PR DESCRIPTION
## Description

See #1581, #1580, #1553 

- added dispatch of event on successful item processing - when 200, 201, 202 HTTP codes are returned
- fixed Slack notification message for 0 items and empty message w/ flag icon
- added Event subscriber that logs a message when queue item POST returns 201, 202 codes. NOTE: it is also logged in Slack.
- added environment indicator to Slack notifications coming from va_gov_post_api

## Testing done

Sample slack messages below
<img width="901" alt="Screen Shot 2020-04-22 at 3 23 46 PM" src="https://user-images.githubusercontent.com/16477724/80038581-2dc32e80-84b3-11ea-8d34-8d52a115e616.png">


## Screenshots


## QA steps

1. add api sandbox creds in settings.php
1. add test slack webhook in settings.php to QA slack notifications
1. in order to test 201, 202 code responses ->  add `200` code to array of options at this line {INSERT}
1. add legit item to queue
1. process queue manually
- [x]  check the log - it should have a warning entry `Post API: facility vha_523A5 doesn't exist and was removed from queue. POST response code - 200. ENV: lando.`
- [ ] process queue again (hopefully you still have those 3 hanging 404 items locally) and confirm you get the failure message in slack w/  env indicator.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
