### PR TITLE
VACMS-2537 add rowid to va form

### DIFF
--- a/config/sync/core.entity_form_display.node.va_form.default.yml
+++ b/config/sync/core.entity_form_display.node.va_form.default.yml
@@ -12,12 +12,14 @@ dependencies:
     - field.field.node.va_form.field_va_form_deleted
     - field.field.node.va_form.field_va_form_deleted_date
     - field.field.node.va_form.field_va_form_issue_date
+    - field.field.node.va_form.field_va_form_language
     - field.field.node.va_form.field_va_form_link_teasers
     - field.field.node.va_form.field_va_form_name
     - field.field.node.va_form.field_va_form_num_pages
     - field.field.node.va_form.field_va_form_number
     - field.field.node.va_form.field_va_form_related_forms
     - field.field.node.va_form.field_va_form_revision_date
+    - field.field.node.va_form.field_va_form_row_id
     - field.field.node.va_form.field_va_form_title
     - field.field.node.va_form.field_va_form_tool_intro
     - field.field.node.va_form.field_va_form_tool_url
@@ -72,7 +74,7 @@ third_party_settings:
         - field_va_form_type
         - field_benefit_categories
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -97,6 +99,7 @@ third_party_settings:
     group_editable_forms_data:
       children:
         - title
+        - field_va_form_row_id
         - field_va_form_url
         - field_va_form_number
         - field_va_form_title
@@ -121,7 +124,7 @@ third_party_settings:
       children:
         - field_alert
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -177,29 +180,35 @@ content:
     region: content
   field_va_form_administration:
     type: options_select
-    weight: 23
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   field_va_form_deleted:
-    weight: 25
+    weight: 26
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   field_va_form_deleted_date:
-    weight: 26
+    weight: 27
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_va_form_issue_date:
     type: datetime_default
-    weight: 21
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_va_form_language:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_va_form_link_teasers:
     type: entity_reference_paragraphs
     weight: 8
@@ -222,14 +231,14 @@ content:
     region: content
   field_va_form_num_pages:
     type: number
-    weight: 24
+    weight: 25
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_va_form_number:
     type: string_textfield
-    weight: 19
+    weight: 20
     region: content
     settings:
       size: 60
@@ -247,13 +256,20 @@ content:
     region: content
   field_va_form_revision_date:
     type: datetime_default
-    weight: 22
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_va_form_row_id:
+    weight: 18
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+    region: content
   field_va_form_title:
     type: string_textfield
-    weight: 20
+    weight: 21
     region: content
     settings:
       size: 60
@@ -283,14 +299,14 @@ content:
     region: content
   field_va_form_url:
     type: link_default
-    weight: 18
+    weight: 19
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
   field_va_form_usage:
-    weight: 4
+    weight: 5
     settings:
       rows: 5
       placeholder: ''

--- a/config/sync/core.entity_view_display.node.va_form.default.yml
+++ b/config/sync/core.entity_view_display.node.va_form.default.yml
@@ -11,12 +11,14 @@ dependencies:
     - field.field.node.va_form.field_va_form_deleted
     - field.field.node.va_form.field_va_form_deleted_date
     - field.field.node.va_form.field_va_form_issue_date
+    - field.field.node.va_form.field_va_form_language
     - field.field.node.va_form.field_va_form_link_teasers
     - field.field.node.va_form.field_va_form_name
     - field.field.node.va_form.field_va_form_num_pages
     - field.field.node.va_form.field_va_form_number
     - field.field.node.va_form.field_va_form_related_forms
     - field.field.node.va_form.field_va_form_revision_date
+    - field.field.node.va_form.field_va_form_row_id
     - field.field.node.va_form.field_va_form_title
     - field.field.node.va_form.field_va_form_tool_intro
     - field.field.node.va_form.field_va_form_tool_url
@@ -39,7 +41,7 @@ third_party_settings:
         - field_va_form_type
         - field_benefit_categories
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         id: ''
@@ -52,7 +54,7 @@ third_party_settings:
         - field_va_form_tool_intro
         - field_va_form_tool_url
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         id: ''
@@ -69,10 +71,11 @@ third_party_settings:
         - field_va_form_num_pages
         - field_va_form_number
         - field_va_form_revision_date
+        - field_va_form_row_id
         - field_va_form_title
         - field_va_form_url
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: fieldset
       format_settings:
         description: 'This content is maintained in the VA Forms DB and updated nightly.'
@@ -86,7 +89,7 @@ bundle: va_form
 mode: default
 content:
   field_alert:
