### PR TITLE
VACMS-1615 Set revisions correctly.

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_facility_nca.yml
+++ b/config/sync/migrate_plus.migration.va_node_facility_nca.yml
@@ -93,15 +93,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: 'Update of Facility API data by migration.'
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: nca_facility
@@ -109,8 +121,13 @@ destination:
   plugin: 'entity:node'
   default_bundle: nca_facility
   overwrite_properties:
+    - changed
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
     - title
+    - uid
 migration_dependencies:
   required: {  }

--- a/config/sync/migrate_plus.migration.va_node_facility_vba.yml
+++ b/config/sync/migrate_plus.migration.va_node_facility_vba.yml
@@ -83,15 +83,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: 'Update of Facility API data by migration.'
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: vba_facility
@@ -99,8 +111,13 @@ destination:
   plugin: 'entity:node'
   default_bundle: vba_facility
   overwrite_properties:
+    - changed
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
     - title
+    - uid
 migration_dependencies:
   required: {  }

--- a/config/sync/migrate_plus.migration.va_node_facility_vet_centers.yml
+++ b/config/sync/migrate_plus.migration.va_node_facility_vet_centers.yml
@@ -83,15 +83,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: 'Update of Facility API data by migration.'
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: vet_center
@@ -99,8 +111,13 @@ destination:
   plugin: 'entity:node'
   default_bundle: vet_center
   overwrite_properties:
+    - changed
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
     - title
+    - uid
 migration_dependencies:
   required: {  }

--- a/config/sync/migrate_plus.migration.va_node_facility_vet_centers_status.yml
+++ b/config/sync/migrate_plus.migration.va_node_facility_vet_centers_status.yml
@@ -71,9 +71,14 @@ process:
       plugin: get
       source: id
   nid:
-    plugin: migration_lookup
-    migration: va_node_facility_vet_centers
-    source: '@field_facility_locator_api_id'
+    -
+      plugin: migration_lookup
+      migration: va_node_facility_vet_centers
+      source: '@field_facility_locator_api_id'
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Skipped: Node because it has not been initially migrated.'
   field_operating_status_facility:
     -
       plugin: static_map
@@ -104,15 +109,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: 'Update of status by migration.'
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: vet_center
@@ -120,9 +137,14 @@ destination:
   plugin: 'entity:node'
   default_bundle: vet_center
   overwrite_properties:
+    - changed
     - field_operating_status_facility
     - field_operating_status_more_info
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
+    - uid
 migration_dependencies:
   required: {  }

--- a/config/sync/migrate_plus.migration.va_node_health_care_local_facility.yml
+++ b/config/sync/migrate_plus.migration.va_node_health_care_local_facility.yml
@@ -199,15 +199,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: 'Update of Facility API data by migration.'
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: health_care_local_facility
@@ -215,17 +227,22 @@ destination:
   plugin: 'entity:node'
   default_bundle: health_care_local_facility
   overwrite_properties:
-    - title
     - field_address/address_line1
     - field_address/administrative_area
     - field_address/country_code
     - field_address/locality
     - field_address/postal_code
-    - field_facility_classification
     - field_facility_hours/value
+    - changed
+    - field_facility_classification
     - field_mental_health_phone
     - field_phone_number
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
+    - title
+    - uid
 migration_dependencies:
   required: {  }

--- a/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -219,9 +219,14 @@ process:
       plugin: concat
       delimiter: ''
   nid:
-    plugin: migration_lookup
-    migration: va_node_health_care_local_facility
-    source: '@field_facility_locator_api_id'
+    -
+      plugin: migration_lookup
+      migration: va_node_health_care_local_facility
+      source: '@field_facility_locator_api_id'
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Skipped: Node because it has not been initially migrated.'
   field_operating_status_facility:
     -
       plugin: static_map
@@ -263,12 +268,24 @@ process:
   uid:
     plugin: default_value
     default_value: 1317
-  revision_uid:
+  new_revision:
     plugin: default_value
-    default_value: 1317
+    default_value: true
+  revision_default:
+    plugin: default_value
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: 'Update of status by migration.'
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  changed:
+    plugin: callback
+    callable: time
   type:
     plugin: default_value
     default_value: health_care_local_facility
@@ -276,9 +293,14 @@ destination:
   plugin: 'entity:node'
   default_bundle: health_care_local_facility
   overwrite_properties:
+    - changed
     - field_operating_status_facility
     - field_operating_status_more_info
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
+    - uid
 migration_dependencies:
   required: {  }

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_nca.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_nca.yml
@@ -106,15 +106,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: "Update of Facility API data by migration."
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: nca_facility
@@ -124,9 +136,14 @@ destination:
   default_bundle: nca_facility
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
+    - changed
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
     - title
