### PR TITLE
VACMS 2912: Force editors to save first as draft or in review, then publish on the proofing pages.

### DIFF
--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -35,7 +35,7 @@ third_party_settings:
         - field_links
         - field_administration
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -51,7 +51,7 @@ third_party_settings:
         - field_description
         - field_meta_title
       parent_name: ''
-      weight: 0
+      weight: 1
       format_type: fieldset
       format_settings:
         id: ''
@@ -68,7 +68,7 @@ third_party_settings:
         - field_spokes
         - field_related_links
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         id: ''
@@ -82,7 +82,7 @@ third_party_settings:
         - field_teaser_text
         - field_home_page_hub_label
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -97,6 +97,11 @@ targetEntityType: node
 bundle: landing_page
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_administration:
     weight: 15
     label: above
@@ -208,7 +213,6 @@ content:
     type: list_default
     region: content
 hidden:
-  content_moderation_control: true
   field_meta_tags: true
   field_page_last_built: true
   field_plainlanguage_date: true

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -296,6 +296,12 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
     }
 
   }
+
+  // Add after_build callback for Press Release node forms.
+  if ($form_id === 'node_press_release_form' || $form_id === 'node_press_release_edit_form') {
+    $form['field_address']['widget']['#after_build'][] = 'va_gov_backend_press_release_address_after_build';
+  }
+
 }
 
 /**
@@ -303,14 +309,9 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
  */
 function va_gov_backend_field_widget_moderation_state_default_form_alter(&$element, FormStateInterface $form_state, $context) {
   // Remove "Published" from available moderation states.
-  $baseFormId = $form_state->getBuildInfo()['base_form_id'];
-  if ($baseFormId === 'node_form') {
+  $base_form_id = $form_state->getBuildInfo()['base_form_id'];
+  if ($base_form_id === 'node_form') {
     unset($element['state']['#options']['published']);
-  }
-
-  // Add after_build callback for Press Release node forms.
-  if ($form_id === 'node_press_release_form' || $form_id === 'node_press_release_edit_form') {
-    $form['field_address']['widget']['#after_build'][] = 'va_gov_backend_press_release_address_after_build';
   }
 }
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -308,7 +308,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
  * Implements hook_field_widget_WIDGET_TYPE_form_alter() for moderation_state widgets.
  */
 function va_gov_backend_field_widget_moderation_state_default_form_alter(&$element, FormStateInterface $form_state, $context) {
-  // Remove "Published" from available moderation states.
+  // Permit publication only from the proofing page, not the edit form.
   $base_form_id = $form_state->getBuildInfo()['base_form_id'];
   if ($base_form_id === 'node_form') {
     unset($element['state']['#options']['published']);

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -294,6 +294,18 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
     if (!in_array($node_type, $types_in_workflow)) {
       unset($form['actions']['preview']);
     }
+
+  }
+}
+
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter() for moderation_state widgets.
+ */
+function va_gov_backend_field_widget_moderation_state_default_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // Remove "Published" from available moderation states.
+  $baseFormId = $form_state->getBuildInfo()['base_form_id'];
+  if ($baseFormId === 'node_form') {
+    unset($element['state']['#options']['published']);
   }
 
   // Add after_build callback for Press Release node forms.

--- a/tests/behat/Drupal/FeatureContext.php
+++ b/tests/behat/Drupal/FeatureContext.php
@@ -148,17 +148,17 @@ class FeatureContext extends DevShopDrupalContext implements SnippetAcceptingCon
   /**
    * Check that an html element exists.
    *
-   * @param string $element
+   * @param string $selector
    *   The css selector.
    *
    * @Then the :element element should exist
    */
-  public function theElementShouldExist($element) {
+  public function theElementShouldExist($selector) {
     $session = $this->getSession();
-    $element = $session->getPage()->find('css', $element);
+    $element = $session->getPage()->find('css', $selector);
 
     if (NULL === $element) {
-      throw new \InvalidArgumentException(sprintf('Could not evaluate XPath: "%s"', $element));
+      throw new \InvalidArgumentException(sprintf('Could not evaluate XPath: "%s"', $selector));
     }
   }
 

--- a/tests/behat/Drupal/FeatureContext.php
+++ b/tests/behat/Drupal/FeatureContext.php
@@ -151,7 +151,7 @@ class FeatureContext extends DevShopDrupalContext implements SnippetAcceptingCon
    * @param string $selector
    *   The css selector.
    *
-   * @Then the :element element should exist
+   * @Then the :selector element should exist
    */
   public function theElementShouldExist($selector) {
     $session = $this->getSession();

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -128,6 +128,11 @@ Feature: CMS Users may effectively create & edit content
     And I fill in "Name" with "Test Office - BeHaT 404"
     And I press "Save"
     Then I should see "VA.gov URL" in the "#block-entitymetadisplay" element
+
+    # (Re-)Publish the node.
+    And I select "Published" from "Change to"
+    And I fill in "Log message" with "Test publishing"
+    And I press "Apply"
     And I should see "(pending)" in the "#block-entitymetadisplay" element
 
     # Archive the node.
@@ -149,7 +154,6 @@ Feature: CMS Users may effectively create & edit content
     And I should see "State" in the "#edit-field-address-0" element
 
 @content_editing
-<<<<<<< HEAD
   Scenario: Log in and confirm that System-wide alerts can be created and edited
     When I am logged in as a user with the "content_admin" role
 

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -126,7 +126,7 @@ Feature: CMS Users may effectively create & edit content
 
 @content_editing
   Scenario: Confirm that content cannot be published directly from the node edit form.
-    Given I am logged in as a user with the "administrator" role
+    Given I am logged in as a user with the "content_admin" role
     And I am at "node/add/press_release"
     Then I should see "Create News Release"
 
@@ -137,5 +137,5 @@ Feature: CMS Users may effectively create & edit content
     And I should see "Draft" in the "#edit-moderation-state-0-state" element
     And I should see "In review" in the "#edit-moderation-state-0-state" element
 
-    # Verify that the workflow state selector does not contain the "published" option.
+    # Verify that the workflow state selector does not contain the "Published" option.
     And I should not see "Published" in the "#edit-moderation-state-0-state" element

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -107,6 +107,7 @@ Feature: CMS Users may effectively create & edit content
     And I should see "State" in the "#edit-field-address-0" element
 
 @content_editing
+<<<<<<< HEAD
   Scenario: Log in and confirm that System-wide alerts can be created and edited
     When I am logged in as a user with the "content_admin" role
 
@@ -125,32 +126,23 @@ Feature: CMS Users may effectively create & edit content
     Then I should see "BeHat Alert Body"
 
 @content_editing
-  Scenario: Confirm that content cannot be published directly from the node edit form.
+  Scenario Outline: Confirm that content cannot be published directly from the node edit form but can from the node view.
     Given I am logged in as a user with the "content_admin" role
-    And I am at "node/add/press_release"
-    Then I should see "Create News Release"
-
-    # Confirm that the workflow state selector is present for the "press release" content type.
-    And the "#edit-moderation-state-0-state" element should exist
-
-    # Verify that the workflow state selector contains the "Draft" and "In review" options.
-    And I should see "Draft" in the "#edit-moderation-state-0-state" element
-    And I should see "In review" in the "#edit-moderation-state-0-state" element
-
-    # Verify that the workflow state selector does not contain the "Published" option.
-    And I should not see "Published" in the "#edit-moderation-state-0-state" element
-
-    # Save the content.
-    And I fill in "Press Release Title" with "Test Press Release - BeHaT"
-    And I fill in "News releases listing" with "3054"
-    And I fill in "Owner" with "5"
-    And I fill in "City" with "Altoona"
-    And I fill in "State" with "PA"
-    And I fill in "Introduction" with "Test press release introduction."
-    And I fill in "Full text of the Press Release" with "Test full text of the press release."
-    And I press "Save"
-    Then I should see "Test Press Release - BeHaT"
-
-    # Verify that the proofing page offers the correct options.
-    And the "#edit-new-state" element should exist
-    And I should see "Published" in the "#edit-new-state" element
+    And I am viewing an <type> with the title <title>
+    Then the "#edit-new-state" element should exist
+    Then I should see "published" in the "#edit-new-state" element    
+    And I visit the "edit" page for a node with the title <title>
+    Then "#edit-moderation-state-0-state" should not contain "published"
+    Examples:
+      | type                             | title                                 |
+      | "page"                           | "page page"                           |
+      | "landing_page"                   | "landing_page page"                   |
+      | "health_care_region_detail_page" | "health_care_region_detail_page page" |
+      | "event"                          | "event page"                          |
+      | "event_listing"                  | "event_listing page"                  |
+      | "health_care_local_facility"     | "health_care_local_facility page"     |
+      | "health_care_region_page"        | "health_care_region_page page"        |
+      | "press_release"                  | "press_release page"                  |
+      | "outreach_asset"                 | "outreach_asset page"                 |
+      | "publication_listing"            | "publication_listing page"            |
+      | "news_story"                     | "news_story page"                     |

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -139,3 +139,18 @@ Feature: CMS Users may effectively create & edit content
 
     # Verify that the workflow state selector does not contain the "Published" option.
     And I should not see "Published" in the "#edit-moderation-state-0-state" element
+
+    # Save the content.
+    And I fill in "Press Release Title" with "Test Press Release - BeHaT"
+    And I fill in "News releases listing" with "3054"
+    And I fill in "Owner" with "5"
+    And I fill in "City" with "Altoona"
+    And I fill in "State" with "PA"
+    And I fill in "Introduction" with "Test press release introduction."
+    And I fill in "Full text of the Press Release" with "Test full text of the press release."
+    And I press "Save"
+    Then I should see "Test Press Release - BeHaT"
+
+    # Verify that the proofing page offers the correct options.
+    And the "#edit-new-state" element should exist
+    And I should see "Published" in the "#edit-new-state" element

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -123,3 +123,19 @@ Feature: CMS Users may effectively create & edit content
     # Confirm that paragraph can be edited inline
     And I press "edit-field-banner-alert-entities-0-actions-ief-entity-edit"
     Then I should see "BeHat Alert Body"
+
+@content_editing
+  Scenario: Confirm that content cannot be published directly from the node edit form.
+    Given I am logged in as a user with the "administrator" role
+    And I am at "node/add/press_release"
+    Then I should see "Create News Release"
+
+    # Confirm that the workflow state selector is present for the "press release" content type.
+    And the "#edit-moderation-state-0-state" element should exist
+
+    # Verify that the workflow state selector contains the "Draft" and "In review" options.
+    And I should see "Draft" in the "#edit-moderation-state-0-state" element
+    And I should see "In review" in the "#edit-moderation-state-0-state" element
+
+    # Verify that the workflow state selector does not contain the "published" option.
+    And I should not see "Published" in the "#edit-moderation-state-0-state" element

--- a/tests/behat/features/decoupled.feature
+++ b/tests/behat/features/decoupled.feature
@@ -24,7 +24,11 @@ Feature: The VA Website is generated inside the Drupal CMS code.
     And I should see "Recent changes" in the ".view-right-sidebar-latest-revision" element
 
     # Test content publishing.
-    Then I set the node with title "VA blind and low vision rehabilitation services - EDITED" to "published"
+    And I am at "/node/2/latest"
+    And the "#edit-new-state" element should exist
+    And I should see "published" in the "#edit-new-state" element
+    And I fill in "Change to" with "published"
+    Then I press "Apply"
 
     # Test content unpublishing.
     Then I set the node with title "VA health care" to "unpublished"

--- a/tests/behat/features/perms.feature
+++ b/tests/behat/features/perms.feature
@@ -85,7 +85,10 @@ Feature: Permissions
 
     Then I am logged in as a user with the "content_publisher" role
     And I visit the "edit" page for a node with the title <title>
-    Then "#edit-moderation-state-0-state" should contain "published"
+    Then "#edit-moderation-state-0-state" should not contain "published"
+    And I am viewing an <type> with the title <title>
+    And the "#edit-new-state" element should exist
+    And I should see "published" in the "#edit-new-state" element
     Examples:
       | type                             | title                                 |
       | "page"                           | "page page"                           |

--- a/tests/behat/features/perms.feature
+++ b/tests/behat/features/perms.feature
@@ -89,6 +89,12 @@ Feature: Permissions
     And I am viewing an <type> with the title <title>
     And the "#edit-new-state" element should exist
     And I should see "published" in the "#edit-new-state" element
+
+    And I select "Published" from "Change to"
+    And I fill in "Log message" with "Test publishing"
+    And I press "Apply"
+    Then I should see " has been updated."
+
     Examples:
       | type                             | title                                 |
       | "page"                           | "page page"                           |


### PR DESCRIPTION
## Description

See #2912.

I'm fairly new to this process, so any omissions/failures/errors/etc are unintentional.

## Testing done
Created and ran a Behat test.

## Screenshots

Edit Form:
<img width="269" alt="Screen Shot 2020-10-19 at 3 00 23 PM" src="https://user-images.githubusercontent.com/1318579/96505590-f643fd80-121b-11eb-9133-d5a67419ada9.png">

Proofing (Such As Is):
<img width="514" alt="Screen Shot 2020-10-19 at 3 00 48 PM" src="https://user-images.githubusercontent.com/1318579/96505593-f6dc9400-121b-11eb-824f-983a5d4b5980.png">

## QA steps
As user with permission to create a node of a type with moderation enabled, e.g. `press_release`.
1. Open a form to create a new node of that type.
2. Confirm that "Published" is not an option for the Moderation State widget.
3. Save the node as a draft or for review.
4. Confirm that "Published" is now an option for the Moderation State widget.

## Definition of Done
- [ ] Release notes are forthcoming.
