### PR TITLE
VACMS-1585: UI to force-queue facilities.

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\va_gov_post_api\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Entity\Node;
+use Psr\Log\LogLevel;
+
+/**
+ * Class VaGovFacilityForceQueueForm.
+ */
+class VaGovFacilityForceQueueForm extends FormBase {
+
+  /**
+   * Config settings.
+   *
+   * @var string Config settings
+   */
+  const SETTINGS = 'va_gov_post_api.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      static::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'facility_force_queue_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Queries to get total number of facilities for each type for reference.
+    $health_care_local_facility = \Drupal::entityQuery('node')
+      ->condition('type', 'health_care_local_facility')
+      ->execute();
+
+    $nca_facility = \Drupal::entityQuery('node')
+      ->condition('type', 'nca_facility')
+      ->execute();
+
+    $vba_facility = \Drupal::entityQuery('node')
+      ->condition('type', 'vba_facility')
+      ->execute();
+
+    $vet_center = \Drupal::entityQuery('node')
+      ->condition('type', 'vet_center')
+      ->execute();
+
+    $form['description'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('This form queues ALL facilities of selected type for sync to Lighthouse.'),
+    ];
+
+    $form['facility_type'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Facility type'),
+      '#description' => t('Select a facility type to queue.'),
+      '#options' => [
+        'health_care_local_facility' => $this->t('VAMC facilities') . ' (' . count($health_care_local_facility) . ')',
+        'nca_facility' => $this->t('NCA facilities') . ' (' . count($nca_facility) . ')',
+        'vba_facility' => $this->t('VBA facilities') . ' (' . count($vba_facility) . ')',
+        'vet_center' => $this->t('Vet Centers') . ' (' . count($vet_center) . ')',
+      ],
+      '#required' => TRUE,
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Force-Queue Selected Facilities'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $facility_type = $form_state->getValue('facility_type');
+
+    // Enable force update.
+    $this->configFactory()
+      ->getEditable(static::SETTINGS)
+      ->set('bypass_data_check', 1)
+      ->save();
+
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', $facility_type)
+      ->execute();
+
+    if (!empty($nids)) {
+      try {
+        $nodes = Node::loadMultiple($nids);
+        foreach ($nodes as $node) {
+          _post_api_add_facility_to_queue($node);
+        }
+
+        $this->logger('va_gov_post_api')
+          ->log(LogLevel::INFO, 'VA.gov Post API: %total %type nodes queued for sync to Lighthouse.', [
+            '%type' => $facility_type,
+            '%total' => count($nodes),
+          ]);
+
+        $this->messenger()->addStatus(sprintf('%d %s nodes queued for sync to Lighthouse.', count($nodes), $facility_type));
+      }
+      catch (\Exception $e) {
+        $this->logger('va_gov_post_api')
+          ->log(LogLevel::ERROR, 'VA.gov Post API: Failed queuing facilities of type %type. %e', [
+            '%type' => $facility_type,
+            '%e' => $e->getMessage(),
+          ]);
+
+        $this->messenger()->addError(sprintf('Failed queuing facilities of type %s. Check log and try again.', $facility_type));
+      }
+    }
+    else {
+      // Didn't find facilities to process. Houston, we have a problem!
+      $this->logger('va_gov_post_api')
+        ->log(LogLevel::ERROR, 'VA.gov Post API: Found 0 facilities of type %type! This is a serious issue that requires immediate attention!', [
+          '%type' => $facility_type,
+        ]);
+
+      $this->messenger()->addError(sprintf('Found 0 facilities of type %s! This is a serious issue that requires immediate attention!', $facility_type));
+    }
+
+    // Disable force update.
+    $this->configFactory()
+      ->getEditable(static::SETTINGS)
+      ->set('bypass_data_check', 0)
+      ->save();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.links.menu.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.links.menu.yml
@@ -1,5 +1,12 @@
+va_gov_post_api.facility_force_queue_form:
+  title: Force-Queue Facilities
+  description: 'VA.gov Post API - Force-Queue Facilities for sync.'
+  route_name: va_gov_post_api.facility_force_queue_form
+  parent: post_api.admin_home
+  weight: 3
 va_gov_post_api.admin_settings:
   title: VA.gov Post API Settings
   description: 'VA.gov Post API settings.'
   route_name: va_gov_post_api.admin_settings
   parent: post_api.admin_home
+  weight: 4

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.routing.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.routing.yml
@@ -7,3 +7,12 @@ va_gov_post_api.admin_settings:
     _permission: 'administer site configuration'
   options:
     _admin_route: TRUE
+va_gov_post_api.facility_force_queue_form:
+  path: '/admin/config/va-gov-post-api/facility-force-queue'
+  defaults:
+    _form: '\Drupal\va_gov_post_api\Form\VaGovFacilityForceQueueForm'
+    _title: 'Facility Force-Queue Form'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE


### PR DESCRIPTION
## Description

See #1585 . 

- Adds UI that allows to force-queue facilities of specific type for sync to Lighthouse

## Screenshots

New menu item 
<img width="438" alt="Screen Shot 2020-04-30 at 2 27 21 PM" src="https://user-images.githubusercontent.com/16477724/80755908-df371500-8aee-11ea-804f-d428ed54a233.png">

Form
<img width="796" alt="Screen Shot 2020-04-30 at 2 27 34 PM" src="https://user-images.githubusercontent.com/16477724/80755921-e6f6b980-8aee-11ea-9989-94f41d1adc10.png">


## QA steps

As user 1

- [ ] visit http://va-gov-cms.lndo.site/admin/config/va-gov-post-api/facility-force-queue
- [ ] confirm facility node count is displayed next to each facility. This ui element is added to reinforce the success message that is displayed after submitting the form that also contains count of processed nodes
- [ ] submit the form w/ facility type selected
   - [ ] confirm that facilities are queued at https://va-gov-cms.lndo.site/admin/config/post-api/queue
   - [ ] confirm that success message is received w/ node count
   - [ ] confirm dblog message was recorded
- [ ] **test failures**:
   - [ ] **zero facilities returned in query**: set `$nid=[]` to empty array on line 97 of `docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php` and submit the form.
   - [ ] **exception thrown for whatever reason**: add `throw new \Exception('Houston, we have a problem');` on line 67 of `docroot/modules/custom/va_gov_post_api/va_gov_post_api.module`, submit the form, check log  

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
