### PR TITLE
VACMS-2254: Changing default paragraph instance for phone number to none

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -92,7 +92,7 @@ content:
       closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
-      default_paragraph_type: phone_number
+      default_paragraph_type: _none
       features:
         add_above: '0'
         collapse_edit_all: collapse_edit_all


### PR DESCRIPTION
## Description
See #2254 

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/87463782-fced2400-c5df-11ea-851b-773416f264e0.png)

## QA steps
- As an admin, go to `/node/add/health_care_local_health_service` and visually verify that phone paragraph instance fields do not appear