### PR TITLE
VACMS-1645: Fix disable_menu_link warning.

### DIFF
--- a/docroot/modules/custom/disable_node_menu_item/disable_node_menu_item.module
+++ b/docroot/modules/custom/disable_node_menu_item/disable_node_menu_item.module
@@ -78,7 +78,6 @@ function disable_node_menu_item_submit(array $form, FormStateInterface $form_sta
     $menu_links = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $node->id()]);
     if (count($menu_links)) {
       foreach ($menu_links as $menu_link) {
-        $definition = $menu_link->getPluginDefinition();
         $definition['enabled'] = $form_state->getValue(['menu', 'link_enabled']);
         $menu_link_manager->updateDefinition($menu_link->getPluginId(), $definition);
       }


### PR DESCRIPTION
## Description

See #1645 . 

This PR fixes PHP warning specified in #1645 
Original assumption was that this warning may have contributed to DB locks.
Unfortunately, this fix will not have any significant effects on reducing DB locks, since database writes have only been reduced on account of less messages written to DBlog.

## QA steps

As Admin user:
- [x] edit node 725 - `/node/725/edit` 
- [x] update menu link title in "MENU SETTINGS" fieldset
- [x] Save the node using "Save" button (not "Save and continue")
- [x] review menu links `/admin/structure/menu/manage/careers-employment-benefits` and confirm your title change took effect
- [x] review log `/admin/reports/dblog` and confirm that it does not contain warning like this `Warning: Creating default object from empty value in Drupal\menu_link_content\Plugin\Menu\MenuLinkContent->updateLink() (line 237 of /var/www/cms/docroot/core/modules/menu_link_content/src/Plugin/Menu/MenuLinkContent.php)...`
- [x] edit node 725 - `/node/725/edit` and uncheck "Enable in menu" checkbox in "MENU SETTINGS" fieldset. Save the node and verify that menu link is now disabled in `/admin/structure/menu/manage/careers-employment-benefits` and log `/admin/reports/dblog` does not contain warnings
