### PR TITLE
VACMS-2464 Alter reverse field logic for deletes and unpublishes

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
@@ -43,6 +43,7 @@ class ListDataCompiler {
     'publication_listing' => ['field_listing'],
     'regional_health_care_service_des' => ['field_regional_health_service', 'field_clinical_health_services'],
     'story_listing' => ['field_listing'],
+    'vamc_operating_status_and_alerts' => ['field_banner_alert_vamcs'],
     // Should be lists, but can not find anything that points to these as a
     // reverse entity reference.
     // 'health_services_listing', Connected through Taxonomy

--- a/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ListDataCompiler.php
@@ -90,14 +90,17 @@ class ListDataCompiler {
    *   The entity which may reference lists.
    * @param \Drupal\va_gov_content_export\TomeExporter $tomeExporter
    *   The tome exporter.
-   *
-   * @todo This implementation creates one risk of failure in that, any list
-   * item that has been moved from one list to another, will not know to remove
-   * it from the original list.
-   * https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2464 .
    */
   public function updateReverseEntityReferenceLists(ContentEntityInterface $entity, TomeExporter $tomeExporter) {
     $entityReferenceTargetNids = $this->getListNids($entity);
+    // Check to see if we have to update any removals from reverse fields.
+    $original = !empty($entity->original) ? $entity->original : NULL;
+    if (!empty($original)) {
+      $entityReferenceTargetNidsRemovals = $this->getListNids($original);
+      // Merge any removals with other reverse entity refrerences to update.
+      $entityReferenceTargetNids = $entityReferenceTargetNids + $entityReferenceTargetNidsRemovals;
+    }
+
     $entityReferenceTargetNidsToUpdateLater = [];
     $targetNodesToUpdateLater = [];
     if (!empty($entityReferenceTargetNids)) {

--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -128,8 +128,8 @@ class TomeExporter extends Exporter {
     foreach (array_keys($entity->getTranslationLanguages()) as $langcode) {
       $this->contentStorage->delete(TomeSyncHelper::getContentName($entity->getTranslation($langcode)));
     }
-    // @todo Look to see if any reverse entity fields were part of this deleted
-    // entity, and update them.
+    // There may have been reverse entity references that need to be updated.
+    $this->listDataCompiler->updateReverseEntityReferenceLists($entity, $this);
     if ($entity instanceof FileInterface) {
       $this->fileSync->deleteFileExport($entity);
     }

--- a/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
+++ b/docroot/modules/custom/va_gov_content_export/src/TomeExporter.php
@@ -128,6 +128,8 @@ class TomeExporter extends Exporter {
     foreach (array_keys($entity->getTranslationLanguages()) as $langcode) {
       $this->contentStorage->delete(TomeSyncHelper::getContentName($entity->getTranslation($langcode)));
     }
+    // @todo Look to see if any reverse entity fields were part of this deleted
+    // entity, and update them.
     if ($entity instanceof FileInterface) {
       $this->fileSync->deleteFileExport($entity);
     }


### PR DESCRIPTION
## Description

See #2464. 




## QA steps
1. Edit /node/7829 (an event) and change its " Where should the event be listed?" from "Outreach: to "Va Coatseville health care Events" and save the node.
![image](https://user-images.githubusercontent.com/5752113/94049198-a69c1e80-fda2-11ea-9182-1d59ddc89807.png)
- [x] validate that   Outreach hub events list export 
/docroot/sites/default/files/cms-export-content/node.30295cab-89be-4173-a33c-8c0ca0a85d07.json
does not contain an entry for  node 7829 in `"reverse_field_listing": [`    (the entries are in order, it would be the last one in the file if it was there)
![image](https://user-images.githubusercontent.com/5752113/94049973-a05a7200-fda3-11ea-80b9-2b20d039f7fd.png)
- [x] Validate that the export for VA Coatesville events 
/docroot/sites/default/files/cms-export-content/node.92fad4d5-d4b0-472d-894d-7dbf5a01d2c5.json  contains an entry in `"reverse_field_listing": [` 
![image](https://user-images.githubusercontent.com/5752113/94050986-f7147b80-fda4-11ea-83ab-c5a95a394cb0.png)


2. Delete node/7829
- [x] Validate that the export for VA Coatesville events 
/docroot/sites/default/files/cms-export-content/node.92fad4d5-d4b0-472d-894d-7dbf5a01d2c5.json  contains no entry for node 7829 in `"reverse_field_listing": [`  
![image](https://user-images.githubusercontent.com/5752113/94050394-31c9e400-fda4-11ea-9ac3-a5e779a32dc7.png)

