### PR TITLE
VACMS-000 Eliminate fatal error making a new content type.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -351,7 +351,7 @@ function _va_gov_backend_gtm_settings() {
     $sections['contentTitle'] = $node->getTitle();
     $sections['contentType'] = $node->bundle();
 
-    if(property_exists($node, 'field_administration')){
+    if (property_exists($node, 'field_administration')) {
       $section_entity_id = $node->field_administration->getString();
       // Load up our section name.
       $section_entity_load = !empty($section_entity_load) ? Term::load($section_entity_id) : '';

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -351,10 +351,13 @@ function _va_gov_backend_gtm_settings() {
     $sections['contentTitle'] = $node->getTitle();
     $sections['contentType'] = $node->bundle();
 
-    $section_entity_id = $node->field_administration->getString();
-    // Load up our section name.
-    $section_entity_load = !empty($section_entity_load) ? Term::load($section_entity_id) : '';
-    $sections['contentOwner'] = !empty($section_entity_load) ? $section_entity_load->getName() : '';
+    if(property_exists($node, 'field_administration')){
+      $section_entity_id = $node->field_administration->getString();
+      // Load up our section name.
+      $section_entity_load = !empty($section_entity_load) ? Term::load($section_entity_id) : '';
+      $sections['contentOwner'] = !empty($section_entity_load) ? $section_entity_load->getName() : '';
+    }
+
   }
   return $sections;
 }


### PR DESCRIPTION
## Description

This operation currently acts on all content types and make the assumption of the property 'field_administration' being there.  If the content type is new, and does not have the property, a fatal error creates white screen.

The PR simply removes the assumption so there is no catastrophic failure.

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
