### PR TITLE
VACMS-2895: Learning Center Detail Page + Landing Page content types

### DIFF
--- a/config/sync/core.base_field_override.node.basic_landing_page.promote.yml
+++ b/config/sync/core.base_field_override.node.basic_landing_page.promote.yml
@@ -1,0 +1,22 @@
+uuid: 92caf010-f883-440f-aac8-0b3a81a9743c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.basic_landing_page
+id: node.basic_landing_page.promote
+field_name: promote
+entity_type: node
+bundle: basic_landing_page
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.basic_landing_page.status.yml
+++ b/config/sync/core.base_field_override.node.basic_landing_page.status.yml
@@ -1,0 +1,22 @@
+uuid: 57acb8f3-df87-4644-8842-94591b811251
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.basic_landing_page
+id: node.basic_landing_page.status
+field_name: status
+entity_type: node
+bundle: basic_landing_page
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.basic_landing_page.title.yml
+++ b/config/sync/core.base_field_override.node.basic_landing_page.title.yml
@@ -1,0 +1,18 @@
+uuid: 16d24809-420e-4bd6-a053-43834d4c3017
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.basic_landing_page
+id: node.basic_landing_page.title
+field_name: title
+entity_type: node
+bundle: basic_landing_page
+label: 'Page title'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.node.support_resources_detail_page.promote.yml
+++ b/config/sync/core.base_field_override.node.support_resources_detail_page.promote.yml
@@ -1,0 +1,22 @@
+uuid: 1983c0d8-8a50-460d-a501-91de8440826f
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.support_resources_detail_page
+id: node.support_resources_detail_page.promote
+field_name: promote
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.support_resources_detail_page.status.yml
+++ b/config/sync/core.base_field_override.node.support_resources_detail_page.status.yml
@@ -1,0 +1,22 @@
+uuid: 5e0e05e2-ad17-4c7a-91c2-543fbd5147cc
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.support_resources_detail_page
+id: node.support_resources_detail_page.status
+field_name: status
+entity_type: node
+bundle: support_resources_detail_page
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.support_resources_detail_page.title.yml
+++ b/config/sync/core.base_field_override.node.support_resources_detail_page.title.yml
@@ -1,0 +1,18 @@
+uuid: 60a217eb-e82e-40b2-b858-7f7857fe403c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.support_resources_detail_page
+id: node.support_resources_detail_page.title
+field_name: title
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Page title'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
@@ -1,0 +1,206 @@
+uuid: 4ebd0dd2-a83c-46a1-b52e-3dde38242842
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.basic_landing_page.field_administration
+    - field.field.node.basic_landing_page.field_content_block
+    - field.field.node.basic_landing_page.field_description
+    - field.field.node.basic_landing_page.field_intro_text_limited_html
+    - field.field.node.basic_landing_page.field_meta_title
+    - field.field.node.basic_landing_page.field_product
+    - node.type.basic_landing_page
+    - workflows.workflow.editorial
+  module:
+    - allowed_formats
+    - content_moderation
+    - field_group
+    - paragraphs_browser
+    - path
+    - textfield_counter
+third_party_settings:
+  field_group:
+    group_title_and_introduction:
+      children:
+        - title
+        - field_intro_text_limited_html
+      parent_name: ''
+      weight: 0
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Title and introduction'
+      region: content
+    group_meta_tags:
+      children:
+        - field_meta_title
+        - field_description
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Meta Tags'
+      region: content
+    group_governance:
+      children:
+        - field_product
+        - field_administration
+      parent_name: ''
+      weight: 3
+      format_type: details_sidebar
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: 1
+        required_fields: 1
+        weight: '-10'
+      label: Governance
+      region: content
+    group_editorial_workflow:
+      children:
+        - moderation_state
+        - status
+      parent_name: ''
+      weight: 4
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Editorial workflow'
+      region: content
+id: node.basic_landing_page.default
+targetEntityType: node
+bundle: basic_landing_page
+mode: default
+content:
+  field_administration:
+    weight: 27
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_content_block:
+    weight: 2
+    settings:
+      title: 'Content block'
+      title_plural: 'Content blocks'
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: all
+      closed_mode_threshold: '0'
+      add_mode: paragraphs_browser
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: 0
+        add_above: 0
+      paragraphs_browser: content
+      modal_width: 80%
+      modal_height: auto
+    third_party_settings: {  }
+    type: paragraphs_browser
+    region: content
+  field_description:
+    weight: 6
+    settings:
+      size: 120
+      placeholder: ''
+      maxlength: 120
+      counter_position: after
+      js_prevent_submit: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
+      count_html_characters: false
+    third_party_settings: {  }
+    type: string_textfield_with_counter
+    region: content
+  field_intro_text_limited_html:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+      maxlength: 1000
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
+    type: text_textarea_with_counter
+    region: content
+  field_meta_title:
+    weight: 5
+    settings:
+      size: 70
+      placeholder: ''
+      maxlength: 70
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
+    third_party_settings: {  }
+    type: string_textfield_with_counter
+    region: content
+  field_product:
+    weight: 26
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 12
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 13
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield_with_counter
+    weight: 1
+    region: content
+    settings:
+      size: 70
+      placeholder: ''
+      maxlength: 70
+      counter_position: after
+      js_prevent_submit: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
+      count_html_characters: false
+    third_party_settings: {  }
+  url_redirects:
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  promote: true
+  sticky: true
+  uid: true

--- a/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
@@ -67,6 +67,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
         - status
       parent_name: ''
       weight: 4

