### PR TITLE
VISN 19 SECOND GROUP SYSTEM MENUS

### DIFF
--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -540,25 +540,49 @@ definitions:
     enabled: true
     expanded: false
   entity__menu__edit_form__va-cheyenne-health-care:
+    weight: 2
     menu_name: admin
     parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
-    weight: 3
     expanded: false
     enabled: true
   entity__menu__edit_form__va-eastern-colorado-health-care:
-    weight: 5
+    weight: 3
     menu_name: admin
     parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
     expanded: false
     enabled: true
   entity__menu__edit_form__va-montana-health-care:
-    weight: 6
+    weight: 5
     menu_name: admin
     parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
     expanded: false
     enabled: true
   entity__menu__edit_form__va-western-colorado-health-care:
+    weight: 9
+    menu_name: admin
+    parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
+    expanded: false
+    enabled: true
+  entity__menu__edit_form__va-eastern-oklahoma-health-care:
+    weight: 4
+    menu_name: admin
+    parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
+    enabled: true
+    expanded: false
+  entity__menu__edit_form__va-oklahoma-health-care:
+    weight: 6
+    menu_name: admin
+    parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
+    expanded: false
+    enabled: true
+  entity__menu__edit_form__va-salt-lake-city-health-care:
     weight: 7
+    menu_name: admin
+    parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
+    expanded: false
+    enabled: true
+  entity__menu__edit_form__va-sheridan-health-care:
+    weight: 8
     menu_name: admin
     parent: 'menu_link_content:ab76053f-ae99-4fbc-a42f-0b39f1c26829'
     expanded: false

--- a/config/sync/node.type.event.yml
+++ b/config/sync/node.type.event.yml
@@ -13,11 +13,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.event_listing.yml
+++ b/config/sync/node.type.event_listing.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.health_care_local_facility.yml
+++ b/config/sync/node.type.health_care_local_facility.yml
@@ -13,11 +13,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.health_care_region_detail_page.yml
+++ b/config/sync/node.type.health_care_region_detail_page.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.health_care_region_page.yml
+++ b/config/sync/node.type.health_care_region_page.yml
@@ -13,11 +13,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.health_services_listing.yml
+++ b/config/sync/node.type.health_services_listing.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.leadership_listing.yml
+++ b/config/sync/node.type.leadership_listing.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.locations_listing.yml
+++ b/config/sync/node.type.locations_listing.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.news_story.yml
+++ b/config/sync/node.type.news_story.yml
@@ -13,11 +13,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.person_profile.yml
+++ b/config/sync/node.type.person_profile.yml
@@ -13,11 +13,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.press_release.yml
+++ b/config/sync/node.type.press_release.yml
@@ -13,11 +13,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.press_releases_listing.yml
+++ b/config/sync/node.type.press_releases_listing.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.publication_listing.yml
+++ b/config/sync/node.type.publication_listing.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.story_listing.yml
+++ b/config/sync/node.type.story_listing.yml
@@ -14,11 +14,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/node.type.vamc_operating_status_and_alerts.yml
+++ b/config/sync/node.type.vamc_operating_status_and_alerts.yml
@@ -13,11 +13,15 @@ third_party_settings:
       - va-cheyenne-health-care
       - va-coatesville-health-care
       - va-eastern-colorado-health-care
+      - va-eastern-oklahoma-health-care
       - va-erie-health-care
       - va-lebanon
       - va-montana-health-care
+      - va-oklahoma-health-care
       - va-philadelphia-health-care
       - pittsburgh-health-care
+      - va-salt-lake-city-health-care
+      - va-sheridan-health-care
       - va-western-colorado-health-care
       - va-wilkes-barre-health-care
       - va-wilmington-health-care

--- a/config/sync/system.menu.va-eastern-oklahoma-health-care.yml
+++ b/config/sync/system.menu.va-eastern-oklahoma-health-care.yml
@@ -1,0 +1,14 @@
+uuid: ca6155ab-7fee-4431-936e-1dc1d28b52fc
+langcode: en
+status: true
+dependencies:
+  module:
+    - workbench_menu_access
+third_party_settings:
+  workbench_menu_access:
+    access_scheme:
+      200: '200'
+id: va-eastern-oklahoma-health-care
+label: 'VA Eastern Oklahoma health care'
+description: ''
+locked: false

--- a/config/sync/system.menu.va-oklahoma-health-care.yml
+++ b/config/sync/system.menu.va-oklahoma-health-care.yml
@@ -1,0 +1,14 @@
+uuid: 6b6ac08b-532c-465c-933c-59aa8d6a9b9a
+langcode: en
+status: true
+dependencies:
+  module:
+    - workbench_menu_access
+third_party_settings:
+  workbench_menu_access:
+    access_scheme:
+      201: '201'
+id: va-oklahoma-health-care
+label: 'VA Oklahoma health care'
+description: ''
+locked: false

