### PR TITLE
VACMS-3196: Q&A field_answer refactoring

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.rich_text_char_limit_1000.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.rich_text_char_limit_1000.default.yml
@@ -1,0 +1,34 @@
+uuid: 88a98cb8-98e1-4fbf-9816-94cca42258f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.rich_text_char_limit_1000.field_wysiwyg
+    - paragraphs.paragraphs_type.rich_text_char_limit_1000
+  module:
+    - allowed_formats
+    - textfield_counter
+id: paragraph.rich_text_char_limit_1000.default
+targetEntityType: paragraph
+bundle: rich_text_char_limit_1000
+mode: default
+content:
+  field_wysiwyg:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+      maxlength: 1000
+      counter_position: after
+      js_prevent_submit: true
+      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      count_html_characters: false
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
+    type: text_textarea_with_counter
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_view_display.paragraph.rich_text_char_limit_1000.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.rich_text_char_limit_1000.default.yml
@@ -1,0 +1,23 @@
+uuid: 32b0cf17-7155-42e8-8d09-cac02fc9ebee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.rich_text_char_limit_1000.field_wysiwyg
+    - paragraphs.paragraphs_type.rich_text_char_limit_1000
+  module:
+    - text
+id: paragraph.rich_text_char_limit_1000.default
+targetEntityType: paragraph
+bundle: rich_text_char_limit_1000
+mode: default
+content:
+  field_wysiwyg:
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/field.field.node.q_a.field_answer.yml
+++ b/config/sync/field.field.node.q_a.field_answer.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_answer
     - node.type.q_a
-    - paragraphs.paragraphs_type.wysiwyg
+    - paragraphs.paragraphs_type.rich_text_char_limit_1000
   module:
     - entity_reference_revisions
 id: node.q_a.field_answer
@@ -23,117 +23,126 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      wysiwyg: wysiwyg
+      rich_text_char_limit_1000: rich_text_char_limit_1000
     target_bundles_drag_drop:
       address:
-        weight: -38
+        weight: -73
         enabled: false
       alert:
-        weight: -41
+        weight: -76
         enabled: false
       alert_single:
-        weight: 40
+        weight: -57
+        enabled: false
+      audience_topics:
+        weight: -54
         enabled: false
       button:
-        weight: 31
+        weight: -58
         enabled: false
       checklist:
-        weight: 42
+        weight: -56
         enabled: false
       checklist_item:
-        weight: 43
+        weight: -55
         enabled: false
       collapsible_panel:
-        weight: -44
+        weight: -79
         enabled: false
       collapsible_panel_item:
-        weight: -37
+        weight: -72
+        enabled: false
+      contact_information:
+        weight: -50
         enabled: false
       downloadable_file:
-        weight: -36
+        weight: -71
         enabled: false
       email_contact:
-        weight: 47
+        weight: -52
         enabled: false
       expandable_text:
-        weight: -35
+        weight: -70
         enabled: false
       health_care_local_facility_servi:
-        weight: -34
+        weight: -69
         enabled: false
       link_teaser:
-        weight: -33
+        weight: -68
         enabled: false
       list_of_link_teasers:
-        weight: -32
+        weight: -67
         enabled: false
       list_of_links:
-        weight: 52
+        weight: -48
         enabled: false
       lists_of_links:
-        weight: 51
+        weight: -49
         enabled: false
       media:
-        weight: -31
+        weight: -66
         enabled: false
       media_list_images:
-        weight: 55
+        weight: -45
         enabled: false
       media_list_videos:
-        weight: 56
+        weight: -44
         enabled: false
       non_reusable_alert:
-        weight: 57
-        enabled: false
-      number_callout:
-        weight: -42
-        enabled: false
-      phone_number:
-        weight: -30
-        enabled: false
-      process:
         weight: -43
         enabled: false
+      number_callout:
+        weight: -77
+        enabled: false
+      phone_number:
+        weight: -65
+        enabled: false
+      process:
+        weight: -78
+        enabled: false
       q_a:
-        weight: -29
+        weight: -64
         enabled: false
       q_a_group:
-        weight: 62
+        weight: -42
         enabled: false
       q_a_section:
-        weight: -28
+        weight: -63
         enabled: false
       react_widget:
-        weight: -40
+        weight: -75
         enabled: false
+      rich_text_char_limit_1000:
+        enabled: true
+        weight: -81
       service_location:
-        weight: 47
+        weight: -53
         enabled: false
       service_location_address:
-        weight: 48
+        weight: -51
         enabled: false
       situation_update:
-        weight: -27
+        weight: -62
         enabled: false
       spanish_translation_summary:
-        weight: -26
+        weight: -61
         enabled: false
       staff_profile:
-        weight: -25
+        weight: -60
         enabled: false
       starred_horizontal_rule:
-        weight: -24
+        weight: -59
         enabled: false
       step:
-        weight: 53
+        weight: -47
         enabled: false
       step_by_step:
-        weight: 54
+        weight: -46
         enabled: false
       table:
-        weight: -39
+        weight: -74
         enabled: false
       wysiwyg:
-        enabled: true
-        weight: -45
+        weight: -80
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/sync/field.field.paragraph.rich_text_char_limit_1000.field_wysiwyg.yml
+++ b/config/sync/field.field.paragraph.rich_text_char_limit_1000.field_wysiwyg.yml
@@ -1,0 +1,27 @@
+uuid: 2cee68e2-55e2-4895-9fa6-2e6ccc3b4fa1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_wysiwyg
+    - paragraphs.paragraphs_type.rich_text_char_limit_1000
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text_limited: rich_text_limited
+    rich_text: '0'
+    plain_text: '0'
+id: paragraph.rich_text_char_limit_1000.field_wysiwyg
+field_name: field_wysiwyg
+entity_type: paragraph
+bundle: rich_text_char_limit_1000
+label: Text
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.storage.node.field_answer.yml
+++ b/config/sync/field.storage.node.field_answer.yml
@@ -14,7 +14,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/paragraphs.paragraphs_type.rich_text_char_limit_1000.yml
+++ b/config/sync/paragraphs.paragraphs_type.rich_text_char_limit_1000.yml
@@ -1,0 +1,10 @@
+uuid: 3ffc29ff-5b72-4f6a-a51b-7076c3f62f22
+langcode: en
+status: true
+dependencies: {  }
+id: rich_text_char_limit_1000
+label: 'Rich text - char limit 1000'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/scripts/content/VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
+++ b/scripts/content/VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @file VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
+ *
+ * One-time migration for Q&A content type Answer field paragraphs.
+ */
+
+use Drupal\paragraphs\Entity\Paragraph;
+use Psr\Log\LogLevel;
+
+
+// Ensure that the new configuration is present.
+$field_answer_target = \Drupal::config('field.field.node.q_a.field_answer')->get('settings.handler_settings.target_bundles');
+if (!isset($field_answer_target['rich_text_char_limit_1000'])) {
+  print("The required paragraph configuration is not present, exiting!\n");
+  exit(1);
+}
+
+$updated = 0;
+$failed = 0;
+$failed_nids = [];
+
+$qas = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['type' => 'q_a']);
+
+foreach ($qas as $qa) {
+  // Load the old paragraph instance if present.
+  $paragraph_old = $qa->get('field_answer')->first()->get('entity')->getTarget()->getValue();
+
+  // Proceed if the paragraph is present and not of the new type.
+  if ($paragraph_old instanceof Paragraph && $paragraph_old->bundle() == 'wysiwyg') {
+    $text_value = $paragraph_old->get('field_wysiwyg')->getValue()[0]['value'];
+
+    if (isset($text_value)) {
+      // Create a new paragraph instance with the previous paragraph's
+      // text and connect it to the Q&A node.
+      $paragraph_new = Paragraph::create([
+        'type' => 'rich_text_char_limit_1000',
+        'field_wysiwyg' => [
+          'value' => $text_value,
+          'format' => 'rich_text_limited',
+        ],
+      ]);
+      $paragraph_new->isNew();
+      $paragraph_new->save();
+
+      $new_answer = [
+        'target_id' => $paragraph_new->id(),
+        'target_revision_id' => $paragraph_new->getRevisionId(),
+      ];
+      $qa->set('field_answer', $new_answer);
+      $qa->setNewRevision(TRUE);
+      $qa->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+      $qa->setRevisionUserId(1);
+      $qa->setRevisionLogMessage('Migration from the old answer to a new answer field with limited characters.');
+      $qa->set('moderation_state', 'draft');
+      $saved = $qa->save();
+
+      // Delete the old paragraph from the DB.
+      $paragraph_old->delete();
+    }
+  }
+
+  $updated = (is_int($saved) && $saved > 0) ? $updated + 1 : $updated;
+  $failed = (is_int($saved) && $saved <= 0) ? $failed + 1 : $failed;
+  $failed_nids = (is_int($saved) && $saved <= 0) ? $failed_nids[$qa->id()] : $failed_nids;
+
+  Drupal::logger('va_gov_backend')->log(LogLevel::INFO, 'Migrated field_answer fields content for Q&A node "%id".', [
+    '%id' => $qa->id(),
+  ]);
+}
+
+Drupal::logger('va_gov_backend')
+  ->log(LogLevel::INFO, 'Answer values for Q&A nodes were successfully migrated for %updated out of %count entities. %failed %failed_nids', [
+    '%count' => count($qas),
+    '%updated' => $updated,
+    '%failed' => $failed ? 'Failed to update ' . $failed . ' out of %count.' : NULL,
+    '%failed_nids' => count($failed_nids) ? 'Failed nids: ' . implode(', ', $failed_nids) . '.' : NULL,
+  ]);
+
+print(
+  t('Answer values for Q&A nodes were successfully migrated for @updated out of @count entities. @failed @failed_nids', [
+      '@count' => count($qas),
+      '@updated' => $updated,
+      '@failed' => $failed ? 'Failed to update ' . $failed . ' out of %count.' : NULL,
+      '@failed_nids' => count($failed_nids) ? 'Failed nids: ' . implode(', ', $failed_nids) . '.' : NULL,
+    ]
+  )
+);

