### PR TITLE
VACMS-2064: Adding ief trigger submit to our preview submit.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -61,7 +61,7 @@ function va_gov_build_trigger_form_alter(&$form, FormStateInterface $form_state,
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state array.
  */
-function va_gov_build_trigger_form_alter_submit(array &$form, FormStateInterface &$form_state) {
+function va_gov_build_trigger_form_alter_submit(array &$form, FormStateInterface $form_state) {
 
   // We want to associate our user with the revision.
   $uid = Drupal::currentUser()->id();

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -42,19 +42,26 @@ function va_gov_build_trigger_form_alter(&$form, FormStateInterface $form_state,
   if (in_array('node_form', (array) $form['#theme'])) {
 
     $form['actions']['preview'] = [
+      '#ief_submit_trigger' => TRUE,
+      '#ief_submit_trigger_all' => TRUE,
       '#type' => 'submit',
       '#weight' => 10,
       '#value' => 'Save and continue editing',
       '#submit' => ['::submitForm', 'va_gov_build_trigger_form_alter_submit'],
     ];
-  }
 
+  }
 }
 
 /**
- * Implements hook_form_alter().
+ * Submit function for va_gov_build_trigger_form_alter.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state array.
  */
-function va_gov_build_trigger_form_alter_submit(&$form, FormStateInterface $form_state) {
+function va_gov_build_trigger_form_alter_submit(array &$form, FormStateInterface &$form_state) {
 
   // We want to associate our user with the revision.
   $uid = Drupal::currentUser()->id();
@@ -63,7 +70,7 @@ function va_gov_build_trigger_form_alter_submit(&$form, FormStateInterface $form
   $node = $form_state->getFormObject()->getEntity();
   $node->setNewRevision(TRUE);
   $node->revision_log = 'Created revision for node in preview';
-  $node->setRevisionCreationTime(REQUEST_TIME);
+  $node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
 
   // Save it as unpublished and associate with user.
   $node->setRevisionUserId($uid);


### PR DESCRIPTION
## Description
See #2064 
Turns out ief needs to have `#ief_submit_trigger` flag added to submit handler to attach parent entity, otherwise it's thrown away when parent form us saved.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/87360211-9f050180-c537-11ea-9aee-408d13ab0a7b.png)

## QA steps
As and admin, go to `/node/72/edit`, and add an item to `Support Services` in right rail.
Click `Save and continue editing` and visually verify that item added is still available.