### PR TITLE
Add LinkItem normalizer

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/Normalizer/LinkItemNormalizer.php
+++ b/docroot/modules/custom/va_gov_content_export/src/Normalizer/LinkItemNormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\va_gov_content_export\Normalizer;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\link\LinkItemInterface;
+use Drupal\link\Plugin\Field\FieldType\LinkItem;
+use Drupal\serialization\Normalizer\FieldItemNormalizer;
+
+/**
+ * Normalizer for Link Items.
+ */
+class LinkItemNormalizer extends FieldItemNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = LinkItemInterface::class;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []) {
+    $attributes = parent::normalize($object, $format, $context);
+    /** @var \Drupal\link\LinkItemInterface $object */
+    if ($format === Json::getFileExtension()) {
+      $attributes[LinkItem::mainPropertyName()] = $object->getUrl()->toString();
+    }
+    return $attributes;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.services.yml
@@ -4,6 +4,10 @@ services:
     arguments: ['@entity.manager']
     tags:
       - { name: normalizer, priority: 1 }
+  services.normalizer.va_gov_content_export.link:
+    class: Drupal\va_gov_content_export\Normalizer\LinkItemNormalizer
+    tags:
+      - { name: normalizer, priority: 8 }
   tome_sync.exporter.va_gov_content_export:
     class: Drupal\va_gov_content_export\TomeExporter
     decorates: tome_sync.exporter


### PR DESCRIPTION
## Description

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/13177. 

Link fields were not exporting the full url.  They were using the Drupal uri schema.  GraphQL has it's own logic (`Drupal\graphql_core\Plugin\GraphQL\Fields\Entity\Fields\Link\LinkUrl`)to change the format of a link field outside of using normalizers.  My solution is to use a normalizer on JSON output.

## Testing done

Ran bulk export and saved the node to note the output of link files.
* View json file `docroot/sites/default/files/cms-export-content/paragraph.98ab52e2-2bc4-44a8-b05a-33024e467572.json`
* See that is contains the incorrect format for `field_link`
```
    "field_link": [
        {
            "uri": "entity:node/1e8a72b4-c54c-432e-b53a-ef6a7969f40e",
            "title": "Get help from a patient advocate",
            "options": []
        }
    ],
```
* Save node `node/318/edit`
* View json file `docroot/sites/default/files/cms-export-content/paragraph.98ab52e2-2bc4-44a8-b05a-33024e467572.json`
* See updated `field_link`
```
    "field_link": [
        {
            "uri": "\/pittsburgh-health-care\/patient-advocates",
            "title": "Get help from a patient advocate",
            "options": []
        }
    ],
```