### PR TITLE
VACMS-998 Remove redirect_after_login from codebase.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,6 @@
         "drupal/pfm": "^1.1",
         "drupal/post_api": "1.x-dev",
         "drupal/redirect": "^1.3",
-        "drupal/redirect_after_login": "^2.5",
         "drupal/redirect_options": "^1.2",
         "drupal/rest_menu_tree": "^1.1",
         "drupal/restui": "^1.16",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e833ad8919e55d0e45f78de49d4cc57",
+    "content-hash": "337398a5702d4e92f4450d842baaa249",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -9114,58 +9114,6 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
-            }
-        },
-        {
-            "name": "drupal/redirect_after_login",
-            "version": "2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/redirect_after_login.git",
-                "reference": "8.x-2.5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/redirect_after_login-8.x-2.5.zip",
-                "reference": "8.x-2.5",
-                "shasum": "66c0e1823581bb4bb6087d43e964132c9434bda0"
-            },
-            "require": {
-                "drupal/core": "~8.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-2.5",
-                    "datestamp": "1552929184",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Rahul Kumar",
-                    "homepage": "https://www.drupal.org/u/rahul-kr-sh",
-                    "role": "Author"
-                },
-                {
-                    "name": "rahul-kr-sh",
-                    "homepage": "https://www.drupal.org/user/3561577"
-                }
-            ],
-            "description": "Redirect user after login to a configured url",
-            "homepage": "https://drupal.org/project/redirect_after_login",
-            "support": {
-                "source": "https://git.drupalcode.org/project/redirect_after_login"
             }
         },
         {


### PR DESCRIPTION
## Description

See #998  

THis module has already been uninstalled and made its way to production.  This is simply the followup to remove it from the codebase.

## QA steps

There is no QA as there is nothing to test.  
