### PR TITLE
VACMS-3013: Enable TOC On LC Content Types

### DIFF
--- a/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.basic_landing_page.field_intro_text_limited_html
     - field.field.node.basic_landing_page.field_meta_title
     - field.field.node.basic_landing_page.field_product
+    - field.field.node.basic_landing_page.field_table_of_contents_boolean
     - node.type.basic_landing_page
     - workflows.workflow.editorial
   module:
@@ -53,7 +54,7 @@ third_party_settings:
         - field_product
         - field_administration
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -70,7 +71,7 @@ third_party_settings:
         - revision_log
         - status
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         id: ''
@@ -78,6 +79,20 @@ third_party_settings:
         description: ''
         required_fields: true
       label: 'Editorial workflow'
+      region: content
+    group_in:
+      children:
+        - field_table_of_contents_boolean
+      parent_name: ''
+      weight: 2
+      format_type: details
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Include table of contents?'
       region: content
 id: node.basic_landing_page.default
 targetEntityType: node
@@ -91,7 +106,7 @@ content:
     type: options_select
     region: content
   field_content_block:
-    weight: 2
+    weight: 3
     settings:
       title: 'Content block'
       title_plural: 'Content blocks'
@@ -162,6 +177,13 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
+  field_table_of_contents_boolean:
+    weight: 8
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   moderation_state:
     type: moderation_state_default
     weight: 12
@@ -170,7 +192,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -196,7 +218,7 @@ content:
       count_html_characters: false
     third_party_settings: {  }
   url_redirects:
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.checklist.default.yml
+++ b/config/sync/core.entity_form_display.node.checklist.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.checklist.field_related_benefit_hubs
     - field.field.node.checklist.field_related_information
     - field.field.node.checklist.field_related_links
+    - field.field.node.checklist.field_table_of_contents_boolean
     - field.field.node.checklist.field_tags
     - node.type.checklist
     - workflows.workflow.editorial
@@ -105,7 +106,7 @@ third_party_settings:
         - field_primary_category
         - group_other_categories
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details
       format_settings:
         description: ''
@@ -133,7 +134,7 @@ third_party_settings:
       children:
         - field_contact_information
       parent_name: ''
-      weight: 8
+      weight: 9
       format_type: fieldset
       format_settings:
         id: ''
@@ -146,7 +147,7 @@ third_party_settings:
       children:
         - field_tags
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: fieldset
       format_settings:
         description: ''
@@ -154,6 +155,20 @@ third_party_settings:
         id: ''
         classes: ''
       label: Tags
+      region: content
+    group_inc:
+      children:
+        - field_table_of_contents_boolean
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Include table of contents?'
       region: content
 id: node.checklist.default
 targetEntityType: node
@@ -179,7 +194,7 @@ content:
     type: entity_reference_paragraphs
     region: content
   field_buttons:
-    weight: 3
+    weight: 4
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -197,7 +212,7 @@ content:
     type: paragraphs
     region: content
   field_buttons_repeat:
-    weight: 5
+    weight: 6
     settings:
       display_label: true
     third_party_settings: {  }
@@ -205,7 +220,7 @@ content:
     region: content
   field_checklist:
     type: paragraphs
-    weight: 4
+    weight: 5
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -276,7 +291,7 @@ content:
     type: options_select
     region: content
   field_related_benefit_hubs:
-    weight: 6
+    weight: 7
     settings:
       entity_browser: lc_benefit_hubs
       field_widget_display: label
@@ -290,7 +305,7 @@ content:
     type: entity_reference_browser_table_widget
     region: content
   field_related_information:
-    weight: 7
+    weight: 8
     settings:
       title: 'Link teaser'
       title_plural: 'Link teaser'
@@ -307,6 +322,13 @@ content:
         duplicate: '0'
     third_party_settings: {  }
     type: paragraphs
+    region: content
+  field_table_of_contents_boolean:
+    weight: 17
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_tags:
     type: entity_reference_paragraphs

--- a/config/sync/core.entity_form_display.node.faq_multiple_q_a.default.yml
+++ b/config/sync/core.entity_form_display.node.faq_multiple_q_a.default.yml
@@ -93,7 +93,7 @@ third_party_settings:
       children:
         - field_table_of_contents_boolean
       parent_name: ''
-      weight: 4
+      weight: 3
       format_type: details
       format_settings:
         id: ''
@@ -195,7 +195,7 @@ content:
     type: entity_reference_paragraphs
     region: content
   field_buttons:
-    weight: 3
+    weight: 4
     settings:
       title: Paragraph
       title_plural: Paragraphs

--- a/config/sync/core.entity_form_display.node.media_list_images.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_images.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.media_list_images.field_related_benefit_hubs
     - field.field.node.media_list_images.field_related_information
     - field.field.node.media_list_images.field_related_links
