### PR TITLE
VACMS 3042 Increase PHPUnit loginPerformance benchmark time to 5

### DIFF
--- a/tests/phpunit/PerformanceLoginTest.php
+++ b/tests/phpunit/PerformanceLoginTest.php
@@ -63,7 +63,7 @@ class LoginPerformance extends ExistingSiteBase {
    */
   public function benchmarkTime() {
     return [
-      [4],
+      [5],
     ];
   }
 


### PR DESCRIPTION
## Description

See #3042 

## Testing done


## Screenshots


## QA steps
as a DevOps Engineer:
- [ ] Build new image on CMS-Test that includes this modified test.
- [ ] Deploy new image to CMS-Test Dev and Staging.
- [ ] Run tests against newly deployed CMS-Test environments.
- [ ] Then validate Acceptance Criteria from issue
  - [ ] Tests no longer fail on PHP LoginPerformance unit test.

## Definition of Done
- [ ] PHPUnit tests for Login Performance no longer fail when longer than 4 seconds.
