### PR TITLE
VACMS-2243: Add extensions that should be scanned by phpcs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -377,7 +377,7 @@
             "find docroot/modules/custom docroot/themes -name '*.install' -print0 | xargs -0 -n1 php -l > /dev/null"
         ],
         "va:test:cs": [
-            "phpcs --ignore=*.md,*.min.css,styles.css,wysiwyg.css,*/node_modules/*,*/simplesaml*/* --standard=./docroot/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml docroot/modules/custom docroot/themes/custom --colors"
+            "phpcs --ignore=*.md,*.min.css,styles.css,wysiwyg.css,*/node_modules/*,*/simplesaml*/* --extensions=php,module,inc,install,profile,engine,theme,js,css --standard=./docroot/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml docroot/modules/custom docroot/themes/custom --colors"
         ],
         "va:test:unit": "phpunit tests/phpunit --colors=always --exclude-group=disabled",
         "va:cbf": "phpcbf --ignore=*.md,*.min.css,uswds.css,*/node_modules/*,*/simplesaml*/* --standard=./docroot/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml docroot/modules/custom docroot/themes/custom --colors",

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -155,9 +155,11 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
  * function modifies the form to eliminate UI noise.
  *
  * @param array $form
+ *   Form object.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
  */
-function _va_gov_backend_vbo_facility_status_form_ui(&$form, FormStateInterface $form_state) {
+function _va_gov_backend_vbo_facility_status_form_ui(array &$form, FormStateInterface $form_state) {
   // This if Facility Status form.
   // Clean up the UI.
   $bundle_fields = [];

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -138,7 +138,7 @@ function _vagov_consumers_disable_non_vha_facilities_api_form_fields(array &$for
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state by reference.
  */
-function _vagov_consumers_modify_va_form_fields(&$form, $form_id, \Drupal\Core\Form\FormStateInterface &$form_state) {
+function _vagov_consumers_modify_va_form_fields(array &$form, $form_id, FormStateInterface &$form_state) {
   if ($form_id === 'node_va_form_edit_form' || $form_id === 'node_va_form_form') {
     $node = $form_state->getformObject()->getEntity();
     $title = "<h1>{$node->getTitle()}</h1>";
@@ -167,7 +167,7 @@ function _vagov_consumers_modify_va_form_fields(&$form, $form_id, \Drupal\Core\F
     ];
     $form['field_va_form_tool_intro']['#states'] = [
       'visible' => [
-        ':input[id="edit-field-va-form-tool-url-0-uri"]' => ['filled' => true],
+        ':input[id="edit-field-va-form-tool-url-0-uri"]' => ['filled' => TRUE],
       ],
     ];
   }
@@ -179,14 +179,14 @@ function _vagov_consumers_modify_va_form_fields(&$form, $form_id, \Drupal\Core\F
  * Adds node rendered as 'external_content' to form and removes the first
  * fieldgroup with id of 'external-content'.
  *
- * @param $form
+ * @param array $form
  *   The form content.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
  * @param string $display_if_empty_field
  *   The field to check for empty.  If empty, external content fields appear.
  */
-function _va_gov_consumers_disable_external_content_editing(&$form, FormStateInterface $form_state, $display_if_empty_field) {
+function _va_gov_consumers_disable_external_content_editing(array &$form, FormStateInterface $form_state, $display_if_empty_field) {
   $node = $form_state->getformObject()->getEntity();
 
   $is_admin = in_array('administrator', \Drupal::currentUser()->getRoles());
@@ -234,11 +234,15 @@ function va_gov_consumers_preprocess_node(&$variables) {
 
     if ($node->getType() === 'va_form') {
       $label = 'Forms DB Data';
-      $message = 'The following information about this VA form comes from the VA forms database, and any changes are updated here nightly.  Contact the form administration for further information.';
+      $message = 'The following information about this VA form comes from the VA forms database, and any changes are updated here nightly. Contact the form administration for further information.';
     }
 
+    // phpcs:disable
+    // Disabling phpcs here due to the warning
+    // "Only string literals should be passed to t() where possible".
     $variables['external_content_label'] = new TranslatableMarkup($label);
     $variables['external_content_message'] = new TranslatableMarkup($message);
+    // phpcs:enable
   }
   elseif ($variables['view_mode'] === 'full' && $node->getType() === "va_form") {
     $viewBuilder = \Drupal::entityTypeManager()->getViewBuilder('node');

--- a/docroot/modules/custom/va_gov_migrate/va_gov_migrate.install
+++ b/docroot/modules/custom/va_gov_migrate/va_gov_migrate.install
@@ -13,7 +13,6 @@ use Drupal\migrate\MigrateMessage;
 use Drupal\migrate_tools\MigrateExecutable;
 use Psr\Log\LogLevel;
 
-
 /**
  * Move a migration data file to public file system.
  *
@@ -32,7 +31,6 @@ function _va_gov_migrate_move_data_file($filename) {
   $destination = PublicStream::basePath() . "/migrate_source";
   \Drupal::service('file_system')->prepareDirectory($destination, FileSystemInterface::CREATE_DIRECTORY);
   $destination .= "/$filename";
-
 
   $new_location = \Drupal::service('file_system')->copy($file_source, $destination, FileSystemInterface::EXISTS_REPLACE);
   if (empty($new_location)) {

--- a/docroot/modules/custom/va_gov_migrate/va_gov_migrate.module
+++ b/docroot/modules/custom/va_gov_migrate/va_gov_migrate.module
@@ -5,16 +5,23 @@
  * Contains va_gov_migrate.module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_entity_presave().
  */
-function va_gov_migrate_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
+function va_gov_migrate_entity_presave(EntityInterface $entity) {
   _va_gov_migrate_process_va_form($entity);
 }
 
-function _va_gov_migrate_process_va_form(Drupal\Core\Entity\EntityInterface $entity) {
+/**
+ * Process VA Form.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity.
+ */
+function _va_gov_migrate_process_va_form(EntityInterface $entity) {
   if ($entity->bundle() !== 'va_form') {
     return;
   }

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.install
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.install
@@ -16,7 +16,7 @@ function va_gov_post_api_update_8002(&$sandbox) {
 
   // Grab our nodes and set the count.
   if (empty($sandbox['total'])) {
-    // Enable force update
+    // Enable force update.
     $config
       ->set('bypass_data_check', 1)
       ->save();
@@ -59,12 +59,10 @@ function va_gov_post_api_update_8002(&$sandbox) {
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
   if ($sandbox['#finished'] === 1) {
     Drupal::logger('va_gov_post_api')
-    ->log(LogLevel::INFO, 'Completed all %total nodes queued for Lighthouse.', [
-      '%total' => $sandbox['total'],
-    ]);
+      ->log(LogLevel::INFO, 'Completed all %total nodes queued for Lighthouse.', ['%total' => $sandbox['total']]);
     $config
       ->set('bypass_data_check', 0)
       ->save();
-     return "Completed updating ALL facility nodes.";
+    return "Completed updating ALL facility nodes.";
   }
 }

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -81,6 +81,7 @@ function _post_api_add_facility_to_queue(EntityInterface $entity) {
  * Compose and return payload array.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity.
  *
  * @return array
  *   Payload array.


### PR DESCRIPTION
## Description

See #2243. 

## Testing done

- [ ] Review phpcs test that ran for the first commit in this PR and confirm that `.module` files are now tested by code sniffer and are throwing errors + breaking the build.
- [ ] review phpcs tests for the second commit in this PR which addresses all previous phpcs errors and confirm all tests are now passing.

