### PR TITLE
VACMS-2756 Add file_public_base_url to lando dev,staging and prod env…

### DIFF
--- a/docroot/sites/default/settings/settings.dev.php
+++ b/docroot/sites/default/settings/settings.dev.php
@@ -22,6 +22,7 @@ $config['system.logging']['error_level'] = 'all';
 $config['environment_indicator.indicator']['bg_color'] = '#05F901';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Development';
+$settings['file_public_base_url'] = 'https://dev.cms.va.gov/sites/default/files';
 
 
 $settings['trusted_host_patterns'] = [

--- a/docroot/sites/default/settings/settings.lando.php
+++ b/docroot/sites/default/settings/settings.lando.php
@@ -25,6 +25,8 @@ $config['environment_indicator.indicator']['name'] = 'Lando';
 // Link to this file locally since lando can not access prod where the real
 // file exists.  You will need to copy the file from the same path on prod.
 $config['migrate_plus.migration.va_node_form']['source']['urls'] = ['http://va-gov-cms.lndo.site/sites/default/files/migrate_source/va_forms_data.csv'];
+$settings['file_public_base_url'] = 'http://va-gov-cms.lndo.site/sites/default/files';
+
 
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.

--- a/docroot/sites/default/settings/settings.lando.php
+++ b/docroot/sites/default/settings/settings.lando.php
@@ -27,7 +27,6 @@ $config['environment_indicator.indicator']['name'] = 'Lando';
 $config['migrate_plus.migration.va_node_form']['source']['urls'] = ['http://va-gov-cms.lndo.site/sites/default/files/migrate_source/va_forms_data.csv'];
 $settings['file_public_base_url'] = 'http://va-gov-cms.lndo.site/sites/default/files';
 
-
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.
     'localhost',

--- a/docroot/sites/default/settings/settings.prod.php
+++ b/docroot/sites/default/settings/settings.prod.php
@@ -21,6 +21,7 @@ $config['system.logging']['error_level'] = 'none';
 $config['environment_indicator.indicator']['bg_color'] = '#ff2301';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Production';
+$settings['file_public_base_url'] = 'https://prod.cms.va.gov/sites/default/files';
 
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.

--- a/docroot/sites/default/settings/settings.staging.php
+++ b/docroot/sites/default/settings/settings.staging.php
@@ -21,6 +21,7 @@ $config['system.logging']['error_level'] = 'none';
 $config['environment_indicator.indicator']['bg_color'] = '#fffb03';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Staging';
+$settings['file_public_base_url'] = 'https://staging.cms.va.gov/sites/default/files';
 
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.


### PR DESCRIPTION
## Description

See #2756 . 

## Testing done
1. Saved a node with a defined image `/node/2299/edit`
2. inspected the output of that page in the content export 
`node.5f30741e-d04b-4d0e-858a-3ab94334e3ca.json`
3. examined metatag image paths to make sure they contained the proper domain and path.
![image](https://user-images.githubusercontent.com/5752113/91207284-82cbb700-e6d6-11ea-9de1-b43abc6598a2.png)

4. Examined path to page and made sure it was unaffected.

![image](https://user-images.githubusercontent.com/5752113/91207320-92e39680-e6d6-11ea-975d-bf9fb3858c2d.png)

5. Examined view of the page to make sure the rendering of the image still worked
`/wilkes-barre-health-care/locations/northampton-county-va-clinic`
![image](https://user-images.githubusercontent.com/5752113/91207440-bd355400-e6d6-11ea-817f-65e4587586ea.png)


## Screenshots


## QA steps
Testing wont be possible in CI because those paths are dyanmic and unaffected by these changes.   Will need to be tested on dev or staging.

As an admin:

- [ ]  Save a node with a defined image `https://staging.cms.va.gov/node/2299/edit`
- [ ]  inspect the output of that page in the content export 
`docroot/sites/default/files/cms-export-content/node.5f30741e-d04b-4d0e-858a-3ab94334e3ca.json`
- [ ]  examine metatag image paths in the export file to make sure it contains the proper domain and path like this
`"image_src": "https:\/\/staging.cms.va.gov\/sites\/default\/files\/2020-04\/Northampton_480x330.jpg",`
- [ ] scroll down to the path element and make sure the path to the node is root relative like 
`"path": "\/wilkes-barre-health-care\/locations\/northampton-county-va-clinic"`
- [ ] Examine the view mode of the page `https://staging.cms.va.gov/wilkes-barre-health-care/locations/northampton-county-va-clinic` and validate the page still shows the image.



## Definition of Done
- [ ] Product release are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
