### PR TITLE
VACMS-1500: Post API Cron killswitch.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8960,7 +8960,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "4622e86655b42ca2665ea1bb85e431c8e02be8ec"
+                "reference": "4e2b4137fe29ce9cc22afe95c2397779de9a2e26"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8972,7 +8972,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1587495437",
+                    "datestamp": "1588086396",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8994,7 +8994,7 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/post_api"
             },
-            "time": "2020-04-22T21:56:03+00:00"
+            "time": "2020-04-28T15:19:28+00:00"
         },
         {
             "name": "drupal/redirect",

--- a/config/sync/post_api.settings.yml
+++ b/config/sync/post_api.settings.yml
@@ -1,1 +1,2 @@
 queueworker_max_runtime: '60'
+pause_cron_processing: 0


### PR DESCRIPTION
## Description

See #1500. 

Adds "Pause processing on Cron" configuration option to Post API

## QA steps

- [x] as an admin, visit /admin/config/post-api/config and confirm "Pause processing on Cron" configuration option is available in a form of a checkbox
- [x] leave checkbox unchecked; add item to queue; remove sandbox creds if you have them locally; clear cache; run cron `lando drush cron`, confirm the queue is being processed and you get log messages from post api
- [x] check the checkbox to pause processing on Cron; run cron; confirm the queue is not processed by verifying that there are no new log messages in dblog 
- [x] process queue manually. Confirm manual queue processing is not affected by the new config option.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
