### PR TITLE
VAGOV-1657: Increase PerformanceLoginTest ceiling from 2 to 3.

### DIFF
--- a/tests/phpunit/CreateMediaTest.php
+++ b/tests/phpunit/CreateMediaTest.php
@@ -59,9 +59,9 @@ class CreateMediaTest extends ExistingSiteBase {
 
     // Test assertion.
     $secs = number_format($microsecs, 3);
-    $this->assertLessThan($benchmark, $secs, "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
+    $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
 
-    $message = "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
+    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
     fwrite(STDERR, print_r($message, TRUE));
   }
 

--- a/tests/phpunit/CreateTaxonomyTermTest.php
+++ b/tests/phpunit/CreateTaxonomyTermTest.php
@@ -40,9 +40,9 @@ class CreateTaxonomyTerm extends ExistingSiteBase {
 
     // Test assertion.
     $secs = number_format($microsecs, 3);
-    $this->assertLessThan($benchmark, $secs, "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
+    $this->assertLessThan($benchmark, $secs, __METHOD__  . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
 
-    $message = "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
+    $message = __METHOD__  . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
     fwrite(STDERR, print_r($message, TRUE));
   }
 

--- a/tests/phpunit/PerformanceCreateNodeTest.php
+++ b/tests/phpunit/PerformanceCreateNodeTest.php
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class CreateNodePerformance extends ExistingSiteBase {
 
   /**
-   * A test method to deterine the amount of time it takes to create a node.
+   * A test method to determine the amount of time it takes to create a node.
    *
    * @group performance
    * @group all
@@ -43,9 +43,9 @@ class CreateNodePerformance extends ExistingSiteBase {
 
     // Test assertion.
     $secs = number_format($microsecs, 3);
-    $this->assertLessThan($benchmark, $secs, "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
+    $this->assertLessThan($benchmark, $secs, __METHOD__  . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
 
-    $message = "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
+    $message = __METHOD__  . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
     fwrite(STDERR, print_r($message, TRUE));
   }
 

--- a/tests/phpunit/PerformanceEditNodeTest.php
+++ b/tests/phpunit/PerformanceEditNodeTest.php
@@ -46,9 +46,9 @@ class EditNodePerformance extends ExistingSiteBase {
 
     // Test assertion.
     $secs = number_format($microsecs, 3);
-    $this->assertLessThan($benchmark, $secs, "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds for type " . $type . ".\n");
+    $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds for type " . $type . ".\n");
 
-    $message = "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds for type " . $type . ".\n";
+    $message = __METHOD__  . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds for type " . $type . ".\n";
     fwrite(STDERR, print_r($message, TRUE));
   }
 

--- a/tests/phpunit/PerformanceLoginTest.php
+++ b/tests/phpunit/PerformanceLoginTest.php
@@ -47,9 +47,9 @@ class LoginPerformance extends ExistingSiteBase {
 
     // Test assertion.
     $secs = number_format($microsecs, 3);
-    $this->assertLessThan($benchmark, $secs, "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
+    $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
 
-    $message = "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
+    $message = __METHOD__  . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
     fwrite(STDERR, print_r($message, TRUE));
   }
 

--- a/tests/phpunit/PerformanceLoginTest.php
+++ b/tests/phpunit/PerformanceLoginTest.php
@@ -19,12 +19,16 @@ class LoginPerformance extends ExistingSiteBase {
    */
   public function testLoginPerformance($benchmark) {
 
+    // Creates a user. Will be automatically cleaned up at the end of the test.
     $author = $this->createUser();
     $author->addRole('content_editor');
     $author->save();
 
-    // Warm some cache before testing so login test will be more realistic.
+    // Warm cache before testing so login test will be realistic.
     $this->drupalLogin($author);
+    // Logout here because if we don't then drupalLogin() automatically calls
+    // drupalLogout() on the next drupalLogin() invocation, which is unrealistic.
+    $this->drupalLogout();
 
     // Start timer.
     $mtime = microtime();
@@ -32,7 +36,6 @@ class LoginPerformance extends ExistingSiteBase {
     $mtime = $mtime[1] + $mtime[0];
     $starttime = $mtime;
 
-    // Creates a user. Will be automatically cleaned up at the end of the test.
     $this->drupalLogin($author);
 
     // End timer.

--- a/tests/phpunit/PerformanceLoginTest.php
+++ b/tests/phpunit/PerformanceLoginTest.php
@@ -53,13 +53,15 @@ class LoginPerformance extends ExistingSiteBase {
   /**
    * Returns benchmark time to beat in order for test to succeed.
    *
+   * @see https://github.com/department-of-veterans-affairs/va.gov-cms/issues/1657#issuecomment-631755887
+   *
    * @return array
    *   Array containing entity type as string and expected count as int
    */
   public function benchmarkTime() {
-    return array(
-      array(2),
-    );
+    return [
+      [3],
+    ];
   }
 
 }

--- a/tests/phpunit/PerformancePreviewTest.php
+++ b/tests/phpunit/PerformancePreviewTest.php
@@ -99,9 +99,9 @@ class PreviewPerformance extends ExistingSiteBase {
 
     // Test assertion.
     $secs = number_format($microsecs, 3);
-    $this->assertLessThan($benchmark, $secs, "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
+    $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
 
-    $message = "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
+    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
     fwrite(STDERR, print_r($message, TRUE));
   }
 


### PR DESCRIPTION
See #1657.

This PR:
* Increases the ceiling from 2 to 3 - see https://github.com/department-of-veterans-affairs/va.gov-cms/issues/1657#issuecomment-631755887
* Adds a drupalLogout()
* Adds `__METHOD__` names to the output so we know what test is running/passing, instead of waiting until the end for a failure. 