### PR TITLE
VACMS-2814: Adding new paragraph checklist field config.

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.checklist.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.checklist.default.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - field.field.paragraph.checklist.field_checklist_sections
     - field.field.paragraph.checklist.field_section_header
+    - field.field.paragraph.checklist.field_section_intro
     - paragraphs.paragraphs_type.checklist
   module:
     - paragraphs
+    - textfield_counter
 id: paragraph.checklist.default
 targetEntityType: paragraph
 bundle: checklist
@@ -15,7 +17,7 @@ mode: default
 content:
   field_checklist_sections:
     type: paragraphs
-    weight: 1
+    weight: 2
     settings:
       title: 'Checklist section'
       title_plural: 'Checklist sections'
@@ -37,8 +39,27 @@ content:
     settings:
       size: 60
       placeholder: ''
+      maxlength: 70
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
     third_party_settings: {  }
-    type: string_textfield
+    type: string_textfield_with_counter
+    region: content
+  field_section_intro:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+      maxlength: 300
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings: {  }
+    type: string_textarea_with_counter
     region: content
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.paragraph.checklist.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.checklist.default.yml
@@ -57,7 +57,7 @@ content:
       counter_position: after
       js_prevent_submit: true
       count_html_characters: true
-      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
     type: string_textarea_with_counter
     region: content

--- a/config/sync/core.entity_form_display.paragraph.checklist.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.checklist.default.yml
@@ -43,7 +43,7 @@ content:
       counter_position: after
       js_prevent_submit: true
       count_html_characters: true
-      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
       use_field_maxlength: false
     third_party_settings: {  }
     type: string_textfield_with_counter

--- a/config/sync/core.entity_form_display.paragraph.checklist_item.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.checklist_item.default.yml
@@ -31,7 +31,7 @@ content:
       counter_position: after
       js_prevent_submit: true
       count_html_characters: true
-      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
       use_field_maxlength: false
     third_party_settings: {  }
     type: string_textfield_with_counter

--- a/config/sync/core.entity_form_display.paragraph.checklist_item.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.checklist_item.default.yml
@@ -5,14 +5,17 @@ dependencies:
   config:
     - field.field.paragraph.checklist_item.field_checklist_items
     - field.field.paragraph.checklist_item.field_section_header
+    - field.field.paragraph.checklist_item.field_section_intro
     - paragraphs.paragraphs_type.checklist_item
+  module:
+    - textfield_counter
 id: paragraph.checklist_item.default
 targetEntityType: paragraph
 bundle: checklist_item
 mode: default
 content:
   field_checklist_items:
-    weight: 1
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -24,8 +27,27 @@ content:
     settings:
       size: 60
       placeholder: ''
+      maxlength: 70
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
     third_party_settings: {  }
-    type: string_textfield
+    type: string_textfield_with_counter
+    region: content
+  field_section_intro:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+      maxlength: 300
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings: {  }
+    type: string_textarea_with_counter
     region: content
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.paragraph.checklist_item.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.checklist_item.default.yml
@@ -45,7 +45,7 @@ content:
       counter_position: after
       js_prevent_submit: true
       count_html_characters: true
-      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
     type: string_textarea_with_counter
     region: content

--- a/config/sync/core.entity_view_display.paragraph.checklist.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.checklist.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.checklist.field_checklist_sections
     - field.field.paragraph.checklist.field_section_header
+    - field.field.paragraph.checklist.field_section_intro
     - paragraphs.paragraphs_type.checklist
   module:
     - entity_reference_revisions
@@ -15,7 +16,7 @@ mode: default
 content:
   field_checklist_sections:
     type: entity_reference_revisions_entity_view
-    weight: 1
+    weight: 2
     label: above
     settings:
       view_mode: default
@@ -29,6 +30,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_section_intro:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
 hidden:
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.checklist_item.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.checklist_item.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.checklist_item.field_checklist_items
     - field.field.paragraph.checklist_item.field_section_header
+    - field.field.paragraph.checklist_item.field_section_intro
     - paragraphs.paragraphs_type.checklist_item
 id: paragraph.checklist_item.default
 targetEntityType: paragraph
@@ -12,7 +13,7 @@ bundle: checklist_item
 mode: default
 content:
   field_checklist_items:
-    weight: 1
+    weight: 2
     label: above
     settings:
       link_to_entity: false
@@ -26,6 +27,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_section_intro:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
 hidden:
   search_api_excerpt: true

