### PR TITLE
VACMS-2924: Adding lc categories vocab.

### DIFF
--- a/config/sync/taxonomy.vocabulary.lc_categories.yml
+++ b/config/sync/taxonomy.vocabulary.lc_categories.yml
@@ -1,0 +1,8 @@
+uuid: 31c71133-d63c-4b27-91e7-e3583ec1eb63
+langcode: en
+status: true
+dependencies: {  }
+name: 'Learning Center Categories'
+vid: lc_categories
+description: ''
+weight: 0

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -87,6 +87,7 @@ Feature: Content model bundles
 | WYSIWYG | wysiwyg | Paragraph type | An open-ended text field. |
 | Audience - Beneficiaries | audience_beneficiaries | Vocabulary |  |
 | Audience - Non-beneficiaries | audience_non_beneficiaries | Vocabulary |  |
+| Learning Center Categories | lc_categories | Vocabulary |  |
 | Sections | administration | Vocabulary | Represents a hierarchy of the VA, partly for governance purposes. |
 | Type of Redirect | type_of_redirect | Vocabulary |  |
 | VHA health service taxonomy | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |


### PR DESCRIPTION
## Description
See #2924 

## Testing done
Visual / Behat

## QA steps
Verify `admin/structure/taxonomy/manage/lc_categories/overview` exists