### PR TITLE
VATEAM-11312 Add ListDataCompiler to va_gov_content_export.

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
@@ -2,10 +2,9 @@
 
 namespace Drupal\va_gov_content_export;
 
-use Drupal;
-use Drupal\Core\File\FileSystemInterface;
-use Drupal\Core\File\FileSystemInterface;
-use Symfony\Component\Serializer\Serializer;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Class ListDataCompiler.
@@ -15,26 +14,25 @@ use Symfony\Component\Serializer\Serializer;
 class ListDataCompiler {
 
   /**
-   * A Drupal file system object.
+   * Drupal\Core\Entity\EntityTypeManagerInterface object.
    *
-   * @var \Drupal\Core\File\FileSystemInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $fileSystem;
+  protected $entityTypeManager;
 
   /**
-   * A Symfony serializer object.
-   *
-   * @var \Symfony\Component\Serializer\Serializer
-   */
-  protected $serializer;
-
-  /**
-   * An array of excluded entity types.
+   * An array of entity types that should be treated as lists.
    *
    * @var string[]
    */
-  protected static $excludedTypes = [
-
+  protected static $listEntityTypes = [
+    'event_listing',
+    'health_services_listing',
+    'leadership_listing',
+    'locations_listing',
+    'press_releases_listing',
+    'publication_listing',
+    'story_listing',
   ];
 
   /**
@@ -49,86 +47,173 @@ class ListDataCompiler {
   /**
    * ListDataCompiler constructor.
    *
-   * @param \Drupal\Core\File\FileSystemInterface $fileSystem
-   *   Drupal FileSystem.
-   * @param \Symfony\Component\Serializer\Serializer $serializer
-   *   The serializer.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
    */
-  public function __construct(FileSystemInterface $fileSystem, Serializer $serializer) {
-    $this->fileSystem = $fileSystem;
-    $this->serializer = $serializer;
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
   }
 
-
-
   /**
-   * Generate lists export files.
+   * Update related lists.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity which may reference lists.
+   * @param \Drupal\va_gov_content_export\TomeExporter $tomeExporter
+   *   The tome exporter.
+   *
+   * @todo This implementation creates one risk of failure in that, any list
+   * item that has been moved from one list to another, will not know to remove
+   * it from the original list.
    */
-  public function generateLists(ContentEntityInterface $entity) : void {
+  public function updateLists(ContentEntityInterface $entity, TomeExporter $tomeExporter) {
     $listNids = $this->getListNids($entity);
+    $listNidsToUpdateLater = [];
+    $listEntitiesToUpdateLater = [];
     if (!empty($listNids)) {
       // Process each list this entity should appear in.
-      foreach ($listNids as $listNid) {
-        $this->generateList($entity, $listNid);
+      foreach ($listNids as $listNid => $listFieldName) {
+        $listNidsToUpdateLater[] = $this->updateList($entity, $listNid, $listFieldName);
+      }
+      $listNidsToUpdateLater = array_filter($listNidsToUpdateLater);
+    }
+    if (!empty($listNidsToUpdateLater)) {
+      // Load the list entities that need to be exported.
+      $listEntitiesToUpdateLater = $this->entityTypeManager->getStorage('node')
+        ->loadMultiple($listNidsToUpdateLater);
+      // Export the lists to have their reverse field list updated.
+      foreach ($listEntitiesToUpdateLater as $listEntityToUpdate) {
+        // Update the list export json.
+        $tomeExporter->exportContent($listEntityToUpdate);
       }
     }
-
   }
 
-
   /**
-   * Generate a single list json with a UID matching the list nid.
-   *
-   * This creates the file in the pattern
-   * list.UUID.json
+   * Update a list to add the list data as ->reverse_field_list.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *   The entity that is in a list.
-   * @param int $list_nid
+   *   The entity is a list or in a list.
+   * @param int $listNid
    *   The node id of ths list this entity belongs in.
+   * @param string $listFieldName
+   *   The field machine name to use as the reverse entity reference.
+   *
+   * @return int
+   *   The node id of a list to be updated.
    */
-  public function $generateList(ContentEntityInterface $entity, $listNid) {
-   $listUUID = $this->lookupListUUID($listNid);
-   $listItems = $this->queryListItemNodes();
-   $this->writeListFile($listItems, $listUUID);
+  public function updateList(ContentEntityInterface $entity, $listNid, $listFieldName) {
+    // Check if $entity is the list, or if we need to get the list.
+    $current_nid = $entity->id();
+    if ($this->isList($entity) && ((int) $entity->id() === $listNid)) {
+      // Add the list to the list entity.
+      $listNodes = $this->queryListItemNodes($listNid, $listFieldName);
+      $list = $this->buildList($listNodes);
+      $entity->values['reverse_field_list'] = $list;
+    }
+    else {
+      return $listNid;
+    }
+
+    return FALSE;
+
   }
 
   /**
-   * Checks if this entity belongs in a list.
+   * Check whether the entity is a list.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check for being a list.
+   *
+   * @return bool
+   *   True is the entity is one known to be a list.
+   */
+  protected function isList(ContentEntityInterface $entity) : bool {
+    if (($entity instanceof NodeInterface) && $entity->getEntityTypeId() === 'node') {
+      if (in_array($entity->bundle(), static::$listEntityTypes)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Getter for the list nids related to this entity.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity to check.
    *
    * @return array
-   *   An array of node ids, one for each list the entity belongs in.
+   *   NodeId and fieldname pairs, one for each list the entity belongs in.
    */
-  protected function getListNids(ContentEntityInterface $entity) : bool {
+  protected function getListNids(ContentEntityInterface $entity) {
     $listNids = [];
-
-    foreach (static::$listingFields as $listingField) {
-      if ($entity->hasField($listingField)) {
-        // It has a field that is a reference to a list.
-        $lists = $entity->get($listingField)->value;
-        $listNids = array_merge($listNids, $lists);
+    if ($this->isList($entity)) {
+      // This is a list so just return the nid.
+      $listNids[$entity->id()] = 'field_listing';
+    }
+    else {
+      // Look to see if it has any listing fields.
+      foreach (static::$listingFields as $listingField) {
+        if ($entity->hasField($listingField)) {
+          // It has a field that is a reference to a list.
+          $lists = $entity->$listingField;
+          foreach ($lists as $list) {
+            $listNids[$list->target_id] = $listingField;
+          }
+        }
       }
     }
 
     return $listNids;
   }
 
+  /**
+   * Query for all the published nodes that belong in this list.
+   *
+   * @param int $listNid
+   *   The node id of the list.
+   * @param string $fieldName
+   *   The machine name of the field to lookup.
+   *
+   * @return array
+   *   An array of nodes that belong in the list.
+   */
+  protected function queryListItemNodes($listNid, $fieldName) {
+    $nodes = [];
+    $nodeIds = $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery()
+      ->condition('status', 1)
+      ->condition($fieldName, $listNid, '=')
+      ->execute();
 
+    if (!empty($nodeIds)) {
+      // Load the nodes.
+      $nodes = $this->entityTypeManager
+        ->getStorage('node')
+        ->loadMultiple($nodeIds);
+    }
 
-  protected function writeListFile($listItems, $listUUID) {
-    $content = $this->buildContent();
-    // Do stuff to put content in the file.
-    $filename = "list.{$listUUID}.json";
+    return $nodes;
   }
 
-  protected function buildContent($listItems, $listUUID) {
-    $url = $entity->toUrl();
+  /**
+   * Build the list of nodes to add to the list.
+   *
+   * @param array $listNodes
+   *   An array of node objects that reference the list.
+   *
+   * @return array
+   *   An array of list items in nid -> uuid pairs.
+   */
+  protected function buildList(array $listNodes) : array {
+    $list = [];
+    foreach ($listNodes as $listNode) {
+      $list[$listNode->id()] = $listNode->uuid();
+    }
+
+    return $list;
   }
 
 }

--- a/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
@@ -65,6 +65,7 @@ class ListDataCompiler {
    * @todo This implementation creates one risk of failure in that, any list
    * item that has been moved from one list to another, will not know to remove
    * it from the original list.
+   * https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2464 .
    */
   public function updateLists(ContentEntityInterface $entity, TomeExporter $tomeExporter) {
     $listNids = $this->getListNids($entity);
@@ -78,6 +79,8 @@ class ListDataCompiler {
       $listNidsToUpdateLater = array_filter($listNidsToUpdateLater);
     }
     if (!empty($listNidsToUpdateLater)) {
+      // @todo Add a check to bypass this if the bulk export is running.
+      // https://github.com/ ... /va.gov-cms/issues/2481.
       // Load the list entities that need to be exported.
       $listEntitiesToUpdateLater = $this->entityTypeManager->getStorage('node')
         ->loadMultiple($listNidsToUpdateLater);

--- a/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\va_gov_content_export;
+
+use Drupal;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Class ListDataCompiler.
+ *
+ * @package Drupal\va_gov_content_export
+ */
+class ListDataCompiler {
+
+  /**
+   * A Drupal file system object.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * A Symfony serializer object.
+   *
+   * @var \Symfony\Component\Serializer\Serializer
+   */
+  protected $serializer;
+
+  /**
+   * An array of excluded entity types.
+   *
+   * @var string[]
+   */
+  protected static $excludedTypes = [
+
+  ];
+
+  /**
+   * An array of field names to treat as a reference to a list.
+   *
+   * @var array
+   */
+  protected static $listingFields = [
+    'field_listing',
+  ];
+
+  /**
+   * ListDataCompiler constructor.
+   *
+   * @param \Drupal\Core\File\FileSystemInterface $fileSystem
+   *   Drupal FileSystem.
+   * @param \Symfony\Component\Serializer\Serializer $serializer
+   *   The serializer.
+   */
+  public function __construct(FileSystemInterface $fileSystem, Serializer $serializer) {
+    $this->fileSystem = $fileSystem;
+    $this->serializer = $serializer;
+  }
+
+
+
+  /**
+   * Generate lists export files.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity which may reference lists.
+   */
+  public function generateLists(ContentEntityInterface $entity) : void {
+    $listNids = $this->getListNids($entity);
+    if (!empty($listNids)) {
+      // Process each list this entity should appear in.
+      foreach ($listNids as $listNid) {
+        $this->generateList($entity, $listNid);
+      }
+    }
+
+  }
+
+
+  /**
+   * Generate a single list json with a UID matching the list nid.
+   *
+   * This creates the file in the pattern
+   * list.UUID.json
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity that is in a list.
+   * @param int $list_nid
+   *   The node id of ths list this entity belongs in.
+   */
+  public function $generateList(ContentEntityInterface $entity, $listNid) {
+   $listUUID = $this->lookupListUUID($listNid);
+   $listItems = $this->queryListItemNodes();
+   $this->writeListFile($listItems, $listUUID);
+  }
+
+  /**
+   * Checks if this entity belongs in a list.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check.
+   *
+   * @return array
+   *   An array of node ids, one for each list the entity belongs in.
+   */
+  protected function getListNids(ContentEntityInterface $entity) : bool {
+    $listNids = [];
+
+    foreach (static::$listingFields as $listingField) {
+      if ($entity->hasField($listingField)) {
+        // It has a field that is a reference to a list.
+        $lists = $entity->get($listingField)->value;
+        $listNids = array_merge($listNids, $lists);
+      }
+    }
+
+    return $listNids;
+  }
+
+
+
+  protected function writeListFile($listItems, $listUUID) {
+    $content = $this->buildContent();
+    // Do stuff to put content in the file.
+    $filename = "list.{$listUUID}.json";
+  }
+
+  protected function buildContent($listItems, $listUUID) {
+    $url = $entity->toUrl();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_export/src/Normalizer/ContentEntityNormalizer.php
+++ b/docroot/modules/custom/va_gov_content_export/src/Normalizer/ContentEntityNormalizer.php
@@ -28,6 +28,10 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
       $values['entityUrl']['breadcrumb'] = $breadcrumb_values;
       $values['entityUrl']['path'] = $entity->url();
     }
+    if (isset($entity->values['reverse_field_list'])) {
+      // This pseudo field exists, so add its data.
+      $values['reverse_field_list'] = $entity->values['reverse_field_list'];
+    }
 
     return $values;
   }

--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_content_export;
 
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\file\FileInterface;
@@ -13,7 +14,6 @@ use Drupal\tome_sync\FileSyncInterface;
 use Drupal\tome_sync\TomeSyncHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Serializer;
-use Drupal\Core\Entity\ContentEntityInterface;
 
 /**
  * Exporter class for Tome.
@@ -39,11 +39,18 @@ class TomeExporter extends Exporter {
   ];
 
   /**
-   * Add breadcrumb to Entity.
+   * The BreadcrumbEntity Manager.
    *
    * @var \Drupal\va_gov_content_export\AddBreadcrumbToEntity
    */
   protected $addBreadcrumbToEntity;
+
+  /**
+   * The ListDataCompiler Service.
+   *
+   * @var \Drupal\va_gov_content_export\ListDataCompiler
+   */
+  protected $listDataCompiler;
 
   /**
    * Creates an Exporter object.
@@ -64,6 +71,8 @@ class TomeExporter extends Exporter {
    *   The file sync service.
    * @param \Drupal\va_gov_content_export\AddBreadcrumbToEntity $addBreadcrumbToEntity
    *   The BreadcrumbEntity Manager.
+   * @param \Drupal\va_gov_content_export\ListDataCompiler $listDataCompiler
+   *   The list data compiler service.
    */
   public function __construct(
     StorageInterface $content_storage,
@@ -72,12 +81,14 @@ class TomeExporter extends Exporter {
     EventDispatcherInterface $event_dispatcher,
     AccountSwitcherInterface $account_switcher,
     FileSyncInterface $file_sync,
-    AddBreadcrumbToEntity $addBreadcrumbToEntity
+    AddBreadcrumbToEntity $addBreadcrumbToEntity,
+    ListDataCompiler $listDataCompiler
   ) {
     parent::__construct($content_storage, $serializer, $entity_type_manager,
       $event_dispatcher, $account_switcher, $file_sync);
 
     $this->addBreadcrumbToEntity = $addBreadcrumbToEntity;
+    $this->listDataCompiler = $listDataCompiler;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -69,9 +69,9 @@ class TomeExporter extends Exporter {
    *   The account switcher.
    * @param \Drupal\tome_sync\FileSyncInterface $file_sync
    *   The file sync service.
-   * @param \Drupal\va_gov_content_export\AddBreadcrumbToEntity $addBreadcrumbToEntity
+   * @param \Drupal\va_gov_content_export\AddBreadcrumbToEntity $add_breadcrumb_to_entity
    *   The BreadcrumbEntity Manager.
-   * @param \Drupal\va_gov_content_export\ListDataCompiler $listDataCompiler
+   * @param \Drupal\va_gov_content_export\ListDataCompiler $list_data_compiler
    *   The list data compiler service.
    */
   public function __construct(
@@ -81,14 +81,14 @@ class TomeExporter extends Exporter {
     EventDispatcherInterface $event_dispatcher,
     AccountSwitcherInterface $account_switcher,
     FileSyncInterface $file_sync,
-    AddBreadcrumbToEntity $addBreadcrumbToEntity,
-    ListDataCompiler $listDataCompiler
+    AddBreadcrumbToEntity $add_breadcrumb_to_entity,
+    ListDataCompiler $list_data_compiler
   ) {
     parent::__construct($content_storage, $serializer, $entity_type_manager,
       $event_dispatcher, $account_switcher, $file_sync);
 
-    $this->addBreadcrumbToEntity = $addBreadcrumbToEntity;
-    $this->listDataCompiler = $listDataCompiler;
+    $this->addBreadcrumbToEntity = $add_breadcrumb_to_entity;
+    $this->listDataCompiler = $list_data_compiler;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -105,6 +105,7 @@ class TomeExporter extends Exporter {
     // We override all of the parent export to not create the index file.
     $this->switchToAdmin();
     $this->addBreadcrumbToEntity->alterEntity($entity);
+    $this->listDataCompiler->updateLists($entity, $this);
     $data = $this->serializer->normalize($entity, 'json');
     $this->contentStorage->write(TomeSyncHelper::getContentName($entity), $data);
 

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
@@ -25,4 +25,4 @@ services:
     - { name: 'event_subscriber' }
   va_gov.content_export.list_data_compiler:
     class: Drupal\va_gov_content_export\ListDataCompiler
-    arguments: ['@file_system', '@serializer']
+    arguments: ['@entity_type.manager']

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
@@ -7,7 +7,7 @@ services:
   tome_sync.exporter.va_gov_content_export:
     class: Drupal\va_gov_content_export\TomeExporter
     decorates: tome_sync.exporter
-    arguments: ['@tome_sync.storage.content', '@serializer', '@entity_type.manager', '@event_dispatcher', '@account_switcher', '@tome_sync.file_sync', '@va_gov.content_export.breadcrumb_update']
+    arguments: ['@tome_sync.storage.content', '@serializer', '@entity_type.manager', '@event_dispatcher', '@account_switcher', '@tome_sync.file_sync', '@va_gov.content_export.breadcrumb_update', '@va_gov.content_export.list_data_compiler']
   va_gov.content_export.breadcrumb_update:
     class: Drupal\va_gov_content_export\AddBreadcrumbToEntity
     arguments: ['@breadcrumb', '@router.route_provider', '@paramconverter_manager', '@graphql.buffer.subrequest', '@current_route_match']
@@ -23,3 +23,6 @@ services:
     class: Drupal\va_gov_content_export\EventSubscriber\ContentExportPreTarSubscriber
     tags:
     - { name: 'event_subscriber' }
+  va_gov.content_export.list_data_compiler:
+    class: Drupal\va_gov_content_export\ListDataCompiler
+    arguments: ['@file_system', '@serializer']


### PR DESCRIPTION
## Description

See  https://github.com/department-of-veterans-affairs/va.gov-team/issues/11312. 

##Acceptance Criteria
- [x] On saving a list node, the reverse_field_list data is added to the content export for that node and include an array of list items by node ID : UUID pairs.
- [x] On saving a list item that belongs to one or more lists, the list content export will be updated to include current array of list items.
- [x] On full CMS content export, the reverse_field_list will be up-to-date on all list node exports.

## Testing done
All QA steps


## QA steps
As an admin:
1. Edit a list node `/pittsburgh-health-care/events`
    a.  Save the node
    - [ ] Inspect the file at `docroot/sites/default/files/cms-export-content/node.4d0b3e6f-37d6-46aa-9f71-0e5615511e91.json` and scroll down near the end of the content and validate that it has an element `reverse_field_list` that contains many NID : UUID pairs that represent list items that should appear on that list.

2. Add a new event 
   a. Go to /node/add/event and assign it to  event listing "VA Pittsburgh Health care events"  Fill out all required fields.
   b. Publish and save the node.  Make note of its node id.
   - [ ] inspect the file  `docroot/sites/default/files/cms-export-content/node.4d0b3e6f-37d6-46aa-9f71-0e5615511e91.json` and validate that the node id you just created is referenced in the element element `reverse_field_list`

3. Run the full content export  Steps -> https://github.com/department-of-veterans-affairs/va.gov-cms/blob/master/READMES/cms-export.md#caveats
  - [ ] Inspect the file at `docroot/sites/default/files/cms-export-content/node.4d0b3e6f-37d6-46aa-9f71-0e5615511e91.json` and scroll down near the end of the content and validate that it has an element `reverse_field_list` that contains many NID : UUID pairs that represent list items that should appear on that list.


