### PR TITLE
VACMS-1506: Post API Status UI

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8960,7 +8960,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "4622e86655b42ca2665ea1bb85e431c8e02be8ec"
+                "reference": "575ae0b8183d5675c996e84157c2166ad03cf50e"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8972,7 +8972,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1587495437",
+                    "datestamp": "1588087190",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8994,7 +8994,7 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/post_api"
             },
-            "time": "2020-04-22T21:56:03+00:00"
+            "time": "2020-04-29T14:55:09+00:00"
         },
         {
             "name": "drupal/redirect",

--- a/docroot/modules/custom/va_gov_post_api/src/Form/VaGovPostApiSettingsForm.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Form/VaGovPostApiSettingsForm.php
@@ -4,6 +4,9 @@ namespace Drupal\va_gov_post_api\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\Url;
 
 /**
  * Class VaGovPostApiSettingsForm.
@@ -28,7 +31,32 @@ class VaGovPostApiSettingsForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('va_gov_post_api.settings');
 
-    $form['bypass_data_check'] = [
+    // Variables to compose Post API status.
+    $set = '<span style="color:green">&#x2714;</span>';
+    $error = '<span style="color:red">&#x2716;</span>';
+    $slack_webhook = Settings::get('slack_webhook_url', NULL);
+    $slack_webhook_indicator = $slack_webhook ? $set : $error;
+    $slack_webhook_status_markup = $slack_webhook ? $slack_webhook : $this->t('Slack Webhook URL is not set in settings.php.');
+    $post_api_status_link_markup = $this->t('<a href="@post_api_status">Post API Status</a>', ['@post_api_status' => Url::fromUri('internal:/admin/config/post-api/config')->toString()]);
+
+    $form['status'] = [
+      '#type' => 'details',
+      '#title' => $this->t('VA.gov Post API status'),
+      '#open' => TRUE,
+    ];
+
+    $form['status']['va_gov_post_api_status'] = [
+      '#type' => 'markup',
+      '#markup' => Markup::create('<p>' . $slack_webhook_indicator . ' <strong>' . $this->t('Slack Webhook URL:') . '</strong> ' . $slack_webhook_status_markup . '</p><p>' . $post_api_status_link_markup . '</p>'),
+    ];
+
+    $form['config'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Configuration options'),
+      '#open' => TRUE,
+    ];
+
+    $form['config']['bypass_data_check'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Bypass data comparison'),
       '#description' => $this->t('If checked, all saved nodes will be queued for syncing bypassing a requirement for updated data.'),


### PR DESCRIPTION
## Description

See #1506 .

-  Added Post API status UI.
- Added VA.gov Post API status UI - check if Slack Webhook is set

## Screenshots

### Post API Status UI

**variables are set**
<img width="1065" alt="Screen Shot 2020-04-29 at 8 44 52 AM" src="https://user-images.githubusercontent.com/16477724/80611713-38704d00-89f8-11ea-9e67-b1d68d4d0478.png">


**variables are NOT set**
<img width="1075" alt="Screen Shot 2020-04-29 at 8 43 45 AM" src="https://user-images.githubusercontent.com/16477724/80611730-3c9c6a80-89f8-11ea-822a-69636ddb4d86.png">


### VA.gov Post API Status UI

**variables are set**
<img width="1072" alt="Screen Shot 2020-04-29 at 8 44 59 AM" src="https://user-images.githubusercontent.com/16477724/80611742-402ff180-89f8-11ea-8a3e-e156441abf3e.png">

**variables are NOT set**
<img width="1070" alt="Screen Shot 2020-04-29 at 8 45 38 AM" src="https://user-images.githubusercontent.com/16477724/80611754-43c37880-89f8-11ea-9cc4-48b08a43faed.png">


## QA steps

As an Administrator, locally
- [ ] unset all Post API variables in settings.php if set previously: `$settings['post_api_endpoint_host']`, `$settings['post_api_apikey']`, `$settings['slack_webhook_url']`
- [ ]  visit https://va-gov-cms.lndo.site/admin/config/post-api/config and confirm that status section indicates that Endpoint Host and Apikey are NOT set as shown on screenshots above
- [ ]  visit https://va-gov-cms.lndo.site/admin/config/va-gov-post-api/config and confirm that status section indicates that Slack Webhook URL is NOT set as shown on screenshots above
- [ ] assign any value to all Post API variables in settings.php: `$settings['post_api_endpoint_host']`, `$settings['post_api_apikey']`, `$settings['slack_webhook_url']`
- [ ]  visit https://va-gov-cms.lndo.site/admin/config/post-api/config and confirm that status section indicates that Endpoint Host and Apikey are set as shown on screenshots above
- [ ]  visit https://va-gov-cms.lndo.site/admin/config/va-gov-post-api/config and confirm that status section indicates that Slack Webhook URL is set as shown on screenshots above

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
