### PR TITLE
VACMS-2903 Allow export dir to be changed in the drush command

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php
@@ -35,6 +35,13 @@ class BuildCommands {
   protected $executableFinder;
 
   /**
+   * Set the tome export directory.
+   *
+   * @var string
+   */
+  protected $exportDir;
+
+  /**
    * BuildCommands constructor.
    *
    * @param \Drupal\tome_sync\ExporterInterface $exporter
@@ -71,7 +78,11 @@ class BuildCommands {
 
     $executable = $this->executableFinder->findExecutable('va-gov-cms-export-all-content');
     foreach (array_chunk($id_pairs, $entity_count) as $chunk) {
-      $commands[] = $executable . ' va-gov-cms-export-content ' . escapeshellarg(implode(',', $chunk));
+      $cmd = $executable . ' va-gov-cms-export-content ' . escapeshellarg(implode(',', $chunk));
+      if ($this->getExportDir()) {
+        $cmd .= ' --export-dir=' . escapeshellarg($this->getExportDir());
+      }
+      $commands[] = $cmd;
     }
 
     return $commands;
@@ -171,6 +182,26 @@ class BuildCommands {
     }
 
     return $collected_errors;
+  }
+
+  /**
+   * Get the export Directory.
+   *
+   * @return string
+   *   The export directory.
+   */
+  public function getExportDir(): string {
+    return $this->exportDir;
+  }
+
+  /**
+   * Set the export directory.
+   *
+   * @param string $exportDir
+   *   The directory to use for the export.
+   */
+  public function setExportDir(string $exportDir): void {
+    $this->exportDir = $exportDir;
   }
 
 }

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.drush.inc
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.drush.inc
@@ -5,6 +5,7 @@
  * CMS Export commands.
  */
 
+use Drupal\Core\Site\Settings;
 use Drupal\va_gov_content_export\ExportCommand\ExportCommandException;
 use Drush\Log\LogLevel;
 
@@ -19,6 +20,9 @@ function va_gov_content_export_drush_command() {
     'arguments' => [
       'chunk' => 'A comma separated list of ID pairs in the format entity_type_id:id.',
     ],
+    'options' => [
+      'export-dir' => 'Override the default content export directory',
+    ],
     'required-arguments' => TRUE,
   ];
 
@@ -28,6 +32,7 @@ function va_gov_content_export_drush_command() {
       'process-count' => 'Limits the number of processes to run concurrently.',
       'entity-count' => 'The number of entities to export per process.',
       'delete-existing' => 'Delete the exiting CMS Export folder.',
+      'export-dir' => 'Override the default content export directory',
     ],
   ];
 
@@ -58,8 +63,19 @@ function va_gov_content_export_drush_command() {
  */
 function drush_va_gov_content_export_va_gov_cms_export_content($chunk) {
   $id_pairs = explode(',', $chunk);
+  $export_dir = drush_get_option('export-dir', '');
+
   try {
-    \Drupal::service('va_gov.content_export.export_command')->exportPairs($id_pairs);
+    // Update the export directory before calling the service since the path is
+    // injected into the JSON service which is injected into this service.
+    if ($export_dir) {
+      $settings = Settings::getAll();
+      $settings['tome_content_directory'] = $export_dir;
+      new Settings($settings);
+    }
+
+    $export_service = \Drupal::service('va_gov.content_export.export_command');
+    $export_service->exportPairs($id_pairs);
   }
   catch (ExportCommandException $e) {
     drush_log($e->getMessage(), LogLevel::ERROR);
@@ -75,10 +91,15 @@ function drush_va_gov_content_export_va_gov_cms_export_all_content() {
   $process_count = drush_get_option('process-count', 1);
   $entity_count = drush_get_option('entity-count', 'all');
   $delete_existing = drush_get_option('delete-existing', FALSE);
+  $export_dir = drush_get_option('export-dir', '');
 
   $command = \Drupal::service('va_gov.content_export.export_all_command');
   if ($delete_existing) {
     $command->deleteExportDirectories();
+  }
+
+  if ($export_dir) {
+    $command->setExportDir($export_dir);
   }
 
   $commands = $command->buildCommands($entity_count);

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -215,5 +215,8 @@ else {
 }
 $settings['file_public_base_url'] = "{$webhost}/sites/default/files";
 
+// Extend the limit of the tome cache table beyond 5000 rows.
+// See https://www.drupal.org/node/3162499.
+$settings['database_cache_max_rows']['bins']['tome_static'] = -1;
 $settings['tome_content_directory'] = 'public://cms-export-content';
 $settings['tome_files_directory'] = 'public://cms-export-files';


### PR DESCRIPTION
## Description

See #2903. 

## Testing done
* Ran all cms export on with out the `export-dir` options: `lando drush va-gov-cms-export-all-content --process-count=8 --entity-count=500`
* Ran all cms export overriding the export directory: `lando drush va-gov-cms-export-all-content --process-count=8 --entity-count=500 --export-dir="public://cms-export-2"`
* Checked to see to see the new directory was created and contains contents
![image](https://user-images.githubusercontent.com/121603/94468114-ee9bb680-0191-11eb-9a00-eea62697acf9.png)

* Ran a diff on the two directories and they are the same.

![image](https://user-images.githubusercontent.com/121603/94468167-0115f000-0192-11eb-9700-d4e4541a1523.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/3014)
<!-- Reviewable:end -->
