### PR TITLE
VACMS-1243: Render user sections on their profiles.

### DIFF
--- a/config/sync/block.block.user_sections.yml
+++ b/config/sync/block.block.user_sections.yml
@@ -1,0 +1,20 @@
+uuid: b43c51d9-21bc-435d-b556-80975868df22
+langcode: en
+status: true
+dependencies:
+  module:
+    - va_gov_user
+  theme:
+    - vagovadmin
+id: user_sections
+theme: vagovadmin
+region: content
+weight: 0
+provider: null
+plugin: va_gov_user_sections
+settings:
+  id: va_gov_user_sections
+  label: Sections
+  provider: va_gov_user
+  label_display: visible
+visibility: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -170,6 +170,7 @@ module:
   va_gov_migrate: 0
   va_gov_post_api: 0
   va_gov_preview: 0
+  va_gov_user: 0
   video_embed_field: 0
   video_embed_media: 0
   views_bulk_edit: 0

--- a/config/sync/lightning_core.versions.yml
+++ b/config/sync/lightning_core.versions.yml
@@ -221,6 +221,7 @@ va_gov_login: 0.0.0
 va_gov_migrate: 0.0.0
 va_gov_notifications: 0.0.0
 va_gov_post_api: 0.0.0
+va_gov_user: 0.0.0
 video_embed_field: 2.0.0
 video_embed_media: 2.0.0
 views: 8.6.2

--- a/config/sync/views.view.sections_tree.yml
+++ b/config/sync/views.view.sections_tree.yml
@@ -285,7 +285,7 @@ display:
           admin_label: ''
           empty: false
           tokenize: false
-          content: "<p>&nbsp;</p>\r\n<p>Content and permissions are organized by section. You can edit content in sections to which you are assigned.</p>\r\n<h2>Find content by section</h2>"
+          content: "<p>Content and permissions are organized by section. You can edit content in sections to which you are assigned.</p>\r\n<h3>Find content by section</h3>"
           plugin_id: text_custom
       footer: {  }
       empty: {  }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -218,7 +218,7 @@ function va_gov_backend_workbench_assign_user_form_submit(array $form, FormState
  */
 function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
   $user_id = \Drupal::currentUser()->id();
-  $perms_service = \Drupal::service('va_gov_backend.user_perms');
+  $perms_service = \Drupal::service('va_gov_user.user_perms');
   // Grabs items user can access per section associations.
   $allowed_options = $perms_service->userOptionsStorage($form, $targets, $user_id);
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.services.yml
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.services.yml
@@ -1,4 +1,0 @@
-services:
-    va_gov_backend.user_perms:
-        class: Drupal\va_gov_backend\Service\UserPermsService
-        arguments: ["@current_user", "@entity_type.manager"]

--- a/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
+++ b/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
@@ -82,7 +82,7 @@ class UserSections extends BlockBase implements ContainerFactoryPluginInterface 
     // Get currently viewed profile.
     $user = $this->routeMatch->getParameter('user');
 
-    // Other users need to see only sections assigned to their profiles.
+    // Get ids of sections assigned to user profile.
     $query = $this->database->select('section_association__user_id', 'sau');
     $query->join('section_association', 'sa', 'sau.entity_id = sa.id');
     $query->condition('sau.user_id_target_id', $user->id());
@@ -102,6 +102,8 @@ class UserSections extends BlockBase implements ContainerFactoryPluginInterface 
       return $view->buildRenderable();
     }
 
+    // Use has access only to some sections.
+    // Compose list.
     $entity_storage = $this->entityTypeManager->getStorage('taxonomy_term');
     $terms = $entity_storage->loadMultiple($results);
 