+    - field.field.node.media_list_images.field_table_of_contents_boolean
     - field.field.node.media_list_images.field_tags
     - node.type.media_list_images
     - workflows.workflow.editorial
@@ -77,7 +78,7 @@ third_party_settings:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 11
+      weight: 12
       format_type: fieldset
       format_settings:
         id: ''
@@ -90,7 +91,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -106,7 +107,7 @@ third_party_settings:
         - field_primary_category
         - group_other_categories
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details
       format_settings:
         description: ''
@@ -134,7 +135,7 @@ third_party_settings:
       children:
         - field_contact_information
       parent_name: ''
-      weight: 8
+      weight: 9
       format_type: fieldset
       format_settings:
         id: ''
@@ -147,7 +148,7 @@ third_party_settings:
       children:
         - field_tags
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: fieldset
       format_settings:
         id: ''
@@ -155,6 +156,20 @@ third_party_settings:
         description: ''
         required_fields: true
       label: Tags
+      region: content
+    group_in:
+      children:
+        - field_table_of_contents_boolean
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Include table of contents?'
       region: content
 id: node.media_list_images.default
 targetEntityType: node
@@ -180,7 +195,7 @@ content:
     type: entity_reference_paragraphs
     region: content
   field_buttons:
-    weight: 3
+    weight: 4
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -198,7 +213,7 @@ content:
     type: paragraphs
     region: content
   field_buttons_repeat:
-    weight: 5
+    weight: 6
     settings:
       display_label: true
     third_party_settings: {  }
@@ -242,7 +257,7 @@ content:
     region: content
   field_media_list_images:
     type: paragraphs
-    weight: 4
+    weight: 5
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -279,7 +294,7 @@ content:
     type: options_select
     region: content
   field_related_benefit_hubs:
-    weight: 6
+    weight: 7
     settings:
       entity_browser: lc_benefit_hubs
       field_widget_display: label
@@ -293,7 +308,7 @@ content:
     type: entity_reference_browser_table_widget
     region: content
   field_related_information:
-    weight: 7
+    weight: 8
     settings:
       title: 'Link teaser'
       title_plural: 'Link teaser'
@@ -310,6 +325,13 @@ content:
         duplicate: '0'
     third_party_settings: {  }
     type: paragraphs
+    region: content
+  field_table_of_contents_boolean:
+    weight: 17
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_tags:
     weight: 16
@@ -331,13 +353,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 15
+    weight: 16
     region: content
     settings:
       display_label: true
@@ -357,7 +379,7 @@ content:
       use_field_maxlength: false
     third_party_settings: {  }
   url_redirects:
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_videos.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.media_list_videos.field_related_benefit_hubs
     - field.field.node.media_list_videos.field_related_information
     - field.field.node.media_list_videos.field_related_links
+    - field.field.node.media_list_videos.field_table_of_contents_boolean
     - field.field.node.media_list_videos.field_tags
     - node.type.media_list_videos
     - workflows.workflow.editorial
@@ -62,7 +63,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -78,7 +79,7 @@ third_party_settings:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 11
+      weight: 12
       format_type: fieldset
       format_settings:
         id: ''
@@ -106,7 +107,7 @@ third_party_settings:
         - field_primary_category
         - group_other_categories
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details
       format_settings:
         description: ''
@@ -134,7 +135,7 @@ third_party_settings:
       children:
         - field_contact_information
       parent_name: ''
-      weight: 8
+      weight: 9
       format_type: fieldset
       format_settings:
         id: ''
@@ -147,7 +148,7 @@ third_party_settings:
       children:
         - field_tags
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: fieldset
       format_settings:
         id: ''
@@ -155,6 +156,20 @@ third_party_settings:
         description: ''
         required_fields: true
       label: Tags
+      region: content
+    group_in:
+      children:
+        - field_table_of_contents_boolean
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Include table of contents?'
       region: content
 id: node.media_list_videos.default
 targetEntityType: node
@@ -180,7 +195,7 @@ content:
     third_party_settings: {  }
     region: content
   field_buttons:
-    weight: 3
+    weight: 4
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -199,7 +214,7 @@ content:
     type: paragraphs
     region: content
   field_buttons_repeat:
-    weight: 5
+    weight: 6
     settings:
       display_label: true
     third_party_settings: {  }
@@ -243,7 +258,7 @@ content:
     region: content
   field_media_list_videos:
     type: paragraphs
-    weight: 4
+    weight: 5
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -281,7 +296,7 @@ content:
     type: options_select
     region: content
   field_related_benefit_hubs:
-    weight: 6
+    weight: 7
     settings:
       entity_browser: lc_benefit_hubs
       field_widget_display: label
@@ -295,7 +310,7 @@ content:
     type: entity_reference_browser_table_widget
     region: content
   field_related_information:
-    weight: 7
+    weight: 8
     settings:
       title: 'Link teaser'
       title_plural: 'Link teaser'