--- a/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
@@ -1,0 +1,276 @@
+uuid: ab7211a1-fea4-4a04-9304-27d2eebd6030
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.lc_benefit_hubs
+    - field.field.node.support_resources_detail_page.field_administration
+    - field.field.node.support_resources_detail_page.field_alert_single
+    - field.field.node.support_resources_detail_page.field_buttons
+    - field.field.node.support_resources_detail_page.field_buttons_repeat
+    - field.field.node.support_resources_detail_page.field_content_block
+    - field.field.node.support_resources_detail_page.field_description
+    - field.field.node.support_resources_detail_page.field_intro_text_limited_html
+    - field.field.node.support_resources_detail_page.field_meta_title
+    - field.field.node.support_resources_detail_page.field_related_benefit_hubs
+    - field.field.node.support_resources_detail_page.field_related_information
+    - node.type.support_resources_detail_page
+  module:
+    - allowed_formats
+    - content_moderation
+    - entity_browser_table
+    - field_group
+    - paragraphs
+    - paragraphs_browser
+    - path
+    - textfield_counter
+third_party_settings:
+  field_group:
+    group_title_and_introduction:
+      children:
+        - title
+        - field_intro_text_limited_html
+      parent_name: ''
+      weight: 0
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Title and introduction'
+      region: content
+    group_include_alert:
+      children:
+        - field_alert_single
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Include Alert'
+      region: content
+    group_meta_tags:
+      children:
+        - field_description
+        - field_meta_title
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Meta Tags'
+      region: content
+    group_editorial_workflow:
+      children:
+        - moderation_state
+      parent_name: ''
+      weight: 10
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Editorial workflow'
+      region: content
+    group_governance:
+      children:
+        - field_administration
+      parent_name: ''
+      weight: 11
+      format_type: details_sidebar
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: 1
+        required_fields: 1
+        weight: '-10'
+      label: Governance
+      region: content
+id: node.support_resources_detail_page.default
+targetEntityType: node
+bundle: support_resources_detail_page
+mode: default
+content:
+  field_administration:
+    weight: 9
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_alert_single:
+    weight: 2
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: alert_single
+    third_party_settings: {  }
+    type: entity_reference_paragraphs
+    region: content
+  field_buttons:
+    weight: 5
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: button
+      features:
+        add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
+    third_party_settings: {  }
+    type: paragraphs
+    region: content
+  field_buttons_repeat:
+    weight: 7
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_content_block:
+    weight: 6
+    settings:
+      title: 'Content block'
+      title_plural: 'Content blocks'
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: '0'
+      add_mode: paragraphs_browser
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: 0
+        add_above: 0
+      paragraphs_browser: content
+      modal_width: 80%
+      modal_height: auto
+    third_party_settings: {  }
+    type: paragraphs_browser
+    region: content
+  field_description:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_intro_text_limited_html:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+      maxlength: 1000
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
+    type: text_textarea_with_counter
+    region: content
+  field_meta_title:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_related_benefit_hubs:
+    weight: 8
+    settings:
+      entity_browser: lc_benefit_hubs
+      field_widget_display: label
+      field_widget_remove: '1'
+      open: '1'
+      selection_mode: selection_append
+      field_widget_edit: 0
+      field_widget_replace: 0
+      field_widget_display_settings: {  }
+    third_party_settings: {  }
+    type: entity_reference_browser_table_widget
+    region: content
+  field_related_information:
+    type: paragraphs
+    weight: 9
+    settings:
+      title: 'Link teaser'
+      title_plural: 'Link teasers'
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: link_teaser
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: '0'
+    third_party_settings: {  }
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 16
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 14
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield_with_counter
+    weight: 1
+    region: content
+    settings:
+      size: 70
+      placeholder: ''
+      maxlength: 70
+      counter_position: after
+      js_prevent_submit: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
+      count_html_characters: false
+    third_party_settings: {  }
+  url_redirects:
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  promote: true
+  sticky: true
+  uid: true

--- a/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
@@ -72,6 +72,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 9
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.support_resources_detail_page.field_meta_title
     - field.field.node.support_resources_detail_page.field_related_benefit_hubs
     - field.field.node.support_resources_detail_page.field_related_information
+    - field.field.node.support_resources_detail_page.field_table_of_contents_boolean
     - node.type.support_resources_detail_page
     - workflows.workflow.editorial
   module:
@@ -72,7 +73,7 @@ third_party_settings:
       children:
         - moderation_state
       parent_name: ''
-      weight: 10
+      weight: 9
       format_type: fieldset
       format_settings:
         id: ''
@@ -85,7 +86,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 11
+      weight: 10
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -95,6 +96,20 @@ third_party_settings:
         required_fields: 1
         weight: '-10'
       label: Governance
+      region: content
+    group_include_toc:
+      children:
+        - field_table_of_contents_boolean
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: false
+        open: false
+      label: 'Include table of contents?'
       region: content
 id: node.support_resources_detail_page.default
 targetEntityType: node
@@ -120,7 +135,7 @@ content:
     type: entity_reference_paragraphs
     region: content
   field_buttons:
-    weight: 5
+    weight: 4
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -139,14 +154,14 @@ content:
     type: paragraphs
     region: content
   field_buttons_repeat:
-    weight: 7
+    weight: 6
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   field_content_block:
-    weight: 6
+    weight: 5
     settings:
       title: 'Content block'
       title_plural: 'Content blocks'
@@ -212,7 +227,7 @@ content:
     type: string_textfield_with_counter
     region: content
   field_related_benefit_hubs:
-    weight: 8
+    weight: 7
     settings:
       entity_browser: lc_benefit_hubs
       field_widget_display: label
@@ -227,7 +242,7 @@ content:
     region: content
   field_related_information:
     type: paragraphs
-    weight: 9
+    weight: 8
     settings:
       title: 'Link teaser'
       title_plural: 'Link teasers'
@@ -244,6 +259,13 @@ content:
         duplicate: '0'
     third_party_settings: {  }
     region: content
+  field_table_of_contents_boolean:
+    weight: 14
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   moderation_state:
     type: moderation_state_default
     weight: 16
@@ -252,7 +274,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 12
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -260,7 +282,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 14
+    weight: 13
     region: content
     third_party_settings: {  }
   title:
@@ -278,7 +300,7 @@ content:
       count_html_characters: false
     third_party_settings: {  }
   url_redirects:
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.support_resources_detail_page.field_related_benefit_hubs
     - field.field.node.support_resources_detail_page.field_related_information
     - node.type.support_resources_detail_page
+    - workflows.workflow.editorial
   module:
     - allowed_formats
     - content_moderation
@@ -169,10 +170,16 @@ content:
   field_description:
     weight: 3
     settings:
-      size: 60
+      size: 70
       placeholder: ''
+      maxlength: 70
+      counter_position: after
+      js_prevent_submit: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
+      count_html_characters: false
     third_party_settings: {  }
-    type: string_textfield
+    type: string_textfield_with_counter
     region: content
   field_intro_text_limited_html:
     weight: 2
@@ -193,10 +200,16 @@ content:
   field_meta_title:
     weight: 4
     settings:
-      size: 60
+      size: 120
       placeholder: ''
+      maxlength: 120
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      use_field_maxlength: false
     third_party_settings: {  }
-    type: string_textfield
+    type: string_textfield_with_counter
     region: content
   field_related_benefit_hubs:
     weight: 8

