### PR TITLE
VACMS-3311: remove extra characters

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,7 @@
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
-    <!-- Do not limit the amount of memory tests take to run. -->y[
+    <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     <env name="SIMPLETEST_BASE_URL" value="http://127.0.0.1"/>


### PR DESCRIPTION
## Description

See #3311 

## Testing done

Ran phpunit locally.

## QA steps

1. Run phpunit
- [x] Validate that warning no longer appears and test results are correct
