### PR TITLE
VACMS-2399 Exclude documentation_page from content export.

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -35,7 +35,7 @@ class TomeExporter extends Exporter {
     'content_moderation_state',
     'crop',
     'node.documentation_page',
-    'path_alias';
+    'path_alias',
     'site_alert',
     'user_history',
     'user_role',

--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -33,7 +33,10 @@ class TomeExporter extends Exporter {
    */
   protected static $excludedTypes = [
     'content_moderation_state',
+    'crop',
     'node.documentation_page',
+    'path_alias';
+    'site_alert',
     'user_history',
     'user_role',
     'user',

--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -33,9 +33,10 @@ class TomeExporter extends Exporter {
    */
   protected static $excludedTypes = [
     'content_moderation_state',
-    'user',
-    'user_role',
+    'node.documentation_page',
     'user_history',
+    'user_role',
+    'user',
   ];
 
   /**
@@ -88,7 +89,10 @@ class TomeExporter extends Exporter {
    * {@inheritDoc}
    */
   public function exportContent(ContentEntityInterface $entity) {
-    if (in_array($entity->getEntityTypeId(), static::$excludedTypes, TRUE)) {
+    $type = $entity->getEntityTypeId();
+    // If it's a node, attach the bundle.
+    $type = ($type === 'node') ? "{$type}.{$entity->bundle()}" : $type;
+    if (in_array($type, static::$excludedTypes, TRUE)) {
       return;
     }
 


### PR DESCRIPTION
## Description

See #2399. 

- [ ] Save a documentation page locally.  Validate that no tome file for that node is present in the export. (delete all the files first then it is easier to see that one was not created.)

- [ ] Run the full export via drush validate that no documentation_page nodes are present.


Post release steps:
- [ ] Run drush content bulk export on prod
