### PR TITLE
VACMS-3176: Add R&S content types to linkit profile

### DIFF
--- a/config/sync/linkit.linkit_profile.default.yml
+++ b/config/sync/linkit.linkit_profile.default.yml
@@ -17,9 +17,12 @@ matchers:
     settings:
       metadata: '[node:field_administration] | Created by [node:author] on [node:created:html_date]'
       bundles:
+        basic_landing_page: basic_landing_page
+        checklist: checklist
         documentation_page: documentation_page
         event: event
         event_listing: event_listing
+        faq_multiple_q_a: faq_multiple_q_a
         health_care_local_facility: health_care_local_facility
         health_care_region_detail_page: health_care_region_detail_page
         health_care_region_page: health_care_region_page
@@ -27,6 +30,8 @@ matchers:
         landing_page: landing_page
         leadership_listing: leadership_listing
         locations_listing: locations_listing
+        media_list_images: media_list_images
+        media_list_videos: media_list_videos
         nca_facility: nca_facility
         news_story: news_story
         office: office
@@ -36,7 +41,10 @@ matchers:
         press_release: press_release
         press_releases_listing: press_releases_listing
         publication_listing: publication_listing
+        q_a: q_a
+        step_by_step: step_by_step
         story_listing: story_listing
+        support_resources_detail_page: support_resources_detail_page
         vamc_operating_status_and_alerts: vamc_operating_status_and_alerts
         vba_facility: vba_facility
         vet_center: vet_center


### PR DESCRIPTION
## Description

See #3176 

## Testing done

Verified that R&S content is available to link with linkit widget.

## Screenshots

<img width="1062" alt="Screen Shot 2020-10-14 at 4 37 57 PM" src="https://user-images.githubusercontent.com/101649/96052895-a4762e80-0e3b-11eb-9bc3-aaf533318d0b.png">

## QA steps

As a user with the content admin role:
1. Create a "press release" node
- [x] Verify that R&S content is available to search and link using the link button on the rich text editor

## Definition of Done
- [ ] Product release notes are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
