### PR TITLE
VACMS-2934: Add html formatting constraint checks to table cells.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/ValidCellHtml.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/ValidCellHtml.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that the table cell has valid html.
+ *
+ * @Constraint(
+ *   id = "ValidCellHtml",
+ *   label = @Translation("Valid Cell Html", context = "Validation"),
+ *   type = "string"
+ * )
+ */
+class ValidCellHtml extends Constraint {
+
+  /**
+   * The message that will be shown if the value is not valid html.
+   *
+   * @var \Drupal\va_gov_backend\Plugin\Validation\Constraint
+   */
+  public $notValidCellHtml = 'Table field contains html errors: %errorMessage';
+
+}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/ValidCellHtmlValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/ValidCellHtmlValidator.php
@@ -17,29 +17,55 @@ class ValidCellHtmlValidator extends ConstraintValidator {
   public function validate($item, Constraint $constraint) {
     // Make sure error reporting is on.
     libxml_use_internal_errors(TRUE);
-    $dom = new DOMDocument();
-    $tableString = '';
+    $errors = [];
     // Build up our html string from all cells.
-    foreach ($item->value as $key => $cells) {
-      if ($key !== 'caption') {
-        foreach ($cells as $cell) {
-          $tableString .= $cell;
+    foreach ($item->value as $row_num => $row_cells) {
+      if ($row_num === 'caption') {
+        // Caption can't contain any html.
+        $caption = $row_cells;
+        $stripped_caption = strip_tags($caption);
+        if (strcmp($caption, $stripped_caption) !== 0) {
+          // They differ so there must have been tags.
+          $errors["caption"] = "Caption can not contain html.";
+        }
+      }
+      else {
+        foreach ($row_cells as $col_num => $cell) {
+          if (!empty(trim($cell))) {
+            $dom = new DOMDocument();
+            $dom->loadHTML($cell);
+            // There may be multiple errors so process all of them.
+            $cell_errors = '';
+            foreach (libxml_get_errors() as $error) {
+              if (!empty($error->message)) {
+                $cell_errors .= "- {$error->message}\n";
+              }
+            }
+
+            if (!empty($cell_errors)) {
+              // Adjust the column and row numbers for humans who don't start
+              // counting at 0.
+              $human_row = $row_num + 1;
+              $human_col = $col_num + 1;
+              $errors["{$human_row}x{$human_col}"] = $cell_errors;
+            }
+
+            // Clear out the messages in buffer.
+            libxml_clear_errors();
+          }
         }
       }
     }
-    $dom->loadHTML($tableString);
-    // If we have errors, create a message string.
-    if (!empty(libxml_get_errors())) {
-      $errorString = '';
-      $i = 1;
-      foreach (libxml_get_errors() as $error) {
-        $errorString .= ' ----- ' . $i . ') ' . $error->message;
-        $i++;
+
+    // If we have errors, create a message string from the errors.
+    $error_string = '';
+    if (!empty($errors)) {
+      foreach ($errors as $cell_id => $error) {
+        $error_string .= "$cell_id - $error\n";
       }
-      // Clear out the messages in buffer.
-      libxml_clear_errors();
+
       // Deliver the bad news.
-      $this->context->addViolation($constraint->notValidCellHtml, ['%errorMessage' => $errorString]);
+      $this->context->addViolation($constraint->notValidCellHtml, ['%errorMessage' => $error_string]);
     }
   }
 

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/ValidCellHtmlValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/ValidCellHtmlValidator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use DOMDocument;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the ValidCellHtml constraint.
+ */
+class ValidCellHtmlValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($item, Constraint $constraint) {
+    // Make sure error reporting is on.
+    libxml_use_internal_errors(TRUE);
+    $dom = new DOMDocument();
+    $tableString = '';
+    // Build up our html string from all cells.
+    foreach ($item->value as $key => $cells) {
+      if ($key !== 'caption') {
+        foreach ($cells as $cell) {
+          $tableString .= $cell;
+        }
+      }
+    }
+    $dom->loadHTML($tableString);
+    // If we have errors, create a message string.
+    if (!empty(libxml_get_errors())) {
+      $errorString = '';
+      $i = 1;
+      foreach (libxml_get_errors() as $error) {
+        $errorString .= ' ----- ' . $i . ') ' . $error->message;
+        $i++;
+      }
+      // Clear out the messages in buffer.
+      libxml_clear_errors();
+      // Deliver the bad news.
+      $this->context->addViolation($constraint->notValidCellHtml, ['%errorMessage' => $errorString]);
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -926,6 +926,10 @@ function va_gov_backend_entity_bundle_field_info_alter(&$fields, EntityTypeInter
   if ($entity_type->id() === 'paragraph' && $bundle === 'phone_number' && isset($fields['field_phone_number'])) {
     $fields['field_phone_number']->addConstraint('ValidPhoneNumber');
   }
+  // Add tablefield cell html validation.
+  if ($entity_type->id() === 'paragraph' && $bundle === 'table' && isset($fields['field_table'])) {
+    $fields['field_table']->addConstraint('ValidCellHtml');
+  }
   // Add title duplication prevention validation to q_a nodes.
   if ($entity_type->id() === 'node' && $bundle === 'q_a' && isset($fields['title'])) {
     $fields['title']->addConstraint('UniqueTitle');


### PR DESCRIPTION
## Description
See #2934 
@kevwalsh @oksana-c have a look at the screenshot / form when qa'ing. 

**BAD NEWS**: You'll notice that every cell is highlighted when a violation is detected - I haven't been able to figure out a way (at least not with constraints) to target individual cells.

**GOOD NEWS**: Html entries are all being caught, and this approach will solve the challenges that editors are having with missed / mismatched tags breaking pages.

Just lemme know if this approach will suffice.

## Testing done
Visual 

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/98000425-7b054e80-1dba-11eb-9a60-265c5eda329e.png)

## QA steps
- As an administrator, go to `/node/471/edit`
- In Main content section, add a table paragraph
- Enter content with broken html tags in multiple cells
- Save form, and confirm error notifications occur and specify each improperly formatted html instance  