### PR TITLE
VACMS-000 Remove conflicting language on maintenance page.

### DIFF
--- a/docroot/sites/default/maintenance.html
+++ b/docroot/sites/default/maintenance.html
@@ -41,10 +41,11 @@
         font-size: 18px;
     }
 </style>
+<meta http-equiv="refresh" content="20" />
 </head>
 <body>
 <div class="site-alert">
-  <p><strong>System update in progress</strong><br><br>Sit tight! Stay on this page to avoid losing unsaved changes. <br>Updates generally take up to 15 minutes. Refresh the page again to see if the site is available.</p>
+  <p><strong>System update in progress</strong><br><br>Sit tight! The site will appear when the update is complete. <br>Updates generally take up to 15 minutes.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Description

The current language gives conflicting instructions.   This removes the conflict.
![image](https://user-images.githubusercontent.com/5752113/92969153-6e174f00-f44a-11ea-91c8-39f547a4bcf1.png)

(scale of text did not change... that is just due to the screenshot sizes)
It will look like 
![image](https://user-images.githubusercontent.com/5752113/92969858-b71bd300-f44b-11ea-8d8e-f8cf5c0af6fc.png)

Cpde was also added to make the browser auto-refresh every 20 seconds to make this behave in a manner similar to the actual site alert screen.


