### PR TITLE
VACMS-000: Update gtm to use env-2 instead of env-5.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/gtm_tag_push.js
+++ b/docroot/modules/custom/va_gov_backend/js/gtm_tag_push.js
@@ -12,6 +12,6 @@
     j = d.createElement(s),
     dl = l != 'dataLayer' ? '&l=' + l : '';
   j.async = true;
-  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '&gtm_auth=GDc7Zfyf8G-0S5j8FC1WXQ&gtm_preview=env-5&gtm_cookies_win=x';
+  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '&gtm_auth=GDc7Zfyf8G-0S5j8FC1WXQ&gtm_preview=env-2&gtm_cookies_win=x';
   f.parentNode.insertBefore(j, f);
 })(window, document, 'script', 'dataLayer', 'GTM-WQ3DLLB');

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -423,7 +423,7 @@ function _va_gov_backend_gtm_settings() {
  */
 function va_gov_backend_page_bottom(array &$page_bottom) {
   // Add GTM noscript iframe to body.
-  $gtm_noscript = Markup::create('<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WQ3DLLB&gtm_auth=GDc7Zfyf8G-0S5j8FC1WXQ&gtm_preview=env-5&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>');
+  $gtm_noscript = Markup::create('<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WQ3DLLB&gtm_auth=GDc7Zfyf8G-0S5j8FC1WXQ&gtm_preview=env-2&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>');
   $page_bottom['va_gov_backend'] = ['#markup' => $gtm_noscript];
 }
 


### PR DESCRIPTION
## Description
Per @jonwehausen, gtm needs to be pointed to `env-2` (currently points to `env-5`). This pr replaces 2 instances of `env-5` with env-2

## Testing done
Codebase grep

## Screenshots
N/A

## QA steps
N/A