### PR TITLE
VACMS-2687: Sort child terms by term weight not TID.

### DIFF
--- a/config/sync/views.view.child_terms.yml
+++ b/config/sync/views.view.child_terms.yml
@@ -148,7 +148,21 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-      sorts: {  }
+      sorts:
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: standard
       title: 'Child sections'
       header:
         area:


### PR DESCRIPTION
## Description

See #2687. 

## Testing done

Before

![image](https://user-images.githubusercontent.com/643678/90424895-df065980-e08c-11ea-9092-15ef17f44767.png)


After

![VAMC_facilities___VA_gov_CMS](https://user-images.githubusercontent.com/643678/90425062-27be1280-e08d-11ea-8e42-f17d6b27e64f.jpg)



## QA steps

1. Go to /section/vamc-facilities and check sorting
