### PR TITLE
Add section_association to exclude list for cms export breadcrumb creation

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/AddBreadcrumbToEntity.php
+++ b/docroot/modules/custom/va_gov_content_export/src/AddBreadcrumbToEntity.php
@@ -64,6 +64,7 @@ class AddBreadcrumbToEntity {
     'content_moderation_state',
     'paragraph',
     'file',
+    'section_association',
   ];
 
   /**


### PR DESCRIPTION
## Description

See #2906 . 

## Testing done

* Ran the bulk export and no longer saw the error message
`lando drush va-gov-cms-export-all-content --process-count=8 --entity-count=500`

![Recent log messages | VA gov CMS 2020-09-23 10-24-46](https://user-images.githubusercontent.com/121603/94026247-68ddcc80-fd87-11ea-8b8f-18be9fffb918.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/2976)
<!-- Reviewable:end -->