--- a/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
+++ b/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\va_gov_user\Plugin\Block;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a block of links to User Sections.
+ *
+ * @Block(
+ *   id = "va_gov_user_sections",
+ *   admin_label = @Translation("Sections")
+ * )
+ */
+class UserSections extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Database connection.
+   *
+   * @var \Drupal\Core\Database\Database
+   */
+  private $database;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return ['user'];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, Connection $database, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->routeMatch = $route_match;
+    $this->database = $database;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('database'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    // Get currently viewed profile.
+    $user = $this->routeMatch->getParameter('user');
+
+    // Other users need to see only sections assigned to their profiles.
+    $query = $this->database->select('section_association__user_id', 'sau');
+    $query->join('section_association', 'sa', 'sau.entity_id = sa.id');
+    $query->condition('sau.user_id_target_id', $user->id());
+    $query->fields('sa', ['section_id']);
+    $results = $query->execute()->fetchCol();
+
+    // Viewed profile is content_admin or administrator
+    // OR
+    // user has access to ALL sections -
+    // Render sections tree.
+    if ($user->hasRole('content_admin') || $user->hasRole('administrator') || in_array('administration', $results)) {
+      $view = Views::getView('sections_tree');
+      $view->setDisplay('block_1');
+      $view->preExecute();
+      $view->execute();
+
+      return $view->buildRenderable();
+    }
+
+    $entity_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $terms = $entity_storage->loadMultiple($results);
+
+    $links = [];
+
+    foreach ($terms as $term) {
+      $links[$term->id()] = [
+        'title' => $term->getName(),
+        'url' => Url::fromRoute('entity.taxonomy_term.canonical', ['taxonomy_term' => $term->id()]),
+      ];
+    }
+
+    if (!empty($links)) {
+      return [
+        'links' => [
+          '#theme' => 'links',
+          '#links' => $links,
+        ],
+      ];
+    }
+    else {
+      // User is not assigned to any sections, display onboarding lingo.
+      // @todo: Update lingo.
+      return [
+        'section_assignment' => [
+          '#markup' => $this->t('Contact #cms-support for VA section assignment.'),
+        ],
+      ];
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    // Only display on User View route.
+    return AccessResult::allowedif($this->routeMatch->getRouteName() === 'entity.user.canonical');
+  }
+
+}

