### PR TITLE
VACMS-3233 Remove duplicate yml task for daily/migrate/va_forms.

### DIFF
--- a/tasks-periodic.yml
+++ b/tasks-periodic.yml
@@ -38,12 +38,6 @@ va/background/daily/migrate/nca_facility:
     - drush $DRUSH_ALIAS migrate-reset-status va_node_facility_nca
     - drush $DRUSH_ALIAS migrate-import va_node_facility_nca
 
-va/background/daily/migrate/va_form:
-  description: Run migrate va_forms nightly.
-  command:
-    - drush $DRUSH_ALIAS migrate-reset-status va_node_form
-    - drush $DRUSH_ALIAS migrate-import va_node_form
-
 # Run with:  composer yaml-tests --tests-file=tasks-periodic.yml periodic
 # http://jenkins.vfs.va.gov/job/cms/job/cms-periodic
 va/background/periodic/migrate/facility_status:


### PR DESCRIPTION
## Description

See #3233 . 

## Testing done
Running  `composer yaml-tests --tests-file=tasks-periodic.yml daily` only runs migrate/va_forms once.


## QA steps
This job is run by jenkins each night.  
Devshop does not have access to the url to get the source data CSV, do it will not be able to run the migration.
This is a removal of a duplicate only, it is low risk and needs no extended testing on CI.  (fully realizing I have jinxed myself by stating that)


