### PR TITLE
VACMS-9167: Upgrade facility endpoint from v0 to v1.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -136,7 +136,7 @@ $config['govdelivery_bulletins.settings']['govdelivery_username'] = getenv('CMS_
 $config['govdelivery_bulletins.settings']['govdelivery_password'] = getenv('CMS_GOVDELIVERY_PASSWORD') ?: FALSE;
 
 // Set migration settings from environment variables.
-$facility_api_urls = [getenv('CMS_VAGOV_API_URL') . '/services/va_facilities/v0/facilities/all'];
+$facility_api_urls = [getenv('CMS_VAGOV_API_URL') . '/services/va_facilities/v1/facilities/all'];
 $facility_api_key = getenv('CMS_VAGOV_API_KEY');
 $facility_migrations = [
   'va_node_health_care_local_facility',

--- a/tests/phpunit/PostApiQueueTest.php
+++ b/tests/phpunit/PostApiQueueTest.php
@@ -29,7 +29,7 @@ class PostApiQueueTest extends ExistingSiteBase {
   public static $mockData = [
     'nid' => 1546,
     'uid' => 'facility_status_vha_568A4',
-    'endpoint_path' => '/services/va_facilities/v0/facilities/vha_568A4/cms-overlay',
+    'endpoint_path' => '/services/va_facilities/v1/facilities/vha_568A4/cms-overlay',
     'payload' => [
       'operating_status' => [
         'code' => 'CLOSED',


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-team/issues/9167
Upgrades facilities api endpoint from v0 to v1. This should just be a change in the endpoint path - the data structure that is changing isn't associated with any of the data we are consuming.

## Screenshots
N/A
