### PR TITLE
VACMS-1957: Allow aria-label attribute for links.

### DIFF
--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -50,7 +50,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol type start> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <hr> <br> <p class="va-address-block"> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title class=" usa-button usa-button-primary usa-button-secondary va-button-primary login-required"> <drupal-entity data-* title alt data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button data-langcode>'
+      allowed_html: '<em> <strong> <b> <cite> <blockquote cite> <ul type> <ol type start> <li> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <hr> <br> <p class="va-address-block"> <a href hreflang aria-label data-entity-substitution data-entity-type data-entity-uuid title class=" usa-button usa-button-primary usa-button-secondary va-button-primary login-required"> <drupal-entity data-* title alt data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button data-langcode>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:


### PR DESCRIPTION
## Description

See #1957. 

## Testing done

Manual 

## Screenshots


## QA steps

- Go to /node/add/page
- Add a link in a WYSIWYG field like so: `<a href="tel:711" aria-label="TTY. 7 1 1.">711</a>`
- Save the node
- aria-label should be retained in the content
