### PR TITLE
Revert "VACMS-2903 Allow export dir to be changed in the drush command"

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php
@@ -35,13 +35,6 @@ class BuildCommands {
   protected $executableFinder;
 
   /**
-   * Set the tome export directory.
-   *
-   * @var string
-   */
-  protected $exportDir;
-
-  /**
    * BuildCommands constructor.
    *
    * @param \Drupal\tome_sync\ExporterInterface $exporter
@@ -78,11 +71,7 @@ class BuildCommands {
 
     $executable = $this->executableFinder->findExecutable('va-gov-cms-export-all-content');
     foreach (array_chunk($id_pairs, $entity_count) as $chunk) {
-      $cmd = $executable . ' va-gov-cms-export-content ' . escapeshellarg(implode(',', $chunk));
-      if ($this->getExportDir()) {
-        $cmd .= ' --export-dir=' . escapeshellarg($this->getExportDir());
-      }
-      $commands[] = $cmd;
+      $commands[] = $executable . ' va-gov-cms-export-content ' . escapeshellarg(implode(',', $chunk));
     }
 
     return $commands;
@@ -182,26 +171,6 @@ class BuildCommands {
     }
 
     return $collected_errors;
-  }
-
-  /**
-   * Get the export Directory.
-   *
-   * @return string
-   *   The export directory.
-   */
-  public function getExportDir(): string {
-    return $this->exportDir;
-  }
-
-  /**
-   * Set the export directory.
-   *
-   * @param string $exportDir
-   *   The directory to use for the export.
-   */
-  public function setExportDir(string $exportDir): void {
-    $this->exportDir = $exportDir;
   }
 
 }

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.drush.inc
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.drush.inc
@@ -5,7 +5,6 @@
  * CMS Export commands.
  */
 
-use Drupal\Core\Site\Settings;
 use Drupal\va_gov_content_export\ExportCommand\ExportCommandException;
 use Drush\Log\LogLevel;
 
@@ -20,9 +19,6 @@ function va_gov_content_export_drush_command() {
     'arguments' => [
       'chunk' => 'A comma separated list of ID pairs in the format entity_type_id:id.',
     ],
-    'options' => [
-      'export-dir' => 'Override the default content export directory',
-    ],
     'required-arguments' => TRUE,
   ];
 
@@ -32,7 +28,6 @@ function va_gov_content_export_drush_command() {
       'process-count' => 'Limits the number of processes to run concurrently.',
       'entity-count' => 'The number of entities to export per process.',
       'delete-existing' => 'Delete the exiting CMS Export folder.',
-      'export-dir' => 'Override the default content export directory',
     ],
   ];
 