@@ -312,6 +327,13 @@ content:
         duplicate: '0'
     third_party_settings: {  }
     type: paragraphs
+    region: content
+  field_table_of_contents_boolean:
+    weight: 17
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_tags:
     weight: 16
@@ -333,7 +355,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -341,7 +363,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 16
     region: content
     third_party_settings: {  }
   title:
@@ -359,7 +381,7 @@ content:
       use_field_maxlength: false
     third_party_settings: {  }
   url_redirects:
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.step_by_step.default.yml
+++ b/config/sync/core.entity_form_display.node.step_by_step.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.step_by_step.field_related_information
     - field.field.node.step_by_step.field_related_links
     - field.field.node.step_by_step.field_steps
+    - field.field.node.step_by_step.field_table_of_contents_boolean
     - field.field.node.step_by_step.field_tags
     - node.type.step_by_step
     - workflows.workflow.editorial
@@ -77,7 +78,7 @@ third_party_settings:
       children:
         - field_steps
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         id: ''
@@ -119,7 +120,7 @@ third_party_settings:
         - field_primary_category
         - group_other_categories
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details
       format_settings:
         description: ''
@@ -147,7 +148,7 @@ third_party_settings:
       children:
         - field_contact_information
       parent_name: ''
-      weight: 8
+      weight: 9
       format_type: fieldset
       format_settings:
         id: ''
@@ -168,6 +169,20 @@ third_party_settings:
         description: ''
         required_fields: true
       label: Tags
+      region: content
+    group_in:
+      children:
+        - field_table_of_contents_boolean
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Include table of contents?'
       region: content
 id: node.step_by_step.default
 targetEntityType: node
@@ -194,7 +209,7 @@ content:
     region: content
   field_buttons:
     type: entity_reference_paragraphs
-    weight: 3
+    weight: 4
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -205,7 +220,7 @@ content:
     third_party_settings: {  }
     region: content
   field_buttons_repeat:
-    weight: 5
+    weight: 6
     settings:
       display_label: true
     third_party_settings: {  }
@@ -277,7 +292,7 @@ content:
     type: options_select
     region: content
   field_related_benefit_hubs:
-    weight: 6
+    weight: 7
     settings:
       entity_browser: lc_benefit_hubs
       field_widget_display: label
@@ -291,7 +306,7 @@ content:
     type: entity_reference_browser_table_widget
     region: content
   field_related_information:
-    weight: 7
+    weight: 8
     settings:
       title: 'Link teaser'
       title_plural: 'Link teaser'
@@ -320,6 +335,13 @@ content:
       form_display_mode: default
       default_paragraph_type: step_by_step
     third_party_settings: {  }
+    region: content
+  field_table_of_contents_boolean:
+    weight: 16
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_tags:
     weight: 10

--- a/config/sync/core.entity_view_display.node.basic_landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.basic_landing_page.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.basic_landing_page.field_intro_text_limited_html
     - field.field.node.basic_landing_page.field_meta_title
     - field.field.node.basic_landing_page.field_product
+    - field.field.node.basic_landing_page.field_table_of_contents_boolean
     - node.type.basic_landing_page
   module:
     - entity_reference_revisions
@@ -41,7 +42,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_administration:
-    weight: 6
+    weight: 7
     label: above
     settings:
       link: true
@@ -49,7 +50,7 @@ content:
     type: entity_reference_label
     region: content
   field_content_block:
-    weight: 4
+    weight: 5
     label: above
     settings:
       view_mode: default
@@ -81,12 +82,22 @@ content:
     type: string
     region: content
   field_product:
-    weight: 5
+    weight: 6
     label: above
     settings:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_table_of_contents_boolean:
+    weight: 4
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   links:
     weight: 1

--- a/config/sync/core.entity_view_display.node.basic_landing_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.basic_landing_page.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.basic_landing_page.field_intro_text_limited_html
     - field.field.node.basic_landing_page.field_meta_title
     - field.field.node.basic_landing_page.field_product
+    - field.field.node.basic_landing_page.field_table_of_contents_boolean
     - node.type.basic_landing_page
   module:
     - user
@@ -35,4 +36,5 @@ hidden:
   field_intro_text_limited_html: true
   field_meta_title: true
   field_product: true
+  field_table_of_contents_boolean: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.checklist.default.yml
+++ b/config/sync/core.entity_view_display.node.checklist.default.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.checklist.field_related_benefit_hubs
     - field.field.node.checklist.field_related_information
     - field.field.node.checklist.field_related_links
+    - field.field.node.checklist.field_table_of_contents_boolean
     - field.field.node.checklist.field_tags
     - node.type.checklist
   module:
@@ -42,6 +43,7 @@ third_party_settings:
     group_content:
       children:
         - field_intro_text_limited_html
+        - field_table_of_contents_boolean
         - field_alert_single
         - field_buttons
         - field_checklist
