### PR TITLE
VACMS-1646 Disable build trigger if cli runs on BRD.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
@@ -113,7 +113,7 @@ class BuildFrontend {
       // Save pending state.
       $this->setPendingState(1);
     }
-    elseif ((!empty($jenkins_build_environment)) && array_key_exists($jenkins_build_environment, self::WEB_ENVIRONMENTS)) {
+    elseif ((!empty($jenkins_build_environment)) && array_key_exists($jenkins_build_environment, self::WEB_ENVIRONMENTS) && (PHP_SAPI !== 'cli')) {
       // This is in a BRD environment.
       $va_cms_bot_github_username = Settings::get('va_cms_bot_github_username');
       $va_cms_bot_github_auth_token = Settings::get('va_cms_bot_github_auth_token');


### PR DESCRIPTION
## Description

See #1646 . 



## QA steps

This testing can only be done on dev or staging.
- [x] After this commit is deployed to dev or staging, validate that the jenkins FE build did not get triggered by the running of php unit test .
- [x] on dev go to https://dev.cms.va.gov/admin/content/deploy and click the "Release content button"  Validate that the content release was triggered in Jenkins.
