### PR TITLE
VACMS-3395: Editors can't publish some content types.

### DIFF
--- a/config/sync/core.entity_view_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_health_service.default.yml
@@ -27,7 +27,7 @@ third_party_settings:
     group_vha_health_service_name_an:
       children: {  }
       parent_name: ''
-      weight: 15
+      weight: 10
       format_type: fieldset
       format_settings:
         description: ''
@@ -39,7 +39,7 @@ third_party_settings:
       children:
         - field_body
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         description: ''
@@ -55,7 +55,7 @@ third_party_settings:
         - field_online_scheduling_availabl
         - field_phone_numbers_paragraph
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -68,6 +68,11 @@ targetEntityType: node
 bundle: health_care_local_health_service
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_appointments_help_text:
     type: markup
     weight: 9
@@ -107,7 +112,7 @@ content:
     region: content
   field_regional_health_service:
     type: entity_reference_entity_view
-    weight: 0
+    weight: 1
     region: content
     label: hidden
     settings:
@@ -116,7 +121,7 @@ content:
     third_party_settings: {  }
   field_service_location:
     type: entity_reference_revisions_entity_view
-    weight: 7
+    weight: 4
     label: hidden
     settings:
       view_mode: default
@@ -131,7 +136,6 @@ content:
     type: list_default
     region: content
 hidden:
-  content_moderation_control: true
   field_administration: true
   field_facility_location: true
   field_facility_service_loc_help: true

--- a/config/sync/core.entity_view_display.node.va_form.default.yml
+++ b/config/sync/core.entity_view_display.node.va_form.default.yml
@@ -41,7 +41,7 @@ third_party_settings:
         - field_va_form_type
         - field_benefit_categories
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         id: ''
@@ -54,7 +54,7 @@ third_party_settings:
         - field_va_form_tool_intro
         - field_va_form_tool_url
       parent_name: ''
-      weight: 7
+      weight: 8
       format_type: fieldset
       format_settings:
         id: ''
@@ -68,8 +68,8 @@ third_party_settings:
         - field_va_form_deleted
         - field_va_form_deleted_date
         - field_va_form_issue_date
-        - field_va_form_num_pages
         - field_va_form_number
+        - field_va_form_num_pages
         - field_va_form_revision_date
         - field_va_form_row_id
         - field_va_form_title
@@ -88,8 +88,13 @@ targetEntityType: node
 bundle: va_form
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_alert:
-    weight: 4
+    weight: 5
     label: above
     settings:
       view_mode: default
@@ -106,14 +111,14 @@ content:
     type: entity_reference_label
     region: content
   field_meta_tags:
-    weight: 1
+    weight: 2
     label: above
     settings: {  }
     third_party_settings: {  }
     type: metatag_empty_formatter
     region: content
   field_va_form_language:
-    weight: 3
+    weight: 4
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -121,7 +126,7 @@ content:
     region: content
   field_va_form_link_teasers:
     type: entity_reference_revisions_entity_view
-    weight: 9
+    weight: 10
     label: above
     settings:
       view_mode: default
@@ -129,7 +134,7 @@ content:
     third_party_settings: {  }
     region: content
   field_va_form_name:
-    weight: 2
+    weight: 3
     label: above
     settings:
       link_to_entity: false
@@ -137,7 +142,7 @@ content:
     type: string
     region: content
   field_va_form_related_forms:
-    weight: 8
+    weight: 9
     label: above
     settings:
       link: true
@@ -171,19 +176,18 @@ content:
     type: list_default
     region: content
   field_va_form_usage:
-    weight: 6
+    weight: 7
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   links:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  content_moderation_control: true
   field_administration: true
   field_va_form_administration: true
   field_va_form_deleted: true

--- a/config/sync/core.entity_view_display.node.vamc_operating_status_and_alerts.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_operating_status_and_alerts.default.yml
@@ -20,15 +20,12 @@ targetEntityType: node
 bundle: vamc_operating_status_and_alerts
 mode: default
 content:
-  field_banner_alert:
-    weight: 1
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
+  content_moderation_control:
+    weight: 0
     region: content
-  field_facility_operating_status:
+    settings: {  }
+    third_party_settings: {  }
+  field_banner_alert:
     weight: 2
     label: above
     settings:
@@ -36,8 +33,16 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  field_facility_operating_status:
+    weight: 3
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_links:
-    weight: 4
+    weight: 5
     label: above
     settings:
       trim_length: 80
@@ -49,7 +54,7 @@ content:
     type: link
     region: content
   field_office:
-    weight: 0
+    weight: 1
     label: above
     settings:
       link: true
@@ -57,14 +62,13 @@ content:
     type: entity_reference_label
     region: content
   field_operating_status_emerg_inf:
-    weight: 3
+    weight: 4
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
 hidden:
-  content_moderation_control: true
   field_administration: true
   field_meta_tags: true
   links: true

--- a/config/sync/core.entity_view_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.default.yml
@@ -16,8 +16,13 @@ targetEntityType: node
 bundle: vet_center
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_administration:
-    weight: 104
+    weight: 5
     label: above
     settings:
       link: true
@@ -25,7 +30,7 @@ content:
     type: entity_reference_label
     region: content
   field_facility_locator_api_id:
-    weight: 101
+    weight: 2
     label: above
     settings:
       link_to_entity: false
@@ -33,24 +38,23 @@ content:
     type: string
     region: content
   field_operating_status_facility:
-    weight: 102
+    weight: 3
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_operating_status_more_info:
-    weight: 103
+    weight: 4
     label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
     region: content
   links:
-    weight: 100
+    weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
-  content_moderation_control: true
   search_api_excerpt: true

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -180,15 +180,35 @@ Feature: CMS Users may effectively create & edit content
     And I visit the "edit" page for a node with the title <title>
     Then "#edit-moderation-state-0-state" should not contain "published"
     Examples:
-      | type                             | title                                 |
-      | "page"                           | "page page"                           |
-      | "landing_page"                   | "landing_page page"                   |
-      | "health_care_region_detail_page" | "health_care_region_detail_page page" |
-      | "event"                          | "event page"                          |
-      | "event_listing"                  | "event_listing page"                  |
-      | "health_care_local_facility"     | "health_care_local_facility page"     |
-      | "health_care_region_page"        | "health_care_region_page page"        |
-      | "press_release"                  | "press_release page"                  |
-      | "outreach_asset"                 | "outreach_asset page"                 |
-      | "publication_listing"            | "publication_listing page"            |
-      | "news_story"                     | "news_story page"                     |
+      | type                                | title                                     |
+      | "page"                              | "page page"                               |
+      | "landing_page"                      | "landing_page page"                       |
+      | "basic_landing_page"                | "basic_landing_page page"                 |
+      | "checklist"                         | "checklist page"                          |
+      | "documentation_page"                | "documentation_page page"                 |
+      | "faq_multiple_q_a"                  | "faq_multiple_q_a page"                   |
+      | "health_services_listing"           | "health_services_listing page"            |
+      | "health_care_region_detail_page"    | "health_care_region_detail_page page"     |
+      | "event"                             | "event page"                              |
+      | "event_listing"                     | "event_listing page"                      |
+      | "health_care_local_facility"        | "health_care_local_facility page"         |
+      | "health_care_region_page"           | "health_care_region_page page"            |
+      | "press_release"                     | "press_release page"                      |
+      | "outreach_asset"                    | "outreach_asset page"                     |
+      | "publication_listing"               | "publication_listing page"                |
+      | "news_story"                        | "news_story page"                         |
+      | "leadership_listing"                | "leadership_listing page"                 |
+      | "locations_listing"                 | "locations_listing page"                  |
+      | "media_list_images"                 | "media_list_images page"                  |
+      | "media_list_videos"                 | "media_list_videos page"                  |
+      | "nca_facility"                      | "nca_facility page"                       |
+      | "office"                            | "office page"                             |
+      | "press_releases_listing"            | "press_releases_listing page"             |
+      | "q_a"                               | "q_a page"                                |
+      | "step_by_step"                      | "step_by_step page"                       |
+      | "story_listing"                     | "story_listing page"                      |
+      | "support_resources_detail_page"     | "support_resources_detail_page page"      |
+      | "support_service"                   | "support_service page"                    |
+      | "va_form"                           | "va_form page"                            |
+      | "vba_facility"                      | "vba_facility page"                       |
+      | "vet_center"                        | "vet_center page"                         |