--- a/config/sync/system.menu.va-salt-lake-city-health-care.yml
+++ b/config/sync/system.menu.va-salt-lake-city-health-care.yml
@@ -1,0 +1,14 @@
+uuid: 998d9958-ee99-4eba-9bf6-7d4e73321a54
+langcode: en
+status: true
+dependencies:
+  module:
+    - workbench_menu_access
+third_party_settings:
+  workbench_menu_access:
+    access_scheme:
+      202: '202'
+id: va-salt-lake-city-health-care
+label: 'VA Salt Lake City health care'
+description: ''
+locked: false

--- a/config/sync/system.menu.va-sheridan-health-care.yml
+++ b/config/sync/system.menu.va-sheridan-health-care.yml
@@ -1,0 +1,14 @@
+uuid: 9b523408-b100-45c9-94a7-ebeba2b93d88
+langcode: en
+status: true
+dependencies:
+  module:
+    - workbench_menu_access
+third_party_settings:
+  workbench_menu_access:
+    access_scheme:
+      203: '203'
+id: va-sheridan-health-care
+label: 'VA Sheridan health care'
+description: ''
+locked: false

--- a/tests/behat/drupal-spec-tool/menus.feature
+++ b/tests/behat/drupal-spec-tool/menus.feature
@@ -33,13 +33,17 @@ Feature: Menus
 | Tools | tools | User tool links, often added by modules |
 | VA Altoona health care | va-altoona-health-care | va.gov/altoona-health-care |
 | VA Butler health care | va-butler-health-care | va.gov/butler-health-care |
+| VA Cheyenne health care | va-cheyenne-health-care |  |
 | VA Coatesville health care | va-coatesville-health-care | va.gov/coatesville-health-care |
+| VA Eastern Colorado health care | va-eastern-colorado-health-care |  |
+| VA Eastern Oklahoma health care | va-eastern-oklahoma-health-care |  |
 | VA Erie health care | va-erie-health-care | va.gov/erie-health-care |
 | VA Lebanon health care | va-lebanon | va.gov/lebanon-health-care |
+| VA Montana health care | va-montana-health-care |  |
+| VA Oklahoma health care | va-oklahoma-health-care |  |
 | VA Philadelphia health care | va-philadelphia-health-care | va.gov/philadelphia-health-care |
+| VA Salt Lake City health care | va-salt-lake-city-health-care |  |
+| VA Sheridan health care | va-sheridan-health-care |  |
+| VA Western Colorado health care | va-western-colorado-health-care |  |
 | VA Wilkes-Barre health care | va-wilkes-barre-health-care | va.gov/wilkes-barre-health-care |
 | VA Wilmington health care | va-wilmington-health-care | va.gov/wilmington-health-care |
-| VA Western Colorado health care | va-western-colorado-health-care |  |
-| VA Montana health care | va-montana-health-care |  |
-| VA Eastern Colorado health care | va-eastern-colorado-health-care |  |
-| VA Cheyenne health care | va-cheyenne-health-care |  |


### PR DESCRIPTION
## Description

Map out and Create Admin and Editorial Menus for VISN-19 Systems( Issue id : #10342).

## QA steps

As admin

Visit <Manage/content/menus/VAMC system menus> and validate that menus displayed match this.
<img width="921" alt="Screen Shot 2020-06-29 at 9 02 35 AM" src="https://user-images.githubusercontent.com/56320995/86823415-d74da100-c05a-11ea-8fc8-d79447fde9dc.png">

Visit </admin/structure/types/manage/health_care_region_detail_page> and validate that the content type 
have new Menu items (VISN-19 systems) selected as enabled (check box) to match this.

Visit </admin/structure/types/manage/health_services_listing> and validate that the content type have new 
Menu items (VISN-19 systems) selected as enabled (check box) to match this.
 
<img width="1680" alt="Screen Shot 2020-07-07 at 1 35 42 PM" src="https://user-images.githubusercontent.com/56320995/86823560-f77d6000-c05a-11ea-85c1-14ce92ad5644.png">


Visit <Sections/veterans health administration/VAMC facilities> and validate that menus displayed for 
VISN-19 match this.
<img width="1680" alt="Screen Shot 2020-07-07 at 1 37 12 PM" src="https://user-images.githubusercontent.com/56320995/86823642-1aa80f80-c05b-11ea-8188-802bb3fb31f3.png">


Visit <Manage/Content/Menus/CMS administration/Administration> and validate that VISN 19 systems are 
assigned as child.
<img width="1680" alt="Screen Shot 2020-07-07 at 1 34 16 PM" src="https://user-images.githubusercontent.com/56320995/86823731-33182a00-c05b-11ea-9dca-0973fb07cadc.png">
