### PR TITLE
sync-db.sh add env var to pull sanitized db from correct s3 bucket

### DIFF
--- a/scripts/sync-db.sh
+++ b/scripts/sync-db.sh
@@ -13,10 +13,11 @@ if [ -z "$CMS_APP_NAME" ]; then
 fi
 
 
-# Setup
-# @todo check if Lando stack is running, if not return error message or just start it
-echo "Downloading latest PROD database"
-curl --remote-name --remote-header-name https://dsva-vagov-prod-${CMS_APP_NAME}-backup-sanitized.s3-us-gov-west-1.amazonaws.com/database/cms-prod-db-sanitized-latest.sql.gz
+# Download and unzip the sanitized database snapshot.
+HOSTNAME="https://dsva-vagov-prod-${CMS_APP_NAME}-backup-sanitized.s3-us-gov-west-1.amazonaws.com"
+FILEPATH="database/cms-prod-db-sanitized-latest.sql.gz"
+echo "Downloading latest PROD database from: ${HOSTNAME}/${FILEPATH}"
+curl --remote-name "${HOSTNAME}/${FILEPATH}"
 gunzip --force cms-prod-db-sanitized-latest.sql.gz 2> /dev/null || true &&
 
 echo "Downloaded PROD Database to .dumps/cms-prod-db-sanitized-latest.sql"

--- a/scripts/sync-db.sh
+++ b/scripts/sync-db.sh
@@ -4,18 +4,25 @@
 set -e
 
 # Allow script to be run anywhere in git repo
-cd $(git rev-parse --show-toplevel)/.dumps
+cd "$(git rev-parse --show-toplevel)"/.dumps
+
+# On BRD, CMS_APP_NAME is set upstream in Devops/Ansible.
+# If it is not set (local usage) assign 'cms' to it.
+if [ -z "$CMS_APP_NAME" ]; then
+  CMS_APP_NAME=cms
+fi
+
 
 # Setup
 # @todo check if Lando stack is running, if not return error message or just start it
 echo "Downloading latest PROD database"
-curl --remote-name --remote-header-name https://dsva-vagov-prod-cms-backup-sanitized.s3-us-gov-west-1.amazonaws.com/database/cms-prod-db-sanitized-latest.sql.gz
+curl --remote-name --remote-header-name https://dsva-vagov-prod-${CMS_APP_NAME}-backup-sanitized.s3-us-gov-west-1.amazonaws.com/database/cms-prod-db-sanitized-latest.sql.gz
 gunzip --force cms-prod-db-sanitized-latest.sql.gz 2> /dev/null || true &&
 
 echo "Downloaded PROD Database to .dumps/cms-prod-db-sanitized-latest.sql"
 
 # BRD DEV, STAGING, PROD only
-if [ ! -z "$CMS_BRD" ]; then
+if [ -n "$CMS_IS_BRD" ]; then
     echo "Dropping existing database tables"
     drush sql-drop --yes
     echo "Database tables dropped"
@@ -24,15 +31,14 @@ if [ ! -z "$CMS_BRD" ]; then
     echo "Database import complete"
 fi
 # Local only
-if [ -z "$CMS_BRD" ]; then
-echo $CMS_BRD;
+if [ -z "$CMS_IS_BRD" ]; then
 echo "Purging devel configuration files."
-    rm -f $(git rev-parse --show-toplevel)/config/sync/devel.settings.yml
-    rm -f $(git rev-parse --show-toplevel)/config/sync/devel.toolbar.settings.yml
-    rm -f $(git rev-parse --show-toplevel)/config/sync/system.menu.devel.yml
-    rm -f $(git rev-parse --show-toplevel)/config/dev/devel.settings.yml
-    rm -f $(git rev-parse --show-toplevel)/config/dev/devel.toolbar.settings.yml
-    rm -f $(git rev-parse --show-toplevel)/config/dev/system.menu.devel.yml
+    rm -f "$(git rev-parse --show-toplevel)"/config/sync/devel.settings.yml
+    rm -f "$(git rev-parse --show-toplevel)"/config/sync/devel.toolbar.settings.yml
+    rm -f "$(git rev-parse --show-toplevel)"/config/sync/system.menu.devel.yml
+    rm -f "$(git rev-parse --show-toplevel)"/config/dev/devel.settings.yml
+    rm -f "$(git rev-parse --show-toplevel)"/config/dev/devel.toolbar.settings.yml
+    rm -f "$(git rev-parse --show-toplevel)"/config/dev/system.menu.devel.yml
 echo "Importing database."
     lando db-import cms-prod-db-sanitized-latest.sql
 fi


### PR DESCRIPTION
## Description
see #2556 
https://github.com/department-of-veterans-affairs/devops/pull/7415

## Testing done
Tested locally with lando by `export CMS_IS_BRD="true"` and `export CMS_APP_NAME="cms-test"` and also without, works. 
