### PR TITLE
VACMS-1904: Improve help text for event facility fields.

### DIFF
--- a/config/sync/field.field.node.event.field_facility_location.yml
+++ b/config/sync/field.field.node.event.field_facility_location.yml
@@ -11,7 +11,7 @@ field_name: field_facility_location
 entity_type: node
 bundle: event
 label: 'Facility location'
-description: 'If your event takes place in a VA facility, select it here (and don''t add an address below!). '
+description: 'If your event takes place in a VA facility, select it here. '
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
## Description

See #1904. 

## Testing done

Manual.

## QA

Go to /node/add/event. For the facility field, help text no longer instructs user to not include the address.