-    weight: 3
+    weight: 4
     label: above
     settings:
       view_mode: default
@@ -109,9 +112,16 @@ content:
     third_party_settings: {  }
     type: metatag_empty_formatter
     region: content
+  field_va_form_language:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
   field_va_form_link_teasers:
     type: entity_reference_revisions_entity_view
-    weight: 8
+    weight: 9
     label: above
     settings:
       view_mode: default
@@ -127,7 +137,7 @@ content:
     type: string
     region: content
   field_va_form_related_forms:
-    weight: 7
+    weight: 8
     label: above
     settings:
       link: true
@@ -161,7 +171,7 @@ content:
     type: list_default
     region: content
   field_va_form_usage:
-    weight: 5
+    weight: 6
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -182,6 +192,7 @@ hidden:
   field_va_form_num_pages: true
   field_va_form_number: true
   field_va_form_revision_date: true
+  field_va_form_row_id: true
   field_va_form_title: true
   field_va_form_url: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.va_form.external_content.yml
+++ b/config/sync/core.entity_view_display.node.va_form.external_content.yml
@@ -12,12 +12,14 @@ dependencies:
     - field.field.node.va_form.field_va_form_deleted
     - field.field.node.va_form.field_va_form_deleted_date
     - field.field.node.va_form.field_va_form_issue_date
+    - field.field.node.va_form.field_va_form_language
     - field.field.node.va_form.field_va_form_link_teasers
     - field.field.node.va_form.field_va_form_name
     - field.field.node.va_form.field_va_form_num_pages
     - field.field.node.va_form.field_va_form_number
     - field.field.node.va_form.field_va_form_related_forms
     - field.field.node.va_form.field_va_form_revision_date
+    - field.field.node.va_form.field_va_form_row_id
     - field.field.node.va_form.field_va_form_title
     - field.field.node.va_form.field_va_form_tool_intro
     - field.field.node.va_form.field_va_form_tool_url
@@ -38,7 +40,7 @@ third_party_settings:
         - field_benefit_categories
         - field_va_form_type
       parent_name: ''
-      weight: 19
+      weight: 20
       format_type: fieldset
       format_settings:
         id: ''
@@ -51,7 +53,7 @@ third_party_settings:
         - field_va_form_tool_intro
         - field_va_form_tool_url
       parent_name: ''
-      weight: 20
+      weight: 21
       format_type: fieldset
       format_settings:
         id: ''
@@ -69,7 +71,7 @@ mode: external_content
 content:
   field_va_form_administration:
     type: entity_reference_label
-    weight: 5
+    weight: 6
     region: content
     label: above
     settings:
@@ -77,9 +79,9 @@ content:
     third_party_settings: {  }
   field_va_form_deleted:
     type: boolean
-    weight: 7
+    weight: 8
     region: content
-    label: inline
+    label: above
     settings:
       format: true-false
       format_custom_true: ''
@@ -87,7 +89,7 @@ content:
     third_party_settings: {  }
   field_va_form_deleted_date:
     type: datetime_default
-    weight: 8
+    weight: 9
     region: content
     label: above
     settings:
@@ -96,7 +98,7 @@ content:
     third_party_settings: {  }
   field_va_form_issue_date:
     type: datetime_default
-    weight: 3
+    weight: 4
     region: content
     label: above
     settings:
@@ -105,7 +107,7 @@ content:
     third_party_settings: {  }
   field_va_form_num_pages:
     type: number_integer
-    weight: 6
+    weight: 7
     region: content
     label: above
     settings:
@@ -122,16 +124,25 @@ content:
     third_party_settings: {  }
   field_va_form_revision_date:
     type: datetime_default
-    weight: 4
+    weight: 5
     region: content
     label: above
     settings:
       timezone_override: ''
       format_type: short_date_no_time
     third_party_settings: {  }
+  field_va_form_row_id:
+    type: number_integer
+    weight: 2
+    region: content
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
   field_va_form_title:
     type: string
-    weight: 2
+    weight: 3
     region: content
     label: above
     settings:
@@ -155,6 +166,7 @@ hidden:
   field_alert: true
   field_benefit_categories: true
   field_meta_tags: true
+  field_va_form_language: true
   field_va_form_link_teasers: true
   field_va_form_name: true
   field_va_form_related_forms: true