+    - uid
 # Dependency on other migrations.
 migration_dependencies:
   required: {  }

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vba.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vba.yml
@@ -95,15 +95,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: "Update of Facility API data by migration."
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: vba_facility
@@ -113,9 +125,14 @@ destination:
   default_bundle: vba_facility
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
+    - changed
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
     - title
+    - uid
 # Dependency on other migrations.
 migration_dependencies:
   required: {  }

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers.yml
@@ -95,15 +95,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: "Update of Facility API data by migration."
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: vet_center
@@ -113,9 +125,14 @@ destination:
   default_bundle: vet_center
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
+    - changed
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
     - title
+    - uid
 # Dependency on other migrations.
 migration_dependencies:
   required: {  }

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers_status.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers_status.yml
@@ -81,9 +81,14 @@ process:
       source: id
   # Need to have this update the same node as migrated in by the main migration.
   nid:
-    plugin: migration_lookup
-    migration: va_node_facility_vet_centers
-    source: '@field_facility_locator_api_id'
+    -
+      plugin: migration_lookup
+      migration: va_node_facility_vet_centers
+      source: '@field_facility_locator_api_id'
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Skipped: Node because it has not been initially migrated.'
   field_operating_status_facility:
     -
       plugin: static_map
@@ -122,15 +127,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: "Update of status by migration."
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: vet_center
@@ -140,10 +157,15 @@ destination:
   default_bundle: vet_center
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
+    - changed
     - field_operating_status_facility
     - field_operating_status_more_info
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
+    - uid
 # Dependency on other migrations.
 migration_dependencies:
   required: {  }

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility.yml
@@ -213,15 +213,27 @@ process:
   moderation_state:
     plugin: default_value
     default_value: draft
-  uid:
+  changed:
+    plugin: callback
+    callable: time
+  new_revision:
     plugin: default_value
-    default_value: 1317
-  revision_uid:
+    default_value: true
+  revision_default:
     plugin: default_value
-    default_value: 1317
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: "Update of Facility API data by migration."
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  uid:
+    plugin: default_value
+    default_value: 1317
   type:
     plugin: default_value
     default_value: health_care_local_facility
@@ -231,18 +243,23 @@ destination:
   default_bundle: health_care_local_facility
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
-    - title
     - 'field_address/address_line1'
     - 'field_address/administrative_area'
     - 'field_address/country_code'
     - 'field_address/locality'
     - 'field_address/postal_code'
-    - field_facility_classification
     - 'field_facility_hours/value'
+    - changed
+    - field_facility_classification
     - field_mental_health_phone
     - field_phone_number
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
+    - title
+    - uid
 # Dependency on other migrations.
 migration_dependencies:
   required: {  }

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -231,9 +231,14 @@ process:
       delimiter: ''
   # Need to have this update the same node as migrated in by the main migration.
   nid:
-    plugin: migration_lookup
-    migration: va_node_health_care_local_facility
-    source: '@field_facility_locator_api_id'
+    -
+      plugin: migration_lookup
+      migration: va_node_health_care_local_facility
+      source: '@field_facility_locator_api_id'
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Skipped: Node because it has not been initially migrated.'
   field_operating_status_facility:
     -
       plugin: static_map
@@ -283,12 +288,24 @@ process:
   uid:
     plugin: default_value
     default_value: 1317
-  revision_uid:
+  new_revision:
     plugin: default_value
-    default_value: 1317
+    default_value: true
+  revision_default:
+    plugin: default_value
+    default_value: true
   revision_log:
     plugin: default_value
     default_value: "Update of status by migration."
+  revision_timestamp:
+    plugin: callback
+    callable: time
+  revision_uid:
+    plugin: default_value
+    default_value: 1317
+  changed:
+    plugin: callback
+    callable: time
   type:
     plugin: default_value
     default_value: health_care_local_facility
@@ -298,10 +315,15 @@ destination:
   default_bundle: health_care_local_facility
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
+    - changed
     - field_operating_status_facility
     - field_operating_status_more_info
+    - new_revision
+    - revision_default
     - revision_log
+    - revision_timestamp
     - revision_uid
+    - uid
 # Dependency on other migrations.
 migration_dependencies:
   required: {  }


### PR DESCRIPTION
## Description

Revision history on the sidebar has not matched the updated dates and the history in the revisions tab.

This PR makes them all match

Content View
![image](https://user-images.githubusercontent.com/5752113/80504750-75c5d380-8941-11ea-883c-823cf14ecf14.png)

Revisions Tab
![image](https://user-images.githubusercontent.com/5752113/80504930-ae65ad00-8941-11ea-9502-82808e0a48ed.png)




## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
Triggering migrations on  pr environments will not have effect now that they are not being run as updates.  

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
