### PR TITLE
VACMS-2385: Update human names for listing types.

### DIFF
--- a/config/sync/node.type.event_listing.yml
+++ b/config/sync/node.type.event_listing.yml
@@ -55,7 +55,7 @@ third_party_settings:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0
     when_to_delete: 0
-name: 'Event listing page'
+name: 'Events list'
 type: event_listing
 description: 'A listing of events.'
 help: ''

--- a/config/sync/node.type.health_services_listing.yml
+++ b/config/sync/node.type.health_services_listing.yml
@@ -55,7 +55,7 @@ third_party_settings:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0
     when_to_delete: 0
-name: 'Health services listing page'
+name: 'Health services list'
 type: health_services_listing
 description: 'A listing of health services.'
 help: ''

--- a/config/sync/node.type.leadership_listing.yml
+++ b/config/sync/node.type.leadership_listing.yml
@@ -55,7 +55,7 @@ third_party_settings:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0
     when_to_delete: 0
-name: 'Leadership listing page'
+name: 'Leadership list'
 type: leadership_listing
 description: 'A listing of staff members.'
 help: ''

--- a/config/sync/node.type.locations_listing.yml
+++ b/config/sync/node.type.locations_listing.yml
@@ -55,7 +55,7 @@ third_party_settings:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0
     when_to_delete: 0
-name: 'Locations listing page'
+name: 'Locations list'
 type: locations_listing
 description: 'A listing of locations.'
 help: ''

--- a/config/sync/node.type.press_releases_listing.yml
+++ b/config/sync/node.type.press_releases_listing.yml
@@ -55,7 +55,7 @@ third_party_settings:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0
     when_to_delete: 0
-name: 'News release listing page'
+name: 'News releases list'
 type: press_releases_listing
 description: 'A listing of news releases.'
 help: ''

--- a/config/sync/node.type.story_listing.yml
+++ b/config/sync/node.type.story_listing.yml
@@ -55,7 +55,7 @@ third_party_settings:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0
     when_to_delete: 0
-name: 'Story listing page'
+name: 'Stories list'
 type: story_listing
 description: 'A listing of stories.'
 help: ''

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -116,7 +116,7 @@ display:
             type: none
             fail: ignore
           validate_options: {  }
-          depth: '4'
+          depth: 4
           break_phrase: false
           use_taxonomy_term_path: false
           entity_type: node

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -22,21 +22,21 @@ Feature: Content model bundles
       | Document | document | Media type | A locally hosted document, such as a PDF. |
       | Embedded image | media | Paragraph type | For adding an image inline |
       | Event | event | Content type | For online or in-person events like support groups, outreach events, public lectures, and more. |
-      | Event listing page | event_listing | Content type | A listing of events. |
+      | Events list | event_listing | Content type | A listing of events. |
       | Expandable Text | expandable_text | Paragraph type | Text that expands upon click. |
       | FAQ - multiple Q&As | faq_multiple_q_a | Content type | Curated collection of Q&As. |
-      | Health services listing page | health_services_listing | Content type | A listing of health services. |
+      | Health services list | health_services_listing | Content type | A listing of health services. |
       | Image | image | Media type | Locally hosted images. |
-      | Leadership listing page | leadership_listing | Content type | A listing of staff members. |
+      | Leadership list | leadership_listing | Content type | A listing of staff members. |
       | Link teaser | link_teaser | Paragraph type | A link followed by a description. For building inline "menus" of content. |
       | Link to file or video | downloadable_file | Paragraph type | For image or document downloads. |
       | List of link teasers | list_of_link_teasers | Paragraph type | A paragraph that contains only one type of paragraph: Link teaser. |
       | List of links | list_of_links | Paragraph type | A set of links, with link text and URL required, and an optional header. |
       | Lists of links | lists_of_links | Paragraph type | A list of links, or several lists of links, with an optional section header. |
-      | Locations listing page | locations_listing | Content type | A listing of locations. |
+      | Locations list | locations_listing | Content type | A listing of locations. |
       | NCA facility | nca_facility | Content type | A facility within National Cemetery Administration system. |
       | News release | press_release | Content type | Announcements directed at members of the media for the purpose of publicizing newsworthy events/happenings/programs at specific facilities or healthcare systems. |
-      | News release listing page | press_releases_listing | Content type | A listing of news releases. |
+      | News releases list | press_releases_listing | Content type | A listing of news releases. |
       | Number callout | number_callout | Paragraph type | Number callouts can be used in the context of a question & answer, where the answer can be summarized in a short phrase that is number-oriented. |
       | Office | office | Content type | An office at the VA, which may have contact info, events, news, and a leadership page in some cases. |
       | Phone number | phone_number | Paragraph type |  |
@@ -60,7 +60,7 @@ Feature: Content model bundles
       | Step by step | step_by_step | Paragraph type | An ordered list (1, 2, 3, 4, N) of steps. |
       | Step-by-Step | step_by_step | Content type | An ordered list (1, 2, 3, 4, N) of steps with Call to Action buttons. |
       | Story | news_story | Content type | Community stories highlight the role of a VA facility, program, or healthcare system in a Veteran's journey. They may be a case study of a specific patient, a description of a new or successful program, or a community-interest story. |
