### PR TITLE
VACMS 2456 media list videos content type

### DIFF
--- a/config/sync/core.base_field_override.node.media_list_videos.promote.yml
+++ b/config/sync/core.base_field_override.node.media_list_videos.promote.yml
@@ -1,0 +1,22 @@
+uuid: 56b269ba-50bf-4c77-9e29-b6e2b127b4e8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.media_list_videos
+id: node.media_list_videos.promote
+field_name: promote
+entity_type: node
+bundle: media_list_videos
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.media_list_videos.status.yml
+++ b/config/sync/core.base_field_override.node.media_list_videos.status.yml
@@ -1,0 +1,22 @@
+uuid: 9dfd4bcb-71b7-4b01-a23d-ad70c53a8800
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.media_list_videos
+id: node.media_list_videos.status
+field_name: status
+entity_type: node
+bundle: media_list_videos
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.media_list_videos.title.yml
+++ b/config/sync/core.base_field_override.node.media_list_videos.title.yml
@@ -1,0 +1,18 @@
+uuid: 97fc9157-fe3b-4c4d-86d3-56b0b68e9524
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.media_list_videos
+id: node.media_list_videos.title
+field_name: title
+entity_type: node
+bundle: media_list_videos
+label: 'Page title'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.entity_form_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_videos.default.yml
@@ -1,0 +1,236 @@
+uuid: 0189b8c5-a3cb-4d59-9dfd-b56a6594c681
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.media_list_videos.field_administration
+    - field.field.node.media_list_videos.field_alert_single
+    - field.field.node.media_list_videos.field_buttons
+    - field.field.node.media_list_videos.field_buttons_repeat
+    - field.field.node.media_list_videos.field_description
+    - field.field.node.media_list_videos.field_intro_text_limited_html
+    - field.field.node.media_list_videos.field_media_list_videos
+    - field.field.node.media_list_videos.field_meta_title
+    - node.type.media_list_videos
+    - workflows.workflow.editorial
+  module:
+    - allowed_formats
+    - content_moderation
+    - field_group
+    - paragraphs
+    - path
+    - textfield_counter
+third_party_settings:
+  field_group:
+    group_title_and_introduction:
+      children:
+        - title
+        - field_intro_text_limited_html
+      parent_name: ''
+      weight: 0
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Title and introduction'
+      region: content
+    group_include_alert:
+      children:
+        - field_alert_single
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: 'Alerts draw attention to information that may be critical to a veteran, family member, or caregiver. You can <a href="/block/add/alert?destination=/admin/content/alerts">create a new alert</a>, or reuse an existing one.'
+        required_fields: false
+      label: 'Include Alert'
+      region: content
+    group_governance:
+      children:
+        - field_administration
+      parent_name: ''
+      weight: 7
+      format_type: details_sidebar
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: 1
+        required_fields: 1
+        weight: '-10'
+      label: Governance
+      region: content
+    group_editorial_workflow:
+      children:
+        - moderation_state
+      parent_name: ''
+      weight: 6
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Editorial workflow'
+      region: content
+    group_meta_tags:
+      children:
+        - field_meta_title
+        - field_description
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Meta Tags'
+      region: content
+id: node.media_list_videos.default
+targetEntityType: node
+bundle: media_list_videos
+mode: default
+content:
+  field_administration:
+    weight: 11
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_alert_single:
+    type: entity_reference_paragraphs
+    weight: 2
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: alert_single
+    third_party_settings: {  }
+    region: content
+  field_buttons:
+    weight: 3
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: button
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+    type: paragraphs
+    region: content
+  field_buttons_repeat:
+    weight: 5
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_description:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_intro_text_limited_html:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+      maxlength: 1000
+      counter_position: after
+      textcount_status_message: 'Characters Remaining: <span class="remaining_count">@remaining_count</span>'
+      js_prevent_submit: false
+      count_html_characters: false
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
+    type: text_textarea_with_counter
+    region: content
+  field_media_list_videos:
+    type: paragraphs
+    weight: 4
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: media_list_videos
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+    region: content
+  field_meta_title:
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 2
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 10
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield_with_counter
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+      maxlength: 150
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Characters Remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
+    third_party_settings: {  }
+  url_redirects:
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  promote: true
+  sticky: true
+  uid: true

