### PR TITLE
VACMS-000: Fixing unique event ID persistence on gtm push.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/gtm_tag_trackers.js
+++ b/docroot/modules/custom/va_gov_backend/js/gtm_tag_trackers.js
@@ -74,7 +74,8 @@
 
             // Special handling for menu nav items.
             menuTraverser(el);
-
+            // Unset old Unique ID.
+            dataCollection['gtm.uniqueEventId'] = '';
             // Now send it to the dataLayer.
             dataLayer.push(dataCollection);
           });


### PR DESCRIPTION
## Description
Per convo with Brian Martin (VSP Analytics and Insights team):
> One issue I found is that the uniqueEventId persists between events when the page isn't being reloaded. 

> Maybe a delete dataCollection['gtm.uniqueEventId']  before the push to the dataLayer

## Testing done
Click and console.

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/82565773-f47ced80-9b48-11ea-94f9-6c404afb8e8f.png)


## QA steps
Will be qa'd by analytics team after merge (they need to test against staging).