### PR TITLE
VACMS-11163: Add production environment variable id switch.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/gtm_tag_push.js
+++ b/docroot/modules/custom/va_gov_backend/js/gtm_tag_push.js
@@ -8,10 +8,11 @@
     'gtm.start': new Date().getTime(),
     event: 'gtm.js'
   });
+  const env = drupalSettings.environmentIndicator.name === "Production" ? "2" : "5";
   var f = d.getElementsByTagName(s)[0],
     j = d.createElement(s),
     dl = l != 'dataLayer' ? '&l=' + l : '';
   j.async = true;
-  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '&gtm_auth=hHvHnY1eIx1IOSJMAnOBLA&gtm_preview=env-2&gtm_cookies_win=x';
+  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '&gtm_auth=hHvHnY1eIx1IOSJMAnOBLA&gtm_preview=env-' + env + '&gtm_cookies_win=x';
   f.parentNode.insertBefore(j, f);
 })(window, document, 'script', 'dataLayer', 'GTM-WQ3DLLB');

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -568,7 +568,9 @@ function _va_gov_backend_gtm_settings() {
  */
 function va_gov_backend_page_bottom(array &$page_bottom) {
   // Add GTM noscript iframe to body.
-  $gtm_noscript = Markup::create('<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WQ3DLLB&gtm_auth=hHvHnY1eIx1IOSJMAnOBLA&gtm_preview=env-2&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>');
+  $env_name = \Drupal::config('environment_indicator.indicator')->get('name');
+  $env_num = $env_name === 'Production' ? '2' : '5';
+  $gtm_noscript = Markup::create('<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WQ3DLLB&gtm_auth=hHvHnY1eIx1IOSJMAnOBLA&gtm_preview=env-' . $env_num . '&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>');
   $page_bottom['va_gov_backend'] = ['#markup' => $gtm_noscript];
 }
 


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-team/issues/11163
Per @jonwehausen , we need a switch to differentiate production from all other environments. So, if we are on prod, gtm is environment 2. All others are tracked as environment 5.

## Testing done
Visual inspection in console.

