### PR TITLE
Lower content-only deploy release_wait time from 5 to 0.

### DIFF
--- a/docroot/sites/default/settings/settings.prod.php
+++ b/docroot/sites/default/settings/settings.prod.php
@@ -3,7 +3,7 @@
 // @codingStandardsIgnoreFile
 
 $settings['jenkins_build_job_path'] = '/job/deploys/job/vets-gov-autodeploy-vets-website';
-$settings['jenkins_build_job_params'] = '/buildWithParameters?' . 'release_wait=5' . '&' . 'use_latest_release=true';
+$settings['jenkins_build_job_params'] = '/buildWithParameters?' . 'release_wait=0' . '&' . 'use_latest_release=true';
 $settings['jenkins_build_job_url'] = $settings['jenkins_build_job_host'] . $settings['jenkins_build_job_path'] . $settings['jenkins_build_job_params'];
 
 $config['config_split.config_split.dev']['status'] = FALSE;


### PR DESCRIPTION
We originally had 20+ minute build/deploy times and this didn't matter
much, but now that we are going for sub-1minute times this matters a
lot.


## Description

Resolves #2081.   

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

## Definition of Done
- [ ] Product release notes 
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)