--- a/config/sync/core.entity_view_display.node.basic_landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.basic_landing_page.default.yml
@@ -1,0 +1,97 @@
+uuid: 3cff9a57-fa52-45d7-a48c-ae7d48f7dd2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.basic_landing_page.field_administration
+    - field.field.node.basic_landing_page.field_content_block
+    - field.field.node.basic_landing_page.field_description
+    - field.field.node.basic_landing_page.field_intro_text_limited_html
+    - field.field.node.basic_landing_page.field_meta_title
+    - field.field.node.basic_landing_page.field_product
+    - node.type.basic_landing_page
+  module:
+    - entity_reference_revisions
+    - field_group
+    - text
+    - user
+third_party_settings:
+  field_group:
+    group_metadata:
+      children:
+        - field_meta_title
+        - field_description
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: meta-content
+        description: ''
+      label: Metadata
+      region: content
+id: node.basic_landing_page.default
+targetEntityType: node
+bundle: basic_landing_page
+mode: default
+content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_administration:
+    weight: 6
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_content_block:
+    weight: 4
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_description:
+    weight: 5
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_intro_text_limited_html:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_meta_title:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_product:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  links:
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.basic_landing_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.basic_landing_page.teaser.yml
@@ -1,0 +1,38 @@
+uuid: c0a5948e-51b1-4319-81fd-a7794b4f2dac
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.basic_landing_page.field_administration
+    - field.field.node.basic_landing_page.field_content_block
+    - field.field.node.basic_landing_page.field_description
+    - field.field.node.basic_landing_page.field_intro_text_limited_html
+    - field.field.node.basic_landing_page.field_meta_title
+    - field.field.node.basic_landing_page.field_product
+    - node.type.basic_landing_page
+  module:
+    - user
+id: node.basic_landing_page.teaser
+targetEntityType: node
+bundle: basic_landing_page
+mode: teaser
+content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_administration: true
+  field_content_block: true
+  field_description: true
+  field_intro_text_limited_html: true
+  field_meta_title: true
+  field_product: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_view_display.node.support_resources_detail_page.default.yml
@@ -16,15 +16,36 @@ dependencies:
     - node.type.support_resources_detail_page
   module:
     - entity_reference_revisions
+    - field_group
     - text
     - user
+third_party_settings:
+  field_group:
+    group_metadata:
+      children:
+        - field_description
+        - field_meta_title
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: meta-content
+        description: ''
+      label: Metadata
+      region: content
 id: node.support_resources_detail_page.default
 targetEntityType: node
 bundle: support_resources_detail_page
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_administration:
-    weight: 107
+    weight: 10
     label: above
     settings:
       link: true
@@ -32,7 +53,7 @@ content:
     type: entity_reference_label
     region: content
   field_alert_single:
-    weight: 102
+    weight: 4
     label: above
     settings:
       view_mode: default
@@ -41,7 +62,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_buttons:
-    weight: 103
+    weight: 5
     label: above
     settings:
       view_mode: default
@@ -50,7 +71,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_buttons_repeat:
-    weight: 104
+    weight: 7
     label: above
     settings:
       format: default
@@ -60,7 +81,7 @@ content:
     type: boolean
     region: content
   field_content_block:
-    weight: 110
+    weight: 6
     label: above
     settings:
       view_mode: default
@@ -69,7 +90,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_description:
-    weight: 105
+    weight: 4
     label: above
     settings:
       link_to_entity: false
@@ -77,14 +98,14 @@ content:
     type: string
     region: content
   field_intro_text_limited_html:
-    weight: 101
+    weight: 3
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   field_meta_title:
-    weight: 106
+    weight: 5
     label: above
     settings:
       link_to_entity: false
@@ -92,16 +113,17 @@ content:
     type: string
     region: content
   field_related_benefit_hubs:
-    weight: 108
+    weight: 8
     label: above
     settings:
-      link: true
+      view_mode: default
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
     region: content
   field_related_information:
     type: entity_reference_revisions_entity_view
-    weight: 109
+    weight: 9
     label: above
     settings:
       view_mode: default
@@ -109,9 +131,9 @@ content:
     third_party_settings: {  }
     region: content
   links:
-    weight: 100
+    weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_view_display.node.support_resources_detail_page.default.yml
@@ -1,0 +1,117 @@
+uuid: 5668b3f3-8034-4f2c-8aba-b973d3bee5f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.support_resources_detail_page.field_administration
+    - field.field.node.support_resources_detail_page.field_alert_single
+    - field.field.node.support_resources_detail_page.field_buttons
+    - field.field.node.support_resources_detail_page.field_buttons_repeat
+    - field.field.node.support_resources_detail_page.field_content_block
+    - field.field.node.support_resources_detail_page.field_description
+    - field.field.node.support_resources_detail_page.field_intro_text_limited_html
+    - field.field.node.support_resources_detail_page.field_meta_title
+    - field.field.node.support_resources_detail_page.field_related_benefit_hubs
+    - field.field.node.support_resources_detail_page.field_related_information
+    - node.type.support_resources_detail_page
+  module:
+    - entity_reference_revisions
+    - text
+    - user
+id: node.support_resources_detail_page.default
+targetEntityType: node
+bundle: support_resources_detail_page
+mode: default
+content:
+  field_administration:
+    weight: 107
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_alert_single:
+    weight: 102
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_buttons:
+    weight: 103
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_buttons_repeat:
+    weight: 104
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_content_block:
+    weight: 110
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_description:
+    weight: 105
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_intro_text_limited_html:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_meta_title:
+    weight: 106
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_related_benefit_hubs:
+    weight: 108
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_related_information:
+    type: entity_reference_revisions_entity_view
+    weight: 109
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_view_display.node.support_resources_detail_page.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.support_resources_detail_page.field_meta_title
     - field.field.node.support_resources_detail_page.field_related_benefit_hubs
     - field.field.node.support_resources_detail_page.field_related_information
+    - field.field.node.support_resources_detail_page.field_table_of_contents_boolean
     - node.type.support_resources_detail_page
   module:
     - entity_reference_revisions
@@ -129,6 +130,16 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    region: content
+  field_table_of_contents_boolean:
+    weight: 11
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   links:
     weight: 1

--- a/config/sync/core.entity_view_display.node.support_resources_detail_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.support_resources_detail_page.teaser.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.support_resources_detail_page.field_meta_title
     - field.field.node.support_resources_detail_page.field_related_benefit_hubs
     - field.field.node.support_resources_detail_page.field_related_information
+    - field.field.node.support_resources_detail_page.field_table_of_contents_boolean
     - node.type.support_resources_detail_page
   module:
     - user
@@ -22,6 +23,11 @@ targetEntityType: node
 bundle: support_resources_detail_page
 mode: teaser
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   links:
     weight: 100
     settings: {  }
@@ -38,4 +44,5 @@ hidden:
   field_meta_title: true
   field_related_benefit_hubs: true
   field_related_information: true