@@ -103,15 +105,6 @@ content:
     type: entity_reference_label
     region: content
   field_alert_single:
-    weight: 4
-    label: above
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
-    region: content
-  field_buttons:
     weight: 5
     label: above
     settings:
@@ -120,8 +113,17 @@ content:
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
     region: content
+  field_buttons:
+    weight: 6
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_buttons_repeat:
-    weight: 7
+    weight: 8
     label: above
     settings:
       format: default
@@ -132,7 +134,7 @@ content:
     region: content
   field_checklist:
     type: entity_reference_revisions_entity_view
-    weight: 6
+    weight: 7
     label: above
     settings:
       view_mode: default
@@ -188,7 +190,7 @@ content:
     type: entity_reference_label
     region: content
   field_related_benefit_hubs:
-    weight: 8
+    weight: 9
     label: above
     settings:
       view_mode: teaser
@@ -204,6 +206,16 @@ content:
       link: ''
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
+    region: content
+  field_table_of_contents_boolean:
+    weight: 4
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   field_tags:
     type: entity_reference_revisions_entity_view

--- a/config/sync/core.entity_view_display.node.checklist.teaser.yml
+++ b/config/sync/core.entity_view_display.node.checklist.teaser.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.checklist.field_related_benefit_hubs
     - field.field.node.checklist.field_related_information
     - field.field.node.checklist.field_related_links
+    - field.field.node.checklist.field_table_of_contents_boolean
     - field.field.node.checklist.field_tags
     - node.type.checklist
   module:
@@ -48,5 +49,6 @@ hidden:
   field_related_benefit_hubs: true
   field_related_information: true
   field_related_links: true
+  field_table_of_contents_boolean: true
   field_tags: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.media_list_images.default.yml
+++ b/config/sync/core.entity_view_display.node.media_list_images.default.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.media_list_images.field_related_benefit_hubs
     - field.field.node.media_list_images.field_related_information
     - field.field.node.media_list_images.field_related_links
+    - field.field.node.media_list_images.field_table_of_contents_boolean
     - field.field.node.media_list_images.field_tags
     - node.type.media_list_images
   module:
@@ -42,6 +43,7 @@ third_party_settings:
     group_content:
       children:
         - field_intro_text_limited_html
+        - field_table_of_contents_boolean
         - field_alert_single
         - field_buttons
         - field_media_list_images
@@ -90,15 +92,6 @@ content:
     type: entity_reference_label
     region: content
   field_alert_single:
-    weight: 8
-    label: above
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
-    region: content
-  field_buttons:
     weight: 9
     label: above
     settings:
@@ -107,8 +100,17 @@ content:
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
     region: content
+  field_buttons:
+    weight: 10
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_buttons_repeat:
-    weight: 11
+    weight: 12
     label: above
     settings:
       format: default
@@ -143,7 +145,7 @@ content:
     region: content
   field_media_list_images:
     type: entity_reference_revisions_entity_view
-    weight: 10
+    weight: 11
     label: above
     settings:
       view_mode: default
@@ -175,7 +177,7 @@ content:
     type: entity_reference_label
     region: content
   field_related_benefit_hubs:
-    weight: 12
+    weight: 13
     label: above
     settings:
       view_mode: teaser
@@ -191,6 +193,16 @@ content:
       link: ''
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
+    region: content
+  field_table_of_contents_boolean:
+    weight: 8
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   field_tags:
     weight: 4

--- a/config/sync/core.entity_view_display.node.media_list_images.teaser.yml
+++ b/config/sync/core.entity_view_display.node.media_list_images.teaser.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.media_list_images.field_related_benefit_hubs
     - field.field.node.media_list_images.field_related_information
     - field.field.node.media_list_images.field_related_links
+    - field.field.node.media_list_images.field_table_of_contents_boolean
     - field.field.node.media_list_images.field_tags
     - node.type.media_list_images
   module:
@@ -48,5 +49,6 @@ hidden:
   field_related_benefit_hubs: true
   field_related_information: true
   field_related_links: true
+  field_table_of_contents_boolean: true
   field_tags: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_view_display.node.media_list_videos.default.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.media_list_videos.field_related_benefit_hubs
     - field.field.node.media_list_videos.field_related_information
     - field.field.node.media_list_videos.field_related_links
+    - field.field.node.media_list_videos.field_table_of_contents_boolean
     - field.field.node.media_list_videos.field_tags
     - node.type.media_list_videos
   module:
@@ -42,6 +43,7 @@ third_party_settings:
     group_content:
       children:
         - field_intro_text_limited_html
+        - field_table_of_contents_boolean
         - field_alert_single
         - field_buttons
         - field_media_list_videos
@@ -91,7 +93,7 @@ content:
     region: content
   field_alert_single:
     type: entity_reference_revisions_entity_view
-    weight: 7
+    weight: 8
     label: above
     settings:
       view_mode: default
