### PR TITLE
VACMS-1528 Disable revision autoclean cron and set limits on unlimited.

### DIFF
--- a/config/sync/node_revisions_autoclean.settings.yml
+++ b/config/sync/node_revisions_autoclean.settings.yml
@@ -1,11 +1,11 @@
-enable_on_cron: 1
+enable_on_cron: 0
 enable_on_node_update: 1
 _core:
   default_config_hash: UblN00sCWoyDV-yZe4SE80vKQEQmZHLWmxtaQmJLLaI
 node:
   documentation_page: 50
   event: 50
-  health_care_local_facility: 50
+  health_care_local_facility: 500
   health_care_region_detail_page: 50
   health_care_region_page: 50
   landing_page: 50
@@ -18,18 +18,21 @@ node:
   regional_health_care_service_des: 50
   support_service: 50
   library: 0
-  health_care_local_health_service: 0
+  health_care_local_health_service: 50
   vamc_banner_alert: 50
-  vamc_operating_status_and_alerts: 0
+  vamc_operating_status_and_alerts: 50
   full_width_banner_alert: 50
-  event_listing: 0
-  publication_listing: 0
-  press_releases_listing: 0
-  leadership_listing: 0
-  vba_facility: 50
-  nca_facility: 0
-  veterans_center: 0
-  vet_center: 0
+  event_listing: 50
+  publication_listing: 50
+  press_releases_listing: 50
+  leadership_listing: 50
+  vba_facility: 500
+  nca_facility: 500
+  veterans_center: 50
+  vet_center: 500
+  health_services_listing: 50
+  locations_listing: 50
+  story_listing: 50
 interval:
   documentation_page: '0'
   event: '0'
@@ -58,3 +61,6 @@ interval:
   nca_facility: '0'
   veterans_center: '0'
   vet_center: '0'
+  health_services_listing: '0'
+  locations_listing: '0'
+  story_listing: '0'


### PR DESCRIPTION
The setting of cron was adding an item to the queue for every node saved.
This was causing the queue table to grow out of control to the point
where it got too big to process on cron.

## Description

See _issueid_. 

## Testing done


## Screenshots


## QA steps

As user _uid_ with admin
1. Go to here /admin/config/content/revisions-autoclean
- [ ] Validate that the cron option is not enabled 
![image](https://user-images.githubusercontent.com/5752113/80153811-43585700-858c-11ea-91b6-952526206d60.png)

- [ ] Validate that all "Limit revisions for node type *" have a revision count number set that is NOT 0.


