### PR TITLE
Revert "VACMS-2756 Add file_public_base_url to lando dev,staging and …

### DIFF
--- a/docroot/sites/default/settings/settings.dev.php
+++ b/docroot/sites/default/settings/settings.dev.php
@@ -22,7 +22,6 @@ $config['system.logging']['error_level'] = 'all';
 $config['environment_indicator.indicator']['bg_color'] = '#05F901';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Development';
-$settings['file_public_base_url'] = 'https://dev.cms.va.gov/sites/default/files';
 
 
 $settings['trusted_host_patterns'] = [

--- a/docroot/sites/default/settings/settings.lando.php
+++ b/docroot/sites/default/settings/settings.lando.php
@@ -25,7 +25,6 @@ $config['environment_indicator.indicator']['name'] = 'Lando';
 // Link to this file locally since lando can not access prod where the real
 // file exists.  You will need to copy the file from the same path on prod.
 $config['migrate_plus.migration.va_node_form']['source']['urls'] = ['http://va-gov-cms.lndo.site/sites/default/files/migrate_source/va_forms_data.csv'];
-$settings['file_public_base_url'] = 'http://va-gov-cms.lndo.site/sites/default/files';
 
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.

--- a/docroot/sites/default/settings/settings.prod.php
+++ b/docroot/sites/default/settings/settings.prod.php
@@ -21,7 +21,6 @@ $config['system.logging']['error_level'] = 'none';
 $config['environment_indicator.indicator']['bg_color'] = '#ff2301';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Production';
-$settings['file_public_base_url'] = 'https://prod.cms.va.gov/sites/default/files';
 
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.

--- a/docroot/sites/default/settings/settings.staging.php
+++ b/docroot/sites/default/settings/settings.staging.php
@@ -21,7 +21,6 @@ $config['system.logging']['error_level'] = 'none';
 $config['environment_indicator.indicator']['bg_color'] = '#fffb03';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Staging';
-$settings['file_public_base_url'] = 'https://staging.cms.va.gov/sites/default/files';
 
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.


### PR DESCRIPTION
…prod env… (#2761)"

This reverts commit ddf91d229e8d9fb3347307e678e6bc70aa7ed268.

This is needed to remove the domain that is breaking the front end build because jenkins can  not resolve the actual domain.