+  field_table_of_contents_boolean: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.support_resources_detail_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.support_resources_detail_page.teaser.yml
@@ -1,0 +1,41 @@
+uuid: 9bfe86a3-8330-46ff-b53c-dec634ac3bb2
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.support_resources_detail_page.field_administration
+    - field.field.node.support_resources_detail_page.field_alert_single
+    - field.field.node.support_resources_detail_page.field_buttons
+    - field.field.node.support_resources_detail_page.field_buttons_repeat
+    - field.field.node.support_resources_detail_page.field_content_block
+    - field.field.node.support_resources_detail_page.field_description
+    - field.field.node.support_resources_detail_page.field_intro_text_limited_html
+    - field.field.node.support_resources_detail_page.field_meta_title
+    - field.field.node.support_resources_detail_page.field_related_benefit_hubs
+    - field.field.node.support_resources_detail_page.field_related_information
+    - node.type.support_resources_detail_page
+  module:
+    - user
+id: node.support_resources_detail_page.teaser
+targetEntityType: node
+bundle: support_resources_detail_page
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_administration: true
+  field_alert_single: true
+  field_buttons: true
+  field_buttons_repeat: true
+  field_content_block: true
+  field_description: true
+  field_intro_text_limited_html: true
+  field_meta_title: true
+  field_related_benefit_hubs: true
+  field_related_information: true
+  search_api_excerpt: true

--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -42,67 +42,67 @@ definitions:
     expanded: false
     enabled: true
   node__add__health_care_local_facility:
-    weight: 30
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__health_care_region_page:
-    weight: 27
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__health_care_local_health_service:
     weight: 31
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
-  node__add__press_release:
-    weight: 15
+  node__add__health_care_region_page:
+    weight: 28
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
-  node__add__office:
-    weight: 17
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__publication_listing:
-    weight: 19
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__outreach_asset:
-    weight: 18
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__regional_health_care_service_des:
+  node__add__health_care_local_health_service:
     weight: 32
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
+  node__add__press_release:
+    weight: 16
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__office:
+    weight: 18
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__publication_listing:
+    weight: 20
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__outreach_asset:
+    weight: 19
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__regional_health_care_service_des:
+    weight: 33
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
   node__add__person_profile:
-    weight: 21
+    weight: 22
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__news_story:
-    weight: 23
+    weight: 24
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__support_service:
-    weight: 25
+    weight: 26
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -282,13 +282,13 @@ definitions:
     expanded: false
     enabled: true
   node__add__full_width_banner_alert:
-    weight: 28
+    weight: 29
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__vamc_operating_status_and_alerts:
-    weight: 29
+    weight: 30
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -498,43 +498,43 @@ definitions:
     expanded: false
     enabled: true
   node__add__locations_listing:
-    weight: 11
+    weight: 12
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__nca_facility:
-    weight: 14
+    weight: 15
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__press_releases_listing:
-    weight: 16
+    weight: 17
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__story_listing:
-    weight: 24
+    weight: 25
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__vba_facility:
-    weight: 33
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__vet_center:
     weight: 34
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
+  node__add__vet_center:
+    weight: 35
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
   node__add__va_form:
-    weight: 26
+    weight: 27
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -588,7 +588,7 @@ definitions:
     expanded: false
     enabled: true
   node__add__q_a:
-    weight: 20
+    weight: 21
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -726,7 +726,7 @@ definitions:
     expanded: false
     enabled: true
   node__add__step_by_step:
-    weight: 22
+    weight: 23
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -942,13 +942,19 @@ definitions:
     enabled: true
     expanded: false
   node__add__media_list_videos:
-    weight: 13
+    weight: 14
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__media_list_images:
-    weight: 12
+    weight: 13
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__support_resources_detail_page:
+    weight: 11
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     enabled: true

--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -42,67 +42,67 @@ definitions:
     expanded: false
     enabled: true
   node__add__health_care_local_facility:
-    weight: 31
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__health_care_region_page:
-    weight: 28
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__health_care_local_health_service:
     weight: 32
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
-  node__add__press_release:
-    weight: 16
+  node__add__health_care_region_page:
+    weight: 29
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
-  node__add__office:
-    weight: 18
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__publication_listing:
-    weight: 20
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__outreach_asset:
-    weight: 19
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__regional_health_care_service_des:
+  node__add__health_care_local_health_service:
     weight: 33
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
+  node__add__press_release:
+    weight: 17
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__office:
+    weight: 19
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__publication_listing:
+    weight: 21
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__outreach_asset:
+    weight: 20
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__regional_health_care_service_des:
+    weight: 34
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
   node__add__person_profile:
-    weight: 22
+    weight: 23
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__news_story:
-    weight: 24
+    weight: 25
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__support_service:
-    weight: 26
+    weight: 27
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -282,13 +282,13 @@ definitions:
     expanded: false
     enabled: true
   node__add__full_width_banner_alert:
-    weight: 29
+    weight: 30
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__vamc_operating_status_and_alerts:
-    weight: 30
+    weight: 31
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -492,49 +492,49 @@ definitions:
     expanded: false
     enabled: true
   node__add__leadership_listing:
-    weight: 10
+    weight: 11
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__locations_listing:
-    weight: 12
+    weight: 13
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__nca_facility:
-    weight: 15
+    weight: 16
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__press_releases_listing:
-    weight: 17
+    weight: 18
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__story_listing:
-    weight: 25
+    weight: 26
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__vba_facility:
-    weight: 34
-    menu_name: admin
-    parent: admin_toolbar_tools.add_content
-    expanded: false
-    enabled: true
-  node__add__vet_center:
     weight: 35
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
+  node__add__vet_center:
+    weight: 36
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
   node__add__va_form:
-    weight: 27
+    weight: 28
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -588,7 +588,7 @@ definitions:
     expanded: false
     enabled: true
   node__add__q_a:
-    weight: 21
+    weight: 22
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -726,7 +726,7 @@ definitions:
     expanded: false
     enabled: true
   node__add__step_by_step:
-    weight: 23
+    weight: 24
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
@@ -942,19 +942,25 @@ definitions:
     enabled: true
     expanded: false
   node__add__media_list_videos:
-    weight: 14
+    weight: 15
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__media_list_images:
-    weight: 13
+    weight: 14
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     expanded: false
     enabled: true
   node__add__support_resources_detail_page:
-    weight: 11
+    weight: 12
+    menu_name: admin
+    parent: admin_toolbar_tools.add_content
+    expanded: false
+    enabled: true
+  node__add__basic_landing_page:
+    weight: 10
     menu_name: admin
     parent: admin_toolbar_tools.add_content
     enabled: true

