### PR TITLE
VACMS-1371 disable api fields

### DIFF
--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -38,6 +38,31 @@ function _va_gov_consumers_content() {
  * Implements hook_form_alter().
  */
 function va_gov_consumers_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  _vagov_consumers_disable_vha_api_form_fields($form, $form_id);
+  _vagov_consumers_disable_non_vha_facilities_api_form_fields($form, $form_id);
+}
+
+/**
+ * Callback for table field widget.
+ *
+ * @param object $element
+ *   The field object.
+ */
+function _va_gov_consumers_customize_table($element) {
+  unset($element['tablefield']['import']);
+  unset($element['tablefield']['rebuild']);
+  return $element;
+}
+
+/**
+ * Disable api sourced fields on vha local facility to prevent human editing.
+ *
+ * @param array $form
+ *   A drupal form array by reference.
+ * @param string $form_id
+ *   The machine name for the form.
+ */
+function _vagov_consumers_disable_vha_api_form_fields(array &$form, $form_id) {
   if ($form_id === 'node_health_care_local_facility_edit_form' || $form_id === 'node_health_care_local_facility_form') {
     if (empty($form['title']['widget'][0]['value']['#default_value'])) {
       $form['title']['widget'][0]['value']['#default_value'] = t('API Data');
@@ -59,13 +84,26 @@ function va_gov_consumers_form_alter(&$form, FormStateInterface $form_state, $fo
 }
 
 /**
- * Callback for table field widget.
+ * Disable api sourced fields on non vha facilities to prevent human editing.
  *
- * @param object $element
- *   The field object.
+ * @param array $form
+ *   A drupal form array by reference.
+ * @param string $form_id
+ *   The machine name for the form.
  */
-function _va_gov_consumers_customize_table($element) {
-  unset($element['tablefield']['import']);
-  unset($element['tablefield']['rebuild']);
-  return $element;
+function _vagov_consumers_disable_non_vha_facilities_api_form_fields(array &$form, $form_id) {
+  $target_forms = [
+
+  ];
+  if (in_array($form_id, $target_forms)) {
+    if (empty($form['title']['widget'][0]['value']['#default_value'])) {
+      $form['title']['widget'][0]['value']['#default_value'] = t('API Data');
+    }
+    // Disable items that are populated by the Facility API migration.
+    $form['title']['widget'][0]['value']['#attributes']['disabled'] = TRUE;
+
+    // @TODO Do we want to disable the api id.  If it is populated, I think we do.
+
+  }
+
 }

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -70,9 +70,9 @@ function _vagov_consumers_disable_vha_api_form_fields(array &$form, $form_id) {
 
     // Disable the facility locator API field if it is populated because it
     // should not be altered, or it will deviate from the API.
-    if (!empty($form["field_facility_locator_api_id"]["widget"][0]["value"]["#default_value"])) {
-      $form["field_facility_locator_api_id"]["widget"][0]["value"]['#attributes']['disabled'] = TRUE;
-      $form["field_facility_locator_api_id"]["widget"][0]["value"]["#description"] =t('Synced to the Facility API.  If you need to change this, please contact CMS Support.');
+    if (!empty($form['field_facility_locator_api_id']['widget'][0]['value']['#default_value'])) {
+      $form['field_facility_locator_api_id']['widget'][0]['value']['#attributes']['disabled'] = TRUE;
+      $form['field_facility_locator_api_id']['widget'][0]['value']['#description'] = t('Synced to the Facility API.  If you need to change this, please contact CMS Support.');
     }
     // Disable items that are populated by the Facility API migration.
     $form['title']['widget'][0]['value']['#attributes']['disabled'] = TRUE;
@@ -119,9 +119,9 @@ function _vagov_consumers_disable_non_vha_facilities_api_form_fields(array &$for
     }
     // Disable the facility locator API field if it is populated because it
     // should not be altered, or it will deviate from the API.
-    if (!empty($form["field_facility_locator_api_id"]["widget"][0]["value"]["#default_value"])) {
-      $form["field_facility_locator_api_id"]["widget"][0]["value"]['#attributes']['disabled'] = TRUE;
-      $form["field_facility_locator_api_id"]["widget"][0]["value"]["#description"] =t('Synced to the Facility API.  If you need to change this, please contact CMS Support.');
+    if (!empty($form['field_facility_locator_api_id']['widget'][0]['value']['#default_value'])) {
+      $form['field_facility_locator_api_id']['widget'][0]['value']['#attributes']['disabled'] = TRUE;
+      $form['field_facility_locator_api_id']['widget'][0]['value']['#description'] = t('Synced to the Facility API.  If you need to change this, please contact CMS Support.');
     }
   }
 }

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -67,6 +67,13 @@ function _vagov_consumers_disable_vha_api_form_fields(array &$form, $form_id) {
     if (empty($form['title']['widget'][0]['value']['#default_value'])) {
       $form['title']['widget'][0]['value']['#default_value'] = t('API Data');
     }
+
+    // Disable the facility locator API field if it is populated because it
+    // should not be altered, or it will deviate from the API.
+    if (!empty($form["field_facility_locator_api_id"]["widget"][0]["value"]["#default_value"])) {
+      $form["field_facility_locator_api_id"]["widget"][0]["value"]['#attributes']['disabled'] = TRUE;
+      $form["field_facility_locator_api_id"]["widget"][0]["value"]["#description"] =t('Synced to the Facility API.  If you need to change this, please contact CMS Support.');
+    }
     // Disable items that are populated by the Facility API migration.
     $form['title']['widget'][0]['value']['#attributes']['disabled'] = TRUE;
     $form['field_facility_classification']['widget']['#attributes']['disabled'] = TRUE;
@@ -93,17 +100,28 @@ function _vagov_consumers_disable_vha_api_form_fields(array &$form, $form_id) {
  */
 function _vagov_consumers_disable_non_vha_facilities_api_form_fields(array &$form, $form_id) {
   $target_forms = [
-
+    'node_nca_facility_edit_form',
+    'node_nca_facility_form',
+    'node_vba_facility_edit_form',
+    'node_vba_facility_form',
+    'node_vet_center_edit_form',
+    'node_vet_center_form',
   ];
+
   if (in_array($form_id, $target_forms)) {
     if (empty($form['title']['widget'][0]['value']['#default_value'])) {
-      $form['title']['widget'][0]['value']['#default_value'] = t('API Data');
+      // Prepoulate the title to warn it will be overwritten by api data.
+      $form['title']['widget'][0]['value']['#default_value'] = t('May be overwritten by Facility API Data');
     }
-    // Disable items that are populated by the Facility API migration.
-    $form['title']['widget'][0]['value']['#attributes']['disabled'] = TRUE;
-
-    // @TODO Do we want to disable the api id.  If it is populated, I think we do.
-
+    else {
+      // Disable the title, it has content already.
+      $form['title']['widget'][0]['value']['#attributes']['disabled'] = TRUE;
+    }
+    // Disable the facility locator API field if it is populated because it
+    // should not be altered, or it will deviate from the API.
+    if (!empty($form["field_facility_locator_api_id"]["widget"][0]["value"]["#default_value"])) {
+      $form["field_facility_locator_api_id"]["widget"][0]["value"]['#attributes']['disabled'] = TRUE;
+      $form["field_facility_locator_api_id"]["widget"][0]["value"]["#description"] =t('Synced to the Facility API.  If you need to change this, please contact CMS Support.');
+    }
   }
-
 }


### PR DESCRIPTION
## Description

See #1371  


## QA steps

1. Create a new VBA facility
- [x] Visit /node/add/vba_facility validate that Name of facility is prepopulated, but can be edited.
![image](https://user-images.githubusercontent.com/5752113/80816008-b705ef80-8b9c-11ea-9e47-88ce2c820310.png)


- [x] Validate that Facility Locator API ID field is  editable and contains lots of instructive text.
![image](https://user-images.githubusercontent.com/5752113/80815981-ab1a2d80-8b9c-11ea-8a8f-006640b4d1c6.png)

2 Give it the title of "Mythical VBA" and locator ID of 'vba_2020' then save as draft.
3. Edit the node you just saved.
- [x] Validate the title you gave it persists and that the field is now not able to be edited 
- [x] Validate that the Facility Locator API ID field contains the id you gave it and is not able to be edited.
- [x] Validate that the help text on the Facility Locator API ID field now says "Synced to the Facility API. If you need to change this, please contact CMS Support."
![image](https://user-images.githubusercontent.com/5752113/80816356-62af3f80-8b9d-11ea-9ed7-99bbf822bfa3.png)

5. Visit an existing VHA Facility by going here /node/1706/edit
- [x] Validate that the Facility Locator API ID field contains the id `vha_595GC` and is not able to be edited.
- [x] Validate that the help text on the Facility Locator API ID field now says "Synced to the Facility API. If you need to change this, please contact CMS Support."

![image](https://user-images.githubusercontent.com/5752113/80816544-b457ca00-8b9d-11ea-864b-af35d989bd85.png)

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
