### PR TITLE
VACMS-2223: Adding patch to fix paragraph node form fieldset displays.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -260,6 +260,9 @@
             "drupal/menu_link_content": {
                 "Fix php warning when creating new items": "https://www.drupal.org/files/issues/updateLink-2775665-2.patch"
             },
+            "drupal/paragraphs": {
+                "Fix broken fieldsets on forms": "https://www.drupal.org/files/issues/2020-05-25/3138609-9.patch"
+            },
             "drupal/paragraphs_browser": {
                 "#3057621: Notice: Undefined index: paragraph_type_title": "https://www.drupal.org/files/issues/2019-07-18/undefined-index-paragraph_type_title-trait-3057621-7.patch",
                 "Local version of https://www.drupal.org/project/paragraphs_browser/issues/3116501 to apply correctly": "./patches/paragraphs_browser/remove-paragraph-group-3116501-2.patch"
@@ -288,8 +291,8 @@
             "drupal/textfield_counter": {
                 "Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch"
             },
-            "drupal/tome":{
-                "Allow entity types to be excluded in tome sync":"https://www.drupal.org/files/issues/2020-02-20/tome_export_types-3114961-2.patch"
+            "drupal/tome": {
+                "Allow entity types to be excluded in tome sync": "https://www.drupal.org/files/issues/2020-02-20/tome_export_types-3114961-2.patch"
             },
             "drupal/workflow_participants": {
                 "Fix revision uncaught type error by extending class.": "https://www.drupal.org/files/issues/2019-08-16/workflow_participants-revision-error-3075426-1.patch"


### PR DESCRIPTION
## Description
See #2223 

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/87089477-7f529e00-c204-11ea-828d-957a1f24cd36.png)

## QA steps
- As an admin, go to `/admin/structure/paragraphs_type/q_a_section/form-display` and create a `Details` group, adding all existing fields, and save
- As an admin, go to `node/23/edit` and open the first `Q&A Section` under `Main Content`
- Visually verify that the new fieldset appears, and all fields from the paragraph are contained within