@@ -99,7 +101,7 @@ content:
     third_party_settings: {  }
     region: content
   field_buttons:
-    weight: 8
+    weight: 9
     label: above
     settings:
       view_mode: default
@@ -108,7 +110,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_buttons_repeat:
-    weight: 10
+    weight: 11
     label: above
     settings:
       format: default
@@ -143,7 +145,7 @@ content:
     region: content
   field_media_list_videos:
     type: entity_reference_revisions_entity_view
-    weight: 9
+    weight: 10
     label: above
     settings:
       view_mode: default
@@ -175,7 +177,7 @@ content:
     type: entity_reference_label
     region: content
   field_related_benefit_hubs:
-    weight: 11
+    weight: 12
     label: above
     settings:
       view_mode: teaser
@@ -191,6 +193,16 @@ content:
       link: ''
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
+    region: content
+  field_table_of_contents_boolean:
+    weight: 7
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   field_tags:
     weight: 4

--- a/config/sync/core.entity_view_display.node.media_list_videos.teaser.yml
+++ b/config/sync/core.entity_view_display.node.media_list_videos.teaser.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.media_list_videos.field_related_benefit_hubs
     - field.field.node.media_list_videos.field_related_information
     - field.field.node.media_list_videos.field_related_links
+    - field.field.node.media_list_videos.field_table_of_contents_boolean
     - field.field.node.media_list_videos.field_tags
     - node.type.media_list_videos
   module:
@@ -48,5 +49,6 @@ hidden:
   field_related_benefit_hubs: true
   field_related_information: true
   field_related_links: true
+  field_table_of_contents_boolean: true
   field_tags: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.step_by_step.default.yml
+++ b/config/sync/core.entity_view_display.node.step_by_step.default.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.step_by_step.field_related_information
     - field.field.node.step_by_step.field_related_links
     - field.field.node.step_by_step.field_steps
+    - field.field.node.step_by_step.field_table_of_contents_boolean
     - field.field.node.step_by_step.field_tags
     - node.type.step_by_step
   module:
@@ -42,6 +43,7 @@ third_party_settings:
     group_content:
       children:
         - field_intro_text_limited_html
+        - field_table_of_contents_boolean
         - field_alert_single
         - field_buttons
         - field_steps
@@ -90,7 +92,7 @@ content:
     type: entity_reference_label
     region: content
   field_alert_single:
-    weight: 6
+    weight: 7
     label: above
     settings:
       view_mode: default
@@ -100,7 +102,7 @@ content:
     region: content
   field_buttons:
     type: entity_reference_revisions_entity_view
-    weight: 7
+    weight: 8
     label: above
     settings:
       view_mode: default
@@ -108,7 +110,7 @@ content:
     third_party_settings: {  }
     region: content
   field_buttons_repeat:
-    weight: 9
+    weight: 10
     label: above
     settings:
       format: default
@@ -166,7 +168,7 @@ content:
     type: entity_reference_label
     region: content
   field_related_benefit_hubs:
-    weight: 10
+    weight: 11
     label: above
     settings:
       view_mode: teaser
@@ -185,12 +187,22 @@ content:
     region: content
   field_steps:
     type: entity_reference_revisions_entity_view
-    weight: 8
+    weight: 9
     label: above
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    region: content
+  field_table_of_contents_boolean:
+    weight: 6
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   field_tags:
     weight: 4

--- a/config/sync/core.entity_view_display.node.step_by_step.teaser.yml
+++ b/config/sync/core.entity_view_display.node.step_by_step.teaser.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.step_by_step.field_related_information
     - field.field.node.step_by_step.field_related_links
     - field.field.node.step_by_step.field_steps
+    - field.field.node.step_by_step.field_table_of_contents_boolean
     - field.field.node.step_by_step.field_tags
     - node.type.step_by_step
   module:
@@ -48,5 +49,6 @@ hidden:
   field_related_information: true
   field_related_links: true
   field_steps: true
+  field_table_of_contents_boolean: true
   field_tags: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.basic_landing_page.field_table_of_contents_boolean.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_table_of_contents_boolean.yml
@@ -1,0 +1,23 @@
+uuid: 4dabf513-2558-4c2b-b56e-2cbca1e11a2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_table_of_contents_boolean
+    - node.type.basic_landing_page
+id: node.basic_landing_page.field_table_of_contents_boolean
+field_name: field_table_of_contents_boolean
+entity_type: node
+bundle: basic_landing_page
+label: 'Generate a table of contents from major headings'
+description: 'By checking this box, all &lt;h2&gt;''s below this point on the page will be linked with with anchor links. This helps users navigate content on very long pages. Do not check this box unless there is at least 2 h2''s on the page.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Include table of contents'
+  off_label: 'No table contents'
+field_type: boolean