--- a/config/sync/core.entity_form_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_videos.default.yml
@@ -67,6 +67,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 6
       format_type: fieldset

--- a/config/sync/core.entity_view_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_view_display.node.media_list_videos.default.yml
@@ -1,0 +1,99 @@
+uuid: ff1582d9-13fc-443d-ae3a-37d32ae5b674
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.media_list_videos.field_administration
+    - field.field.node.media_list_videos.field_alert_single
+    - field.field.node.media_list_videos.field_buttons
+    - field.field.node.media_list_videos.field_buttons_repeat
+    - field.field.node.media_list_videos.field_description
+    - field.field.node.media_list_videos.field_intro_text_limited_html
+    - field.field.node.media_list_videos.field_media_list_videos
+    - field.field.node.media_list_videos.field_meta_title
+    - node.type.media_list_videos
+  module:
+    - entity_reference_revisions
+    - text
+    - user
+id: node.media_list_videos.default
+targetEntityType: node
+bundle: media_list_videos
+mode: default
+content:
+  field_administration:
+    weight: 110
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_alert_single:
+    type: entity_reference_revisions_entity_view
+    weight: 105
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_buttons:
+    weight: 102
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_buttons_repeat:
+    weight: 109
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_description:
+    weight: 107
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_intro_text_limited_html:
+    weight: 106
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_media_list_videos:
+    type: entity_reference_revisions_entity_view
+    weight: 104
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_meta_title:
+    weight: 108
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  content_moderation_control: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_view_display.node.media_list_videos.default.yml
@@ -14,15 +14,52 @@ dependencies:
     - node.type.media_list_videos
   module:
     - entity_reference_revisions
+    - field_group
     - text
     - user
+third_party_settings:
+  field_group:
+    group_meta_tags:
+      children:
+        - field_meta_title
+        - field_description
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: 'Meta tags'
+      region: content
+    group_content:
+      children:
+        - field_intro_text_limited_html
+        - field_alert_single
+        - field_buttons
+        - field_media_list_videos
+        - field_buttons_repeat
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: Content
+      region: content
 id: node.media_list_videos.default
 targetEntityType: node
 bundle: media_list_videos
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_administration:
-    weight: 110
+    weight: 8
     label: above
     settings:
       link: true
@@ -31,7 +68,7 @@ content:
     region: content
   field_alert_single:
     type: entity_reference_revisions_entity_view
-    weight: 105
+    weight: 7
     label: above
     settings:
       view_mode: default
@@ -39,7 +76,7 @@ content:
     third_party_settings: {  }
     region: content
   field_buttons:
-    weight: 102
+    weight: 8
     label: above
     settings:
       view_mode: default
@@ -48,7 +85,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_buttons_repeat:
-    weight: 109
+    weight: 10
     label: above
     settings:
       format: default
@@ -58,7 +95,7 @@ content:
     type: boolean
     region: content
   field_description:
-    weight: 107
+    weight: 9
     label: above
     settings:
       link_to_entity: false
@@ -66,7 +103,7 @@ content:
     type: string
     region: content
   field_intro_text_limited_html:
-    weight: 106
+    weight: 6
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -74,7 +111,7 @@ content:
     region: content
   field_media_list_videos:
     type: entity_reference_revisions_entity_view
-    weight: 104
+    weight: 9
     label: above
     settings:
       view_mode: default
@@ -82,7 +119,7 @@ content:
     third_party_settings: {  }
     region: content
   field_meta_title:
-    weight: 108
+    weight: 8
     label: above
     settings:
       link_to_entity: false
@@ -90,10 +127,9 @@ content:
     type: string
     region: content
   links:
-    weight: 100
+    weight: 9
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
-  content_moderation_control: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.media_list_videos.teaser.yml
+++ b/config/sync/core.entity_view_display.node.media_list_videos.teaser.yml
@@ -1,0 +1,38 @@
+uuid: 697bc86a-d165-421c-888c-11e13cab26e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.media_list_videos.field_administration
+    - field.field.node.media_list_videos.field_alert_single
+    - field.field.node.media_list_videos.field_buttons
+    - field.field.node.media_list_videos.field_buttons_repeat
+    - field.field.node.media_list_videos.field_description
+    - field.field.node.media_list_videos.field_intro_text_limited_html
+    - field.field.node.media_list_videos.field_media_list_videos
+    - field.field.node.media_list_videos.field_meta_title
+    - node.type.media_list_videos
+  module:
+    - user
+id: node.media_list_videos.teaser
+targetEntityType: node
+bundle: media_list_videos
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  content_moderation_control: true
+  field_administration: true
+  field_alert_single: true
+  field_buttons: true
+  field_buttons_repeat: true
+  field_description: true
+  field_intro_text_limited_html: true
+  field_media_list_videos: true
+  field_meta_title: true
+  search_api_excerpt: true

--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -42,67 +42,67 @@ definitions:
     expanded: false
     enabled: true
   node__add__health_care_local_facility:
-    weight: 28
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__health_care_region_page:
-    weight: 25
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__health_care_local_health_service:
     weight: 29
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
-  node__add__press_release:
-    weight: 13
+  node__add__health_care_region_page:
+    weight: 26
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
-  node__add__office:
-    weight: 15
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__publication_listing:
-    weight: 17
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__outreach_asset:
-    weight: 16
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__regional_health_care_service_des:
+  node__add__health_care_local_health_service:
     weight: 30
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
+  node__add__press_release:
+    weight: 14
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__office:
+    weight: 16
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__publication_listing:
+    weight: 18
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__outreach_asset:
+    weight: 17
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__regional_health_care_service_des:
+    weight: 31
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
   node__add__person_profile:
-    weight: 19
+    weight: 20
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__news_story:
-    weight: 21
+    weight: 22
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__support_service:
-    weight: 23
+    weight: 24
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -282,13 +282,13 @@ definitions:
     expanded: false
     enabled: true
   node__add__full_width_banner_alert:
-    weight: 26
+    weight: 27
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__vamc_operating_status_and_alerts:
-    weight: 27
+    weight: 28
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -504,37 +504,37 @@ definitions:
     expanded: false
     enabled: true
   node__add__nca_facility:
-    weight: 12
+    weight: 13
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__press_releases_listing:
-    weight: 14
+    weight: 15
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__story_listing:
-    weight: 22
+    weight: 23
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__vba_facility:
-    weight: 31
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__vet_center:
     weight: 32
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
+  node__add__vet_center:
+    weight: 33
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
   node__add__va_form:
-    weight: 24
+    weight: 25
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -588,7 +588,7 @@ definitions:
     expanded: false
     enabled: true
   node__add__q_a:
-    weight: 18
+    weight: 19
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -726,7 +726,7 @@ definitions:
     expanded: false
     enabled: true
   node__add__step_by_step:
-    weight: 20
+    weight: 21
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -939,6 +939,12 @@ definitions:
     weight: 6
     parent: 'menu_link_content:0ef50ec4-b82c-45c2-99e1-ebe7e8ff86a1'
     menu_name: admin
+    enabled: true
+    expanded: false
+  node__add__media_list_videos:
+    weight: 12
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
     enabled: true
     expanded: false
 _core:

