### PR TITLE
VACMS-1959: Standardize editorial workflow fieldset for all content types

### DIFF
--- a/config/sync/core.base_field_override.node.event.title.yml
+++ b/config/sync/core.base_field_override.node.event.title.yml
@@ -8,7 +8,7 @@ id: node.event.title
 field_name: title
 entity_type: node
 bundle: event
-label: 'Name'
+label: Name
 description: ''
 required: true
 translatable: true

--- a/config/sync/core.entity_form_display.node.event_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.event_listing.default.yml
@@ -37,6 +37,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 3
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -61,6 +61,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 9
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
@@ -44,6 +44,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 13
       format_type: fieldset
@@ -181,9 +182,9 @@ content:
       form_display_mode: default
       default_paragraph_type: _none
       features:
-        duplicate: '0'
-        collapse_edit_all: '0'
         add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
     third_party_settings: {  }
     type: paragraphs
     region: content
@@ -239,9 +240,9 @@ content:
       form_display_mode: default
       default_paragraph_type: _none
       features:
-        duplicate: '0'
-        collapse_edit_all: '0'
         add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
     third_party_settings: {  }
     type: paragraphs
     region: content

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -63,6 +63,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 13
       format_type: fieldset
@@ -492,9 +493,9 @@ content:
       form_display_mode: default
       default_paragraph_type: list_of_link_teasers
       features:
+        add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: '0'
-        add_above: '0'
     third_party_settings: {  }
     type: paragraphs
     region: content

--- a/config/sync/core.entity_form_display.node.health_services_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.health_services_listing.default.yml
@@ -39,6 +39,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 4
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -71,6 +71,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 11
       format_type: details
@@ -292,9 +293,9 @@ content:
       form_display_mode: default
       default_paragraph_type: _none
       features:
-        duplicate: '0'
-        collapse_edit_all: '0'
         add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
     third_party_settings: {  }
     type: paragraphs
     region: content

--- a/config/sync/core.entity_form_display.node.leadership_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.leadership_listing.default.yml
@@ -38,6 +38,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 5
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.locations_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.locations_listing.default.yml
@@ -37,6 +37,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 3
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.news_story.default.yml
+++ b/config/sync/core.entity_form_display.node.news_story.default.yml
@@ -41,11 +41,10 @@ third_party_settings:
       region: content
     group_editor:
       children:
-        - group_feature_this_story
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -58,8 +57,8 @@ third_party_settings:
       children:
         - field_featured
         - field_order
-      parent_name: group_editor
-      weight: 20
+      parent_name: ''
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''

--- a/config/sync/core.entity_form_display.node.office.default.yml
+++ b/config/sync/core.entity_form_display.node.office.default.yml
@@ -23,7 +23,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 7
+      weight: 5
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -39,7 +39,7 @@ third_party_settings:
         - field_meta_title
         - field_description
       parent_name: ''
-      weight: 6
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -47,6 +47,21 @@ third_party_settings:
         description: ''
         required_fields: true
       label: 'Meta Tags'
+      region: content
+    group_editorial_workflow:
+      children:
+        - moderation_state
+        - revision_log
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: true
+        required_fields: true
+      label: 'Editorial workflow'
       region: content
 id: node.office.default
 targetEntityType: node
@@ -61,7 +76,7 @@ content:
     region: content
   field_body:
     type: text_textarea
-    weight: 3
+    weight: 1
     region: content
     settings:
       rows: 5
@@ -76,7 +91,7 @@ content:
     type: string_textfield
     region: content
   field_meta_tags:
-    weight: 10
+    weight: 7
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
@@ -97,13 +112,13 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 8
+    weight: 6
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 4
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -116,7 +131,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 5
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.outreach_asset.default.yml
+++ b/config/sync/core.entity_form_display.node.outreach_asset.default.yml
@@ -24,7 +24,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 14
+      weight: 15
       format_type: details_sidebar
       format_settings:
         open: '1'
@@ -39,7 +39,7 @@ third_party_settings:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 13
+      weight: 14
       format_type: fieldset
       format_settings:
         id: ''
@@ -52,7 +52,7 @@ third_party_settings:
       children:
         - field_description
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: fieldset
       format_settings:
         id: ''
@@ -79,7 +79,7 @@ content:
     type: options_select
     region: content
   field_benefits:
-    weight: 15
+    weight: 11
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -112,7 +112,7 @@ content:
     region: content
     third_party_settings: {  }
   field_meta_tags:
-    weight: 11
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -62,6 +62,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 8
       format_type: fieldset
@@ -199,8 +200,8 @@ content:
       autocollapse: none
       closed_mode_threshold: 0
       features:
-        duplicate: duplicate
         collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
     third_party_settings: {  }
     region: content
   field_intro_text:
@@ -256,8 +257,8 @@ content:
       autocollapse: none
       closed_mode_threshold: 0
       features:
-        duplicate: duplicate
         collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
     third_party_settings: {  }
     region: content
   field_table_of_contents_boolean:

--- a/config/sync/core.entity_form_display.node.person_profile.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.person_profile.inline_entity_form.yml
@@ -41,8 +41,8 @@ third_party_settings:
       region: content
     group_e:
       children:
-        - revision_log
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 6
       format_type: fieldset
@@ -222,14 +222,6 @@ content:
     region: content
     settings:
       size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  revision_log:
-    type: string_textarea
-    weight: 0
-    region: content
-    settings:
-      rows: 5
       placeholder: ''
     third_party_settings: {  }
   title:

--- a/config/sync/core.entity_form_display.node.press_releases_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.press_releases_listing.default.yml
@@ -39,6 +39,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 4
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
+++ b/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
@@ -34,6 +34,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 12
       format_type: fieldset


### PR DESCRIPTION
## Description

See #1959 . 

## Screenshots

<img width="1089" alt="Screen Shot 2020-06-15 at 7 07 43 AM" src="https://user-images.githubusercontent.com/16477724/84661006-ed8e9400-aed6-11ea-97fb-7111dc5aef53.png">


## QA steps

As an admin
1. review all content type forms for standardized display of the Editorial workflow fieldset
   1. visit /node/add and open each form in new tab, then examine Editorial workflow fieldset while confirming that Revision log messaage is displayed right under the content state dropdown.



NOTE: two exceptions to the rule are:
1) VACM Facility Health Service content type `/node/add/health_care_local_health_service` since it is not. apart of a workflow
2)  Support service `/node/add/support_service`, which has an extra field in the Editorial workflow fieldset. I am not aware of this exception's purpose, so please confirm that the date field must like within the Editorial workflow fieldset

<img width="1066" alt="Screen Shot 2020-06-15 at 7 10 22 AM" src="https://user-images.githubusercontent.com/16477724/84661378-7f969c80-aed7-11ea-851b-8b9e164bd9ae.png">

- [x] Validated that all content types with the exception of the who listed above, have the log message in the proper location.

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
