### PR TITLE
VACMS-1522 Update site_alert and related patches.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "drupal/role_delegation": "^1.0@alpha",
         "drupal/seckit": "^1.1",
         "drupal/simplesamlphp_auth": "^3.0",
-        "drupal/site_alert": "1.x-dev#7e8a229292ec6cf85cb5e22d8a58afac098c3bd1",
+        "drupal/site_alert": "1.x-dev#d3700174bdddeca1f33c6995fde86e436b034270",
         "drupal/slack": "^1.2",
         "drupal/social_media_links": "^2.6",
         "drupal/tablefield": "^2.1",
@@ -277,9 +277,8 @@
                 "Bypass password requirement for password change if logged in with sso.": "https://www.drupal.org/files/issues/2018-05-01/simplesamlphp_auth-change-password-access-2968598-2.patch"
             },
             "drupal/site_alert": {
-                "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-add_drush_commands-3118800-6.patch",
-                "Add aria https://www.drupal.org/project/site_alert/issues/3120303": "https://www.drupal.org/files/issues/2020-03-17/site_alert-add-508-aria-3120303-3.patch",
-                "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-support_drush8_commands-3118800-7.patch",
+                "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-05-20/site_alert-add_drush_commands-3118800-12.patch",
+                "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-05-20/site_alert-add_drush_commands_for_drush8-3118800-14.patch",
                 "Allow access to /ajax/site_alert route in maintenance mode": "https://www.drupal.org/files/issues/2020-04-29/maintenance-access.patch"
             },
             "drupal/tablefield": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1aaac9f333a063a6b4889f366c99d483",
+    "content-hash": "559e829260431104553c0cf31dad0560",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -9701,7 +9701,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/site_alert.git",
-                "reference": "7e8a229292ec6cf85cb5e22d8a58afac098c3bd1"
+                "reference": "d3700174bdddeca1f33c6995fde86e436b034270"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -9720,9 +9720,8 @@
                     }
                 },
                 "patches_applied": {
-                    "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-add_drush_commands-3118800-6.patch",
-                    "Add aria https://www.drupal.org/project/site_alert/issues/3120303": "https://www.drupal.org/files/issues/2020-03-17/site_alert-add-508-aria-3120303-3.patch",
-                    "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-03-13/site_alert-support_drush8_commands-3118800-7.patch",
+                    "Add drush commands https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-05-20/site_alert-add_drush_commands-3118800-12.patch",
+                    "Make drush commands Drush 8 https://www.drupal.org/project/site_alert/issues/3118800": "https://www.drupal.org/files/issues/2020-05-20/site_alert-add_drush_commands_for_drush8-3118800-14.patch",
                     "Allow access to /ajax/site_alert route in maintenance mode": "https://www.drupal.org/files/issues/2020-04-29/maintenance-access.patch"
                 }
             },
@@ -9749,7 +9748,7 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/site_alert"
             },
-            "time": "2020-03-09T08:06:36+00:00"
+            "time": "2020-04-02T17:11:23+00:00"
         },
         {
             "name": "drupal/slack",


### PR DESCRIPTION
## Description

See #1522 . 




## QA steps
- [x] validate drush create creates `lando drush site_alert:create "alert" "The CMS is up and running, please continue." --severity=low`
![image](https://user-images.githubusercontent.com/5752113/82489903-68b78280-9ab0-11ea-9256-c4e57c7ba06c.png)

- [x] validate drush delete, deletes  `lando drush site_alert:delete alert`
![image](https://user-images.githubusercontent.com/5752113/82489985-8a186e80-9ab0-11ea-90bb-5483dd6d870c.png)
- [x] validate drush delete, works when there is nothing to delete  `lando drush site_alert:delete alert`
![image](https://user-images.githubusercontent.com/5752113/82490046-a9170080-9ab0-11ea-9863-f2b1a6186492.png)


Create a site alert with low severity that expires at a specific time.  
- [ ] View any page on the site after that time and validate that the site alert does not display on the initial page load.