--- a/config/sync/field.field.node.basic_landing_page.field_administration.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_administration.yml
@@ -1,0 +1,29 @@
+uuid: 869c500e-f250-484c-8531-bd3b93eaaba6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_administration
+    - node.type.basic_landing_page
+    - taxonomy.vocabulary.administration
+id: node.basic_landing_page.field_administration
+field_name: field_administration
+entity_type: node
+bundle: basic_landing_page
+label: Owner
+description: 'The VA office or program that owns this content.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.basic_landing_page.field_content_block.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_content_block.yml
@@ -1,0 +1,147 @@
+uuid: dd409a11-bb5f-459c-bab5-3e3d42c3dfc7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_block
+    - node.type.basic_landing_page
+    - paragraphs.paragraphs_type.alert
+    - paragraphs.paragraphs_type.lists_of_links
+    - paragraphs.paragraphs_type.react_widget
+    - paragraphs.paragraphs_type.table
+    - paragraphs.paragraphs_type.wysiwyg
+  module:
+    - entity_reference_revisions
+id: node.basic_landing_page.field_content_block
+field_name: field_content_block
+entity_type: node
+bundle: basic_landing_page
+label: 'Main content'
+description: 'The main body of the page, which appears below the Page Introduction text.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      wysiwyg: wysiwyg
+      lists_of_links: lists_of_links
+      table: table
+      react_widget: react_widget
+      alert: alert
+    target_bundles_drag_drop:
+      address:
+        weight: -70
+        enabled: false
+      alert:
+        enabled: true
+        weight: -71
+      alert_single:
+        weight: -69
+        enabled: false
+      button:
+        weight: -68
+        enabled: false
+      checklist:
+        weight: -67
+        enabled: false
+      checklist_item:
+        weight: -66
+        enabled: false
+      collapsible_panel:
+        weight: -65
+        enabled: false
+      collapsible_panel_item:
+        weight: -64
+        enabled: false
+      downloadable_file:
+        weight: -63
+        enabled: false
+      email_contact:
+        weight: -62
+        enabled: false
+      expandable_text:
+        weight: -61
+        enabled: false
+      health_care_local_facility_servi:
+        weight: -60
+        enabled: false
+      link_teaser:
+        weight: -59
+        enabled: false
+      list_of_link_teasers:
+        weight: -58
+        enabled: false
+      list_of_links:
+        weight: -57
+        enabled: false
+      lists_of_links:
+        enabled: true
+        weight: -74
+      media:
+        weight: -56
+        enabled: false
+      media_list_images:
+        weight: -55
+        enabled: false
+      media_list_videos:
+        weight: -54
+        enabled: false
+      non_reusable_alert:
+        weight: -53
+        enabled: false
+      number_callout:
+        weight: -52
+        enabled: false
+      phone_number:
+        weight: -51
+        enabled: false
+      process:
+        weight: -50
+        enabled: false
+      q_a:
+        weight: -49
+        enabled: false
+      q_a_group:
+        weight: -48
+        enabled: false
+      q_a_section:
+        weight: -47
+        enabled: false
+      react_widget:
+        enabled: true
+        weight: -72
+      service_location:
+        weight: -46
+        enabled: false
+      service_location_address:
+        weight: -45
+        enabled: false
+      situation_update:
+        weight: -44
+        enabled: false
+      spanish_translation_summary:
+        weight: -43
+        enabled: false
+      staff_profile:
+        weight: -42
+        enabled: false
+      starred_horizontal_rule:
+        weight: -41
+        enabled: false
+      step:
+        weight: -40
+        enabled: false
+      step_by_step:
+        weight: -39
+        enabled: false
+      table:
+        enabled: true
+        weight: -73
+      wysiwyg:
+        enabled: true
+        weight: -75
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.basic_landing_page.field_description.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_description.yml
@@ -1,0 +1,19 @@
+uuid: ba4b2909-cee5-46c6-aaf9-be29eb83ed9d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_description
+    - node.type.basic_landing_page
+id: node.basic_landing_page.field_description
+field_name: field_description
+entity_type: node
+bundle: basic_landing_page
+label: 'Meta description'
+description: 'Add a description to be used in search results, social media shares, and teaser listings. (<a href="https://design.va.gov/content-style-guide/seo#meta-properties" target=“_blank”>See further guidelines</a>)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.basic_landing_page.field_intro_text_limited_html.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_intro_text_limited_html.yml
@@ -1,0 +1,27 @@
+uuid: 9570ed3d-e48f-42dc-b806-a802c2f4397b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_intro_text_limited_html
+    - node.type.basic_landing_page
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text_limited: rich_text_limited
+    rich_text: '0'
+    plain_text: '0'
+id: node.basic_landing_page.field_intro_text_limited_html
+field_name: field_intro_text_limited_html
+entity_type: node
+bundle: basic_landing_page
+label: 'Page introduction'
+description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information. This field supports the following HTML tags: <em> <strong> <br> <p> <a>'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.node.basic_landing_page.field_meta_title.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_meta_title.yml
@@ -1,0 +1,19 @@
+uuid: b8489dc9-ae73-4602-a73e-33206cf2f3b7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_title
+    - node.type.basic_landing_page
+id: node.basic_landing_page.field_meta_title
+field_name: field_meta_title
+entity_type: node
+bundle: basic_landing_page
+label: 'Meta title tag'
+description: 'Add a meta title to be used in search results and the browser tab. Use title case capitalization and include " | Veterans Affairs" at the end. (<a href="https://design.va.gov/content-style-guide/seo#meta-properties" target=“_blank”>See further guidelines</a>)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.basic_landing_page.field_product.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_product.yml
@@ -1,0 +1,29 @@
+uuid: 8e0293c0-a8ca-4b60-a1f7-bc78225de05f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_product
+    - node.type.basic_landing_page
+    - taxonomy.vocabulary.products
+id: node.basic_landing_page.field_product
+field_name: field_product
+entity_type: node
+bundle: basic_landing_page
+label: Product
+description: 'Select a product that this page belongs to.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      products: products
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.support_resources_detail_page.field_administration.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_administration.yml
@@ -1,0 +1,29 @@
+uuid: 149b1d75-1a7e-4167-87b6-e8bac10d64ac
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_administration
+    - node.type.support_resources_detail_page
+    - taxonomy.vocabulary.administration
+id: node.support_resources_detail_page.field_administration
+field_name: field_administration
+entity_type: node
+bundle: support_resources_detail_page
+label: Owner
+description: 'The VA office or program that owns this content.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.support_resources_detail_page.field_alert_single.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_alert_single.yml
@@ -1,0 +1,139 @@
+uuid: 5cd7738b-0fd0-4d55-817b-ceabb1797ed3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_alert_single
+    - node.type.support_resources_detail_page
+    - paragraphs.paragraphs_type.alert_single
+  module:
+    - entity_reference_revisions
+id: node.support_resources_detail_page.field_alert_single
+field_name: field_alert_single
+entity_type: node
+bundle: support_resources_detail_page
+label: Alert
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      alert_single: alert_single
+    target_bundles_drag_drop:
+      address:
+        weight: 38
+        enabled: false
+      alert:
+        weight: 39
+        enabled: false
+      alert_single:
+        enabled: true
+        weight: 40
+      button:
+        weight: 41
+        enabled: false
+      checklist:
+        weight: 42
+        enabled: false
+      checklist_item:
+        weight: 43
+        enabled: false
+      collapsible_panel:
+        weight: 44
+        enabled: false
+      collapsible_panel_item:
+        weight: 45
+        enabled: false
+      downloadable_file:
+        weight: 46
+        enabled: false
+      email_contact:
+        weight: 47
+        enabled: false
+      expandable_text:
+        weight: 48
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 49
+        enabled: false
+      link_teaser:
+        weight: 50
+        enabled: false
+      list_of_link_teasers:
+        weight: 51
+        enabled: false
+      list_of_links:
+        weight: 52
+        enabled: false
+      lists_of_links:
+        weight: 53
+        enabled: false
+      media:
+        weight: 54
+        enabled: false
+      media_list_images:
+        weight: 55
+        enabled: false
+      media_list_videos:
+        weight: 56
+        enabled: false
+      non_reusable_alert:
+        weight: 57
+        enabled: false
+      number_callout:
+        weight: 58
+        enabled: false
+      phone_number:
+        weight: 59
+        enabled: false
+      process:
+        weight: 60
+        enabled: false
+      q_a:
+        weight: 61
+        enabled: false
+      q_a_group:
+        weight: 62
+        enabled: false
+      q_a_section:
+        weight: 63
+        enabled: false
+      react_widget:
+        weight: 64
+        enabled: false
+      service_location:
+        weight: 65
+        enabled: false
+      service_location_address:
+        weight: 66
+        enabled: false
+      situation_update:
+        weight: 67
+        enabled: false
+      spanish_translation_summary:
+        weight: 68
+        enabled: false
+      staff_profile:
+        weight: 69
+        enabled: false
+      starred_horizontal_rule:
+        weight: 70
+        enabled: false
+      step:
+        weight: 71
+        enabled: false
+      step_by_step:
+        weight: 72
+        enabled: false
+      table:
+        weight: 73
+        enabled: false
+      wysiwyg:
+        weight: 74
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.support_resources_detail_page.field_buttons.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_buttons.yml
@@ -1,0 +1,139 @@
+uuid: 2dae0a77-db64-4b72-ba26-d6fdf61abad0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_buttons
+    - node.type.support_resources_detail_page
+    - paragraphs.paragraphs_type.button
+  module:
+    - entity_reference_revisions
+id: node.support_resources_detail_page.field_buttons
+field_name: field_buttons
+entity_type: node
+bundle: support_resources_detail_page
+label: 'CTA buttons'
+description: 'Add a Call to Action button. At least 1 required. Up to 2 max.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      button: button
+    target_bundles_drag_drop:
+      address:
+        weight: 38
+        enabled: false
+      alert:
+        weight: 39
+        enabled: false
+      alert_single:
+        weight: 40
+        enabled: false
+      button:
+        enabled: true
+        weight: 41
+      checklist:
+        weight: 42
+        enabled: false
+      checklist_item:
+        weight: 43
+        enabled: false
+      collapsible_panel:
+        weight: 44
+        enabled: false
+      collapsible_panel_item:
+        weight: 45
+        enabled: false
+      downloadable_file:
+        weight: 46
+        enabled: false
+      email_contact:
+        weight: 47
+        enabled: false
+      expandable_text:
+        weight: 48
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 49
+        enabled: false
+      link_teaser:
+        weight: 50
+        enabled: false
+      list_of_link_teasers:
+        weight: 51
+        enabled: false
+      list_of_links:
+        weight: 52
+        enabled: false
+      lists_of_links:
+        weight: 53
+        enabled: false
+      media:
+        weight: 54
+        enabled: false
+      media_list_images:
+        weight: 55
+        enabled: false
+      media_list_videos:
+        weight: 56
+        enabled: false
+      non_reusable_alert:
+        weight: 57
+        enabled: false
+      number_callout:
+        weight: 58
+        enabled: false
+      phone_number:
+        weight: 59
+        enabled: false
+      process:
+        weight: 60
+        enabled: false
+      q_a:
+        weight: 61
+        enabled: false
+      q_a_group:
+        weight: 62
+        enabled: false
+      q_a_section:
+        weight: 63
+        enabled: false
+      react_widget:
+        weight: 64
+        enabled: false
+      service_location:
+        weight: 65
+        enabled: false
+      service_location_address:
+        weight: 66
+        enabled: false
+      situation_update:
+        weight: 67
+        enabled: false
+      spanish_translation_summary:
+        weight: 68
+        enabled: false
+      staff_profile:
+        weight: 69
+        enabled: false
+      starred_horizontal_rule:
+        weight: 70
+        enabled: false
+      step:
+        weight: 71
+        enabled: false
+      step_by_step:
+        weight: 72
+        enabled: false
+      table:
+        weight: 73
+        enabled: false
+      wysiwyg:
+        weight: 74
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.support_resources_detail_page.field_buttons_repeat.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_buttons_repeat.yml
@@ -1,0 +1,23 @@
+uuid: a1843168-42cb-4ae0-80e4-e1d2c51c3405
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_buttons_repeat
+    - node.type.support_resources_detail_page
+id: node.support_resources_detail_page.field_buttons_repeat
+field_name: field_buttons_repeat
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Repeat CTA buttons'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.support_resources_detail_page.field_content_block.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_content_block.yml
@@ -1,0 +1,145 @@
+uuid: 8b48d912-05d6-4a61-8af9-5720b57d11e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_block
+    - node.type.support_resources_detail_page
+    - paragraphs.paragraphs_type.collapsible_panel
+    - paragraphs.paragraphs_type.react_widget
+    - paragraphs.paragraphs_type.table
+    - paragraphs.paragraphs_type.wysiwyg
+  module:
+    - entity_reference_revisions
+id: node.support_resources_detail_page.field_content_block
+field_name: field_content_block
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Main content'
+description: 'The main body of the page, which appears below the CTAs.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      wysiwyg: wysiwyg
+      table: table
+      collapsible_panel: collapsible_panel
+      react_widget: react_widget
+    target_bundles_drag_drop:
+      address:
+        weight: -71
+        enabled: false
+      alert:
+        weight: -70
+        enabled: false
+      alert_single:
+        weight: -69
+        enabled: false
+      button:
+        weight: -68
+        enabled: false
+      checklist:
+        weight: -67
+        enabled: false
+      checklist_item:
+        weight: -66
+        enabled: false
+      collapsible_panel:
+        enabled: true
+        weight: -73
+      collapsible_panel_item:
+        weight: -65
+        enabled: false
+      downloadable_file:
+        weight: -64
+        enabled: false
+      email_contact:
+        weight: -63
+        enabled: false
+      expandable_text:
+        weight: -62
+        enabled: false
+      health_care_local_facility_servi:
+        weight: -61
+        enabled: false
+      link_teaser:
+        weight: -60
+        enabled: false
+      list_of_link_teasers:
+        weight: -59
+        enabled: false
+      list_of_links:
+        weight: -58
+        enabled: false
+      lists_of_links:
+        weight: -57
+        enabled: false
+      media:
+        weight: -56
+        enabled: false
+      media_list_images:
+        weight: -55
+        enabled: false
+      media_list_videos:
+        weight: -54
+        enabled: false
+      non_reusable_alert:
+        weight: -53
+        enabled: false
+      number_callout:
+        weight: -52
+        enabled: false
+      phone_number:
+        weight: -51
+        enabled: false
+      process:
+        weight: -50
+        enabled: false
+      q_a:
+        weight: -49
+        enabled: false
+      q_a_group:
+        weight: -48
+        enabled: false
+      q_a_section:
+        weight: -47
+        enabled: false
+      react_widget:
+        enabled: true
+        weight: -72
+      service_location:
+        weight: -46
+        enabled: false
+      service_location_address:
+        weight: -45
+        enabled: false
+      situation_update:
+        weight: -44
+        enabled: false
+      spanish_translation_summary:
+        weight: -43
+        enabled: false
+      staff_profile:
+        weight: -42
+        enabled: false
+      starred_horizontal_rule:
+        weight: -41
+        enabled: false
+      step:
+        weight: -40
+        enabled: false
+      step_by_step:
+        weight: -39
+        enabled: false
+      table:
+        enabled: true
+        weight: -74
+      wysiwyg:
+        enabled: true
+        weight: -75
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.support_resources_detail_page.field_description.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_description.yml
@@ -1,0 +1,19 @@
+uuid: ce1c4be3-5d46-4ac0-9025-3807827543db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_description
+    - node.type.support_resources_detail_page
+id: node.support_resources_detail_page.field_description
+field_name: field_description
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Meta description'
+description: 'Add a description to be used in search results, social media shares, and teaser listings. (<a href="https://design.va.gov/content-style-guide/seo#meta-properties" target=“_blank”>See further guidelines</a>)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.support_resources_detail_page.field_intro_text_limited_html.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_intro_text_limited_html.yml
@@ -1,0 +1,27 @@
+uuid: 45e0e42d-25f2-4d6d-9090-36558d32a786
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_intro_text_limited_html
+    - node.type.support_resources_detail_page
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text_limited: rich_text_limited
+    rich_text: '0'
+    plain_text: '0'
+id: node.support_resources_detail_page.field_intro_text_limited_html
+field_name: field_intro_text_limited_html
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Page introduction'
+description: 'This is displayed directly beneath the title as an introduction to the page. This text should help a user figure out whether the information on this page is relevant to them, and should be written in the 2nd person. It will never be shown alongside the Description, so it''s ok for it to be duplicative of that information. This field supports the following HTML tags: <em> <strong> <br> <p> <a>'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.node.support_resources_detail_page.field_meta_title.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_meta_title.yml
@@ -1,0 +1,19 @@
+uuid: 4c447ecb-9106-4dd6-b86c-dd5f4593a452
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_title
+    - node.type.support_resources_detail_page
+id: node.support_resources_detail_page.field_meta_title
+field_name: field_meta_title
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Meta title tag'
+description: 'Add a meta title to be used in search results and the browser tab. Use title case capitalization and include " | Veterans Affairs" at the end. (<a href="https://design.va.gov/content-style-guide/seo#meta-properties" target=“_blank”>See further guidelines</a>)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.support_resources_detail_page.field_related_benefit_hubs.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_related_benefit_hubs.yml
@@ -1,0 +1,32 @@
+uuid: 8dabbb41-bf62-490c-b9cc-9e471a7e5167
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_benefit_hubs
+    - node.type.landing_page
+    - node.type.support_resources_detail_page
+  content:
+    - 'node:landing_page:fd822f25-788f-489c-a0fc-b1f7ad6c20d5'
+id: node.support_resources_detail_page.field_related_benefit_hubs
+field_name: field_related_benefit_hubs
+entity_type: node
+bundle: support_resources_detail_page
+label: 'VA Benefit Hubs'
+description: 'Select up to 3 Benefit hubs.<br><br>'
+required: true
+translatable: false
+default_value:
+  -
+    target_uuid: fd822f25-788f-489c-a0fc-b1f7ad6c20d5
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      landing_page: landing_page
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.support_resources_detail_page.field_related_information.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_related_information.yml
@@ -1,0 +1,139 @@
+uuid: e6123765-736f-409a-8b83-a93fff79a8b4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_information
+    - node.type.support_resources_detail_page
+    - paragraphs.paragraphs_type.link_teaser
+  module:
+    - entity_reference_revisions
+id: node.support_resources_detail_page.field_related_information
+field_name: field_related_information
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Related Information'
+description: 'Add up to 5 link teasers.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      link_teaser: link_teaser
+    target_bundles_drag_drop:
+      address:
+        weight: 38
+        enabled: false
+      alert:
+        weight: 39
+        enabled: false
+      alert_single:
+        weight: 40
+        enabled: false
+      button:
+        weight: 41
+        enabled: false
+      checklist:
+        weight: 42
+        enabled: false
+      checklist_item:
+        weight: 43
+        enabled: false
+      collapsible_panel:
+        weight: 44
+        enabled: false
+      collapsible_panel_item:
+        weight: 45
+        enabled: false
+      downloadable_file:
+        weight: 46
+        enabled: false
+      email_contact:
+        weight: 47
+        enabled: false
+      expandable_text:
+        weight: 48
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 49
+        enabled: false
+      link_teaser:
+        enabled: true
+        weight: 50
+      list_of_link_teasers:
+        weight: 51
+        enabled: false
+      list_of_links:
+        weight: 52
+        enabled: false
+      lists_of_links:
+        weight: 53
+        enabled: false
+      media:
+        weight: 54
+        enabled: false
+      media_list_images:
+        weight: 55
+        enabled: false
+      media_list_videos:
+        weight: 56
+        enabled: false
+      non_reusable_alert:
+        weight: 57
+        enabled: false
+      number_callout:
+        weight: 58
+        enabled: false
+      phone_number:
+        weight: 59
+        enabled: false
+      process:
+        weight: 60
+        enabled: false
+      q_a:
+        weight: 61
+        enabled: false
+      q_a_group:
+        weight: 62
+        enabled: false
+      q_a_section:
+        weight: 63
+        enabled: false
+      react_widget:
+        weight: 64
+        enabled: false
+      service_location:
+        weight: 65
+        enabled: false
+      service_location_address:
+        weight: 66
+        enabled: false
+      situation_update:
+        weight: 67
+        enabled: false
+      spanish_translation_summary:
+        weight: 68
+        enabled: false
+      staff_profile:
+        weight: 69
+        enabled: false
+      starred_horizontal_rule:
+        weight: 70
+        enabled: false
+      step:
+        weight: 71
+        enabled: false
+      step_by_step:
+        weight: 72
+        enabled: false
+      table:
+        weight: 73
+        enabled: false
+      wysiwyg:
+        weight: 74
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.support_resources_detail_page.field_table_of_contents_boolean.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_table_of_contents_boolean.yml
@@ -1,0 +1,23 @@
+uuid: e7ee829b-59a1-45af-99ee-bdb6f334d552
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_table_of_contents_boolean
+    - node.type.support_resources_detail_page
+id: node.support_resources_detail_page.field_table_of_contents_boolean
+field_name: field_table_of_contents_boolean
+entity_type: node
+bundle: support_resources_detail_page
+label: 'Generate a table of contents from major headings'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.node.field_product.yml
+++ b/config/sync/field.storage.node.field_product.yml
@@ -1,0 +1,20 @@
+uuid: 2db4674d-a528-4553-ba1e-47715689c987
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_product
+field_name: field_product
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_related_benefit_hubs.yml
+++ b/config/sync/field.storage.node.field_related_benefit_hubs.yml
@@ -1,0 +1,19 @@
+uuid: fa0ddb8e-058d-46cf-9b62-7f66ed1fb195
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_related_benefit_hubs
+field_name: field_related_benefit_hubs
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_related_information.yml
+++ b/config/sync/field.storage.node.field_related_information.yml
@@ -1,0 +1,21 @@
+uuid: 34293110-3eeb-4d9f-932f-2b2cb0226e55
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_related_information
+field_name: field_related_information
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 5
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node.type.basic_landing_page.yml
+++ b/config/sync/node.type.basic_landing_page.yml
@@ -1,0 +1,25 @@
+uuid: b35cc634-601a-409a-8640-71c69a98fbe2
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_revision_delete
+    - node_title_help_text
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+  node_revision_delete:
+    minimum_revisions_to_keep: 50
+    minimum_age_to_delete: 0
+    when_to_delete: 0
+  node_title_help_text:
+    title_help: 'Add a page title with sentence case capitalization. (<a href="https://design.va.gov/content-style-guide/capitalization" target="_blank">See further guidelines</a>) '
+name: 'Landing Page'
+type: basic_landing_page
+description: 'Basic Landing Page can be used to build one-off pages for various products. E.g. a homepage for a specific product.'
+help: ''
+new_revision: true
+preview_mode: 0
+display_submitted: false