--- a/config/sync/field.field.node.media_list_videos.field_administration.yml
+++ b/config/sync/field.field.node.media_list_videos.field_administration.yml
@@ -1,0 +1,29 @@
+uuid: 96db8e80-ea21-430a-9ddd-0fe3fa670e7c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_administration
+    - node.type.media_list_videos
+    - taxonomy.vocabulary.administration
+id: node.media_list_videos.field_administration
+field_name: field_administration
+entity_type: node
+bundle: media_list_videos
+label: Owner
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.media_list_videos.field_alert_single.yml
+++ b/config/sync/field.field.node.media_list_videos.field_alert_single.yml
@@ -1,0 +1,133 @@
+uuid: 579969fe-1d29-4049-a01a-739e1812184c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_alert_single
+    - node.type.media_list_videos
+    - paragraphs.paragraphs_type.alert_single
+  module:
+    - entity_reference_revisions
+id: node.media_list_videos.field_alert_single
+field_name: field_alert_single
+entity_type: node
+bundle: media_list_videos
+label: Alert
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      alert_single: alert_single
+    target_bundles_drag_drop:
+      address:
+        weight: 36
+        enabled: false
+      alert:
+        weight: 37
+        enabled: false
+      alert_single:
+        enabled: true
+        weight: 38
+      button:
+        weight: 39
+        enabled: false
+      checklist:
+        weight: 40
+        enabled: false
+      checklist_item:
+        weight: 41
+        enabled: false
+      collapsible_panel:
+        weight: 42
+        enabled: false
+      collapsible_panel_item:
+        weight: 43
+        enabled: false
+      downloadable_file:
+        weight: 44
+        enabled: false
+      expandable_text:
+        weight: 45
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 46
+        enabled: false
+      link_teaser:
+        weight: 47
+        enabled: false
+      list_of_link_teasers:
+        weight: 48
+        enabled: false
+      list_of_links:
+        weight: 49
+        enabled: false
+      lists_of_links:
+        weight: 50
+        enabled: false
+      media:
+        weight: 51
+        enabled: false
+      media_list_videos:
+        weight: 52
+        enabled: false
+      non_reusable_alert:
+        weight: 53
+        enabled: false
+      number_callout:
+        weight: 54
+        enabled: false
+      phone_number:
+        weight: 55
+        enabled: false
+      process:
+        weight: 56
+        enabled: false
+      q_a:
+        weight: 57
+        enabled: false
+      q_a_group:
+        weight: 58
+        enabled: false
+      q_a_section:
+        weight: 59
+        enabled: false
+      react_widget:
+        weight: 60
+        enabled: false
+      service_location:
+        weight: 61
+        enabled: false
+      service_location_address:
+        weight: 62
+        enabled: false
+      situation_update:
+        weight: 63
+        enabled: false
+      spanish_translation_summary:
+        weight: 64
+        enabled: false
+      staff_profile:
+        weight: 65
+        enabled: false
+      starred_horizontal_rule:
+        weight: 66
+        enabled: false
+      step:
+        weight: 67
+        enabled: false
+      step_by_step:
+        weight: 68
+        enabled: false
+      table:
+        weight: 69
+        enabled: false
+      wysiwyg:
+        weight: 70
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.media_list_videos.field_buttons.yml
+++ b/config/sync/field.field.node.media_list_videos.field_buttons.yml
@@ -1,0 +1,133 @@
+uuid: 11a4c6e6-5bb8-4c52-a67e-d21d341394bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_buttons
+    - node.type.media_list_videos
+    - paragraphs.paragraphs_type.button
+  module:
+    - entity_reference_revisions
+id: node.media_list_videos.field_buttons
+field_name: field_buttons
+entity_type: node
+bundle: media_list_videos
+label: 'CTA buttons'
+description: 'Add a Call to Action button. At least 1 required. Up to 2 max.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      button: button
+    target_bundles_drag_drop:
+      address:
+        weight: 36
+        enabled: false
+      alert:
+        weight: 37
+        enabled: false
+      alert_single:
+        weight: 38
+        enabled: false
+      button:
+        enabled: true
+        weight: 39
+      checklist:
+        weight: 40
+        enabled: false
+      checklist_item:
+        weight: 41
+        enabled: false
+      collapsible_panel:
+        weight: 42
+        enabled: false
+      collapsible_panel_item:
+        weight: 43
+        enabled: false
+      downloadable_file:
+        weight: 44
+        enabled: false
+      expandable_text:
+        weight: 45
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 46
+        enabled: false
+      link_teaser:
+        weight: 47
+        enabled: false
+      list_of_link_teasers:
+        weight: 48
+        enabled: false
+      list_of_links:
+        weight: 49
+        enabled: false
+      lists_of_links:
+        weight: 50
+        enabled: false
+      media:
+        weight: 51
+        enabled: false
+      media_list_videos:
+        weight: 52
+        enabled: false
+      non_reusable_alert:
+        weight: 53
+        enabled: false
+      number_callout:
+        weight: 54
+        enabled: false
+      phone_number:
+        weight: 55
+        enabled: false
+      process:
+        weight: 56
+        enabled: false
+      q_a:
+        weight: 57
+        enabled: false
+      q_a_group:
+        weight: 58
+        enabled: false
+      q_a_section:
+        weight: 59
+        enabled: false
+      react_widget:
+        weight: 60
+        enabled: false
+      service_location:
+        weight: 61
+        enabled: false
+      service_location_address:
+        weight: 62
+        enabled: false
+      situation_update:
+        weight: 63
+        enabled: false
+      spanish_translation_summary:
+        weight: 64
+        enabled: false
+      staff_profile:
+        weight: 65
+        enabled: false
+      starred_horizontal_rule:
+        weight: 66
+        enabled: false
+      step:
+        weight: 67
+        enabled: false
+      step_by_step:
+        weight: 68
+        enabled: false
+      table:
+        weight: 69
+        enabled: false
+      wysiwyg:
+        weight: 70
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.media_list_videos.field_buttons_repeat.yml
+++ b/config/sync/field.field.node.media_list_videos.field_buttons_repeat.yml
@@ -1,0 +1,23 @@
+uuid: acf4e5b8-f7da-447e-bd72-9bd587c424f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_buttons_repeat
+    - node.type.media_list_videos
+id: node.media_list_videos.field_buttons_repeat
+field_name: field_buttons_repeat
+entity_type: node
+bundle: media_list_videos
+label: 'Repeat CTA buttons'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.media_list_videos.field_description.yml
+++ b/config/sync/field.field.node.media_list_videos.field_description.yml
@@ -1,0 +1,19 @@
+uuid: e7597764-29c4-4a3e-b6e8-05f94acc3795
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_description
+    - node.type.media_list_videos
+id: node.media_list_videos.field_description
+field_name: field_description
+entity_type: node
+bundle: media_list_videos
+label: 'Meta description'
+description: 'Add a description to be used in search results, social media shares, and teaser listings. (<a href="https://design.va.gov/content-style-guide/seo#meta-properties" target=“_blank”>See further guidelines</a>)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.media_list_videos.field_intro_text_limited_html.yml
+++ b/config/sync/field.field.node.media_list_videos.field_intro_text_limited_html.yml
@@ -1,0 +1,27 @@
+uuid: aaafe95e-1c1a-4e6e-b2f8-20a870e13724
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_intro_text_limited_html
+    - node.type.media_list_videos
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text_limited: rich_text_limited
+    rich_text: '0'
+    plain_text: '0'
+id: node.media_list_videos.field_intro_text_limited_html
+field_name: field_intro_text_limited_html
+entity_type: node
+bundle: media_list_videos
+label: 'Page introduction'
+description: 'Add an introduction that helps visitors understand if information on the page is relevant to them.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.node.media_list_videos.field_media_list_videos.yml
+++ b/config/sync/field.field.node.media_list_videos.field_media_list_videos.yml
@@ -1,0 +1,133 @@
+uuid: 4431fcaa-b3a9-49ff-87d4-536d19bdaa17
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_media_list_videos
+    - node.type.media_list_videos
+    - paragraphs.paragraphs_type.media_list_videos
+  module:
+    - entity_reference_revisions
+id: node.media_list_videos.field_media_list_videos
+field_name: field_media_list_videos
+entity_type: node
+bundle: media_list_videos
+label: Videos
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      media_list_videos: media_list_videos
+    target_bundles_drag_drop:
+      address:
+        weight: 36
+        enabled: false
+      alert:
+        weight: 37
+        enabled: false
+      alert_single:
+        weight: 38
+        enabled: false
+      button:
+        weight: 39
+        enabled: false
+      checklist:
+        weight: 40
+        enabled: false
+      checklist_item:
+        weight: 41
+        enabled: false
+      collapsible_panel:
+        weight: 42
+        enabled: false
+      collapsible_panel_item:
+        weight: 43
+        enabled: false
+      downloadable_file:
+        weight: 44
+        enabled: false
+      expandable_text:
+        weight: 45
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 46
+        enabled: false
+      link_teaser:
+        weight: 47
+        enabled: false
+      list_of_link_teasers:
+        weight: 48
+        enabled: false
+      list_of_links:
+        weight: 49
+        enabled: false
+      lists_of_links:
+        weight: 50
+        enabled: false
+      media:
+        weight: 51
+        enabled: false
+      media_list_videos:
+        enabled: true
+        weight: 52
+      non_reusable_alert:
+        weight: 53
+        enabled: false
+      number_callout:
+        weight: 54
+        enabled: false
+      phone_number:
+        weight: 55
+        enabled: false
+      process:
+        weight: 56
+        enabled: false
+      q_a:
+        weight: 57
+        enabled: false
+      q_a_group:
+        weight: 58
+        enabled: false
+      q_a_section:
+        weight: 59
+        enabled: false
+      react_widget:
+        weight: 60
+        enabled: false
+      service_location:
+        weight: 61
+        enabled: false
+      service_location_address:
+        weight: 62
+        enabled: false
+      situation_update:
+        weight: 63
+        enabled: false
+      spanish_translation_summary:
+        weight: 64
+        enabled: false
+      staff_profile:
+        weight: 65
+        enabled: false
+      starred_horizontal_rule:
+        weight: 66
+        enabled: false
+      step:
+        weight: 67
+        enabled: false
+      step_by_step:
+        weight: 68
+        enabled: false
+      table:
+        weight: 69
+        enabled: false
+      wysiwyg:
+        weight: 70
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.media_list_videos.field_meta_title.yml
+++ b/config/sync/field.field.node.media_list_videos.field_meta_title.yml
@@ -1,0 +1,19 @@
+uuid: 13720a20-1e0e-4ec2-96dc-77d159c59fba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_title
+    - node.type.media_list_videos
+id: node.media_list_videos.field_meta_title
+field_name: field_meta_title
+entity_type: node
+bundle: media_list_videos
+label: 'Meta title tag'
+description: 'Add a meta title to be used in search results and the browser tab. Use title case capitalization and include " | Veterans Affairs" at the end. (<a href="https://design.va.gov/content-style-guide/seo#meta-properties" target=“_blank”>See further guidelines</a>)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_alert_single.yml
+++ b/config/sync/field.storage.node.field_alert_single.yml
@@ -1,0 +1,21 @@
+uuid: 6fd15b3f-7e5b-4078-bc54-1d865676c33c
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_alert_single
+field_name: field_alert_single
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_media_list_videos.yml
+++ b/config/sync/field.storage.node.field_media_list_videos.yml
@@ -1,0 +1,21 @@
+uuid: 68e3da3c-f7ec-458f-a85c-7bd4309213f3
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_media_list_videos
+field_name: field_media_list_videos
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node.type.media_list_videos.yml
+++ b/config/sync/node.type.media_list_videos.yml
@@ -1,0 +1,29 @@
+uuid: da6cd3d4-ffd5-46ef-9449-3f7e91a44362
+langcode: en
+status: true
+dependencies:
+  module:
+    - lightning_workflow
+    - menu_ui
+    - node_revision_delete
+    - node_title_help_text
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  node_title_help_text:
+    title_help: 'Add a page title with sentence case capitalization. (<a href="https://design.va.gov/content-style-guide/capitalization" target="_blank">See further guidelines</a>) '
+  lightning_workflow:
+    workflow: editorial
+  node_revision_delete:
+    minimum_revisions_to_keep: 200
+    minimum_age_to_delete: 0
+    when_to_delete: 0
+name: 'Media list - Videos'
+type: media_list_videos
+description: ''
+help: ''
+new_revision: true
+preview_mode: 0
+display_submitted: false

