### PR TITLE
VACMS-3189: enable transitioning nodes from approved to published

### DIFF
--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -107,6 +107,7 @@ type_settings:
       to: published
       weight: 0
       from:
+        - approved
         - draft
         - published
         - review

--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -84,6 +84,7 @@ type_settings:
     archive:
       label: Archive
       from:
+        - approved
         - published
       to: archived
       weight: 1

--- a/tests/behat/drupal-spec-tool/workflow.feature
+++ b/tests/behat/drupal-spec-tool/workflow.feature
@@ -4,13 +4,13 @@ Feature: Workflow
   As a site owner
   I want my content to go through workflow prior to publication.
 
-  @dst @workflow
+  @dst @workflow                                                                                                                                                                          
      Scenario: Workflow
        Then exactly the following workflows should exist
        | Label | Machine name | Type |
 | Editorial workflow | editorial | Content moderation |
 
-  @dst @workflow_states
+  @dst @workflow_states                                                                                                                                                                   
      Scenario: Workflow states
        Then exactly the following workflow states should exist
        | Workflow | Label | Machine name |
@@ -20,7 +20,7 @@ Feature: Workflow
 | Editorial workflow | Published | published |
 | Editorial workflow | Archived | archived |
 
-  @dst @workflow_transitions
+  @dst @workflow_transitions                                                                                                                                                              
      Scenario: Workflow transitions
        Then exactly the following workflow transitions should exist
        | Workflow | Label | Machine name | From state | To state |
@@ -33,6 +33,8 @@ Feature: Workflow
 | Editorial workflow | Approve | approve | In review | Approved |
 | Editorial workflow | Publish | publish | Draft | Published |
 | Editorial workflow | Publish | publish | In review | Published |
+| Editorial workflow | Publish | publish | Approved | Published |
 | Editorial workflow | Publish | publish | Published | Published |
+| Editorial workflow | Archive | archive | Approved | Archived |
 | Editorial workflow | Archive | archive | Published | Archived |
 | Editorial workflow | Restore from archive | archived_published | Archived | Published |


### PR DESCRIPTION
## Description

See #3189 

## Testing done

- Logged in as a user with the 'content admin' user.
- Tested approved -> published transition
- Tested approved -> archived transition

## Screenshots
<img width="1161" alt="Screen Shot 2020-10-15 at 4 00 52 PM" src="https://user-images.githubusercontent.com/101649/96190567-b1f4ec80-0eff-11eb-8796-0fd5628105d9.png">

<img width="243" alt="Screen Shot 2020-10-16 at 9 03 52 AM" src="https://user-images.githubusercontent.com/101649/96275501-0abf9600-0f8f-11eb-9515-31e0232990cb.png">

<img width="363" alt="Screen Shot 2020-10-16 at 9 04 09 AM" src="https://user-images.githubusercontent.com/101649/96275499-0abf9600-0f8f-11eb-89c3-fbeb4727de13.png">

<img width="201" alt="Screen Shot 2020-10-16 at 9 05 38 AM" src="https://user-images.githubusercontent.com/101649/96275498-0a26ff80-0f8f-11eb-9527-402714cb4ed0.png">

<img width="211" alt="Screen Shot 2020-10-16 at 9 05 53 AM" src="https://user-images.githubusercontent.com/101649/96275496-0a26ff80-0f8f-11eb-8f41-eed3595e26ec.png">

## QA steps

As a user with the content admin role:
- Create a node and set it to the "Approved" state
- [x] Validate that it can then be moved to "Published"
- Create a node and set it to the "Approved" state
- [x] Validate that it can then be moved to "Archived"

## Definition of Done
- [ ] Product release are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
