### PR TITLE
VACMS-000 Remove menu_breadcrumb from config ignore.

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -1,13 +1,12 @@
 ignored_config_entities:
-  0: devel.settings
-  2: devel.toolbar.settings
-  4: 'devel_generate.*'
-  6: 'devel_kint.*'
-  8: 'govdelivery_bulletins.settings:govdelivery_endpoint'
-  10: 'govdelivery_bulletins.settings:govdelivery_password'
-  12: 'govdelivery_bulletins.settings:govdelivery_username'
-  14: kint.settings
-  16: menu_breadcrumb.settings
-  18: system.menu.devel
+  - devel.settings
+  - devel.toolbar.settings
+  - 'devel_generate.*'
+  - 'devel_kint.*'
+  - 'govdelivery_bulletins.settings:govdelivery_endpoint'
+  - 'govdelivery_bulletins.settings:govdelivery_password'
+  - 'govdelivery_bulletins.settings:govdelivery_username'
+  - kint.settings
+  - system.menu.devel
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk


### PR DESCRIPTION
## Description

The issue is menu breadcrumbs are being altered in prod but are trickling down to content export which does not reflect the current state of prod expected from other developers content export.

