### PR TITLE
VACMS-2528 Reformat reverse_field data on lists.

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
@@ -208,12 +208,18 @@ class ListDataCompiler {
    *   An array of node objects that reference the list.
    *
    * @return array
-   *   An array of list items in nid -> uuid pairs.
+   *   An array of list item objects containing target node data.
    */
   protected function buildList(array $listNodes) : array {
     $list = [];
     foreach ($listNodes as $listNode) {
-      $list[$listNode->id()] = $listNode->uuid();
+      $list_item = new \stdClass();
+      $list_item->target_type = $listNode->getEntityTypeId();
+      $list_item->target_bundle = $listNode->getType();
+      $list_item->target_id = $listNode->id();
+      $list_item->target_uuid = $listNode->uuid();
+
+      $list[] = $list_item;
     }
 
     return $list;


### PR DESCRIPTION
## Description

See #2528. 

## Testing done
Saved list node, validated that list items have the new format.  


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Go to /node/2805/edit and save the node.
2. View the export file created for that node  docroot/sites/default/files/cms-export-content/node.ff3b83fc-7cae-4d5b-8278-9692e0964011.json
3. Scroll to the end of the node file
   - [ ] Validate that it contains an entry similar to this
```
"reverse_field_list": [
        {
            "target_type": "node",
            "target_bundle": "press_release",
            "target_id": "395",
            "target_uuid": "b1439fe5-db2a-4929-94a3-c9f571b882cf"
        },
        {
            "target_type": "node",
            "target_bundle": "press_release",
            "target_id": "396",
            "target_uuid": "1cf543f6-6be5-4a22-bba1-21f652e663ef"
        },
        {
            "target_type": "node",
            "target_bundle": "press_release",
            "target_id": "401",
            "target_uuid": "909d036c-6082-49f8-b19d-4499b736bb1f"
        },

     ...
```  
