### PR TITLE
VACMS-3234: trim link_name url field on import

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_form.yml
+++ b/config/sync/migrate_plus.migration.va_node_form.yml
@@ -21,7 +21,7 @@ source:
     - 'https://prod.cms.va.gov/sites/default/files/migrate_source/va_forms_data.csv'
   delimiter: ','
   enclosure: '"'
-  escape: ''
+  escape: '\'
   header_offset: 1
   multi_value_delimiter: ','
   fields:
@@ -150,6 +150,10 @@ process:
       VA: 'https://www.va.gov/vaforms/va/pdf/'
       VBA: 'http://www.vba.va.gov/pubs/forms/'
     bypass: false
+  non_field_link_name:
+    plugin: callback
+    callable: trim
+    source: link_name
   non_field_url:
     plugin: concat
     source:
@@ -186,7 +190,7 @@ process:
   field_va_form_url:
     plugin: get
     source:
-      - link_name
+      - '@non_field_link_name'
       - '@non_field_url'
   field_va_form_num_pages: Pages
   field_administration: constants/administration_section

--- a/config/sync/migrate_plus.migration.va_node_form.yml
+++ b/config/sync/migrate_plus.migration.va_node_form.yml
@@ -21,7 +21,7 @@ source:
     - 'https://prod.cms.va.gov/sites/default/files/migrate_source/va_forms_data.csv'
   delimiter: ','
   enclosure: '"'
-  escape: '\'
+  escape: \
   header_offset: 1
   multi_value_delimiter: ','
   fields:
@@ -142,6 +142,10 @@ process:
     method: row
     value:
       - 1
+  non_field_link_name:
+    plugin: callback
+    callable: trim
+    source: link_name
   non_field_path:
     plugin: static_map
     source: FormType
@@ -150,10 +154,6 @@ process:
       VA: 'https://www.va.gov/vaforms/va/pdf/'
       VBA: 'http://www.vba.va.gov/pubs/forms/'
     bypass: false
-  non_field_link_name:
-    plugin: callback
-    callable: trim
-    source: link_name
   non_field_url:
     plugin: concat
     source:

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
@@ -23,7 +23,7 @@ source:
     - https://prod.cms.va.gov/sites/default/files/migrate_source/va_forms_data.csv
   delimiter: ","
   enclosure: '"'
-  escape: ''
+  escape: '\'
   header_offset: 1
   # The delimiter used to delimit multi-values in the cell. (optional)
   multi_value_delimiter: ','
@@ -153,6 +153,11 @@ process:
     method: row
     value:
       - 1
+  # Sometimes link_name has a space that confounds the get farther down.
+  non_field_link_name:
+    plugin: callback
+    callable: trim
+    source: link_name
   # A pseudo field to map out paths for different types of forms.
   non_field_path:
     plugin: static_map
@@ -202,7 +207,7 @@ process:
   field_va_form_url:
     plugin: get
     source:
-      - link_name
+      - '@non_field_link_name'
       - '@non_field_url'
 #  field_va_form_tool_url:
 #  field_meta_tags:


### PR DESCRIPTION
## Description

See #3234 

## Testing done

Tested import with link_name field:
- empty
- only containing whitespace
- containing a url
- containing a url with leading/trailing whitespace

## QA steps

1. Run the VA forms import
- [ ] Confirm that the "VA Form 21P-4706b" node has a value for the "Link to form" field