### PR TITLE
VACMS-2091: Add patch to fix error when changing paragraph field to published value.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -232,7 +232,8 @@
                 "2807629 - Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch",
                 "2893933 - claimItem in the database and memory queues does not use expire correctly": "https://www.drupal.org/files/issues/2020-01-07/2893933-34.patch",
                 "2894449 - Indirect modification of overloaded element with Views responsive table": "https://www.drupal.org/files/issues/2018-10-05/core-indirect-modification-of-overloaded-element-2894449-18.patch",
-                "3057267 - User logout during maintenance mode": "https://www.drupal.org/files/issues/2019-09-11/3057267-maintenance-forced-logout-experimental.patch"
+                "3057267 - User logout during maintenance mode": "https://www.drupal.org/files/issues/2019-09-11/3057267-maintenance-forced-logout-experimental.patch",
+                "2859042 - Entity original revision": "https://www.drupal.org/files/issues/2018-07-30/entity_original_revision-2859042-26.patch"
             },
             "drupal/entity_browser": {
                 "Entity display plugin Rendered Entity is missing cache tags/keys": "https://www.drupal.org/files/issues/2020-03-31/rendered-entity-cache-keys-tags-3123876-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d290d41cffd728e5259049ba95a145ac",
+    "content-hash": "a80299b3e9f5de38a78d31cfd542ae45",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -4147,6 +4147,7 @@
                     "2893933 - claimItem in the database and memory queues does not use expire correctly": "https://www.drupal.org/files/issues/2020-01-07/2893933-34.patch",
                     "2894449 - Indirect modification of overloaded element with Views responsive table": "https://www.drupal.org/files/issues/2018-10-05/core-indirect-modification-of-overloaded-element-2894449-18.patch",
                     "3057267 - User logout during maintenance mode": "https://www.drupal.org/files/issues/2019-09-11/3057267-maintenance-forced-logout-experimental.patch",
+                    "2859042 - Entity original revision": "https://www.drupal.org/files/issues/2018-07-30/entity_original_revision-2859042-26.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-11-27/2815221-125.patch",
                     "1356276 - Allow profiles to define a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/2019-11-05/1356276-531-8.8.x-4.patch",


### PR DESCRIPTION
## Description
Core patch to fix error

## Testing done
Confirmed patch worked.

## QA steps

1. Go to http://pr2276.ci.cms.va.gov/node/716/edit
1. Expand Scroll down to the "Main content" field and edit the "list of link teasers"
1. Change the /disabilty link text from `Disability` to `Disability BOO`
1. Set the workflow to Draft and click the "Save" button.
1. Scroll down and validate that the unpublished revision now has `Disability BOO` 
1. Edit the latest revision and scroll down to The link teaser and change `Disability BOO` back to `Disability` and save the revision as either published or draft (makes no difference)
1. Scroll down the page and see that the page now contains `Disability` (no 'BOO')