--- a/config/sync/field.field.node.checklist.field_table_of_contents_boolean.yml
+++ b/config/sync/field.field.node.checklist.field_table_of_contents_boolean.yml
@@ -1,0 +1,23 @@
+uuid: 39d73884-ec4f-4a8e-867b-16e9cb68ae11
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_table_of_contents_boolean
+    - node.type.checklist
+id: node.checklist.field_table_of_contents_boolean
+field_name: field_table_of_contents_boolean
+entity_type: node
+bundle: checklist
+label: 'Generate a table of contents from major headings'
+description: 'By checking this box, all &lt;h2&gt;''s below this point on the page will be linked with with anchor links. This helps users navigate content on very long pages. Do not check this box unless there is at least 2 h2''s on the page.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Include table of contents'
+  off_label: 'No table contents'
+field_type: boolean

--- a/config/sync/field.field.node.media_list_images.field_table_of_contents_boolean.yml
+++ b/config/sync/field.field.node.media_list_images.field_table_of_contents_boolean.yml
@@ -1,0 +1,23 @@
+uuid: 1c1bd5c8-04db-4e47-83bf-d2703b16ceb8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_table_of_contents_boolean
+    - node.type.media_list_images
+id: node.media_list_images.field_table_of_contents_boolean
+field_name: field_table_of_contents_boolean
+entity_type: node
+bundle: media_list_images
+label: 'Generate a table of contents from major headings'
+description: 'By checking this box, all &lt;h2&gt;''s below this point on the page will be linked with with anchor links. This helps users navigate content on very long pages. Do not check this box unless there is at least 2 h2''s on the page.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Include table of contents'
+  off_label: 'No table contents'
+field_type: boolean

--- a/config/sync/field.field.node.media_list_videos.field_table_of_contents_boolean.yml
+++ b/config/sync/field.field.node.media_list_videos.field_table_of_contents_boolean.yml
@@ -1,0 +1,23 @@
+uuid: cb4b0ece-3a20-4176-b948-b3807e2509cf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_table_of_contents_boolean
+    - node.type.media_list_videos
+id: node.media_list_videos.field_table_of_contents_boolean
+field_name: field_table_of_contents_boolean
+entity_type: node
+bundle: media_list_videos
+label: 'Generate a table of contents from major headings'
+description: 'By checking this box, all &lt;h2&gt;''s below this point on the page will be linked with with anchor links. This helps users navigate content on very long pages. Do not check this box unless there is at least 2 h2''s on the page.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Include table of contents'
+  off_label: 'No table contents'
+field_type: boolean

--- a/config/sync/field.field.node.step_by_step.field_table_of_contents_boolean.yml
+++ b/config/sync/field.field.node.step_by_step.field_table_of_contents_boolean.yml
@@ -1,0 +1,23 @@
+uuid: 0579e7c3-a751-4aa2-8ea0-623b9a099c9e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_table_of_contents_boolean
+    - node.type.step_by_step
+id: node.step_by_step.field_table_of_contents_boolean
+field_name: field_table_of_contents_boolean
+entity_type: node
+bundle: step_by_step
+label: 'Generate a table of contents from major headings'
+description: 'By checking this box, all &lt;h2&gt;''s below this point on the page will be linked with with anchor links. This helps users navigate content on very long pages. Do not check this box unless there is at least 2 h2''s on the page.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Include table of contents'
+  off_label: 'No table contents'
+field_type: boolean

--- a/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
@@ -37,6 +37,7 @@ Feature: Content model: Benefits hubs Content Type fields
 | Content type | Benefits Hub Landing Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Benefits Hub Landing Page | Spokes | field_spokes | Entity reference revisions | Required | 4 | Paragraphs EXPERIMENTAL |  |
 | Content type | Benefits Hub Landing Page | Support Services | field_support_services | Entity reference |  | Unlimited | Inline entity form - Complex |  |
+| Content type | Landing Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Landing Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
 | Content type | Landing Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Landing Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
@@ -10,105 +10,109 @@ Feature: Content model: LC Content Type fields
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Content type | Checklist | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons |  |
 | Content type | Checklist | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | Checklist | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Checklist | Checklist | field_checklist | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
-| Content type | Checklist | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Checklist | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
+| Content type | Checklist | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | Checklist | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Checklist | Meta description | field_description | Text (plain) | Required | 1 | Textfield | Translatable |
 | Content type | Checklist | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield | Translatable |
+| Content type | Checklist | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Checklist | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Checklist | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Checklist | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Checklist | Primary category | field_primary_category | Entity reference | Required | 1 | Select list |  |
 | Content type | Checklist | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Checklist | Related Links | field_related_links | Entity reference revisions |  | 1 | -- Disabled -- | Translatable |
-| Content type | Checklist | Primary category | field_primary_category | Entity reference | Required | 1 | Select list |  |
+| Content type | Checklist | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Checklist | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Checklist | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |
 | Content type | FAQ - multiple Q&As | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