--- a/config/sync/search_api.index.content.yml
+++ b/config/sync/search_api.index.content.yml
@@ -50,6 +50,7 @@ field_settings:
           landing_page: default
           leadership_listing: default
           locations_listing: default
+          media_list_videos: default
           nca_facility: default
           news_story: default
           outreach_asset: default

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -89,6 +89,7 @@ display:
               landing_page: default
               leadership_listing: default
               locations_listing: default
+              media_list_videos: default
               nca_facility: default
               news_story: default
               outreach_asset: default

--- a/config/sync/workbench_access.access_scheme.section.yml
+++ b/config/sync/workbench_access.access_scheme.section.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.landing_page.field_administration
     - field.field.node.leadership_listing.field_administration
     - field.field.node.locations_listing.field_administration
+    - field.field.node.media_list_videos.field_administration
     - field.field.node.nca_facility.field_administration
     - field.field.node.news_story.field_administration
     - field.field.node.office.field_administration
@@ -197,6 +198,10 @@ scheme_settings:
     -
       entity_type: node
       bundle: checklist
+      field: field_administration
+    -
+      entity_type: node
+      bundle: media_list_videos
       field: field_administration
     -
       entity_type: taxonomy_term

--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -18,6 +18,7 @@ dependencies:
     - node.type.landing_page
     - node.type.leadership_listing
     - node.type.locations_listing
