### PR TITLE
VACMS-3326: fix ief button on systemwide alerts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "drupal/environment_indicator": "^4.0",
         "drupal/fast_404": "^2.0@alpha",
         "drupal/feature_toggle": "^1.2",
-        "drupal/field_group": "dev-3.x#b245b85f99c48221edf5fb60344dfe53737ae0f9",
+        "drupal/field_group": "^3.1",
         "drupal/fieldhelptext": "^1.0@beta",
         "drupal/govdelivery_bulletins": "^1.2",
         "drupal/graphql": "^3.0",
@@ -252,10 +252,6 @@
             },
             "drupal/entity_clone": {
                 "Cloning child references to nodes has potential to cause memory resource issues": "https://www.drupal.org/files/issues/2020-02-10/entity_clone-child-node-system-drain-3112577-1.patch"
-            },
-            "drupal/field_group": {
-                "Allow to position the group in the advanced (sidebar) column": "https://www.drupal.org/files/issues/2018-07-26/2652642-59.patch",
-                "Incompatibility with inline entity form": "https://www.drupal.org/files/issues/2018-10-30/field_group-inline_entity_form_compatibility-2986704-3.patch"
             },
             "drupal/govdelivery_bulletins": {
                 "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87d85b54b13b2d2c7b93162a9e9faf67",
+    "content-hash": "5f758406f92027ccaffc4d6ad3abef04",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5271,7 +5271,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/field_group.git",
-                "reference": "b245b85f99c48221edf5fb60344dfe53737ae0f9"
+                "reference": "80ff5992b2d7f9a3c3b8614f54d33f80ada7d11e"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -5291,10 +5291,6 @@
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
-                },
-                "patches_applied": {
-                    "Allow to position the group in the advanced (sidebar) column": "https://www.drupal.org/files/issues/2018-07-26/2652642-59.patch",
-                    "Incompatibility with inline entity form": "https://www.drupal.org/files/issues/2018-10-30/field_group-inline_entity_form_compatibility-2986704-3.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5329,7 +5325,7 @@
                 "source": "https://git.drupalcode.org/project/field_group",
                 "issues": "https://www.drupal.org/project/issues/field_group"
             },
-            "time": "2019-05-23T21:31:25+00:00"
+            "time": "2020-06-09T21:44:00+00:00"
         },
         {
             "name": "drupal/fieldhelptext",
@@ -19531,6 +19527,11 @@
                 "squizlabs/php_codesniffer": "^2.7"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "Throw meaningful message for duplicate entry.": "https://patch-diff.githubusercontent.com/raw/TravisCarden/behat-table-comparison/pull/7.patch"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "TravisCarden\\BehatTableComparison\\": "src/BehatTableComparison/"
@@ -19551,12 +19552,7 @@
                 "Behat",
                 "gherkin"
             ],
-            "time": "2018-07-03T17:42:23+00:00",
-            "extra": {
-                "patches_applied": {
-                    "Throw meaningful message for duplicate entry.": "https://patch-diff.githubusercontent.com/raw/TravisCarden/behat-table-comparison/pull/7.patch"
-                }
-            }
+            "time": "2018-07-03T17:42:23+00:00"
         },
         {
             "name": "vipnytt/robotstxtparser",
@@ -19696,7 +19692,6 @@
         "drupal/entity_clone": 10,
         "drupal/entityqueue": 10,
         "drupal/fast_404": 15,
-        "drupal/field_group": 20,
         "drupal/fieldhelptext": 10,
         "drupal/graphql_metatag": 20,
         "drupal/image_style_warmer": 10,

--- a/docroot/modules/custom/va_gov_backend/js/smart_date_interactions.js
+++ b/docroot/modules/custom/va_gov_backend/js/smart_date_interactions.js
@@ -3,22 +3,18 @@
  */
 
 (function (Drupal) {
-  Drupal.behaviors.vaGovServiceLocationAddress = {
+  Drupal.behaviors.smartDateInteractions = {
     attach: function (context, settings) {
-      // Look to see if container div for end time has hidden class.
-      // If it does, hode the All day checkbox.
       const timeEnd = document.querySelector('.time-end');
-      if (timeEnd.classList.contains('hidden')) {
+
+      if (timeEnd !== null && typeof timeEnd === 'object' && timeEnd.classList.contains('hidden')) {
         const alldayLabels = document.querySelectorAll('.allday-label');
+
         alldayLabels.forEach(label => {
           label.style.display = 'none';
           label.classList.add('hidden');
-        })
-        console.log('toggles: ', alldayLabels);
-
-        //context.querySelectorAll('.allday-label').classList.add('hidden');
+        });
       }
-
     }
   };
 

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -105,3 +105,21 @@ Feature: CMS Users may effectively create & edit content
     And I should see "Country" in the "#edit-field-address-0" element
     And I should see "City" in the "#edit-field-address-0" element
     And I should see "State" in the "#edit-field-address-0" element
+
+@content_editing
+  Scenario: Log in and confirm that System-wide alerts can be created and edited
+    When I am logged in as a user with the "content_admin" role
+
+    # Create our initial draft
+    Then I am at "node/add/vamc_operating_status_and_alerts"
+    And I press "Add new banner alert"
+    And I select "Information" from "Alert type"
+    And I fill in "Title" with "BeHat Alert title"
+    And I fill in "Alert body" with "BeHat Alert body"
+    And I press "Save draft and continue editing"
+    Then I should see "Pages for the following VAMC systems"
+    And I should not see "BeHat Alert Body"
+
+    # Confirm that paragraph can be edited inline
+    And I press "edit-field-banner-alert-entities-0-actions-ief-entity-edit"
+    Then I should see "BeHat Alert Body"


### PR DESCRIPTION
## Description

See #3326 

## Testing done

Local testing, added behat test.

## QA steps

As a user with the content editor role,
1. Visit a node with a systemwide banner alert, e.g. /node/1010/edit
1. Click the edit button in the 'System-Wide Alerts' fieldgroup
- [x] Validate that the edit form appears and changes can be saved
- [x] Validate the the 'Add new banner alert' button functions correctly

Edit a facility health service
- [x] validate a phone number could be added
- [x] validate the phone number could be edited.

### CMS user-facing release note

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication.
- [ ] Yes, but it hasn't yet been written (this code is not ready to merge!).
- [ ] No announcement is needed for this code change. 
