### PR TITLE
VACMS-2127 generate entity schemas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
         "drupal/node_link_report": "^1.14",
         "drupal/node_revisions_autoclean": "^1.0@beta",
         "drupal/node_title_help_text": "^1.0",
+        "drupal/openapi": "^1.0@beta",
         "drupal/override_node_options": "^2.4",
         "drupal/paragraphs": "^1.5",
         "drupal/paragraphs_browser": "^1.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee0a0d327a79601db85e485f02af14d5",
+    "content-hash": "777e1bb11572d81d38967112489949e4",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -7942,17 +7942,17 @@
         },
         {
             "name": "drupal/openapi",
-            "version": "1.0.0-beta6",
+            "version": "1.0.0-beta7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/openapi.git",
-                "reference": "8.x-1.0-beta6"
+                "reference": "8.x-1.0-beta7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/openapi-8.x-1.0-beta6.zip",
-                "reference": "8.x-1.0-beta6",
-                "shasum": "2d4db5b56e26f163d4b9641d102f611c12fd7ca4"
+                "url": "https://ftp.drupal.org/files/projects/openapi-8.x-1.0-beta7.zip",
+                "reference": "8.x-1.0-beta7",
+                "shasum": "375fb8f2f883d9bd52746ebdca9fc4de4a39eac5"
             },
             "require": {
                 "drupal/core": "~8.0",
@@ -7965,8 +7965,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.0-beta6",
-                    "datestamp": "1563908885",
+                    "version": "8.x-1.0-beta7",
+                    "datestamp": "1585778030",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -19067,6 +19067,7 @@
         "drupal/markup": 10,
         "drupal/mass_pwreset": 15,
         "drupal/node_revisions_autoclean": 10,
+        "drupal/openapi": 10,
         "drupal/paragraphs_browser": 15,
         "drupal/password_policy": 15,
         "drupal/password_strength": 15,

--- a/config/sync/user.role.content_api_consumer.yml
+++ b/config/sync/user.role.content_api_consumer.yml
@@ -13,6 +13,7 @@ weight: -8
 is_admin: null
 permissions:
   - 'access bulletin queue trigger api'
+  - 'access openapi api docs'
   - 'administer menu'
   - 'use graphql explorer'
   - 'use graphql voyager'

--- a/docroot/modules/custom/va_gov_consumers/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/va_gov_consumers/src/Routing/RouteSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\va_gov_consumers\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * OpenAPI json endpoint route alter to allow basic auth.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // We want to allow basic auth on Open Api endpoint.
+    $route_provider = \Drupal::service('router.route_provider');
+    // This it the path /openapi/jsonapi?_format=json to allow basic auth.
+    $graphql_routes = $route_provider->getRoutesByPattern('openapi/jsonapi');
+    $graphql_iterator = $graphql_routes->getIterator();
+
+    foreach ($graphql_iterator as $route_name => $route_params) {
+      if (($route_name === 'openapi.download') && $route = $collection->get($route_name)) {
+        $route->setOption('_auth', ['basic_auth', 'cookie']);
+        $route->setRequirement('_user_is_logged_in', 'TRUE');
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.info.yml
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.info.yml
@@ -3,6 +3,7 @@ description: Consumes data from external sources
 package: Custom
 dependencies:
   - markdown
+  - openapi
 
 type: module
 core: 8.x

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.services.yml
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.services.yml
@@ -1,0 +1,5 @@
+services:
+  va_gov_consumers.route_subscriber:
+    class: Drupal\va_gov_consumers\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/va_gov_content_export/src/Archive/ArchiveDirectory.php
+++ b/docroot/modules/custom/va_gov_content_export/src/Archive/ArchiveDirectory.php
@@ -5,6 +5,7 @@ namespace Drupal\va_gov_content_export\Archive;
 use Alchemy\Zippy\Archive\ArchiveInterface;
 use Alchemy\Zippy\Zippy;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\va_gov_content_export\Event\ContentExportPreTarEvent;
 
 /**
  * Archive a file path for CMS Content Export.
@@ -62,6 +63,9 @@ class ArchiveDirectory {
 
     // Deleting the file before it's created improves performance.
     $this->fileSystem->delete($archiveArgs->getOutputPath());
+    // Dispatch the Pre Tar event so that subscribers can use it.
+    \Drupal::service('event_dispatcher')->dispatch(ContentExportPreTarEvent::CONTENT_EXPORT_PRE_TAR_EVENT, new ContentExportPreTarEvent("{$archiveArgs->getCurrentWorkingDirectory()}{$archiveArgs->getArchiveDirectory()}", $this->fileSystem));
+
     return $this->zippy->create($real_path, $files, TRUE);
   }
 

--- a/docroot/modules/custom/va_gov_content_export/src/Event/ContentExportPreTarEvent.php
+++ b/docroot/modules/custom/va_gov_content_export/src/Event/ContentExportPreTarEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\va_gov_content_export\Event;
+
+use Drupal\Core\File\FileSystemInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Wraps a node insertion demo event for event listeners.
+ */
+class ContentExportPreTarEvent extends Event {
+
+  const CONTENT_EXPORT_PRE_TAR_EVENT = 'va_gov_content_export.pre.tar';
+
+  /**
+   * The path of files to be tarred.
+   *
+   * @var string
+   */
+  protected $tarPath;
+
+  /**
+   * A Drupal file system object.
+   *
+   * @var Drupal\Core\File\FileSystemInterface
+   */
+  public $fileSystem;
+
+  /**
+   * Constructs a va_gov_content_export event object.
+   *
+   * @param string $tar_path
+   *   The directory that will be tarred.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   Drupal FileSystem.
+   */
+  public function __construct($tar_path, FileSystemInterface $file_system) {
+    $this->tarPath = $tar_path;
+    $this->fileSystem = $file_system;
+  }
+
+  /**
+   * Getter for tarPath.
+   *
+   * @return string
+   *   The path of files to be tarred.
+   */
+  public function getTarPath() {
+    return $this->tarPath;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_export/src/EventSubscriber/ContentExportPreTarSubscriber.php
+++ b/docroot/modules/custom/va_gov_content_export/src/EventSubscriber/ContentExportPreTarSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\va_gov_content_export\EventSubscriber;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\va_gov_content_export\Event\ContentExportPreTarEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Logs the creation of a new node.
+ */
+class ContentExportPreTarSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Adds the openApi schema.json to the content export directory.
+   *
+   * @param \Drupal\va_gov_content_export\Event\ContentExportPreTarEvent $event
+   *   Event object passed on from ContentExportPreTarEvent.
+   */
+  public function addContentSchemaFile(ContentExportPreTarEvent $event) {
+    $router = \Drupal::service('router.no_access_checks');
+    $openapi_router = $router->match('openapi/jsonapi');
+    $schema = new JsonResponse($openapi_router["openapi_generator"]->getSpecification());
+    $file_path = $event->getTarPath();
+    $file = "{$file_path}/meta/schema.json";
+    // Write content to file.
+    // Using the Drupal file system will throw an exception if this fails.
+    $event->fileSystem->saveData($schema->getContent(), $file, FileSystemInterface::EXISTS_REPLACE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[ContentExportPreTarEvent::CONTENT_EXPORT_PRE_TAR_EVENT][] = ['addContentSchemaFile'];
+    return $events;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.info.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.info.yml
@@ -4,5 +4,6 @@ description: 'Export content to JSON files for consumption by frontend build pro
 core: 8.x
 package: 'Custom'
 dependencies:
+  - openapi
   - tome:tome_sync
   - zippylib:zippylib

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
@@ -19,3 +19,7 @@ services:
     arguments: ['@zippy', '@file_system', '@logger.channel.file']
   va_gov.content_export.archive_args_factory:
     class: Drupal\va_gov_content_export\Archive\ArchiveArgsFactory
+  va_gov_content_export.pre.tar:
+    class: Drupal\va_gov_content_export\EventSubscriber\ContentExportPreTarSubscriber
+    tags:
+    - { name: 'event_subscriber' }

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
@@ -16,7 +16,7 @@ services:
     decorates: tome_sync.file_sync
   va_gov.content_export.archive_directory:
     class: Drupal\va_gov_content_export\Archive\ArchiveDirectory
-    arguments: ['@zippy', '@file_system', '@logger.channel.file']
+    arguments: ['@zippy', '@file_system', '@event_dispatcher']
   va_gov.content_export.archive_args_factory:
     class: Drupal\va_gov_content_export\Archive\ArchiveArgsFactory
   va_gov_content_export.pre.tar:

--- a/tests/phpunit/SecurityRolesPermissionsTest.php
+++ b/tests/phpunit/SecurityRolesPermissionsTest.php
@@ -179,6 +179,7 @@ class SecurityRolesPermissions extends ExistingSiteBase {
         'content_api_consumer',
         [
           'access bulletin queue trigger api',
+          'access openapi api docs',
           'administer menu',
           'use graphql explorer',
           'use graphql voyager',


### PR DESCRIPTION
## Description

See #2127 . 

AC:
- [x] A dynamic request for the content schema can be achieve with api_consumer role.
- [x] An exact copy of the content schema is available in the CMS export tar.

## Screenshots


## QA steps
As an unauthenticated user
1. Visit `/openapi/jsonapi?_format=json`
   - [ ] Validate that a basic auth window appears
![image](https://user-images.githubusercontent.com/5752113/86386445-c5858b80-bc5f-11ea-92ef-aef791d24b7a.png)
   - [ ] validate that u:api p:drupal8  allows you to get to the page (will not work in lando)
   - [ ] Validate page with a ton of json appears 
![image](https://user-images.githubusercontent.com/5752113/86386655-11d0cb80-bc60-11ea-8c78-cb44e6c76710.png)

2. visit /cms-export/content
   - [ ] Validate that you are prompted with a download of 
![image](https://user-images.githubusercontent.com/5752113/86387191-cb2fa100-bc60-11ea-8cbe-59647b812439.png)

3. Save the tar and then open it.  
![image](https://user-images.githubusercontent.com/5752113/86387418-219cdf80-bc61-11ea-8b43-224ec9a700e6.png)
    - [ ] 1 Validate that inside the tar is a directory path of `cms-export-content/meta/`
    - [ ] 2 Validate a file `schema.json`
    - [ ] 3. Validate the date and time represent when you first downloaded this file.
    - [ ] 4 Validate that the file is approx 4MB
4. Open the `schema.json` file. 
    - [ ] Validate that it contains a ton of json  (may make your editor unhappy).