+    - node.type.media_list_videos
     - node.type.nca_facility
     - node.type.news_story
     - node.type.office
@@ -131,6 +132,7 @@ type_settings:
       - landing_page
       - leadership_listing
       - locations_listing
+      - media_list_videos
       - nca_facility
       - news_story
       - office

--- a/docroot/modules/custom/va_gov_backend/js/script.js
+++ b/docroot/modules/custom/va_gov_backend/js/script.js
@@ -64,7 +64,7 @@
 
         // Loops through alerts that have non reusable alert fielsets present and disables alert selection field.
         $.each(nonReusableAlertAddedIds,function (key, value) {
-          nonReusableAlertSelectionIds.push($('#' + value).closest('div[id*="subform-field-alert-wrapper"]').find(".paragraphs-subform").first().children(".field--name-field-alert-selection").children().children(".fieldset-wrapper").children().attr("id"));
+          nonReusableAlertSelectionIds.push($('#' + value).closest("div[id*='subform-field-alert-wrapper'],div[id*='alert-single-wrapper']").find(".paragraphs-subform").first().children(".field--name-field-alert-selection").children().children(".fieldset-wrapper").children().attr("id"));
           $.each(nonReusableAlertSelectionIds,function (key, value) {
             $('#' + value + '> div > input').each(function () {
               $(this).prop('disabled', true);

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -38,6 +38,7 @@ Feature: Content model bundles
 | List of links | list_of_links | Paragraph type | A set of links, with link text and URL required, and an optional header. |
 | Lists of links | lists_of_links | Paragraph type | WARNING: Learning Center and User Guides only! A list of links, or several lists of links, with an optional section header. |
 | Locations List | locations_listing | Content type | A listing of VA facilities. |
+| Media list - Videos | media_list_videos | Content type |  |
 | Media list - Images | media_list_images | Paragraph type |  |
 | Media list - Videos | media_list_videos | Paragraph type |  |
 | NCA Facility | nca_facility | Content type | A facility within National Cemetery Administration system. |

--- a/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
@@ -114,6 +114,14 @@ Feature: Content model: Content Type fields
 | Content type | Locations List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Locations List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Locations List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Media list - Videos | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic |  |
+| Content type | Media list - Videos | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | Media list - Videos | Meta description | field_description | Text (plain) | Required | 1 | Textfield | Translatable |
+| Content type | Media list - Videos | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield | Translatable |
+| Content type | Media list - Videos | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Media list - Videos | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Media list - Videos | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Media list - Videos | Videos | field_media_list_videos | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | NCA Facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | NCA Facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
 | Content type | NCA Facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |


### PR DESCRIPTION
## Description

See _issueid_. https://app.zenhub.com/workspaces/vagov-cms-team-5c0e7b864b5806bc2bfc2087/issues/department-of-veterans-affairs/va.gov-cms/2456

## Testing done


## Screenshots


## QA steps

As an admin
1. Login
1. Navigate here: admin/structure/types/manage/media_list_videos
3. Confirm the following AC
 - [ ] content type "Media list - Videos" | media_list_videos exists
    - [ ] add field "Alert" field_alert | entity revisions reference to "Alert (Single)" paragraph only | cardinality single | 
           optional directly under "Title and introduction" fieldset
    - [ ] add field_media_list_videos below CTA buttons field | label "Videos" | entity reference to paragraph type "Media 
           list - Videos" | cardinality - single
    - [ ] editorial / node view experience is using established patterns and does not have UX regressions
    - [ ] spec tool / tests update
4. Regression test the Alert Single component field on the Media List - Videos content type as well as the Step-by-step content type.
  - [ ] Alert single behaviors still work.

## Definition of Done
- [ ] Product release are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
