### PR TITLE
Revert "Bump drupal/menu_breadcrumb from 1.8.0 to 1.14.0 (#2807)"

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7457,26 +7457,26 @@
         },
         {
             "name": "drupal/menu_breadcrumb",
-            "version": "1.14.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/menu_breadcrumb.git",
-                "reference": "8.x-1.14"
+                "reference": "8.x-1.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/menu_breadcrumb-8.x-1.14.zip",
-                "reference": "8.x-1.14",
-                "shasum": "3edeb447410cdb0635d0babbfc641010014bee7f"
+                "url": "https://ftp.drupal.org/files/projects/menu_breadcrumb-8.x-1.8.zip",
+                "reference": "8.x-1.8",
+                "shasum": "db3aee3edd5e34a750297709d74b61c0c7c432f7"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "~8.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.14",
-                    "datestamp": "1598626277",
+                    "version": "8.x-1.8",
+                    "datestamp": "1554988685",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
This reverts commit c080a65c5a175f494c0427fd9d3285a3206e5575.
because the update to menu_breadcrumb may be breaking FE content breadcrumbs.

## Description

See _issueid_. 



## QA steps

Trigger a FE content release:
Go to /pittsburgh-health-care/news-releases/va-pittsburgh-creates-first-va-dialysis-program-in-a-long-term/
- [ ] validate that breadcrumb looks like 
![image](https://user-images.githubusercontent.com/5752113/92019344-77a30780-ed24-11ea-840b-2d801a9ef363.png)

- [ ] validate that "see all releases" link near the bottom of the page points to `/pittsburgh-health-care/news-releases`
![image](https://user-images.githubusercontent.com/5752113/92019480-afaa4a80-ed24-11ea-94b0-83c971636ff9.png)
 

## Definition of Done
- [ ] Product release are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