--- a/config/sync/node.type.support_resources_detail_page.yml
+++ b/config/sync/node.type.support_resources_detail_page.yml
@@ -1,0 +1,25 @@
+uuid: 01022f3a-faa7-4df6-8394-989eb6230b77
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_revision_delete
+    - node_title_help_text
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+  node_revision_delete:
+    minimum_revisions_to_keep: 50
+    minimum_age_to_delete: 0
+    when_to_delete: 0
+  node_title_help_text:
+    title_help: 'Add a page title with sentence case capitalization. (<a href="https://design.va.gov/content-style-guide/capitalization" target="_blank">See further guidelines</a>) '
+name: 'Learning Center Detail Page'
+type: support_resources_detail_page
+description: ''
+help: ''
+new_revision: true
+preview_mode: 0
+display_submitted: false

--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -33,6 +33,7 @@ dependencies:
     - node.type.regional_health_care_service_des
     - node.type.step_by_step
     - node.type.story_listing
+    - node.type.support_resources_detail_page
     - node.type.support_service
     - node.type.va_form
     - node.type.vamc_operating_status_and_alerts
@@ -148,6 +149,7 @@ type_settings:
       - regional_health_care_service_des
       - step_by_step
       - story_listing
+      - support_resources_detail_page
       - support_service
       - va_form
       - vamc_operating_status_and_alerts

