### PR TITLE
VACMS-2015: Sections access for content admins (TEMP fix).

### DIFF
--- a/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
@@ -95,7 +95,11 @@ class UserPermsService {
     $query->fields('sa', ['section_id']);
     $results = $query->execute()->fetchCol();
 
-    if (($key = array_search('administration', $results)) !== FALSE || $user->hasPermission('bypass-workbench-access')) {
+    // @todo: figure out why $user->hasPermission('bypass workbench access')
+    // returns FALSE even though the user has this permission granted.
+    // Temporary workaround is to check for Administrator and Content Admin
+    // roles to indicate that user has access to all sections.
+    if (($key = array_search('administration', $results)) !== FALSE || ($user->hasRole('administrator') || $user->hasRole('content_admin'))) {
       unset($results[$key]);
       $tree = $entity_storage->loadTree('administration');
       foreach ($tree as $term) {


### PR DESCRIPTION
## Description

See #2015 

the fix in this PR is temporary
`hasPermission()` method does not return expected results by role and this issue need a more thorough investigation.
let's deploy this temp fix today, then I'll follow up w/ part II

## Testing done


## Screenshots


## QA steps

See #2015 

login as admin
- [ ] load the list of users `/admin/people` and filter by Content Admin role
- [ ] review Randi.Hecht@va.gov profile and several other that have Content Admin role and confirm they have all sections displayed on their profiles
- [ ] load the list of users `/admin/people` and filter by Administrator role
- [ ] review several user profiles with "Administrator" role. Confirm they have all sections displayed on their profiles
- [ ] load the list of users `/admin/people` and filter by Content Editor role
- [ ] review several Content Editor users that have only some sections assigned to them. confirm they see sections that are assigned to them on their profiles.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