-      | Story listing page | story_listing | Content type | A listing of stories. |
+      | Stories list | story_listing | Content type | A listing of stories. |
       | Support Service | support_service | Content type | Help desks, hotlines, etc, to be contextually placed alongside relevant content. |
       | Table | table | Paragraph type | Add an HTML table with rows and columns. |
       | Type of Redirect | type_of_redirect | Vocabulary |  |

--- a/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
@@ -72,12 +72,12 @@ Feature: Content model: Content Type fields
       | Content type | Event | URL Link Label | field_event_cta | List (text) |  | 1 | Select list |  |
       | Content type | Event | URL of an external page or registration link for this event | field_link | Link |  | 1 | Link | Translatable |
       | Content type | Event | URL of an online event | field_url_of_an_online_event | Link |  | 1 | Link |  |
-      | Content type | Event listing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Event listing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-      | Content type | Event listing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Event listing page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Event listing page | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
-      | Content type | Event listing page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Events list | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Events list | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+      | Content type | Events list | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Events list | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Events list | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+      | Content type | Events list | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
       | Content type | FAQ - multiple Q&As | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic | Translatable |
       | Content type | FAQ - multiple Q&As | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
       | Content type | FAQ - multiple Q&As | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
@@ -86,26 +86,26 @@ Feature: Content model: Content Type fields
       | Content type | FAQ - multiple Q&As | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
       | Content type | FAQ - multiple Q&As | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
       | Content type | FAQ - multiple Q&As | Q&A groups | field_q_a_groups | Entity reference revisions | Required | Unlimited | Paragraphs Classic |  |
-      | Content type | Health services listing page | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic | Translatable |
-      | Content type | Health services listing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Health services listing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-      | Content type | Health services listing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Health services listing page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Health services listing page | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
-      | Content type | Health services listing page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Leadership listing page | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete | Translatable |
-      | Content type | Leadership listing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Leadership listing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-      | Content type | Leadership listing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Leadership listing page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Leadership listing page | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
-      | Content type | Leadership listing page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Locations listing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Locations listing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-      | Content type | Locations listing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Locations listing page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Locations listing page | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
-      | Content type | Locations listing page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Health services list | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic | Translatable |
+      | Content type | Health services list | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Health services list | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+      | Content type | Health services list | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Health services list | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Health services list | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+      | Content type | Health services list | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Leadership list | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete | Translatable |
+      | Content type | Leadership list | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Leadership list | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+      | Content type | Leadership list | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Leadership list | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Leadership list | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+      | Content type | Leadership list | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Locations list | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Locations list | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+      | Content type | Locations list | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Locations list | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Locations list | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+      | Content type | Locations list | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
       | Content type | NCA facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
       | Content type | NCA facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
       | Content type | NCA facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
@@ -120,13 +120,13 @@ Feature: Content model: Content Type fields
       | Content type | News release | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
       | Content type | News release | PDF of Press Release | field_pdf_version | Entity reference |  | 1 | Media library |  |
       | Content type | News release | Release date | field_release_date | Date |  | 1 | Date and time |  |
-      | Content type | News release listing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | News release listing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-      | Content type | News release listing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | News release listing page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | News release listing page | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
-      | Content type | News release listing page | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
-      | Content type | News release listing page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | News releases list | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | News releases list | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+      | Content type | News releases list | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | News releases list | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | News releases list | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+      | Content type | News releases list | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
+      | Content type | News releases list | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
       | Content type | Office | Body | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
       | Content type | Office | Meta description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
       | Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
@@ -181,12 +181,12 @@ Feature: Content model: Content Type fields
       | Content type | Story | Order | field_order | List (integer) |  | 1 | Select list | Translatable |
       | Content type | Story | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
       | Content type | Story | Story listing | field_listing | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Story listing page | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
-      | Content type | Story listing page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Story listing page | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
-      | Content type | Story listing page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-      | Content type | Story listing page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-      | Content type | Story listing page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Stories list | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+      | Content type | Stories list | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Stories list | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
+      | Content type | Stories list | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+      | Content type | Stories list | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+      | Content type | Stories list | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
       | Content type | Support Service | Link | field_link | Link |  | 1 | Link |  |
       | Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
       | Content type | Support Service | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
@@ -306,3 +306,4 @@ Feature: Content model: Content Type fields
       | Content type | VAMC facility health service | Phone number | field_phone_numbers_paragraph | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
       | Content type | VAMC facility health service | Referral required? | field_referral_required | List (text) |  | 1 | Select list |  |
       | Content type | VAMC facility health service | Walk-ins accepted? | field_walk_ins_accepted | List (text) |  | 1 | Select list |  |
+


### PR DESCRIPTION
## Description
See #2385

## Testing done
Visual / Behat

## QA steps
As an admin, confirm that each of the listing types defined in #2385 have had their human readable names changed on the content type page.