### PR TITLE
VACMS-1697: Remove custom revision message to allow core drupal revision message behavior.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.module
@@ -69,7 +69,6 @@ function va_gov_build_trigger_form_alter_submit(array &$form, FormStateInterface
   // Build the revision info.
   $node = $form_state->getFormObject()->getEntity();
   $node->setNewRevision(TRUE);
-  $node->revision_log = 'Created revision for node in preview';
   $node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
 
   // Save it as unpublished and associate with user.


### PR DESCRIPTION
## Description
See #1697 

## Testing done
Visual

## Screenshots
N/A

## QA steps
- As an admin, go to `/node/5676/edit`
- Add a revision log message, and click the `Save and continue editing` button
- Go to `node/5676/revisions` and visually verify that the message you entered appears next to the revision you just created.