--- a/scripts/content/VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
+++ b/scripts/content/VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
@@ -1,13 +1,14 @@
 <?php
+
 /**
- * @file VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
- *
+ * @file
  * One-time migration for Q&A content type Answer field paragraphs.
+ *
+ *  VACMS-3196-qa_rich_text_field_content_migration-2020-10.php.
  */
 
 use Drupal\paragraphs\Entity\Paragraph;
 use Psr\Log\LogLevel;
-
 
 // Ensure that the new configuration is present.
 $field_answer_target = \Drupal::config('field.field.node.q_a.field_answer')->get('settings.handler_settings.target_bundles');
@@ -79,10 +80,9 @@ Drupal::logger('va_gov_backend')
 
 print(
   t('Answer values for Q&A nodes were successfully migrated for @updated out of @count entities. @failed @failed_nids', [
-      '@count' => count($qas),
-      '@updated' => $updated,
-      '@failed' => $failed ? 'Failed to update ' . $failed . ' out of %count.' : NULL,
-      '@failed_nids' => count($failed_nids) ? 'Failed nids: ' . implode(', ', $failed_nids) . '.' : NULL,
-    ]
-  )
+    '@count' => count($qas),
+    '@updated' => $updated,
+    '@failed' => $failed ? 'Failed to update ' . $failed . ' out of %count.' : NULL,
+    '@failed_nids' => count($failed_nids) ? 'Failed nids: ' . implode(', ', $failed_nids) . '.' : NULL,
+  ])
 );

