### PR TITLE
VACMS-2338: Removed node_revisions_autoclean from composer management

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,6 @@
         "drupal/module_missing_message_fixer": "^1.1",
         "drupal/node_link_report": "^1.14",
         "drupal/node_revision_delete": "^1.0",
-        "drupal/node_revisions_autoclean": "^1.0@beta",
         "drupal/node_title_help_text": "^1.0",
         "drupal/openapi": "^1.0@beta",
         "drupal/override_node_options": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a80299b3e9f5de38a78d31cfd542ae45",
+    "content-hash": "a355fd69c4f78e272d9111bfc3b27b88",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -7916,55 +7916,6 @@
             }
         },
         {
-            "name": "drupal/node_revisions_autoclean",
-            "version": "1.0.0-beta5",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/node_revisions_autoclean.git",
-                "reference": "8.x-1.0-beta5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_revisions_autoclean-8.x-1.0-beta5.zip",
-                "reference": "8.x-1.0-beta5",
-                "shasum": "8fe8861ace34815f0ac0faed3c9135bec5a17afa"
-            },
-            "require": {
-                "drupal/core": "^8"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.0-beta5",
-                    "datestamp": "1543085281",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Stéphane Le Merre",
-                    "homepage": "https://www.drupal.org/u/oulalahakabu"
-                },
-                {
-                    "name": "adriancid",
-                    "homepage": "https://www.drupal.org/user/1962106"
-                }
-            ],
-            "description": "This module allows to manage node's revisions store : according to settings, revisions are automaticaly deleted.",
-            "homepage": "http://drupal.org/project/node_revisions_autoclean",
-            "support": {
-                "source": "https://git.drupalcode.org/project/node_revisions_autoclean",
-                "issues": "https://www.drupal.org/project/issues/node_revisions_autoclean"
-            }
-        },
-        {
             "name": "drupal/node_title_help_text",
             "version": "1.2.0",
             "source": {
@@ -9722,8 +9673,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0+18-dev",
-                    "datestamp": "1591770447",
+                    "version": "8.x-1.2+0-dev",
+                    "datestamp": "1594058302",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -19170,7 +19121,6 @@
         "drupal/libraries": 15,
         "drupal/markup": 10,
         "drupal/mass_pwreset": 15,
-        "drupal/node_revisions_autoclean": 10,
         "drupal/openapi": 10,
         "drupal/paragraphs_browser": 15,
         "drupal/password_policy": 15,


### PR DESCRIPTION
## Description

See _issueid_. https://app.zenhub.com/workspaces/vagov-cms-team-5c0e7b864b5806bc2bfc2087/issues/department-of-veterans-affairs/va.gov-cms/2338

## Testing done


## Screenshots


## QA steps

- [ ] Confirm node_revisions_autoclean has been removed from the drupal code base
- [ ] Navigate here /admin/modules
- [ ] Search for node revisions and confirm that node revisions autoclean does not appear

## Definition of Done
- [ ] Product release are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
