### PR TITLE
VACMS-2347 Do not tar files on cms export during deploy

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/Archive/ArchiveDirectory.php
+++ b/docroot/modules/custom/va_gov_content_export/src/Archive/ArchiveDirectory.php
@@ -61,7 +61,7 @@ class ArchiveDirectory {
    */
   public function archive(ArchiveArgs $archiveArgs) : ArchiveInterface {
     // @TODO Add locking/queueing/waiting so only one archive is occurring at a time.
-    $output_dir = dirname($archiveArgs->getOutputPath());
+    $output_dir = $this->fileSystem->dirname($archiveArgs->getOutputPath());
     $this->fileSystem->prepareDirectory($output_dir, FileSystemInterface::CREATE_DIRECTORY);
 
     $input_path = $this->fileSystem->realpath($archiveArgs->getCurrentWorkingDirectory());

--- a/docroot/modules/custom/va_gov_content_export/src/Controller/ContentExport.php
+++ b/docroot/modules/custom/va_gov_content_export/src/Controller/ContentExport.php
@@ -8,6 +8,7 @@ use Drupal\Core\PageCache\ResponsePolicy\KillSwitch;
 use Drupal\va_gov_content_export\Archive\ArchiveArgs;
 use Drupal\va_gov_content_export\Archive\ArchiveArgsFactory;
 use Drupal\va_gov_content_export\Archive\ArchiveDirectory;
+use Drupal\va_gov_content_export\SiteStatusInterface;
 use Exception;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -48,6 +49,13 @@ class ContentExport extends ControllerBase {
   public const ALLOWED_EXPORT_TYPES = ['content', 'asset'];
 
   /**
+   * Site Status.
+   *
+   * @var \Drupal\va_gov_content_export\SiteStatus
+   */
+  private $siteStatus;
+
+  /**
    * ContentExport constructor.
    *
    * @param \Drupal\va_gov_content_export\Archive\ArchiveDirectory $archiver
@@ -56,11 +64,14 @@ class ContentExport extends ControllerBase {
    *   Kill switch.
    * @param \Drupal\va_gov_content_export\Archive\ArchiveArgsFactory $archiveArgsFactory
    *   The Archive Args factory.
+   * @param \Drupal\va_gov_content_export\SiteStatusInterface $siteStatus
+   *   The Site Status Service.
    */
-  public function __construct(ArchiveDirectory $archiver, KillSwitch $killSwitch, ArchiveArgsFactory $archiveArgsFactory) {
+  public function __construct(ArchiveDirectory $archiver, KillSwitch $killSwitch, ArchiveArgsFactory $archiveArgsFactory, SiteStatusInterface $siteStatus) {
     $this->archiver = $archiver;
     $this->killSwitch = $killSwitch;
     $this->archiveArgsFactory = $archiveArgsFactory;
+    $this->siteStatus = $siteStatus;
   }
 
   /**
@@ -70,7 +81,8 @@ class ContentExport extends ControllerBase {
     return new static(
       $container->get('va_gov.content_export.archive_directory'),
       $container->get('page_cache_kill_switch'),
-      $container->get('va_gov.content_export.archive_args_factory')
+      $container->get('va_gov.content_export.archive_args_factory'),
+      $container->get('va_gov.site_status')
     );
   }
 
@@ -97,7 +109,9 @@ class ContentExport extends ControllerBase {
     $this->killSwitch->trigger();
     try {
       $archive_args = $this->getArchiveArgs($export_type);
-      $this->archiver->archive($archive_args);
+      if (!$this->siteStatus->inDeployMode()) {
+        $this->archiver->archive($archive_args);
+      }
       $file_name = $archive_args->getOutputPath();
 
       if (!file_exists($file_name)) {

--- a/docroot/modules/custom/va_gov_content_export/src/Controller/ContentExport.php
+++ b/docroot/modules/custom/va_gov_content_export/src/Controller/ContentExport.php
@@ -8,7 +8,7 @@ use Drupal\Core\PageCache\ResponsePolicy\KillSwitch;
 use Drupal\va_gov_content_export\Archive\ArchiveArgs;
 use Drupal\va_gov_content_export\Archive\ArchiveArgsFactory;
 use Drupal\va_gov_content_export\Archive\ArchiveDirectory;
-use Drupal\va_gov_content_export\SiteStatusInterface;
+use Drupal\va_gov_content_export\SiteStatus\SiteStatusInterface;
 use Exception;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -51,7 +51,7 @@ class ContentExport extends ControllerBase {
   /**
    * Site Status.
    *
-   * @var \Drupal\va_gov_content_export\SiteStatus
+   * @var \Drupal\va_gov_content_export\SiteStatus\SiteStatusInterface
    */
   private $siteStatus;
 
@@ -64,7 +64,7 @@ class ContentExport extends ControllerBase {
    *   Kill switch.
    * @param \Drupal\va_gov_content_export\Archive\ArchiveArgsFactory $archiveArgsFactory
    *   The Archive Args factory.
-   * @param \Drupal\va_gov_content_export\SiteStatusInterface $siteStatus
+   * @param \Drupal\va_gov_content_export\SiteStatus\SiteStatusInterface $siteStatus
    *   The Site Status Service.
    */
   public function __construct(ArchiveDirectory $archiver, KillSwitch $killSwitch, ArchiveArgsFactory $archiveArgsFactory, SiteStatusInterface $siteStatus) {

--- a/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatus.php
+++ b/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\va_gov_content_export;
+namespace Drupal\va_gov_content_export\SiteStatus;
 
 use Drupal\Core\Site\Settings;
 

--- a/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatus.php
+++ b/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\va_gov_content_export;
+
+use Drupal\Core\Site\Settings;
+
+/**
+ * SiteStatus Service.
+ */
+class SiteStatus implements SiteStatusInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function inDeployMode(): bool {
+    return Settings::get('va_site_deploy_mode', FALSE);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatusInterface.php
+++ b/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatusInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\va_gov_content_export;
+namespace Drupal\va_gov_content_export\SiteStatus;
 
 /**
  * Interface SiteStatusInterface.

--- a/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatusInterface.php
+++ b/docroot/modules/custom/va_gov_content_export/src/SiteStatus/SiteStatusInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\va_gov_content_export;
+
+/**
+ * Interface SiteStatusInterface.
+ */
+interface SiteStatusInterface {
+
+  /**
+   * Is the site currently in Deploy Mode.
+   *
+   * @return bool
+   *   In Deploy Mode.
+   */
+  public function inDeployMode() : bool;
+
+}

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
@@ -35,4 +35,4 @@ services:
   va_gov.content_export.executable_finder:
     class: Drupal\va_gov_content_export\ExportCommand\ExecutableFinder
   va_gov.site_status:
-    class: Drupal\va_gov_content_export\SiteStatus
+    class: Drupal\va_gov_content_export\SiteStatus\SiteStatus

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
@@ -34,3 +34,5 @@ services:
     arguments: ['@tome_sync.exporter', '@event_dispatcher', '@va_gov.content_export.executable_finder']
   va_gov.content_export.executable_finder:
     class: Drupal\va_gov_content_export\ExportCommand\ExecutableFinder
+  va_gov.site_status:
+    class: Drupal\va_gov_content_export\SiteStatus


### PR DESCRIPTION
## Description

See #2347 

When the setting `va_site_deploy_mode` is set then the export endpoint should not re-tar the content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/2568)
<!-- Reviewable:end -->