--- a/scripts/content/VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
+++ b/scripts/content/VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
@@ -51,7 +51,7 @@ foreach ($qas as $qa) {
       $qa->set('field_answer', $new_answer);
       $qa->setNewRevision(TRUE);
       $qa->setRevisionCreationTime(\Drupal::time()->getRequestTime());
-      $qa->setRevisionUserId(1);
+      $qa->setRevisionUserId(1317);
       $qa->setRevisionLogMessage('Migration from the old answer to a new answer field with limited characters.');
       $qa->set('moderation_state', 'draft');
       $saved = $qa->save();

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -89,6 +89,7 @@ Feature: Content model bundles
 | Topics | topics | Vocabulary |  |
 | VAMC facility service (non-healthcare service) | health_care_local_facility_servi | Paragraph type | A service available at a specific health care facility, like Parking, or Chaplaincy. |
 | Rich text | wysiwyg | Paragraph type | An open-ended text field. |
+| Rich text - char limit 1000 | rich_text_char_limit_1000 | Paragraph type | |
 | Audience - Beneficiaries | audience_beneficiaries | Vocabulary |  |
 | Audience - Non-beneficiaries | audience_non_beneficiaries | Vocabulary |  |
 | Learning Center Categories | lc_categories | Vocabulary |  |

--- a/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
@@ -78,7 +78,7 @@ Feature: Content model: LC Content Type fields
 | Content type | Media list - Videos | Videos | field_media_list_videos | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Media list - Videos | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |
 | Content type | Q&A | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
-| Content type | Q&A | Answer | field_answer | Entity reference revisions | Required | Unlimited | Paragraphs EXPERIMENTAL |  |
+| Content type | Q&A | Answer | field_answer | Entity reference revisions | Required | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Q&A | Alert | field_alert_single | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Q&A | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Q&A | Enable standalone page | field_standalone_page | Boolean |  | 1 | Single on/off checkbox |  |

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -117,4 +117,4 @@ Feature: Content model: Paragraph fields
 | Paragraph type | VAMC facility service (non-healthcare service) | Service name | field_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Paragraph type | VAMC facility service (non-healthcare service) | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Rich text | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-
+| Paragraph type | Rich text - char limit 1000 | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |


### PR DESCRIPTION
## Description

Part 1 of #3196 

**Goals**:

* allow only one instance of Rich text field to be attached as an answer on a node of Q&A content type
* allow maximum of 1000 characters per answer - current Rich text field allows unlimited chars
* editors should use Rich text limited text format for the answer - currently "Rich text" paragraph defaults to "Rich text" format with extended toolbar.

To accomplish these goals, a new paragraph with specific form display configuration needed to be created, which also requires a migration of existing paragraph value for field_wysiwyg to a new paragraph. See below

**Implementation:**

* created paragraph type `Rich text - char limit 1000` and configured form display mode to render rich text field w/ default (and only) text format - Rich Text Limited with a char counter - max 1000
* updated Q&A content type `field_answer` to allow only references to paragraph type `Rich text - char limit 1000` instead of `Rich text`
* switched `field_answer` cardinality from unlimited to single.

this change still keeps the data from the old paragraph that is attached to `field_answer` in tact, but non-editable. Edit by the user will throw an error on node validation.
**Part 2 of this effort is to run hook_update - ready in PR #3199**

We will need to deploy this config PR during regular deployment and then immediately follow up w/ an update hook PR. @swirtSJW , let's discuss and plan the sequence today at scrum 16th min.

## Testing done


## Screenshots


## QA steps

- [ ] review several nodes of type Q&A and confirm that field "Answer" has an attached paragraph of type "Rich text - char limit 1000", the answer is populated w/ text and text format is set to "Rich Text Limited"
- [ ] confirm only one instance of Rich text paragraph can be added as an answer.
- [ ] review form /node/8225/edit and confirm that the field contains text that is 34 chars longer than set limit. This is expected, PW team will have to go in and edit all Q&As to adhere to max char standard.

## Definition of Done
- [ ] Product release notes are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
- [ ] Content migration script has been run on production and any other applicable environments:
  ```
  # Run from Drupal's docroot:
  drush scr ../scripts/content/VACMS-3196-qa_rich_text_field_content_migration-2020-10.php
  ```
