### PR TITLE
VACMS-1604: Change event URL form widget from linkit to link.

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -30,7 +30,6 @@ dependencies:
     - datetime_range
     - field_group
     - link
-    - linkit
     - media_library
     - metatag
     - path
@@ -289,9 +288,8 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
     third_party_settings: {  }
-    type: linkit
+    type: link_default
     region: content
   moderation_state:
     type: moderation_state_default

--- a/tests/behat/drupal-spec-tool/content_model_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_fields.feature
@@ -67,7 +67,7 @@ Feature: Content model fields
 | Content type | Event | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Event | Event listing | field_listing | Entity reference | Required | 1 | Select list |  |
 | Content type | Event | Order | field_order | List (integer) |  | 1 | Select list |  |
-| Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Linkit |  |
+| Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Link |  |
 | Content type | Event listing | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Event listing | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Event listing | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |


### PR DESCRIPTION
## Description

See #1604

## Testing done
Manual

## Screenshots

![Create_Event___VA_gov_CMS_and_Create_Event___VA_gov_CMS](https://user-images.githubusercontent.com/643678/80165781-3ea29b80-85aa-11ea-94c7-9eeffe15700c.jpg)

## QA steps

As any user go to /node/add/event and review help text for the "online event" URL. it should prevent users from entering /node/2364 etc, and should specify that it must be an external URL.