--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.alert
     - block_content.type.promo
+    - node.type.basic_landing_page
     - node.type.checklist
     - node.type.documentation_page
     - node.type.event
@@ -121,6 +122,7 @@ type_settings:
       - alert
       - promo
     node:
+      - basic_landing_page
       - checklist
       - documentation_page
       - event

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -17,6 +17,8 @@ Feature: Content model bundles
 | Events List | event_listing | Content type | A listing of events. |
 | FAQ - multiple Q&As | faq_multiple_q_a | Content type | Curated collection of Q&As. |
 | Health Services List | health_services_listing | Content type | A listing of health services. |
+| Landing Page | basic_landing_page | Content type | Basic Landing Page can be used to build one-off pages for various products. E.g. a homepage for a specific product. |
+| Learning Center Detail Page | support_resources_detail_page | Content type |  |
 | Leadership List | leadership_listing | Content type | A listing of staff profiles. |
 | Locations List | locations_listing | Content type | A listing of VA facilities. |
 | Media list - Images | media_list_images | Content type |  |

--- a/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_content_type_fields.feature
@@ -106,6 +106,12 @@ Feature: Content model: Content Type fields
 | Content type | Health Services List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Health Services List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Health Services List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Landing Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
+| Content type | Landing Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Landing Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Landing Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Landing Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Landing Page | Product | field_product | Entity reference | Required | 1 | Select list | |
 | Content type | Leadership List | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete | Translatable |
 | Content type | Leadership List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Leadership List | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
@@ -113,6 +119,17 @@ Feature: Content model: Content Type fields
 | Content type | Leadership List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Leadership List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Leadership List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Learning Center Detail Page | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | Learning Center Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Learning Center Detail Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Learning Center Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Learning Center Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Learning Center Detail Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Learning Center Detail Page | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Learning Center Detail Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
+| Content type | Learning Center Detail Page | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | |
+| Content type | Learning Center Detail Page | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | |
+| Content type | Learning Center Detail Page | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Locations List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Locations List | Meta tags | field_meta_tags | Meta tags |  | 1 | Advanced meta tags form | Translatable |
 | Content type | Locations List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |


### PR DESCRIPTION
## Description

See #2895 . 

## Testing done


## Screenshots


## QA steps

- [ ] Two new content types exist:
   1. Learning Center Detail Page `support_resources_detail_page`
   1. Landing Page `basic_landing_page`
- [ ] both content types have Editorial Workflow enabled and revision log is displayed in Editorial workflow fieldset at the bottom of the page