### PR DESCRIPTION
## Description

See #3395 (and, for background, #2912 ).

I missed some content types when ensuring that the moderation controls were always visible and at the top of their view displays.

The affected content types were:
- `health_care_local_health_service`
- `va_form`
- `vamc_operating_status_and_alerts`
- `vet_center`

For each of these, the moderation control on the edit form was updated correctly, but the moderation control on the default display was disabled and consequently nodes of these types could not be published.

## Testing done
Added more test cases for Behat behavioral tests.

## Screenshots


## QA steps
As a user with a role having publish permissions:
1. For each of the content types in moderation, view a node of the specified type that is in a non-published moderation state and verify that it has a moderation control present and that the dropdown contains an option for "Published".
    - [x] `basic_landing_page`: [Resources and support for your VA benefits and services](http://pr3401.ci.cms.va.gov/resources)
    - [x] `checklist`: [TEST COPY: Checklist for scheduling a burial at a national cemetery](http://pr3401.ci.cms.va.gov/node/6924)
    - [x] `documentation_page`: [Managing your account](http://pr3401.ci.cms.va.gov/documentation/managing-your-account)
    - [x] `event`: [Test Outreach](http://pr3401.ci.cms.va.gov/erie-health-care/events/test-outreach)
    - [x] `event_listing`: [Events](http://pr3401.ci.cms.va.gov/nebraska-western-iowa-health-care/events)
    - [x] `faq_multiple_q_a`: [Testing with Beth multi faqs](http://pr3401.ci.cms.va.gov/resources/testing-with-beth-multi-faqs)
This particular page had been deleted, so I created a new one to test
![image](https://user-images.githubusercontent.com/5752113/98373337-17bf2a80-200d-11eb-874b-822ce199990a.png)

    - [ ] ~`full_width_banner_alert`~: Not under moderation control.
    - [x] `health_care_local_facility`: [New Bedford VA Clinic](http://pr3401.ci.cms.va.gov/locations/new-bedford-va-clinic)
    - [x] `health_care_local_health_service`: [Primary care - Montrose VA Clinic](http://pr3401.ci.cms.va.gov/western-colorado-health-care/locations/montrose-va-clinic/primary-care)
    - [x] `health_care_region_detail_page`: [Contact us](http://pr3401.ci.cms.va.gov/syracus-health-care/contact-us)
    - [x] `health_care_region_page`: [VA New York Harbor health care](http://pr3401.ci.cms.va.gov/new-york-harbor-health-care)
    - [x] `health_services_listing`: [Health services](http://pr3401.ci.cms.va.gov/new-york-harbor-health-care/health-services)
    - [x] `landing_page`: [Resources and support for your VA benefits and services](http://pr3401.ci.cms.va.gov/resources)
This page has been published so it doesn't show... so I tested with a new draft on the same content type
![image](https://user-images.githubusercontent.com/5752113/98372613-0c1f3400-200c-11eb-96b2-7e355f512773.png)

    - [x] `leadership_listing`: [Leadership](http://pr3401.ci.cms.va.gov/new-york-harbor-health-care/leadership)
    - [x] `locations_listing`: [Locations](http://pr3401.ci.cms.va.gov/hudson-valley-health-care/locations)
    - [x] `media_list_images`: [TEST COPY: Emblems of belief for headstones and markers](http://pr3401.ci.cms.va.gov/node/6954)
    - [x] `media_list_videos`: [TEST COPY: Watch VetSuccess on Campus videos](http://pr3401.ci.cms.va.gov/node/6950)
    - [x] `nca_facility`: [Ft. Worden](http://pr3401.ci.cms.va.gov/nca-facilities/locations/ft-worden)
    - [x] `news_story`: [Lebanon VAMC receives approval to open new VA Community Clinic in Adams County](http://pr3401.ci.cms.va.gov/lebanon-health-care/news-releases/lebanon-vamc-receives-approval-to-open-new-va-community-clinic-in)
    - [x] `office`: [VA Central Office](http://pr3401.ci.cms.va.gov/va-central-office)
    - [x] `outreach_asset`: [Memorial benefits help honor memory](http://pr3401.ci.cms.va.gov/memorial-benefits-help-honor-memory)
    - [x] `page`: [Contact us v2](http://pr3401.ci.cms.va.gov/contact-us-v2)
    - [x] `person_profile`: [Lebanon Public Affairs Office](http://pr3401.ci.cms.va.gov/lebanon-health-care/staff-profiles/lebanon-public-affairs-office)
    - [x] `press_release`: [Lebanon VAMC to host Veterans info and enrollment fair July 3](http://pr3401.ci.cms.va.gov/lebanon-health-care/news-releases/lebanon-vamc-to-host-veterans-info-and-enrollment-fair-july-3)
    - [x] `press_releases_listing`: [News releases](http://pr3401.ci.cms.va.gov/fargo-health-care/news-releases)
    - [x] `publication_listing`: [Outreach materials](http://pr3401.ci.cms.va.gov/outreach-and-events/outreach-materials)
    - [x] `q_a`: [Can I stop sharing my VA information with an app?](http://pr3401.ci.cms.va.gov/node/8429)
    - [x] `regional_health_care_service_des`: [Urology at VA Montana health care](http://pr3401.ci.cms.va.gov/montana-health-care/health-services/urology-at-va-montana-health-care)
    - [x] `step_by_step`: [TEST COPY: How to change your VA address online](http://pr3401.ci.cms.va.gov/node/6899)
    - [x] `story_listing`: [Stories](http://pr3401.ci.cms.va.gov/albany-health-care/stories)
    - [x] `support_resources_detail_page`: [Request a discharge upgrade or correction](http://pr3401.ci.cms.va.gov/node/8541)
    - [x] `support_service`: [Ask a question online](http://pr3401.ci.cms.va.gov/va-central-office/ask-a-question-online)
    - [x] `va_form`: [About VA Form 10-250](http://pr3401.ci.cms.va.gov/find-forms/about-form-10-250)
    - [x] `vamc_operating_status_and_alerts`: [Operating status - VA Syracuse health care](http://pr3401.ci.cms.va.gov/syracus-health-care/operating-status)
    - [x] `vba_facility`: [Westerly Outbased Benefit Office](http://pr3401.ci.cms.va.gov/vba-facilities/locations/westerly-outbased-benefit-office)
    - [x] `vet_center`: [East Los Angeles Vet Center](http://pr3401.ci.cms.va.gov/vet-centers/locations/east-los-angeles-vet-center)

2. The following bash and `yq` one-liner should list any content types that don't have the content moderation control present and in the `content` region:
```bash
ls -1 config/sync/node.type.* | grep -v full_width_banner_alert | while read filename; do the_basename="$(basename "$filename" ".yml")"; content_type="${the_basename##*\.}"; display_filename="config/sync/core.entity_view_display.node.${content_type}.default.yml"; [ "$(yq r -P "${display_filename}" content.content_moderation_control.region)" != "content" ] && echo "${content_type} content_moderation_control is not in the correct region."; done;
```
In practice, this yields some false positives (`nca_facility` and `vba_facility`) that actually do display the moderation control and I'm digging into why.

## Definition of Done

### CMS user-facing release note

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication.
- [ ] Yes, but it hasn't yet been written (this code is not ready to merge!).
- [ ] No announcement is needed for this code change. 
