### PR TITLE
Clear yarn cache on `composer nuke`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -313,7 +313,7 @@
             "php -r \"chmod('.git/hooks/pre-commit', 0777);\""
         ],
         "nuke": [
-            "rm -rf bin node_modules docroot/libraries docroot/core docroot/modules/contrib docroot/themes/contrib docroot/profiles/contrib/ docroot/vendor",
+            "rm -rf bin node_modules docroot/libraries docroot/core docroot/modules/contrib docroot/themes/contrib docroot/profiles/contrib/ docroot/vendor /var/www/.cache/yarn",
             "composer clear-cache"
         ],
         "va:start": [


### PR DESCRIPTION
This fixes the Fetching Packages failure on local Lando.
> error Couldn't find match for "e5a89baa54cde250d9ab7c553ebf398de9cba5af" in