### PR TITLE
VACMS-2756 Set file path location.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -132,6 +132,8 @@ $settings['config_sync_directory'] = '../config/sync';
 
 $env_type = getenv('CMS_ENVIRONMENT_TYPE') ?: 'ci';
 
+$settings['file_public_base_url'] = "{$_SERVER['HTTP_HOST']}/sites/default/files";
+
 $config['govdelivery_bulletins.settings']['govdelivery_endpoint'] = getenv('CMS_GOVDELIVERY_ENDPOINT') ?: FALSE;
 $config['govdelivery_bulletins.settings']['govdelivery_username'] = getenv('CMS_GOVDELIVERY_USERNAME') ?: FALSE;
 $config['govdelivery_bulletins.settings']['govdelivery_password'] = getenv('CMS_GOVDELIVERY_PASSWORD') ?: FALSE;
@@ -169,11 +171,6 @@ if (file_exists($app_root . '/' . $site_path . '/settings/settings.fast_404.php'
   include $app_root . '/' . $site_path . '/settings/settings.fast_404.php';
 }
 
-// Ansible moves this file into place during deploy, so if it is present we are in deploy mode.
-if (file_exists($app_root . '/' . $site_path . '/settings/settings.deploy.active.php')) {
-  include $app_root . '/' . $site_path . '/settings/settings.deploy.active.php';
-}
-
 /**
  * Load local development override configuration, if available.
  *
@@ -187,16 +184,6 @@ if (file_exists($app_root . '/' . $site_path . '/settings/settings.deploy.active
 // Local settings, must stay at bottom of file, this file is ignored by git.
 if (file_exists($app_root . '/' . $site_path . '/settings/settings.local.php')) {
   include $app_root . '/' . $site_path . '/settings/settings.local.php';
-}
-
-// The VA_GOV_IN_DEPLOY_MODE is set in settings.deploy.active.php.
-// Ths file is copied from settings.deploy.inactive.php. by ansible during deploys.
-if (!empty($GLOBALS['request']) &&
-  is_a($GLOBALS['request'], \Symfony\Component\HttpFoundation\Request::class) &&
-  !empty(getenv('VA_GOV_IN_DEPLOY_MODE'))) {
-
-  $deploy_service = new \Drupal\va_gov_backend\Deploy\DeployService();
-  $deploy_service->run($GLOBALS['request'], $app_root, $site_path);
 }
 
 $settings['tome_content_directory'] = 'public://cms-export-content';

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -132,8 +132,6 @@ $settings['config_sync_directory'] = '../config/sync';
 
 $env_type = getenv('CMS_ENVIRONMENT_TYPE') ?: 'ci';
 
-$settings['file_public_base_url'] = "{$_SERVER['HTTP_HOST']}/sites/default/files";
-
 $config['govdelivery_bulletins.settings']['govdelivery_endpoint'] = getenv('CMS_GOVDELIVERY_ENDPOINT') ?: FALSE;
 $config['govdelivery_bulletins.settings']['govdelivery_username'] = getenv('CMS_GOVDELIVERY_USERNAME') ?: FALSE;
 $config['govdelivery_bulletins.settings']['govdelivery_password'] = getenv('CMS_GOVDELIVERY_PASSWORD') ?: FALSE;
@@ -171,6 +169,11 @@ if (file_exists($app_root . '/' . $site_path . '/settings/settings.fast_404.php'
   include $app_root . '/' . $site_path . '/settings/settings.fast_404.php';
 }
 
+// Ansible moves this file into place during deploy, so if it is present we are in deploy mode.
+if (file_exists($app_root . '/' . $site_path . '/settings/settings.deploy.active.php')) {
+  include $app_root . '/' . $site_path . '/settings/settings.deploy.active.php';
+}
+
 /**
  * Load local development override configuration, if available.
  *
@@ -185,6 +188,27 @@ if (file_exists($app_root . '/' . $site_path . '/settings/settings.fast_404.php'
 if (file_exists($app_root . '/' . $site_path . '/settings/settings.local.php')) {
   include $app_root . '/' . $site_path . '/settings/settings.local.php';
 }
+
+// The VA_GOV_IN_DEPLOY_MODE is set in settings.deploy.active.php.
+// Ths file is copied from settings.deploy.inactive.php. by ansible during deploys.
+if (!empty($GLOBALS['request']) &&
+  is_a($GLOBALS['request'], \Symfony\Component\HttpFoundation\Request::class) &&
+  !empty(getenv('VA_GOV_IN_DEPLOY_MODE'))) {
+
+  $deploy_service = new \Drupal\va_gov_backend\Deploy\DeployService();
+  $deploy_service->run($GLOBALS['request'], $app_root, $site_path);
+}
+
+if (PHP_SAPI === 'cli') {
+  // This is running from drush so set the webhost.
+  $webhost = $webhost_on_cli;
+}
+else {
+  //This is running from a web request.
+  $webhost = "{$_SERVER['REQUEST_SCHEME']}://{$_SERVER['HTTP_HOST']}";
+
+}
+ $settings['file_public_base_url'] = "{$webhost}/sites/default/files";
 
 $settings['tome_content_directory'] = 'public://cms-export-content';
 $settings['tome_files_directory'] = 'public://cms-export-files';

--- a/docroot/sites/default/settings/settings.dev.php
+++ b/docroot/sites/default/settings/settings.dev.php
@@ -23,6 +23,7 @@ $config['environment_indicator.indicator']['bg_color'] = '#05F901';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Development';
 
+$webhost_on_cli = 'https://dev.cms.va.gov';
 
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.

--- a/docroot/sites/default/settings/settings.lando.php
+++ b/docroot/sites/default/settings/settings.lando.php
@@ -22,6 +22,9 @@ $config['system.logging']['error_level'] = 'all';
 $config['environment_indicator.indicator']['bg_color'] = '#05F901';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Lando';
+
+$webhost_on_cliq = 'http://va-gov-cms.lndo.site';
+
 // Link to this file locally since lando can not access prod where the real
 // file exists.  You will need to copy the file from the same path on prod.
 $config['migrate_plus.migration.va_node_form']['source']['urls'] = ['http://va-gov-cms.lndo.site/sites/default/files/migrate_source/va_forms_data.csv'];

--- a/docroot/sites/default/settings/settings.prod.php
+++ b/docroot/sites/default/settings/settings.prod.php
@@ -22,6 +22,8 @@ $config['environment_indicator.indicator']['bg_color'] = '#ff2301';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Production';
 
+$webhost_on_cli = 'https://prod.cms.va.gov';
+
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.
     '10\.199.*',

--- a/docroot/sites/default/settings/settings.staging.php
+++ b/docroot/sites/default/settings/settings.staging.php
@@ -22,6 +22,8 @@ $config['environment_indicator.indicator']['bg_color'] = '#fffb03';
 $config['environment_indicator.indicator']['fg_color'] = '#000000';
 $config['environment_indicator.indicator']['name'] = 'Staging';
 
+$webhost_on_cli = 'https://staging.cms.va.gov';
+
 $settings['trusted_host_patterns'] = [
     // For ALB/ELB Healthchecks.
     '10\.199.*',


### PR DESCRIPTION
## Description

See #2756 . 

## Testing done
1. Saved a node with a defined image `/node/2299/edit`
2. inspected the output of that page in the content export 
`node.5f30741e-d04b-4d0e-858a-3ab94334e3ca.json`
3. examined metatag image paths to make sure they contained the proper domain and path.
![image](https://user-images.githubusercontent.com/5752113/93917075-7be59380-fcd8-11ea-87ae-823d62434437.png)



4. Examined path to page and made sure it was unaffected.

![image](https://user-images.githubusercontent.com/5752113/91207320-92e39680-e6d6-11ea-975d-bf9fb3858c2d.png)

5. Examined view of the page to make sure the rendering of the image still worked
`/wilkes-barre-health-care/locations/northampton-county-va-clinic`
![image](https://user-images.githubusercontent.com/5752113/91207440-bd355400-e6d6-11ea-817f-65e4587586ea.png)


## Screenshots


## QA steps
Testing wont be possible in CI because those paths are dyanmic and unaffected by these changes.   Will need to be tested on dev or staging.

As an admin:

- [ ]  Save a node with a defined image `https://staging.cms.va.gov/node/2299/edit`
- [ ]  inspect the output of that page in the content export 
`docroot/sites/default/files/cms-export-content/node.5f30741e-d04b-4d0e-858a-3ab94334e3ca.json`
- [ ]  examine metatag image paths in the export file to make sure it contains the proper domain and path like this
`"image_src": "\/sites\/default\/files\/2020-04\/Northampton_480x330.jpg",`
- [ ] scroll down to the path element and make sure the path to the node is root relative like 
`"path": "\/wilkes-barre-health-care\/locations\/northampton-county-va-clinic"`
- [ ] Examine the view mode of the page `https://staging.cms.va.gov/wilkes-barre-health-care/locations/northampton-county-va-clinic` and validate the page still shows the image.
- [ ] Check pdf links here /pittsburgh-health-care/stories/free-flu-shots-for-veterans  



## Definition of Done
- [ ] Product release are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
