### PR TITLE
Add a default value for export dir

### DIFF
--- a/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php
+++ b/docroot/modules/custom/va_gov_content_export/src/ExportCommand/BuildCommands.php
@@ -39,7 +39,7 @@ class BuildCommands {
    *
    * @var string
    */
-  protected $exportDir;
+  protected $exportDir = '';
 
   /**
    * BuildCommands constructor.


### PR DESCRIPTION
## Description

Follow up to #3014

The issue was with the `--export-dir` not being passed.  I ran the script and it exported to the default path correctly.

```lando drush va-gov-cms-export-all-content --process-count=8 --entity-count=500 --delete-existing```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/3020)
<!-- Reviewable:end -->
