### PR TITLE
VACMS-3130_3133

### DIFF
--- a/config/sync/field.storage.node.field_online_scheduling_availabl.yml
+++ b/config/sync/field.storage.node.field_online_scheduling_availabl.yml
@@ -19,7 +19,7 @@ settings:
       label: 'No'
     -
       value: not_applicable
-      label: 'Not applicable'
+      label: 'Unknown'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/sync/field.storage.node.field_referral_required.yml
+++ b/config/sync/field.storage.node.field_referral_required.yml
@@ -19,7 +19,7 @@ settings:
       label: 'No'
     -
       value: not_applicable
-      label: 'Not applicable'
+      label: 'Unknown'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/sync/field.storage.node.field_walk_ins_accepted.yml
+++ b/config/sync/field.storage.node.field_walk_ins_accepted.yml
@@ -19,7 +19,7 @@ settings:
       label: 'No'
     -
       value: not_applicable
-      label: 'Not applicable'
+      label: 'Unknown'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -41,7 +41,6 @@ permissions:
   - 'create q_a content'
   - 'create step_by_step content'
   - 'create support_resources_detail_page content'
-  - 'create va_form content'
   - 'create video media'
   - 'delete media'
   - 'edit any checklist content'

--- a/tests/phpunit/SecurityRolesPermissionsTest.php
+++ b/tests/phpunit/SecurityRolesPermissionsTest.php
@@ -225,7 +225,6 @@ class SecurityRolesPermissions extends ExistingSiteBase {
           'create q_a content',
           'create step_by_step content',
           'create support_resources_detail_page content',
-          'create va_form content',
           'create video media',
           'delete media',
           'edit any checklist content',


### PR DESCRIPTION
## Description
See #3130 #3133 

## Testing done
Visual & PhpUnit

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/95876019-a27b7500-0d40-11eb-820c-5600cfcb1d99.png)
![image](https://user-images.githubusercontent.com/2404547/95876050-aad3b000-0d40-11eb-8c3a-537989676daa.png)
![image](https://user-images.githubusercontent.com/2404547/95876079-b1fabe00-0d40-11eb-8b2b-67c101ecf271.png)

## QA steps
- Go to user perms page, and filter by va forms. Visually verify that content editor does not have the create permission.
- Go to a facility service form, and visually verify that unknown is an option for the three select fields.
