### PR TITLE
VACMS-2108 VA Form modifications

### DIFF
--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -42,19 +42,19 @@ definitions:
     expanded: false
     enabled: true
   node__add__health_care_local_facility:
-    weight: 26
+    weight: 27
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__health_care_region_page:
-    weight: 23
+    weight: 24
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__health_care_local_health_service:
-    weight: 27
+    weight: 28
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -84,7 +84,7 @@ definitions:
     expanded: false
     enabled: true
   node__add__regional_health_care_service_des:
-    weight: 28
+    weight: 29
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -282,13 +282,13 @@ definitions:
     expanded: false
     enabled: true
   node__add__full_width_banner_alert:
-    weight: 24
+    weight: 25
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__vamc_operating_status_and_alerts:
-    weight: 25
+    weight: 26
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -522,16 +522,22 @@ definitions:
     expanded: false
     enabled: true
   node__add__vba_facility:
-    weight: 29
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__vet_center:
     weight: 30
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
+  node__add__vet_center:
+    weight: 31
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__va_form:
+    weight: 23
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    enabled: true
+    expanded: false
 _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM

--- a/config/sync/field.field.node.va_form.field_administration.yml
+++ b/config/sync/field.field.node.va_form.field_administration.yml
@@ -7,7 +7,7 @@ dependencies:
     - node.type.va_form
     - taxonomy.vocabulary.administration
   content:
-    - 'taxonomy_term:administration:40ef8d64-fa92-41b6-88c0-4d85dc24e191'
+    - 'taxonomy_term:administration:7d7e2e18-f91e-4af0-bca2-52a9af9a7b3e'
 id: node.va_form.field_administration
 field_name: field_administration
 entity_type: node
@@ -18,7 +18,7 @@ required: true
 translatable: true
 default_value:
   -
-    target_uuid: 40ef8d64-fa92-41b6-88c0-4d85dc24e191
+    target_uuid: 7d7e2e18-f91e-4af0-bca2-52a9af9a7b3e
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/metatag.metatag_defaults.node__va_form.yml
+++ b/config/sync/metatag.metatag_defaults.node__va_form.yml
@@ -1,0 +1,8 @@
+uuid: 9ad568f4-ed58-46a7-809a-023aa60cf80d
+langcode: en
+status: true
+dependencies: {  }
+id: node__va_form
+label: 'Content: VA form'
+tags:
+  description: '[node:field_va_form_usage:value]'

--- a/config/sync/migrate_plus.migration.va_node_form.yml
+++ b/config/sync/migrate_plus.migration.va_node_form.yml
@@ -134,7 +134,7 @@ source:
   constants:
     administration_section: 196
     idprefix: vha_
-    title_prefix: 'Va Form '
+    title_prefix: 'VA Form '
 process:
   migrate/flags/deleted: Deleted
   migrate/deleted_date: DeletedDate

--- a/config/sync/migrate_plus.migration.va_node_form.yml
+++ b/config/sync/migrate_plus.migration.va_node_form.yml
@@ -134,7 +134,7 @@ source:
   constants:
     administration_section: 196
     idprefix: vha_
-    title_prefix: 'VA Form '
+    title_prefix: 'About VA Form '
 process:
   migrate/flags/deleted: Deleted
   migrate/deleted_date: DeletedDate

--- a/config/sync/views.view.va_forms.yml
+++ b/config/sync/views.view.va_forms.yml
@@ -18,6 +18,7 @@ dependencies:
   content:
     - 'taxonomy_term:administration:2c331a6d-b525-4f0c-8bea-4ecde41c7ef0'
     - 'taxonomy_term:administration:867e4dcf-2f99-401a-977a-adb441d53350'
+    - 'taxonomy_term:administration:c20f3989-e93e-49bd-8c95-ad3821042a02'
     - 'taxonomy_term:administration:e5820ec7-83b0-4d03-8ebf-ed50fa8cc211'
     - 'taxonomy_term:administration:edadc39e-dbaa-4fe1-b6a8-344357d6abfe'
   module:
@@ -1148,6 +1149,7 @@ display:
           admin_label: ''
           operator: or
           value:
+            5: 5
             2: 2
             1: 1
             3: 3

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
@@ -143,7 +143,7 @@ source:
   constants:
     administration_section: 196
     idprefix: vha_
-    title_prefix: 'Va Form '
+    title_prefix: 'VA Form '
   # All the fields that are used from the source.
 # The destination fields mapped and processed from source fields.
 process:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
@@ -143,7 +143,7 @@ source:
   constants:
     administration_section: 196
     idprefix: vha_
-    title_prefix: 'VA Form '
+    title_prefix: 'About VA Form '
   # All the fields that are used from the source.
 # The destination fields mapped and processed from source fields.
 process:


### PR DESCRIPTION
## Description

See #2108 . 

## QA steps

As an admin
1. go to /admin/content/va-forms
   - [x] Validate that the options avalable for the Form Administration Filter match screenshot
![image](https://user-images.githubusercontent.com/5752113/85577491-43fe7f80-b607-11ea-8bec-bdc9e214408a.png)
2 Go to /node/add/va_form  and open the "Forms DB Data" field group.  
   - [x] validate that the options in the  form administration  match the options in the filter above  ^^ .
![image](https://user-images.githubusercontent.com/5752113/85578120-d4d55b00-b607-11ea-9bd0-c5d11e9155cd.png)
3. Open the "Meta Tags" field group on the right rail. 
   - [x] Validate that in the "Description" field the token is set for `[node:field_va_form_usage:value]`
![image](https://user-images.githubusercontent.com/5752113/85578627-37c6f200-b608-11ea-8525-c2bf74b3d6a9.png)
4.  Title case fixes require for an update migration to be run. Go to  `/admin/structure/migrate/manage/forms/migrations/va_node_form/execute`
Click the "Update" checbox and then click the "Execute" button
![image](https://user-images.githubusercontent.com/5752113/85582641-96da3600-b60b-11ea-8c3f-070e21ae9918.png)
  When the migration completes, Go to /admin/content/va-forms
   - [x] Validate the the titles have VA in caps.  example: "About VA Form #####" 









## Release steps
-  [ ]  Following deployment to production go to `/admin/structure/migrate/manage/forms/migrations/va_node_form/execute`
Click the "Update" checbox and then click the "Execute" button.   This will correct the capitalization of titles.