--- a/config/sync/core.entity_view_display.node.va_form.teaser.yml
+++ b/config/sync/core.entity_view_display.node.va_form.teaser.yml
@@ -12,12 +12,14 @@ dependencies:
     - field.field.node.va_form.field_va_form_deleted
     - field.field.node.va_form.field_va_form_deleted_date
     - field.field.node.va_form.field_va_form_issue_date
+    - field.field.node.va_form.field_va_form_language
     - field.field.node.va_form.field_va_form_link_teasers
     - field.field.node.va_form.field_va_form_name
     - field.field.node.va_form.field_va_form_num_pages
     - field.field.node.va_form.field_va_form_number
     - field.field.node.va_form.field_va_form_related_forms
     - field.field.node.va_form.field_va_form_revision_date
+    - field.field.node.va_form.field_va_form_row_id
     - field.field.node.va_form.field_va_form_title
     - field.field.node.va_form.field_va_form_tool_intro
     - field.field.node.va_form.field_va_form_tool_url
@@ -47,12 +49,14 @@ hidden:
   field_va_form_deleted: true
   field_va_form_deleted_date: true
   field_va_form_issue_date: true
+  field_va_form_language: true
   field_va_form_link_teasers: true
   field_va_form_name: true
   field_va_form_num_pages: true
   field_va_form_number: true
   field_va_form_related_forms: true
   field_va_form_revision_date: true
+  field_va_form_row_id: true
   field_va_form_title: true
   field_va_form_tool_intro: true
   field_va_form_tool_url: true

--- a/config/sync/field.field.node.va_form.field_va_form_language.yml
+++ b/config/sync/field.field.node.va_form.field_va_form_language.yml
@@ -1,0 +1,23 @@
+uuid: f35818b9-aa85-40f1-996c-766e66353454
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_va_form_language
+    - node.type.va_form
+  module:
+    - options
+id: node.va_form.field_va_form_language
+field_name: field_va_form_language
+entity_type: node
+bundle: va_form
+label: 'Form Language'
+description: 'The language of the form, not the language of this page.'
+required: true
+translatable: false
+default_value:
+  -
+    value: en
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.va_form.field_va_form_row_id.yml
+++ b/config/sync/field.field.node.va_form.field_va_form_row_id.yml
@@ -1,0 +1,23 @@
+uuid: 1d2d15be-027d-4eed-bbc0-c8ee263abf85
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_va_form_row_id
+    - node.type.va_form
+id: node.va_form.field_va_form_row_id
+field_name: field_va_form_row_id
+entity_type: node
+bundle: va_form
+label: 'Row ID'
+description: 'The Row ID from the Forms Database.  This is the only unique identifier in the Forms database.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.storage.node.field_va_form_language.yml
+++ b/config/sync/field.storage.node.field_va_form_language.yml
@@ -1,0 +1,30 @@
+uuid: b1c47262-4ff8-4ddf-92ba-94fe96d44539
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_va_form_language
+field_name: field_va_form_language
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: en
+      label: English
+    -
+      value: es
+      label: Spanish
+    -
+      value: tl
+      label: Tagalog
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_va_form_row_id.yml
+++ b/config/sync/field.storage.node.field_va_form_row_id.yml
@@ -1,0 +1,20 @@
+uuid: e1cfa693-9dcb-46be-96aa-1796d87f905d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_va_form_row_id
+field_name: field_va_form_row_id
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.va_node_form.yml
+++ b/config/sync/migrate_plus.migration.va_node_form.yml
@@ -171,6 +171,7 @@ process:
     bypass: false
   field_va_form_name: FormTitle
   field_va_form_number: displayName
+  field_va_form_row_id: rowid
   field_va_form_title: FormTitle
   field_va_form_type: FormType
   field_va_form_issue_date:
@@ -308,21 +309,22 @@ destination:
   default_bundle: va_form
   overwrite_properties:
     - changed
+    - field_va_form_administration
+    - field_va_form_deleted
+    - field_va_form_deleted_date
+    - field_va_form_issue_date
+    - field_va_form_num_pages
+    - field_va_form_number
+    - field_va_form_revision_date
+    - field_va_form_row_id
+    - field_va_form_title
+    - field_va_form_url
     - new_revision
     - revision_default
     - revision_log
     - revision_timestamp
     - revision_uid
-    - uid
-    - field_va_form_administration
-    - field_va_form_deleted
-    - field_va_form_deleted_date
-    - field_va_form_issue_date
-    - field_va_form_revision_date
-    - field_va_form_num_pages
-    - field_va_form_number
-    - field_va_form_title
-    - field_va_form_url
     - title