--- a/config/sync/field.field.paragraph.checklist.field_section_intro.yml
+++ b/config/sync/field.field.paragraph.checklist.field_section_intro.yml
@@ -1,0 +1,19 @@
+uuid: e7eb8f58-f274-488e-b6da-e0268a5d34c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_section_intro
+    - paragraphs.paragraphs_type.checklist
+id: paragraph.checklist.field_section_intro
+field_name: field_section_intro
+entity_type: paragraph
+bundle: checklist
+label: 'Section Intro'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.paragraph.checklist_item.field_section_intro.yml
+++ b/config/sync/field.field.paragraph.checklist_item.field_section_intro.yml
@@ -1,0 +1,19 @@
+uuid: 46d33397-2a81-4af6-9f4a-ec5f7a294541
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_section_intro
+    - paragraphs.paragraphs_type.checklist_item
+id: paragraph.checklist_item.field_section_intro
+field_name: field_section_intro
+entity_type: paragraph
+bundle: checklist_item
+label: 'Section Intro'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -29,9 +29,11 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Button | Button Label | field_button_label | Text (plain) |  | 1 | Textfield with counter |  |
 | Paragraph type | Button | Button Link | field_button_link | Link |  | 1 | Link |  |
 | Paragraph type | Checklist | Checklist sections | field_checklist_sections | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
-| Paragraph type | Checklist | Section Header | field_section_header | Text (plain) | Required | 1 | Textfield | Translatable |
+| Paragraph type | Checklist | Section Header | field_section_header | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Paragraph type | Checklist | Section Intro | field_section_intro | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Checklist section | Checklist items | field_checklist_items | Text (plain) |  | Unlimited | Textfield |  |
-| Paragraph type | Checklist section | Section Header | field_section_header | Text (plain) |  | 1 | Textfield | Translatable |
+| Paragraph type | Checklist section | Section Header | field_section_header | Text (plain) |  | 1 | Textfield with counter | Translatable |
+| Paragraph type | Checklist section | Section Intro | field_section_intro | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Embedded image | Allow clicks on this image to open it in new tab | field_allow_clicks_on_this_image | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Embedded image | Markup | field_markup | Markup |  | 1 | Markup |  |
 | Paragraph type | Embedded image | Select an image | field_media | Entity reference |  | 1 | Media library |  |
@@ -49,6 +51,10 @@ Feature: Content model: Paragraph fields
 | Paragraph type | List of links | Final link | field_link | Link |  | 1 | Linkit | Translatable |
 | Paragraph type | Lists of links | List of links | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable |
 | Paragraph type | Lists of links | Section Header | field_section_header | Text (plain) |  | 1 | Textfield | Translatable |
+| Paragraph type | Media list - Videos | Section Header | field_section_header | Text (plain) |  | 1 | Textfield | Translatable |
+| Paragraph type | Media list - Videos | Videos | field_videos | Entity reference | Required | Unlimited | Media library |  |
+| Paragraph type | Media list - Images | Images | field_images | Entity reference | Required | Unlimited | Media library |  |
+| Paragraph type | Media list - Images | Section Header | field_section_header | Text (plain) |  | 1 | Textfield | Translatable |
 | Paragraph type | Number callout | Additional information | field_wysiwyg | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Number callout | Short phrase with a number, or time element | field_short_phrase_with_a_number | Text (plain) | Required | 1 | Textfield with counter |  |
 | Paragraph type | Non-reusable Alert | Alert Content | field_va_paragraphs | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL | Translatable |
@@ -98,8 +104,4 @@ Feature: Content model: Paragraph fields
 | Paragraph type | VAMC facility service (non-healthcare service) | Service name | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Paragraph type | VAMC facility service (non-healthcare service) | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | WYSIWYG | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Paragraph type | Media list - Videos | Section Header | field_section_header | Text (plain) |  | 1 | Textfield | Translatable |
-| Paragraph type | Media list - Videos | Videos | field_videos | Entity reference | Required | Unlimited | Media library |  |
-| Paragraph type | Media list - Images | Images | field_images | Entity reference | Required | Unlimited | Media library |  |
-| Paragraph type | Media list - Images | Section Header | field_section_header | Text (plain) |  | 1 | Textfield | Translatable |
 


### PR DESCRIPTION
## Description
See #2814 

## Testing done
Visual / behat

## QA steps
- As an admin, go to `/admin/structure/paragraphs_type/checklist/fields` & `field /admin/structure/paragraphs_type/checklist_item/fields`
- Visually verify that fields on form and in node view mode are ordered with intro below header
- Visually verify that header is limited to 70 chars, and intro is limited to 300 chars.