### PR TITLE
VACMS-2992: Fix Decision reviews homepage breadcrumb.

### DIFF
--- a/config/sync/menu_breadcrumb.settings.yml
+++ b/config/sync/menu_breadcrumb.settings.yml
@@ -14,37 +14,37 @@ menu_breadcrumb_menus:
     weight: -10
     taxattach: 0
     langhandle: 0
-  health-care-benefits-hub:
+  decision-reviews-benefits-h:
     enabled: 1
     weight: -9
     taxattach: 0
     langhandle: 0
-  records-benefits-hub:
+  health-care-benefits-hub:
     enabled: 1
     weight: -8
     taxattach: 0
     langhandle: 0
-  disability-benefits-hub:
+  records-benefits-hub:
     enabled: 1
     weight: -7
     taxattach: 0
     langhandle: 0
-  careers-employment-benefits:
+  disability-benefits-hub:
     enabled: 1
     weight: -6
     taxattach: 0
     langhandle: 0
-  education-benefits-hub:
+  careers-employment-benefits:
     enabled: 1
     weight: -5
     taxattach: 0
     langhandle: 0
-  burials-and-memorials-benef:
+  education-benefits-hub:
     enabled: 1
     weight: -4
     taxattach: 0
     langhandle: 0
-  decision-reviews-benefits-h:
+  burials-and-memorials-benef:
     enabled: 1
     weight: -3
     taxattach: 0
@@ -109,6 +109,11 @@ menu_breadcrumb_menus:
     weight: 9
     taxattach: 0
     langhandle: 0
+  va-palo-alto-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
   va-manchester-health-care:
     enabled: 1
     weight: 10
@@ -139,52 +144,7 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-finger-lakes-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
   va-new-york-harbor-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-salem-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-sierra-nevada-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-shreveport-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-sheridan-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-san-francisco-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-salt-lake-city-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-salisbury-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-richmond-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -194,22 +154,7 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-providence-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-southern-nevada-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-fayetteville-coastal-health-c:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-pacific-islands-health-care:
+  va-northport-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -219,27 +164,27 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-northport-health-care:
+  va-pacific-islands-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-palo-alto-health-care:
+  admin:
+    weight: 10
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-philadelphia-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-eastern-colorado-health-care:
+  va-southeast-louisiana-health-ca:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-fayetteville-arkansas-health-:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-boston-health-care:
+  va-wilkes-barre-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -274,92 +219,7 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-albany-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-alexandria-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-asheville-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-beckley-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-bedford-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-fargo-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-black-hills-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-bronx-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-cheyenne-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-eastern-oklahoma-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-southeast-louisiana-health-ca:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-durham-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-connecticut-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-clarksburg-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-central-iowa-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-central-western-massachusetts:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-central-california-health-car:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-central-arkansas-health-care:
+  va-southern-nevada-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -369,22 +229,57 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-wilkes-barre-health-care:
+  pittsburgh-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-erie-health-care:
+  va-sierra-nevada-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-wilmington-health-care:
+  va-shreveport-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-philadelphia-health-care:
+  va-sheridan-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-san-francisco-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-salt-lake-city-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-salem-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-richmond-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-providence-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-salisbury-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-fayetteville-coastal-health-c:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -394,32 +289,32 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
+  tools:
+    weight: 10
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
+  va-beckley-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-asheville-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
   va-altoona-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-butler-health-care:
+  va-alexandria-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-coatesville-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  footer-bottom-rail:
-    weight: 10
-    enabled: 0
-    taxattach: 0
-    langhandle: 0
-  admin:
-    weight: 10
-    enabled: 0
-    taxattach: 0
-    langhandle: 0
-  pittsburgh-health-care:
+  va-albany-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -429,14 +324,14 @@ menu_breadcrumb_menus:
     enabled: 0
     taxattach: 0
     langhandle: 0
-  tools:
+  sections:
     weight: 10
     enabled: 0
     taxattach: 0
     langhandle: 0
-  sections:
+  va-black-hills-health-care:
+    enabled: 1
     weight: 10
-    enabled: 0
     taxattach: 0
     langhandle: 0
   outreach-and-events:
@@ -459,12 +354,117 @@ menu_breadcrumb_menus:
     enabled: 0
     taxattach: 0
     langhandle: 0
+  footer-bottom-rail:
+    weight: 10
+    enabled: 0
+    taxattach: 0
+    langhandle: 0
   footer:
     weight: 10
     enabled: 0
     taxattach: 0
     langhandle: 0
   documentation:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-bedford-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-boston-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-finger-lakes-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-connecticut-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-fayetteville-arkansas-health-:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-fargo-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-erie-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-eastern-oklahoma-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-eastern-colorado-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-durham-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-coatesville-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-bronx-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-clarksburg-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-cheyenne-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-central-western-massachusetts:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-central-iowa-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-central-california-health-car:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-central-arkansas-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-butler-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-wilmington-health-care:
     enabled: 1
     weight: 10
     taxattach: 0


### PR DESCRIPTION
## Description

See #2992 Visual. 

## Testing done

Visual.

## Screenshots


![VA_Decision_Reviews_And_Appeals___Veterans_Affairs](https://user-images.githubusercontent.com/643678/97996630-0203f800-1db6-11eb-8f95-c3960b7f4f92.jpg)


## QA steps

As anon, go to /decision-reviews

Should be no "Health care" in the breadcrumb. 

