### PR TITLE
VACMS-1421: remove wysiwyg field sync code

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1042,18 +1042,12 @@ function va_gov_backend_pathauto_alias_alter(&$alias, array &$context) {
 
 /**
  * Implements hook_entity_presave().
- *
- * @todo: Remove node page wysiwyg sync after VACMS-1163 is on prod.
  */
 function va_gov_backend_entity_presave(EntityInterface $entity) {
   $bundle_types = ['event', 'news_story', 'press_release', 'outreach_asset'];
 
   if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $bundle_types)) {
     _va_gov_backend_feature_bump($entity);
-  }
-
-  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'page') {
-    _va_gov_backend_sync_wysiwyg_fields($entity);
   }
 }
 
@@ -1089,21 +1083,6 @@ function _va_gov_backend_feature_bump(EntityInterface $entity) {
         $node->save();
       }
     }
-  }
-}
-
-/**
- * Sync field_intro_text with field_intro_text_limited_html.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   Entity.
- */
-function _va_gov_backend_sync_wysiwyg_fields(EntityInterface $entity) {
-  // Match the new intro field with the old intro field.
-  if ($entity->hasField('field_intro_text_limited_html')) {
-    $intro_text_field_data = $entity->field_intro_text->value;
-    $entity->field_intro_text_limited_html->value = $intro_text_field_data;
-    $entity->field_intro_text_limited_html->format = 'rich_text_limited';
   }
 }
 


### PR DESCRIPTION
## Description

See #1421

## Testing done

Tested saving 'page' type nodes and ensured intro content is preserved and updates are visible.


## QA steps

As a user with the content admin role
- [ ] Ensure that changes to the intro field on Benefits Detail Page content are made as expected

## Definition of Done
- [ ] Product release notes are written (or in progress), if required.
- [ ] Documentation has been updated, if applicable.