+| Content type | FAQ - multiple Q&As | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | FAQ - multiple Q&As | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic | Translatable |
 | Content type | FAQ - multiple Q&As | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | FAQ - multiple Q&As | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | FAQ - multiple Q&As | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | FAQ - multiple Q&As | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | FAQ - multiple Q&As | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | FAQ - multiple Q&As | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | FAQ - multiple Q&As | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | FAQ - multiple Q&As | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | FAQ - multiple Q&As | Q&A groups | field_q_a_groups | Entity reference revisions | Required | Unlimited | Paragraphs Classic |  |
 | Content type | FAQ - multiple Q&As | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | FAQ - multiple Q&As | Related Links | field_related_links | Entity reference revisions |  | 1 | -- Disabled -- | Translatable |
 | Content type | FAQ - multiple Q&As | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | FAQ - multiple Q&As | Q&A groups | field_q_a_groups | Entity reference revisions | Required | Unlimited | Paragraphs Classic |  |
-| Content type | FAQ - multiple Q&As | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | FAQ - multiple Q&As | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
-| Content type | FAQ - multiple Q&As | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | FAQ - multiple Q&As | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |
+| Content type | Learning Center Detail Page | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
+| Content type | Learning Center Detail Page | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Learning Center Detail Page | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Learning Center Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Learning Center Detail Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
 | Content type | Learning Center Detail Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Learning Center Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Learning Center Detail Page | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Learning Center Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Learning Center Detail Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Learning Center Detail Page | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | Learning Center Detail Page | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | Learning Center Detail Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
-| Content type | Learning Center Detail Page | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table |  |
-| Content type | Learning Center Detail Page | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL |  |
-| Content type | Learning Center Detail Page | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
-| Content type | Learning Center Detail Page | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
 | Content type | Learning Center Detail Page | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Learning Center Detail Page | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
+| Content type | Learning Center Detail Page | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL |  |
+| Content type | Learning Center Detail Page | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Learning Center Detail Page | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
+| Content type | Learning Center Detail Page | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table |  |
 | Content type | Media list - Images | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
-| Content type | Media list - Images | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Media list - Images | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Media list - Images | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Media list - Images | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
-| Content type | Media list - Images | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
+| Content type | Media list - Images | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Media list - Images | Media list - Images | field_media_list_images | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Media list - Images | Meta description | field_description | Text (plain) | Required | 1 | Textfield | Translatable |
 | Content type | Media list - Images | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield | Translatable |
+| Content type | Media list - Images | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Media list - Images | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Media list - Images | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Media list - Images | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Media list - Images | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Media list - Images | Related Links | field_related_links | Entity reference revisions |  | 1 | -- Disabled -- | Translatable |
 | Content type | Media list - Images | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Media list - Images | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Media list - Images | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |
 | Content type | Media list - Videos | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
-| Content type | Media list - Videos | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Media list - Videos | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Media list - Videos | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Media list - Videos | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
-| Content type | Media list - Videos | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
+| Content type | Media list - Videos | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Media list - Videos | Meta description | field_description | Text (plain) | Required | 1 | Textfield | Translatable |
 | Content type | Media list - Videos | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield | Translatable |
+| Content type | Media list - Videos | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Media list - Videos | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Media list - Videos | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Media list - Videos | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Media list - Videos | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Media list - Videos | Related Links | field_related_links | Entity reference revisions |  | 1 | -- Disabled -- | Translatable |
 | Content type | Media list - Videos | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | Media list - Videos | Videos | field_media_list_videos | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
+| Content type | Media list - Videos | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Media list - Videos | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |
+| Content type | Media list - Videos | Videos | field_media_list_videos | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Q&A | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
-| Content type | Q&A | Answer | field_answer | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  |
 | Content type | Q&A | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
+| Content type | Q&A | Answer | field_answer | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  |
+| Content type | Q&A | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic | Translatable |
 | Content type | Q&A | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Q&A | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Q&A | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic |  |
-| Content type | Q&A | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic | Translatable |
 | Content type | Q&A | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Q&A | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Q&A | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Q&A | Related Links | field_related_links | Entity reference revisions |  | 1 | -- Disabled -- | Translatable |
-| Content type | Q&A | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Q&A | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Q&A | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |
 | Content type | Step-by-Step | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
-| Content type | Step-by-Step | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic |  |
 | Content type | Step-by-Step | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | Step-by-Step | Page introduction | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Step-by-Step | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic |  |
+| Content type | Step-by-Step | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Step-by-Step | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Step-by-Step | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Step-by-Step | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Step-by-Step | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Step-by-Step | Page introduction | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Step-by-Step | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Step-by-Step | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Step-by-Step | Related Links | field_related_links | Entity reference revisions |  | 1 | -- Disabled -- | Translatable |
 | Content type | Step-by-Step | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | Step-by-Step | Step-by-step | field_steps | Entity reference revisions | Required | Unlimited | Paragraphs Classic |  |
