### PR TITLE
VACMS-2729: Take toolbar height into account when going to anchor links

### DIFF
--- a/docroot/themes/custom/vagovadmin/assets/js/anchor_links.js
+++ b/docroot/themes/custom/vagovadmin/assets/js/anchor_links.js
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Anchor link behaviors.
+ */
+
+(function ($, Drupal) {
+
+  'use strict';
+
+  /**
+   * Return the combined height of the admin toolbar & tray.
+   *
+   * @return {number}
+   *   Height in pixels.
+   */
+  Drupal.getAdminToolbarHeight = function () {
+    const toolbarHeight = $('#toolbar-bar').height() || 0;
+    const tooltrayHeight = $('#toolbar-item-administration-tray.toolbar-tray-horizontal').height() || 0;
+    return toolbarHeight + tooltrayHeight;
+  };
+
+  /**
+   * Attaches anchor link behavior to links.
+   *
+   * @type {Drupal~behavior}
+   */
+  Drupal.behaviors.vagovadminAnchorLinks = {
+    attach: function (context) {
+      $('a[href^="#"]').click(function (e) {
+        e.preventDefault();
+
+        var target = $(this).attr('href');
+        var scrollToPosition = $(target).offset().top - (Drupal.getAdminToolbarHeight() + 10);
+
+        $('html').animate({'scrollTop': scrollToPosition}, 500, function () {
+          window.location.hash = '' + target;
+          $('html').animate({'scrollTop': scrollToPosition}, 0);
+        });
+      });
+    }
+  };
+
+})(jQuery, Drupal);

--- a/docroot/themes/custom/vagovadmin/vagovadmin.info.yml
+++ b/docroot/themes/custom/vagovadmin/vagovadmin.info.yml
@@ -7,6 +7,7 @@ ckeditor_stylesheets:
 - assets/css/wysiwyg.css
 screenshot: logo.svg
 libraries:
+  - vagovadmin/global-scripts
   - vagovadmin/styles
 regions:
   header: 'Header'

--- a/docroot/themes/custom/vagovadmin/vagovadmin.libraries.yml
+++ b/docroot/themes/custom/vagovadmin/vagovadmin.libraries.yml
@@ -12,6 +12,12 @@ proofing:
     - core/drupal
     - core/jquery.once
     - core/jquery.ui.tooltip
+global-scripts:
+  js:
+    assets/js/anchor_links.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
 userguides:
   css:
     theme:


### PR DESCRIPTION
## Description

See #2729 

## Testing done

Manual testing on "How to edit detail pages — for VAMCs" page

## QA steps

As a user with the "authenticated" role:
1. Go to /help/product-guides/vamc/by-content-type/detail-pages
1. When clicking anchor links (e.g. "How to find existing Detail Page content to edit")
- [ ] The heading should not be hidden when the tooltray is horizontal
- [ ] The heading should not be hidden when the tooltray is vertical

As an anonymous user:
1. Go to /help/product-guides/vamc/by-content-type/detail-pages
1. When clicking anchor links (e.g. "How to find existing Detail Page content to edit")
- [ ] The heading should not be hidden

### CMS user-facing release note

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication.
- [ ] Yes, but it hasn't yet been written (this code is not ready to merge!).
- [x] No announcement is needed for this code change. 