+    - uid
 migration_dependencies:
   required: {  }

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
@@ -184,6 +184,7 @@ process:
     bypass: FALSE
   field_va_form_name: FormTitle
   field_va_form_number: displayName
+  field_va_form_row_id: rowid
   field_va_form_title: FormTitle
   field_va_form_type: FormType
   # field_va_form_link_teasers:
@@ -299,22 +300,23 @@ destination:
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
     - changed
+    - field_va_form_administration
+    - field_va_form_deleted
+    - field_va_form_deleted_date
+    - field_va_form_issue_date
+    - field_va_form_num_pages
+    - field_va_form_number
+    - field_va_form_revision_date
+    - field_va_form_row_id
+    - field_va_form_title
+    - field_va_form_url
     - new_revision
     - revision_default
     - revision_log
     - revision_timestamp
     - revision_uid
-    - uid
-    - field_va_form_administration
-    - field_va_form_deleted
-    - field_va_form_deleted_date
-    - field_va_form_issue_date
-    - field_va_form_revision_date
-    - field_va_form_num_pages
-    - field_va_form_number
-    - field_va_form_title
-    - field_va_form_url
     - title
+    - uid
 # Dependency on other migrations.
 migration_dependencies:
   required: {  }

--- a/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
@@ -211,6 +211,7 @@ Feature: Content model: Content Type fields
 | Content type | VA form | Form title | field_va_form_title | Text (plain) |  | 1 | Textfield |  |
 | Content type | VA form | Helpful links | field_va_form_link_teasers | Entity reference revisions |  | Unlimited | Paragraphs Classic |  |
 | Content type | VA form | Issue date | field_va_form_issue_date | Date |  | 1 | Date and time |  |
+| Content type | VA form | Form Language | field_va_form_language | List (text) | Required | 1 | Select list |  |
 | Content type | VA form | Link to form | field_va_form_url | Link |  | 1 | Link |  |
 | Content type | VA form | Link to online tool | field_va_form_tool_url | Link |  | 1 | Link |  |
 | Content type | VA form | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
@@ -218,6 +219,7 @@ Feature: Content model: Content Type fields
 | Content type | VA form | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VA form | Related forms | field_va_form_related_forms | Entity reference |  | Unlimited | Autocomplete |  |
 | Content type | VA form | Revision date | field_va_form_revision_date | Date |  | 1 | Date and time |  |
+| Content type | VA form | Row ID | field_va_form_row_id | Number (integer) |  | 1 | Number field |  |
 | Content type | VA form | Tool intro | field_va_form_tool_intro | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | VA form | When to use | field_va_form_usage | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | VAMC facility | Address | field_address | Address |  | 1 | Address | Translatable |
@@ -314,4 +316,3 @@ Feature: Content model: Content Type fields
 | Content type | VAMC facility health service | Appointment phone number(s) | field_phone_numbers_paragraph | Entity reference revisions |  | Unlimited | -- Disabled -- |  |
 | Content type | VAMC facility health service | Referral required? | field_referral_required | List (text) |  | 1 | -- Disabled -- |  |
 | Content type | VAMC facility health service | Walk-ins accepted? | field_walk_ins_accepted | List (text) |  | 1 | -- Disabled -- |  |
-


### PR DESCRIPTION
## Description

See #2537 and #2540 . 

## Testing done
- evaluated forms
- behat tests
- ran migration with --update flag and validated that the row id was populated.


## Screenshots



## QA steps
1.  Visit /node/6059/edit
 - [x] validate that the row id field appears within the Forms DB data feildset
![image](https://user-images.githubusercontent.com/5752113/89680120-51727f00-d8c0-11ea-9efe-705b48d08f4a.png)

- [x] validate that language field is present and required.
![image](https://user-images.githubusercontent.com/5752113/89680166-69e29980-d8c0-11ea-87bd-e8a4849df48b.png)
- [x] validate that english, spanish and tagalog are the available options.

## Post Release steps.
- [ ] Navigate to https://prod.cms.va.gov/admin/structure/migrate/manage/forms/migrations/va_node_form/execute
- [ ] Check the "Update" box, then click the "Execute" button.   
![image](https://user-images.githubusercontent.com/5752113/89680343-c6de4f80-d8c0-11ea-8b00-88cd55fe3eef.png)
This will update all the nodes to make them all have row ids.
- [ ] Notify in va_forms slack channel that `field_va_form_row_id` and `field_va_form_language`  should now be available via graphQL.