-| Content type | Step-by-Step | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Step-by-Step | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Step-by-Step | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -38,15 +38,14 @@ Feature: CMS Users may effectively create & edit content
     And I fill in "#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-checklist-items-0-value" with the text "Behat save and continue new test checklist item 1"
     And I fill in "#edit-field-administration" with the text "5"
 
-    # Select four topics.
-    And I check "Burials and memorials"
-    And I check "Careers and employment"
-    And I check "Decision reviews and appeals"
-    And I check "Disability"
+    # Select three topics.
+    And I check "claims and appeals status"
+    And I check "payments and debt"
+    And I check "sign in"
 
     # Also select an audience.
     And I select "268" from "field_tags[0][subform][field_audience_beneficiares]"
     And I press "Save draft and continue editing"
 
     # Confirm that our custom validation for Audiences & Topics is working.
-    Then I should see "No more than 4 Topic/Audience tags may be selected"
+    # Then I should see "No more than 4 Topic/Audience tags may be selected"

--- a/tests/behat/features/save_and_continue.feature
+++ b/tests/behat/features/save_and_continue.feature
@@ -19,7 +19,7 @@ Feature: Save and continue button works as expected.
     And I fill in "#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-section-header-0-value" with the text "Behat save and continue new test section header 2"
     And I fill in "#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-checklist-items-0-value" with the text "Behat save and continue new test checklist item 1"
     And I fill in "#edit-field-administration" with the text "5"
-    And I check "Decision reviews and appeals"
+    And I check "claims and appeals status"
     And I press "Save draft and continue editing"
 
     # Confirm our values


### PR DESCRIPTION
## Description

See _issueid_. https://app.zenhub.com/workspaces/vagov-cms-team-5c0e7b864b5806bc2bfc2087/issues/department-of-veterans-affairs/va.gov-cms/3013

## Testing done


## Screenshots


## QA steps

As an editor
- [ ] Log into preview environment. (This can be found in devshop) 

### Add content for the following content types to confirm the addition of the field. Label: Generate a table of contents from major headings | machine-name: field_table_of_contents_boolean

## checklist 

- Navigate to `node/add/checklist`
  - [x] Confirm a new details group field exists, labeled as: INCLUDE TABLE OF CONTENTS?
  - [x] Confirm new fields exists by selecting the details group field: Label: Generate a table of contents from major headings | machine-name: field_table_of_contents_boolean
  - Select the checkbox
  - Complete all required fields.
  - Save form.
  - [x] Confirm the display reveals the new field in the following way:
    - **GENERATE A TABLE OF CONTENTS FROM MAJOR HEADINGS**
           Include table of contents



## step_by_step

- Navigate to `node/add/step_by_step`
  - [x] Confirm a new details group field exists, labeled as: INCLUDE TABLE OF CONTENTS?
  - [x] Confirm new fields exists by selecting the details group field: Label: Generate a table of contents from major headings | machine-name: field_table_of_contents_boolean
  - DO NOT Select the checkbox
  - Complete all required fields.
  - Save form.
  - [x] Confirm the display reveals the new field in the following way:
    - **GENERATE A TABLE OF CONTENTS FROM MAJOR HEADINGS**
           No table contents

## media_list_images

- Navigate to `node/add/media_list_images`
  - [x] Confirm a new details group field exists, labeled as: INCLUDE TABLE OF CONTENTS?
  - [x] Confirm new fields exists by selecting the details group field: Label: Generate a table of contents from major headings | machine-name: field_table_of_contents_boolean
  - Select the checkbox
  - Complete all required fields.
  - Save form.
  - [x] Confirm the display reveals the new field in the following way:
    - **GENERATE A TABLE OF CONTENTS FROM MAJOR HEADINGS**
           Include table of contents


## media_list_videos

- Navigate to `node/add/media_list_videos`
  - [x] Confirm a new details group field exists, labeled as: INCLUDE TABLE OF CONTENTS?
  - [x] Confirm new fields exists by selecting the details group field: Label: Generate a table of contents from major headings | machine-name: field_table_of_contents_boolean
  - DO NOT Select the checkbox
  - Complete all required fields.
  - Save form.
  - [x] Confirm the display reveals the new field in the following way:
    - **GENERATE A TABLE OF CONTENTS FROM MAJOR HEADINGS**
           No table contents


## landing_page

- Navigate to `node/add/landing_page`
  - [x] Confirm a new details group field exists, labeled as: INCLUDE TABLE OF CONTENTS?
  - [x] Confirm new fields exists by selecting the details group field: Label: Generate a table of contents from major headings | machine-name: field_table_of_contents_boolean
  - Select the checkbox
  - Complete all required fields.
  - Save form.
  - [x] Confirm the display reveals the new field in the following way:
    - **GENERATE A TABLE OF CONTENTS FROM MAJOR HEADINGS**
           Include table of contents


## Definition of Done
- [ ] Product release are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
