### PR TITLE
VACMS-1534: Project-specific post_api tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "drupal/pathauto": "^1.6",
         "drupal/pathologic": "^1.0@alpha",
         "drupal/pfm": "^1.1",
-        "drupal/post_api": "1.x-dev",
+        "drupal/post_api": "^2.0.1",
         "drupal/redirect": "^1.3",
         "drupal/redirect_options": "^1.2",
         "drupal/rest_menu_tree": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c43cb7fe48e3d5f69d7ac0ea32ccd5fe",
+    "content-hash": "55ae90448b06ba4adc6338955c86deda",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3188,6 +3188,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-4.x": "4.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-4.0-alpha2",
                     "datestamp": "1493956089",
@@ -3213,10 +3216,6 @@
                 {
                     "name": "gregcube",
                     "homepage": "https://www.drupal.org/user/336930"
-                },
-                {
-                    "name": "jrglasgow",
-                    "homepage": "https://www.drupal.org/user/36590"
                 },
                 {
                     "name": "phenaproxima",
@@ -3333,6 +3332,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.0",
                     "datestamp": "1563825485",
@@ -3475,6 +3477,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.2",
                     "datestamp": "1576528386",
@@ -4373,6 +4378,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-3.2",
                     "datestamp": "1550728386",
@@ -5827,6 +5835,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-3.0-rc3",
                     "datestamp": "1572538084",
@@ -5844,10 +5855,6 @@
                 {
                     "name": "fubhy",
                     "homepage": "https://www.drupal.org/user/761344"
-                },
-                {
-                    "name": "joaogarin",
-                    "homepage": "https://www.drupal.org/user/612814"
                 },
                 {
                     "name": "klausi",
@@ -6223,6 +6230,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.1",
                     "datestamp": "1556799496",
@@ -6238,12 +6248,32 @@
             ],
             "authors": [
                 {
+                    "name": "catch",
+                    "homepage": "https://www.drupal.org/user/35733"
+                },
+                {
                     "name": "jonathan1055",
                     "homepage": "https://www.drupal.org/user/92645"
                 },
                 {
+                    "name": "juampynr",
+                    "homepage": "https://www.drupal.org/user/682736"
+                },
+                {
+                    "name": "lussoluca",
+                    "homepage": "https://www.drupal.org/user/138068"
+                },
+                {
                     "name": "moshe weitzman",
                     "homepage": "https://www.drupal.org/user/23"
+                },
+                {
+                    "name": "pcambra",
+                    "homepage": "https://www.drupal.org/user/122101"
+                },
+                {
+                    "name": "salvis",
+                    "homepage": "https://www.drupal.org/user/82964"
                 },
                 {
                     "name": "willzyx",
@@ -6624,6 +6654,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-5.x": "5.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-5.0",
                     "datestamp": "1575473880",
@@ -6670,6 +6703,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-5.x": "5.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-5.0",
                     "datestamp": "1575473880",
@@ -6717,6 +6753,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-5.x": "5.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-5.0",
                     "datestamp": "1575473880",
@@ -8904,23 +8943,26 @@
         },
         {
             "name": "drupal/post_api",
-            "version": "dev-1.x",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "4f0e2cfd9a8beff14526d24babdc5f9e3eecacc7"
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/post_api-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "979e070a1ff7f192b5aaa628130eddfc9bd010a0"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.x-dev",
-                    "datestamp": "1590678996",
+                    "version": "2.0.1",
+                    "datestamp": "1590717054",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8941,8 +8983,7 @@
             "homepage": "https://www.drupal.org/project/post_api",
             "support": {
                 "source": "https://git.drupalcode.org/project/post_api"
-            },
-            "time": "2020-05-28T15:16:11+00:00"
+            }
         },
         {
             "name": "drupal/redirect",
@@ -9471,6 +9512,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.2",
                     "datestamp": "1561463889",
@@ -9578,6 +9622,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-3.16",
                     "datestamp": "1558127887",
@@ -9936,6 +9983,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-3.4",
                     "datestamp": "1545492780",
@@ -9951,16 +10001,12 @@
             ],
             "authors": [
                 {
-                    "name": "NickDickinsonWilde",
+                    "name": "NickWilde",
                     "homepage": "https://www.drupal.org/user/3094661"
                 },
                 {
                     "name": "andrey.troeglazov",
                     "homepage": "https://www.drupal.org/user/3145389"
-                },
-                {
-                    "name": "bmack",
-                    "homepage": "https://www.drupal.org/user/3594520"
                 },
                 {
                     "name": "dstol",
@@ -10166,6 +10212,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.3",
                     "datestamp": "1580961561",
@@ -10201,6 +10250,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.3",
                     "datestamp": "1580961561",
@@ -10236,6 +10288,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.3",
                     "datestamp": "1580961561",
@@ -10697,6 +10752,9 @@
             },
             "type": "metapackage",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.2",
                     "datestamp": "1564103585",
@@ -11226,6 +11284,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.1",
                     "datestamp": "1561124885",
@@ -19014,6 +19075,7 @@
     "stability-flags": {
         "devshop/behat-drupal-extension": 20,
         "drupal/auto_entitylabel": 10,
+        "drupal/blazy": 5,
         "drupal/cer": 15,
         "drupal/content_lock": 15,
         "drupal/cshs": 10,
@@ -19034,7 +19096,6 @@
         "drupal/password_strength": 15,
         "drupal/path_redirect_import": 10,
         "drupal/pathologic": 15,
-        "drupal/post_api": 20,
         "drupal/role_delegation": 15,
         "drupal/site_alert": 20,
         "drupal/tour_ui": 10,
@@ -19053,5 +19114,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1.3"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/tests/phpunit/PostApiQueueTest.php
+++ b/tests/phpunit/PostApiQueueTest.php
@@ -81,11 +81,11 @@ class PostApiQueueTest extends ExistingSiteBase {
 
     $response = $this->processItem(NULL);
     // Payload is empty. Request should fail.
-    $this->assertEqual($response, 404, 'POST request is expected to fail with 404 due to incomplete endpoint URL.');
+    $this->assertEquals(404, $response, 'POST request is expected to fail with 404 due to incomplete endpoint URL.');
 
     $response = $this->processItem(self::$mockData);
     // Payload and credentials are available. POSt should return 200 OK.
-    $this->assertEqual($response, 200, 'POST request is successful.');
+    $this->assertEquals(200, $response,'POST request is successful.');
 
     $queue->deleteQueue();
   }
@@ -114,7 +114,7 @@ class PostApiQueueTest extends ExistingSiteBase {
   /**
    * Create Queue.
    *
-   * @return DatabaseQueue
+   * @return \Drupal\core\Queue\DatabaseQueue
    *   Queue.
    */
   protected function createQueue() {
@@ -122,21 +122,6 @@ class PostApiQueueTest extends ExistingSiteBase {
     $queue = new DatabaseQueue('post_api_queue', Database::getConnection());
     $queue->createQueue();
     return $queue;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function processItem($data) {
-    $apikey = Settings::get('post_api_apikey');
-    $endpoint_path = isset($data['endpoint_path']) ? $data['endpoint_path'] : NULL;
-    $endpoint = Settings::get('post_api_endpoint_host') . $endpoint_path;
-    $payload = isset($data['payload']) ? $data['payload'] : [];
-
-    $request_service = \Drupal::service('post_api.request');
-
-    // Send POST request and return the response.
-    return $request_service->sendRequest($endpoint, $apikey, $payload);
   }
 
   /**
@@ -159,4 +144,20 @@ class PostApiQueueTest extends ExistingSiteBase {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function processItem($data) {
+    $apikey = Settings::get('post_api_apikey');
+    $endpoint_path = isset($data['endpoint_path']) ? $data['endpoint_path'] : NULL;
+    $endpoint = Settings::get('post_api_endpoint_host') . $endpoint_path;
+    $payload = isset($data['payload']) ? $data['payload'] : [];
+
+    $request_service = \Drupal::service('post_api.request');
+
+    // Send POST request and return the response.
+    return $request_service->sendRequest($endpoint, $apikey, $payload);
+  }
+
 }
+

--- a/tests/phpunit/PostApiQueueTest.php
+++ b/tests/phpunit/PostApiQueueTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace tests\phpunit;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Queue\DatabaseQueue;
+use Drupal\Core\Site\Settings;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Tests Post API Queue functionality.
+ *
+ * @group PostApiQueue
+ */
+class PostApiQueueTest extends ExistingSiteBase {
+
+  /**
+   * Modules to install.
+   *
+   * @var array
+   */
+  public static $modules = ['post_api'];
+
+  /**
+   * Mock queue item data.
+   *
+   * @var array
+   */
+  public static $mockData = [
+    'nid' => 1546,
+    'uid' => 'facility_status_vha_568A4',
+    'endpoint_path' => '/services/va_facilities/v0/facilities/vha_568A4/cms-overlay',
+    'payload' => [
+      'operating_status' => [
+        'code' => 'CLOSED',
+        'additional_info' => 'Test additional info',
+      ],
+    ],
+  ];
+
+  public function setUp() {
+    parent::setUp();
+    $queue = new DatabaseQueue('post_api_queue', Database::getConnection());
+    $queue->deleteQueue();
+  }
+
+  /**
+   * Tests queue item expiration.
+   *
+   * NOTE: Core has a bug, where claimItem in the database and memory queues
+   * does not use expire correctly.
+   * Expiration test depend on applied core patch
+   * https://www.drupal.org/project/drupal/issues/2893933#comment-13413895
+   * If patch is not applied, this test will fail.
+   */
+  public function testPostApiQueueItemExpiration() {
+    $queue = $this->createQueue();
+
+    // Test that we can claim an item that is expired and we cannot claim an
+    // item that has not expired yet.
+    $queue->createItem([$this->randomMachineName() => $this->randomMachineName()]);
+    $item = $queue->claimItem();
+    $this->assertNotFalse($item, 'The item can be claimed.');
+    $item = $queue->claimItem();
+    $this->assertFalse($item, 'The item cannot be claimed again.');
+    // Set the expiration date to the current time minus the lease time plus 1
+    // second. It should be possible to reclaim the item.
+    $this->setExpiration($queue, time() - 31);
+    $item = $queue->claimItem();
+    $this->assertNotFalse($item, 'Item can be claimed after expiration.');
+
+    $queue->deleteQueue();
+  }
+
+  /**
+   * Processes mock queue items to test Lighthouse API responses.
+   */
+  public function testPostApiQueueProcessing() {
+    // Create queue.
+    $queue = $this->createQueue();
+
+    $response = $this->processItem(NULL);
+    // Payload is empty. Request should fail.
+    $this->assertEqual($response, 404, 'POST request is expected to fail with 404 due to incomplete endpoint URL.');
+
+    $response = $this->processItem(self::$mockData);
+    // Payload and credentials are available. POSt should return 200 OK.
+    $this->assertEqual($response, 200, 'POST request is successful.');
+
+    $queue->deleteQueue();
+  }
+
+  /**
+   * Queues items and verifies that dedupe method works as expected.
+   */
+  public function testPostApiQueueDedupe() {
+    // Create queue.
+    $queue = $this->createQueue();
+
+    // Check that queue is empty.
+    $this->assertSame(0, $queue->numberOfItems(), 'ERROR: Post API Queue is not empty');
+
+    // Dedupe test.
+    $add_to_queue_service = \Drupal::service('post_api.add_to_queue');
+    // Dedupe while adding.
+    $add_to_queue_service->addToQueue(self::$mockData, TRUE);
+    $add_to_queue_service->addToQueue(self::$mockData, TRUE);
+
+    $this->assertSame(1, $queue->numberOfItems(), 'ERROR: Post API Queue contains duplicate items.');
+
+    $queue->deleteQueue();
+  }
+
+  /**
+   * Create Queue.
+   *
+   * @return DatabaseQueue
+   *   Queue.
+   */
+  protected function createQueue() {
+    // Create queue.
+    $queue = new DatabaseQueue('post_api_queue', Database::getConnection());
+    $queue->createQueue();
+    return $queue;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function processItem($data) {
+    $apikey = Settings::get('post_api_apikey');
+    $endpoint_path = isset($data['endpoint_path']) ? $data['endpoint_path'] : NULL;
+    $endpoint = Settings::get('post_api_endpoint_host') . $endpoint_path;
+    $payload = isset($data['payload']) ? $data['payload'] : [];
+
+    $request_service = \Drupal::service('post_api.request');
+
+    // Send POST request and return the response.
+    return $request_service->sendRequest($endpoint, $apikey, $payload);
+  }
+
+  /**
+   * Set the expiration for different queues.
+   *
+   * @param object $queue
+   *   The queue for which to alter the expiration.
+   * @param int $expire
+   *   The new expiration time.
+   */
+  protected function setExpiration($queue, $expire) {
+    $class = get_class($queue);
+    switch ($class) {
+      case DatabaseQueue::class:
+        \Drupal::database()
+          ->update(DatabaseQueue::TABLE_NAME)
+          ->fields(['expire' => $expire])
+          ->execute();
+        break;
+    }
+  }
+
+}


### PR DESCRIPTION
## Description

See #1534 . 

- added phpunit tests for Post API that are project-specific. Test verifies item expiration logic, for which we have applied a core patch. It is important, because it will notify us immediately if the core patch no longer applies
- added php unit tests to DO contrib post_api that verify basic queue functionality, dedupe logic and expiration logic. NOTE: expiration logic test is reversed see [comments in code](https://git.drupalcode.org/project/post_api/-/blob/2.x/tests/src/Kernel/PostApiQueueTest.php#L59). 


P.S. this PR is constantly getting out of date, so I'll rebase again once reviewed.

## QA steps

- [ ] review added project-specific phpunit tests. Confirm they are passing within our build
- [ ] [review added drupal/post_api phpunit tests](https://www.drupal.org/project/post_api) . confirm they passing.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