@@ -63,19 +58,8 @@ function va_gov_content_export_drush_command() {
  */
 function drush_va_gov_content_export_va_gov_cms_export_content($chunk) {
   $id_pairs = explode(',', $chunk);
-  $export_dir = drush_get_option('export-dir', '');
-
   try {
-    // Update the export directory before calling the service since the path is
-    // injected into the JSON service which is injected into this service.
-    if ($export_dir) {
-      $settings = Settings::getAll();
-      $settings['tome_content_directory'] = $export_dir;
-      new Settings($settings);
-    }
-
-    $export_service = \Drupal::service('va_gov.content_export.export_command');
-    $export_service->exportPairs($id_pairs);
+    \Drupal::service('va_gov.content_export.export_command')->exportPairs($id_pairs);
   }
   catch (ExportCommandException $e) {
     drush_log($e->getMessage(), LogLevel::ERROR);
@@ -91,15 +75,10 @@ function drush_va_gov_content_export_va_gov_cms_export_all_content() {
   $process_count = drush_get_option('process-count', 1);
   $entity_count = drush_get_option('entity-count', 'all');
   $delete_existing = drush_get_option('delete-existing', FALSE);
-  $export_dir = drush_get_option('export-dir', '');
 
   $command = \Drupal::service('va_gov.content_export.export_all_command');
   if ($delete_existing) {
     $command->deleteExportDirectories();
-  }
-
-  if ($export_dir) {
-    $command->setExportDir($export_dir);
   }
 
   $commands = $command->buildCommands($entity_count);

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -215,8 +215,5 @@ else {
 }
 $settings['file_public_base_url'] = "{$webhost}/sites/default/files";
 
-// Extend the limit of the tome cache table beyond 5000 rows.
-// See https://www.drupal.org/node/3162499.
-$settings['database_cache_max_rows']['bins']['tome_static'] = -1;
 $settings['tome_content_directory'] = 'public://cms-export-content';
 $settings['tome_files_directory'] = 'public://cms-export-files';


### PR DESCRIPTION
Reverts department-of-veterans-affairs/va.gov-cms#3014

Passed in CI but failed Staging deploy in http://jenkins.vfs.va.gov/job/deploys/job/cms-vagov-staging/632/consoleFull with below. We only run this command on BRD environments so we actually need a real test for this:

```
TASK [Run bulk CMS Export with 'drush va-gov-cms-export-all-content'] **********
 Monday 28 September 2020  21:18:21 +0000 (0:00:00.024)       0:07:46.617 ****** 
 fatal: [ip-10-247-34-65.us-gov-west-1.compute.internal]: FAILED! => changed=true 
   cmd: source /etc/sysconfig/httpd; /usr/local/bin/drush va-gov-cms-export-all-content --process-count=8 --entity-count=500 --delete-existing 2>&1
   delta: '0:00:01.933795'
   end: '2020-09-28 21:18:23.987152'
   msg: non-zero return code
   rc: 1
   start: '2020-09-28 21:18:22.053357'
   stderr: ''
   stderr_lines: <omitted>
   stdout: |-
     TypeError: Return value of                                               [error]
     Drupal\va_gov_content_export\ExportCommand\BuildCommands::getExportDir()
     must be of the type string, null returned in
     Drupal\va_gov_content_export\ExportCommand\BuildCommands->getExportDir()
     (line 194 of
     /var/www/cms/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php)
     #0
     /var/www/cms/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php(82):
     Drupal\va_gov_content_export\ExportCommand\BuildCommands->getExportDir()
     #1
     /var/www/cms/docroot/modules/custom/va_gov_content_export/va_gov_content_export.drush.inc(105):
     Drupal\va_gov_content_export\ExportCommand\BuildCommands->buildCommands(500)
     #2 /var/www/cms/docroot/vendor/drush/drush/includes/command.inc(422):
     drush_va_gov_content_export_va_gov_cms_export_all_content()
     #3 /var/www/cms/docroot/vendor/drush/drush/includes/command.inc(231):
     _drush_invoke_hooks(Array, Array)
     #4 /var/www/cms/docroot/vendor/drush/drush/includes/command.inc(199):
     drush_command()
     #5
     /var/www/cms/docroot/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67):
     drush_dispatch(Array)
     #6
     /var/www/cms/docroot/vendor/drush/drush/includes/preflight.inc(67):
     Drush\Boot\BaseBoot->bootstrap_and_dispatch()
     #7 phar:///usr/local/bin/drush/bin/drush.php(153): drush_main()
     #8 /usr/local/bin/drush(10): require('phar:///usr/loc...')
     #9 {main}.
     TypeError: Return value of Drupal\va_gov_content_export\ExportCommand\BuildCommands::getExportDir() must be of the type string, null returned in /var/www/cms/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php on line 194 #0 /var/www/cms/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php(82): Drupal\va_gov_content_export\ExportCommand\BuildCommands->getExportDir()
     #1 /var/www/cms/docroot/modules/custom/va_gov_content_export/va_gov_content_export.drush.inc(105): Drupal\va_gov_content_export\ExportCommand\BuildCommands->buildCommands(500)
     #2 /var/www/cms/docroot/vendor/drush/drush/includes/command.inc(422): drush_va_gov_content_export_va_gov_cms_export_all_content()
     #3 /var/www/cms/docroot/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array)
     #4 /var/www/cms/docroot/vendor/drush/drush/includes/command.inc(199): drush_command()
     #5 /var/www/cms/docroot/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)
     #6 /var/www/cms/docroot/vendor/drush/drush/includes/preflight.inc(67): Drush\Boot\BaseBoot->bootstrap_and_dispatch()
     #7 phar:///usr/local/bin/drush/bin/drush.php(153): drush_main()
     #8 /usr/local/bin/drush(10): require('phar:///usr/loc...')
     #9 {main}
     TypeError: Return value of Drupal\va_gov_content_export\ExportCommand\BuildCommands::getExportDir() must be of the type string, null returned in Drupal\va_gov_content_export\ExportCommand\BuildCommands->getExportDir() (line 194 of /var/www/cms/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php).
     Drush command terminated abnormally due to an unrecoverable error.       [error]
   stdout_lines: <omitted>
```