--- a/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
+++ b/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
@@ -51,20 +51,6 @@ class UserSections extends BlockBase implements ContainerFactoryPluginInterface 
   protected $userPerms;
 
   /**
-   * {@inheritdoc}
-   */
-  public function getCacheContexts() {
-    return ['url.path', 'user'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCacheTags() {
-    return ['user:' . $this->routeMatch->getParameter('user')->id()];
-  }
-
-  /**
    * {@inheritDoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, UserPermsService $user_perms) {
@@ -84,6 +70,20 @@ class UserSections extends BlockBase implements ContainerFactoryPluginInterface 
       $container->get('current_route_match'),
       $container->get('va_gov_user.user_perms')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return ['url.path', 'user'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return ['user:' . $this->routeMatch->getParameter('user')->id()];
   }
 
   /**

--- a/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
@@ -83,6 +83,8 @@ class UserPermsService {
    * @return array
    *   Array of user sections where keys are term ids and values are term names.
    *   Special key 'administration' signifies user's assignment to ALL sections.
+   *   NOTE: consumers of this method will have to take care of array key
+   *   'administration' according to their use case.
    */
   public function getSections(AccountInterface $user) {
     $sections = [];

--- a/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
@@ -24,12 +24,11 @@ class UserPermsService {
   private $currentUser;
 
   /**
-   * The entity interface.
+   * The entity type manager.
    *
-   * @var object
-   *  The entity interface object.
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  private $entityInterface;
+  protected $entityTypeManager;
 
   /**
    * Database connection.
@@ -39,20 +38,12 @@ class UserPermsService {
   private $database;
 
   /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * {@inheritDoc}
    */
-  public function __construct(AccountInterface $currentUser, EntityTypeManagerInterface $entityInterface, Connection $database, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(AccountInterface $currentUser, EntityTypeManagerInterface $entityTypeManager, Connection $database) {
     $this->currentUser = $currentUser;
-    $this->entityInterface = $entityInterface;
+    $this->entityTypeManager = $entityTypeManager;
     $this->database = $database;
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -123,7 +114,7 @@ class UserPermsService {
    *   The ancestor terms going up the tree.
    */
   public function entitySections($tid) {
-    $ancestors = \Drupal::service('entity_type.manager')->getStorage("taxonomy_term")->loadAllParents($tid);
+    $ancestors = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($tid);
     $list = [];
     foreach ($ancestors as $term) {
       $list[$term->id()] = $term->label();
@@ -226,13 +217,13 @@ class UserPermsService {
       return TRUE;
     }
 
-    $entity = $this->entityInterface->getStorage($entity_type)->load($entity_id);
+    $entity = $this->entityTypeManager->getStorage($entity_type)->load($entity_id);
 
     // When working with field_listing, we need to fetch an entity from a
     // parent entity's field_office.
     if ($target === 'field_listing') {
       $field_office_target_id = $entity->get('field_office')->target_id;
-      $entity = $this->entityInterface->getStorage($entity_type)->load($field_office_target_id);
+      $entity = $this->entityTypeManager->getStorage($entity_type)->load($field_office_target_id);
     }
 
     // We want create access perm for most cases. For occasional snowflake
@@ -244,15 +235,14 @@ class UserPermsService {
 
     // Special snowflake check for Outreach section - unique perms set beyond
     // scope of workbench_access.
-    $database = \Drupal::database();
-    $query = $database->select('section_association__user_id', 's');
+    $query = $this->database->select('section_association__user_id', 's');
     $query->condition('s.user_id_target_id', $account->id());
     $query->condition('s.entity_id', 4);
     $query->fields('s', ['entity_id']);
     $results = $query->execute()->fetchField();
 
     // Compare user sections against subject section to determine access.
-    return array_reduce(\Drupal::entityTypeManager()->getStorage('access_scheme')->loadMultiple(), function (AccessResult $carry, AccessSchemeInterface $scheme) use ($entity, $op, $account, $results) {
+    return array_reduce($this->entityTypeManager->getStorage('access_scheme')->loadMultiple(), function (AccessResult $carry, AccessSchemeInterface $scheme) use ($entity, $op, $account, $results) {
       $status_class_name = get_class($scheme->getAccessScheme()->checkEntityAccess($scheme, $entity, $op, $account));
       // Return true if we have our special snowflake Outreach listing node.
       if ((count($results) > 0) && ($entity->id() === '736')) {

--- a/docroot/modules/custom/va_gov_user/va_gov_user.info.yml
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.info.yml
@@ -1,0 +1,5 @@
+name: 'VA.gov User Profile'
+description: 'Provides blocks and other functionality for user profiles.'
+package: 'Custom'
+type: module
+core: 8.x

--- a/docroot/modules/custom/va_gov_user/va_gov_user.module
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Contains va_gov_user.module.
+ */

--- a/docroot/modules/custom/va_gov_user/va_gov_user.services.yml
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.services.yml
@@ -1,4 +1,4 @@
 services:
   va_gov_user.user_perms:
     class: Drupal\va_gov_user\Service\UserPermsService
-    arguments: ['@current_user', '@entity_type.manager', '@database', '@entity_type.manager']
+    arguments: ['@current_user', '@entity_type.manager', '@database']

--- a/docroot/modules/custom/va_gov_user/va_gov_user.services.yml
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.services.yml
@@ -1,0 +1,4 @@
+services:
+  va_gov_user.user_perms:
+    class: Drupal\va_gov_user\Service\UserPermsService
+    arguments: ['@current_user', '@entity_type.manager', '@database', '@entity_type.manager']


### PR DESCRIPTION
## Description

See #1243. 

- adds custom block that renders user sections on user profile
   - block output varies depending on whether user has no sections assigned, some section assigned, root section assigned "All sections" or user has roles Administrator or Content Admin
   - users can now view own and other users' sections by visiting their profiles (given they have permission to view other users' profiles)

Note: decision was made to add custom block instead of View, due to the following factors:
- control of pages on which the block appears is much simpler via custom route check - e.g. render only on /user/* would render block on user view page but also on user edit pages and others. We'd need to add another contrib module in order to set correct path pattern in Block UI
- logic for differentiating users with zero, some and all sections would have to live in preprocess functions of a theme that will likely be changed soon. Custom block landed itself well to this requirement w/ much less code needed
 
**User has NO sections assigned** - ( opened UX writing issue for @rachel-kauff to iterate on placeholder lingo - #1684 )
<img width="1040" alt="Screen Shot 2020-05-04 at 1 54 21 PM" src="https://user-images.githubusercontent.com/16477724/81012642-2424b980-8e17-11ea-98de-3885fdf8f50a.png">

**User has some sections assigned**
<img width="996" alt="Screen Shot 2020-05-04 at 1 57 44 PM" src="https://user-images.githubusercontent.com/16477724/81012667-31da3f00-8e17-11ea-995a-29aee1f99341.png">

**User is assigned to a root section which provides access to all sections OR user has role Content Admin or Administrator**
<img width="1127" alt="Screen Shot 2020-05-04 at 1 55 52 PM" src="https://user-images.githubusercontent.com/16477724/81012737-4ae2f000-8e17-11ea-9898-c39d3c1af5c2.png">


## QA steps

As user 1

- [x] visit https://va-gov-cms.lndo.site/admin/people, open profiles of several users in that list while comparing sections displayed in SECTION column with those displayed on user profile View page
- [x] login as `Shawnee.Blair@va.gov` and visit `/user` page - confirm you see Sections block w/ a. message `Contact #cms-support for VA section assignment.`
- [x] login as `Laura.Walsh1@va.gov` and visit `/user` page - confirm you see 4 sections
- [x] as an admin - add a new section for Laura Walsh , then view profile page as user `Laura.Walsh1@va.gov` and confirm you see updated list of sections immediately after page refresh
- [x] login as `howie.brande@va.gov`. Howie does not have roles "Content Admin" or "Administrator", but has access to root section. Confirm you see a tree of all sections when viewing `/user`  page as Howie
- [x] as an admin or user w/ role "Content Admin", view `/user` page and confirm you see a tree of all sections 

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
