### PR TITLE
VACMS-2812: Timezone Migration

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -328,12 +328,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-<<<<<<< HEAD
-  field_datetime_range_timezone: true
-  field_meta_tags: true
-=======
   field_date: true
->>>>>>> VACMS-2812: Disabled old field_date and enabled field_datetime_range_timezone
   promote: true
   status: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -28,11 +28,11 @@ dependencies:
   module:
     - address
     - content_moderation
-    - datetime_range
     - field_group
     - link
     - media_library
     - path
+    - smart_date
     - text
     - textfield_counter
 third_party_settings:
@@ -44,9 +44,9 @@ third_party_settings:
       weight: 8
       format_type: details_sidebar
       format_settings:
-        open: '1'
-        weight: '-15'
-        required_fields: '1'
+        open: true
+        weight: -15
+        required_fields: true
         id: ''
         classes: ''
       label: Governance
@@ -125,9 +125,9 @@ third_party_settings:
         id: ''
         classes: ''
         description: ''
-        open: 0
-        required_fields: 1
-        weight: '0'
+        open: false
+        required_fields: true
+        weight: 0
       label: 'Feature This Content'
       region: content
     group_meta_tags:
@@ -182,12 +182,19 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  field_date:
+  field_datetime_range_timezone:
+    type: smartdate_timezone
     weight: 1
-    settings: {  }
-    third_party_settings: {  }
-    type: daterange_default
     region: content
+    settings:
+      modal: false
+      default_duration: 60
+      default_duration_increments: "30\n60|1 hour\n90\n120|2 hours\ncustom"
+      show_extra: true
+      default_tz: ''
+      custom_tz: ''
+      allowed_timezones: {  }
+    third_party_settings: {  }
   field_description:
     weight: 3
     settings:
@@ -321,8 +328,12 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+<<<<<<< HEAD
   field_datetime_range_timezone: true
   field_meta_tags: true
+=======
+  field_date: true
+>>>>>>> VACMS-2812: Disabled old field_date and enabled field_datetime_range_timezone
   promote: true
   status: true
   sticky: true

--- a/config/sync/core.entity_form_display.paragraph.situation_update.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.situation_update.default.yml
@@ -9,19 +9,26 @@ dependencies:
     - field.field.paragraph.situation_update.field_wysiwyg
     - paragraphs.paragraphs_type.situation_update
   module:
-    - datetime
+    - smart_date
     - text
 id: paragraph.situation_update.default
 targetEntityType: paragraph
 bundle: situation_update
 mode: default
 content:
-  field_date_and_time:
+  field_datetime_range_timezone:
+    type: smartdate_timezone
     weight: 1
-    settings: {  }
-    third_party_settings: {  }
-    type: datetime_default
     region: content
+    settings:
+      modal: false
+      default_duration: 60
+      default_duration_increments: "30\n60|1 hour\n90\n120|2 hours\ncustom"
+      show_extra: true
+      default_tz: ''
+      custom_tz: ''
+      allowed_timezones: {  }
+    third_party_settings: {  }
   field_send_email_to_subscribers:
     weight: 0
     settings:
@@ -39,5 +46,5 @@ content:
     region: content
 hidden:
   created: true
-  field_datetime_range_timezone: true
+  field_date_and_time: true
   status: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -26,10 +26,10 @@ dependencies:
     - node.type.event
   module:
     - address
-    - datetime_range
     - field_group
     - link
     - options
+    - smart_date
     - text
     - user
 third_party_settings:
@@ -48,7 +48,7 @@ third_party_settings:
       region: content
     group_c:
       children:
-        - field_date
+        - field_datetime_range_timezone
         - field_media
         - field_body
         - field_url_of_an_online_event
@@ -71,7 +71,7 @@ third_party_settings:
         - field_location_type
         - field_facility_location
       parent_name: group_c
-      weight: 27
+      weight: 28
       format_type: fieldset
       format_settings:
         id: ''
@@ -86,7 +86,7 @@ third_party_settings:
         - field_event_cost
         - field_additional_information_abo
       parent_name: group_c
-      weight: 28
+      weight: 29
       format_type: fieldset
       format_settings:
         id: ''
@@ -134,22 +134,23 @@ content:
     type: address_default
     region: content
   field_body:
-    weight: 24
+    weight: 25
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
-  field_date:
-    weight: 22
+  field_datetime_range_timezone:
+    type: smartdate_default
+    weight: 23
+    region: content
     label: above
     settings:
-      separator: '-'
+      format: default
+      force_chronological: false
       format_type: medium
       timezone_override: ''
     third_party_settings: {  }
-    type: daterange_default
-    region: content
   field_description:
     weight: 15
     label: above
@@ -167,7 +168,7 @@ content:
     type: string
     region: content
   field_event_cta:
-    weight: 26
+    weight: 27
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -229,7 +230,7 @@ content:
     type: list_default
     region: content
   field_media:
-    weight: 23
+    weight: 24
     label: above
     settings:
       link: true
@@ -244,7 +245,7 @@ content:
     type: list_default
     region: content
   field_url_of_an_online_event:
-    weight: 25
+    weight: 26
     label: above
     settings:
       trim_length: 80
@@ -257,7 +258,7 @@ content:
     region: content
 hidden:
   field_administration: true
-  field_datetime_range_timezone: true
+  field_date: true
   field_listing: true
   field_meta_tags: true
   links: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -26,7 +26,7 @@ dependencies:
     - field.field.node.event.field_url_of_an_online_event
     - node.type.event
   module:
-    - datetime_range
+    - smart_date
     - text
     - user
 id: node.event.teaser
@@ -41,22 +41,23 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_date:
-    type: daterange_custom
+  field_datetime_range_timezone:
+    type: smartdate_default
     weight: 1
     region: content
     label: hidden
     settings:
-      timezone_override: America/New_York
-      date_format: 'l, M d Y h:i a'
-      separator: '-'
+      format: default
+      force_chronological: false
+      format_type: medium
+      timezone_override: ''
     third_party_settings: {  }
 hidden:
   content_moderation_control: true
   field_additional_information_abo: true
   field_address: true
   field_administration: true
-  field_datetime_range_timezone: true
+  field_date: true
   field_description: true
   field_event_cost: true
   field_event_cta: true

--- a/config/sync/core.entity_view_display.paragraph.situation_update.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.situation_update.default.yml
@@ -9,22 +9,24 @@ dependencies:
     - field.field.paragraph.situation_update.field_wysiwyg
     - paragraphs.paragraphs_type.situation_update
   module:
-    - datetime
+    - smart_date
     - text
 id: paragraph.situation_update.default
 targetEntityType: paragraph
 bundle: situation_update
 mode: default
 content:
-  field_date_and_time:
+  field_datetime_range_timezone:
+    type: smartdate_default
     weight: 0
+    region: content
     label: inline
     settings:
-      timezone_override: America/New_York
-      format_type: long
+      format: default
+      force_chronological: false
+      format_type: medium
+      timezone_override: ''
     third_party_settings: {  }
-    type: datetime_default
-    region: content
   field_send_email_to_subscribers:
     weight: 1
     label: inline
@@ -43,5 +45,5 @@ content:
     type: text_default
     region: content
 hidden:
-  field_datetime_range_timezone: true
+  field_date_and_time: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.situation_update.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.situation_update.preview.yml
@@ -10,22 +10,24 @@ dependencies:
     - field.field.paragraph.situation_update.field_wysiwyg
     - paragraphs.paragraphs_type.situation_update
   module:
-    - datetime
+    - smart_date
     - text
 id: paragraph.situation_update.preview
 targetEntityType: paragraph
 bundle: situation_update
 mode: preview
 content:
-  field_date_and_time:
+  field_datetime_range_timezone:
+    type: smartdate_default
     weight: 0
+    region: content
     label: inline
     settings:
-      timezone_override: America/New_York
-      format_type: long
+      format: default
+      force_chronological: false
+      format_type: medium
+      timezone_override: ''
     third_party_settings: {  }
-    type: datetime_default
-    region: content
   field_send_email_to_subscribers:
     weight: 1
     label: inline
@@ -44,5 +46,5 @@ content:
     type: text_default
     region: content
 hidden:
-  field_datetime_range_timezone: true
+  field_date_and_time: true
   search_api_excerpt: true

--- a/config/sync/field.field.paragraph.situation_update.field_datetime_range_timezone.yml
+++ b/config/sync/field.field.paragraph.situation_update.field_datetime_range_timezone.yml
@@ -13,7 +13,7 @@ entity_type: paragraph
 bundle: situation_update
 label: 'Date and time'
 description: ''
-required: false
+required: true
 translatable: false
 default_value:
   -

--- a/scripts/content/VACMS-2812-update-timezone-data-2020-11.php
+++ b/scripts/content/VACMS-2812-update-timezone-data-2020-11.php
@@ -71,6 +71,7 @@ function va_gov_event_field_date_migration(&$database) {
   // Build the select query.
   $rev_result = $database->select('node_revision__field_date', 'r');
   $rev_result->fields('r', ['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_date_value', 'field_date_end_value']);
+  $rev_result->addExpression("TIMESTAMPDIFF(MINUTE, field_date_value, field_date_end_value)", 'field_datetime_range');
   $rev_result->addExpression("UNIX_TIMESTAMP(field_date_value)", 'field_date_value');
   $rev_result->addExpression("UNIX_TIMESTAMP(field_date_end_value)", 'field_date_end_value');
   $record = $rev_result->execute();
@@ -78,7 +79,7 @@ function va_gov_event_field_date_migration(&$database) {
   $rev_record_array = _objToArray($rev_record);
 
   // Build the insert query.
-  $rev_insert = $database->insert('node_revision__field_datetime_range_timezone')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_timezone']);
+  $rev_insert = $database->insert('node_revision__field_datetime_range_timezone')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_duration', 'field_datetime_range_timezone_timezone']);
 
   foreach ($rev_record_array as $rev) {
     $rev_insert->values(
@@ -91,6 +92,7 @@ function va_gov_event_field_date_migration(&$database) {
       'delta' => $rev['delta'],
       'field_datetime_range_timezone_value' => $rev['field_date_value'],
       'field_datetime_range_timezone_end_value' => $rev['field_date_end_value'],
+      'field_datetime_range_timezone_duration' => $rev['field_datetime_range'],
       'field_datetime_range_timezone_timezone' => ""
       ])
     );
@@ -116,6 +118,7 @@ function va_gov_event_field_date_migration(&$database) {
   // Build the select query.
   $node_result = $database->select('node__field_date', 'n');
   $node_result->fields('n', ['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_date_value', 'field_date_end_value']);
+  $node_result->addExpression("TIMESTAMPDIFF(MINUTE, field_date_value, field_date_end_value)", 'field_datetime_range');
   $node_result->addExpression("UNIX_TIMESTAMP(field_date_value)", 'field_date_value');
   $node_result->addExpression("UNIX_TIMESTAMP(field_date_end_value)", 'field_date_end_value');
   $node_record = $node_result->execute();
@@ -123,7 +126,7 @@ function va_gov_event_field_date_migration(&$database) {
   $node_records_array = _objToArray($node_records);
 
   // Build the insert query.
-  $node_insert = $database->insert('node__field_datetime_range_timezone')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_timezone']);
+  $node_insert = $database->insert('node__field_datetime_range_timezone')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_duration', 'field_datetime_range_timezone_timezone']);
 
   foreach ($node_records_array as $node_update) {
     $node_insert->values(
@@ -136,6 +139,7 @@ function va_gov_event_field_date_migration(&$database) {
       'delta' => $node_update['delta'],
       'field_datetime_range_timezone_value' => $node_update['field_date_value'],
       'field_datetime_range_timezone_end_value' => $node_update['field_date_end_value'],
+      'field_datetime_range_timezone_duration' => $node_update['field_datetime_range'],
       'field_datetime_range_timezone_timezone' => ""
       ])
     );

--- a/scripts/content/VACMS-2812-update-timezone-data-2020-11.php
+++ b/scripts/content/VACMS-2812-update-timezone-data-2020-11.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * @file
+ * Migrate all fields_date to field_datetime_range_timezone.
+ *
+ *  VACMS-2812-update-timezone-data-2020-11.php.
+ */
+
+use Psr\Log\LogLevel;
+use Drupal\Core\Database\Database;
+
+// Create database connection.
+$database = \Drupal::database();
+
+// Processing of field date migrations.
+if (isset($database)) {
+  print("SUCCESSFULLY connected to drupal database. Beginning migration...\n\n");
+  va_gov_event_field_date_migration($database);
+  va_gov_situation_update_date_revisions_migration($database);
+}else {
+  print("FAILURE to connect to drupal database\n\n");
+}
+
+/**
+ * Migration of Event field_date to field_datetime_range_timezone.
+ *
+ * @param string $database
+ *  Database connection.
+ *
+ */
+function va_gov_event_field_date_migration(&$database) {
+
+  // Clear node field_datetime_range_timezone revision table.
+  $event_date_revision_clear = $database->delete('node_revision__field_datetime_range_timezone');
+  $event_date_revision_clear->execute();
+
+  // Clear node field_datetime_range_timezone table.
+  $event_date_clear = $database->delete('node__field_datetime_range_timezone');
+  $event_date_clear->execute();
+
+  // Build count of node revision field date.
+  $revision_query = $database->select('node_revision__field_date', 'n');
+  $revision_query->addField('n','bundle');
+  $revision_query->condition('bundle', 'event');
+  $count_query = $revision_query->execute()->fetchAll();
+  $revisions['total'] = count($count_query);
+
+  // Build count of node field date.
+  $node_query = $database->select('node__field_date', 'n');
+  $node_query->addField('n','bundle');
+  $node_query->condition('bundle', 'event');
+  $node_count_query = $node_query->execute()->fetchAll();
+  $node['node_total'] = count($node_count_query);
+
+  print("There are {$revisions['total']} Event revisions with field date to be processed.\n");
+  print("There are {$node['node_total']} Event nodes with field date to be processed.\n\n");
+
+  // Log the number of revisions to be processed.
+  Drupal::logger('va_gov_db')
+  ->log(LogLevel::INFO, 'Number of revisions with field date to be processed: %count .', [
+    '%count' => $revisions['total'],
+  ]);
+
+  // Log the number of nodes to be processed.
+  Drupal::logger('va_gov_db')
+  ->log(LogLevel::INFO, 'Number of nodes with field date to be processed: %count .', [
+    '%count' => $node['node_total'],
+  ]);
+  
+  // Build the select query.
+  $rev_result = $database->select('node_revision__field_date', 'r');
+  $rev_result->fields('r', ['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_date_value', 'field_date_end_value']);
+  $rev_result->addExpression("UNIX_TIMESTAMP(field_date_value)", 'field_date_value');
+  $rev_result->addExpression("UNIX_TIMESTAMP(field_date_end_value)", 'field_date_end_value');
+  $record = $rev_result->execute();
+  $rev_record = $record->fetchAll();
+  $rev_record_array = _objToArray($rev_record);
+
+  // Build the insert query.
+  $rev_insert = $database->insert('node_revision__field_datetime_range_timezone')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_timezone']);
+
+  foreach ($rev_record_array as $rev) {
+    $rev_insert->values(
+      ([
+      'bundle' => $rev['bundle'],
+      'deleted' => $rev['deleted'],
+      'entity_id' => $rev['entity_id'],
+      'revision_id' => $rev['revision_id'],
+      'langcode' => $rev['langcode'],
+      'delta' => $rev['delta'],
+      'field_datetime_range_timezone_value' => $rev['field_date_value'],
+      'field_datetime_range_timezone_end_value' => $rev['field_date_end_value'],
+      'field_datetime_range_timezone_timezone' => ""
+      ])
+    );
+  }
+
+  $show_count = count($rev_record_array);
+  // Do not continue if no results.
+  if ($show_count == 0) {
+    print("No event date revisions were found to be processed.\n");
+  }else {
+    $rev_insert->execute();
+
+    // Log the number of updates.
+    Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'Successfully processed %show_count of %count Event date revision updates.', [
+      '%count' => $revisions['total'],
+      '%show_count' => $show_count,
+    ]);
+
+    print(">>> Successfully processed {$show_count} of {$revisions['total']} Event date revision updates.\n");
+  }
+
+  // Build the select query.
+  $node_result = $database->select('node__field_date', 'n');
+  $node_result->fields('n', ['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_date_value', 'field_date_end_value']);
+  $node_result->addExpression("UNIX_TIMESTAMP(field_date_value)", 'field_date_value');
+  $node_result->addExpression("UNIX_TIMESTAMP(field_date_end_value)", 'field_date_end_value');
+  $node_record = $node_result->execute();
+  $node_records = $node_record->fetchAll();
+  $node_records_array = _objToArray($node_records);
+
+  // Build the insert query.
+  $node_insert = $database->insert('node__field_datetime_range_timezone')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_timezone']);
+
+  foreach ($node_records_array as $node_update) {
+    $node_insert->values(
+      ([
+      'bundle' => $node_update['bundle'],
+      'deleted' => $node_update['deleted'],
+      'entity_id' => $node_update['entity_id'],
+      'revision_id' => $node_update['revision_id'],
+      'langcode' => $node_update['langcode'],
+      'delta' => $node_update['delta'],
+      'field_datetime_range_timezone_value' => $node_update['field_date_value'],
+      'field_datetime_range_timezone_end_value' => $node_update['field_date_end_value'],
+      'field_datetime_range_timezone_timezone' => ""
+      ])
+    );
+  }
+
+  $node_show_count = count($node_records_array);
+  // Do not continue if no results.
+  if ($node_show_count == 0) {
+    print("No event date revisions were found to be processed.\n");
+  }else {
+    $node_insert->execute();
+
+    // Log the number of updates..
+    Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'Successfully processed %show_count of %count node event date updates.', [
+      '%count' => $node['node_total'],
+      '%show_count' => $node_show_count,
+    ]);
+
+    print(">>> Successfully processed {$node_show_count} of {$node['node_total']} node event date updates.\n\n");
+  }
+}
+
+/**
+ * Migration of Situation Update field_date to field_datetime_range_timezone.
+ *
+ * @param string $database
+ *  Database connection.
+ *
+ */
+function va_gov_situation_update_date_revisions_migration(&$database) {
+
+  // Clear paragraph field_datetime_range_timezone revision table.
+  $situation_update_date_revision_clear = $database->delete('paragraph_r__d38323513b');
+  $situation_update_date_revision_clear->execute();
+  
+  // Clear paragraph field_datetime_range_timezone revision table.
+  $situation_update_date_clear = $database->delete('paragraph__field_datetime_range_timezone');
+  $situation_update_date_clear->execute();
+
+  // Build count of revisions.
+  $situation_update_revision_query = $database->select('paragraph_revision__field_date_and_time', 'p');
+  $situation_update_revision_query->addField('p','bundle');
+  $situation_update_revision_query->condition('bundle', 'situation_update');
+  $situation_update_count_query = $situation_update_revision_query->execute()->fetchAll();
+  $situation_updates_revisions['situation_update_total'] = count($situation_update_count_query);
+
+  // Build count of paragraphs.
+  $situation_update_paragraph_query = $database->select('paragraph__field_date_and_time', 'p');
+  $situation_update_paragraph_query->addField('p','bundle');
+  $situation_update_paragraph_query->condition('bundle', 'situation_update');
+  $situation_update_paragraph_count_query = $situation_update_paragraph_query->execute()->fetchAll();
+  $situation_updates_paragraph_count['situation_update_total'] = count($situation_update_paragraph_count_query);
+
+  print("There are {$situation_updates_revisions['situation_update_total']} Situation Update field date revisions to be processed.\n");
+  print("There are {$situation_updates_paragraph_count['situation_update_total']} Situation Update field date paragraphs to be processed.\n\n");
+
+  // Log amount to be processed.
+  Drupal::logger('va_gov_db')
+  ->log(LogLevel::INFO, 'Number of Situation Update field date revisions to be processed: %count .', [
+    '%count' => $situation_updates_revisions['situation_update_total'],
+  ]);
+
+  // Log amount to processed.
+  Drupal::logger('va_gov_db')
+  ->log(LogLevel::INFO, 'Number of Situation Update field date paragraphs to be processed: %count .', [
+    '%count' => $situation_updates_paragraph_count['situation_update_total'],
+  ]);
+
+  // Build the select query.
+  $situation_update_rev_result = $database->select('paragraph_revision__field_date_and_time', 'r');
+  $situation_update_rev_result->fields('r', ['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_date_and_time_value', 'field_date_and_time_value']);
+  $situation_update_rev_result->addExpression("UNIX_TIMESTAMP(field_date_and_time_value)", 'field_date_and_time_value');
+  $situation_update_rev_result->addExpression("UNIX_TIMESTAMP(field_date_and_time_value)", 'field_date_and_time_value');
+  $situation_update_record = $situation_update_rev_result->execute();
+  $situation_update_rev_record = $situation_update_record->fetchAll();
+  $situation_update_rev_record_array = _objToArray($situation_update_rev_record);
+
+  // Build the insert query.
+  $situation_update_rev_insert = $database->insert('paragraph_r__d38323513b')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_timezone']);
+
+  foreach ($situation_update_rev_record_array as $situation_update_rev) {
+    $situation_update_rev_insert->values(
+      ([
+      'bundle' => $situation_update_rev['bundle'],
+      'deleted' => $situation_update_rev['deleted'],
+      'entity_id' => $situation_update_rev['entity_id'],
+      'revision_id' => $situation_update_rev['revision_id'],
+      'langcode' => $situation_update_rev['langcode'],
+      'delta' => $situation_update_rev['delta'],
+      'field_datetime_range_timezone_value' => $situation_update_rev['field_date_and_time_value'],
+      'field_datetime_range_timezone_end_value' => $situation_update_rev['field_date_and_time_value'],
+      'field_datetime_range_timezone_timezone' => ""
+      ])
+    );
+  }
+
+  $situation_update_show_count = count($situation_update_rev_record_array);
+  // Do not continue if no results.
+  if ($situation_update_show_count == 0) {
+    $situation_updates_revisions['#finished'] = 1;
+    return "No Situation Update date revisions were found to be processed.\n";
+  }else {
+    $situation_update_rev_insert->execute();
+    $situation_updates_revisions['#finished'] = 1;
+
+    // Log the number of updates.
+    Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'Successfully processed %show_count of %count Situation Update field date revision updates.', [
+      '%count' => $situation_updates_revisions['situation_update_total'],
+      '%show_count' => $situation_update_show_count,
+    ]);
+
+    print(">>> Successfully processed {$situation_update_show_count} of {$situation_updates_revisions['situation_update_total']} Situation Update field date revision updates.\n");
+  }
+
+  // Build the select query.
+  $paragraph_result = $database->select('paragraph__field_date_and_time', 'n');
+  $paragraph_result->fields('n', ['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_date_and_time_value', 'field_date_and_time_value']);
+  $paragraph_result->addExpression("UNIX_TIMESTAMP(field_date_and_time_value)", 'field_date_and_time_value');
+  $paragraph_result->addExpression("UNIX_TIMESTAMP(field_date_and_time_value)", 'field_date_and_time_value');
+  $paragraph_record = $paragraph_result->execute();
+  $paragraph_records = $paragraph_record->fetchAll();
+  $paragraph_records_array = _objToArray($paragraph_records);
+
+  // Build the insert query.
+  $paragraph_insert = $database->insert('paragraph__field_datetime_range_timezone')->fields(['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta', 'field_datetime_range_timezone_value', 'field_datetime_range_timezone_end_value', 'field_datetime_range_timezone_timezone']);
+
+  foreach ($paragraph_records_array as $paragraph_update) {
+    $paragraph_insert->values(
+      ([
+      'bundle' => $paragraph_update['bundle'],
+      'deleted' => $paragraph_update['deleted'],
+      'entity_id' => $paragraph_update['entity_id'],
+      'revision_id' => $paragraph_update['revision_id'],
+      'langcode' => $paragraph_update['langcode'],
+      'delta' => $paragraph_update['delta'],
+      'field_datetime_range_timezone_value' => $paragraph_update['field_date_and_time_value'],
+      'field_datetime_range_timezone_end_value' => $paragraph_update['field_date_and_time_value'],
+      'field_datetime_range_timezone_timezone' => ""
+      ])
+    );
+  }
+
+  $paragraph_show_count = count($paragraph_records_array);
+  // Do not continue if no results.
+  if ($paragraph_show_count == 0) {
+    print("No event date revisions were found to be processed.\n");
+  }else {
+    $paragraph_insert->execute();
+
+    // Log the number updates.
+    Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'Successfully processed %show_count of %count Situation Updates paragraphs.', [
+      '%count' => $situation_updates_paragraph_count['situation_update_total'],
+      '%show_count' => $paragraph_show_count,
+    ]);
+
+    print(">>> Successfully processed {$paragraph_show_count} of {$situation_updates_paragraph_count['situation_update_total']} Paragraph Situation Update field date updates.\n\n");
+  }
+}
+
+/**
+ * Converts object returned from fetchAll to Array.
+ *
+ * @param object $obj
+ *  Array object to be processed.
+ *
+ */
+function _objToArray($obj) {
+  if(!is_array($obj) && !is_object($obj)) 
+      return $obj;
+  if(is_object($obj)) 
+      $obj = get_object_vars($obj);
+  return 
+      array_map(__FUNCTION__, $obj);
+}

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -104,8 +104,8 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Service location address | Clinic name | field_clinic_name | Text (plain) |  | 1 | Textfield with counter |  |
 | Paragraph type | Service location address | Use the facility's street address? | field_use_facility_address | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Service location address | Wing, Floor, or Room Number | field_wing_floor_or_room_number | Text (plain) |  | 1 | Textfield with counter |  |
-| Paragraph type | Situation update | Date and time | field_date_and_time | Date | Required | 1 | Date and time |  |
-| Paragraph type | Situation update | Date and time | field_datetime_range_timezone | Smart date range |  | 1 | -- Disabled -- |  |
+| Paragraph type | Situation update | Date and time | field_date_and_time | Date | Required | 1 | -- Disabled -- |  |
+| Paragraph type | Situation update | Date and time | field_datetime_range_timezone | Smart date range | Required | 1 | Date and time range with timezone |  |
 | Paragraph type | Situation update | Send email to subscribers via GovDelivery? | field_send_email_to_subscribers | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Situation update | Update | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
 | Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Select list |  |

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -23,8 +23,13 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Event | Additional registration  information | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | Event | Address | field_address | Address |  | 1 | Address |  |
 | Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  |
+<<<<<<< HEAD
 | Content type | Event | Date and time | field_date | Date range |  | 1 | Date and time range |  |
 | Content type | Event | Date and time | field_datetime_range_timezone | Smart date range |  | 1 | -- Disabled -- |  |
+=======
+| Content type | Event | Date and time | field_datetime_range_timezone | Smart date range |  | 1 | Date and time range with timezone |  |
+| Content type | Event | Date and time | field_date | Date range |  | 1 | -- Disabled -- |  |
+>>>>>>> VACMS-2812: Updated behat tests to account for new field_datetime_range_timezone field
 | Content type | Event | Where should the event be listed? | field_listing | Entity reference | Required | 1 | Select list |  |
 | Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  |
 | Content type | Event | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -23,13 +23,8 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Event | Additional registration  information | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | Event | Address | field_address | Address |  | 1 | Address |  |
 | Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  |
-<<<<<<< HEAD
-| Content type | Event | Date and time | field_date | Date range |  | 1 | Date and time range |  |
-| Content type | Event | Date and time | field_datetime_range_timezone | Smart date range |  | 1 | -- Disabled -- |  |
-=======
 | Content type | Event | Date and time | field_datetime_range_timezone | Smart date range |  | 1 | Date and time range with timezone |  |
 | Content type | Event | Date and time | field_date | Date range |  | 1 | -- Disabled -- |  |
->>>>>>> VACMS-2812: Updated behat tests to account for new field_datetime_range_timezone field
 | Content type | Event | Where should the event be listed? | field_listing | Entity reference | Required | 1 | Select list |  |
 | Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  |
 | Content type | Event | Featured | field_featured | Boolean |  | 1 | Single on/off checkbox | Translatable |


### PR DESCRIPTION
## Description

See _issueid_. https://app.zenhub.com/workspaces/vagov-cms-team-5c0e7b864b5806bc2bfc2087/issues/department-of-veterans-affairs/va.gov-cms/2812

## Testing done


## Screenshots


## QA steps

- Pull this branch down locally and stand up a local environment.

### Events

- Navigate here: `/node/9589/edit`
  - [x] Confirm you can see the following:
    - [x] New field called 'DATE AND TIME' that has a 'Start' field and 'End' date fied, Duration and Timezone dropdown that is defaulted to `-default: America/New_York`
    - [x] The 'Start' and 'End' dates are not filled in.

- Confirm original `field_date` values in the database:
  - [x] Execute the following query on your local machines terminal
    - [x] `lando drush sqlc`
    - [x] `select * from node__field_date where entity_id = '9589';`
    - [x] The `field_date_value` is set to: 2020-11-11T19:11:00 
    - [x] The `field_date_end_value` is set to : 2020-11-11T20:11:00

- Navigate here: `/node/9589/revisions`
  - [x] Select any of the past revisions by selecting the datetime link under the Revision column
  - [x] Confirm that a `Date and Time` field does not appear.
  - [x] Grab the revision_id, this is located in the url that proceeds after `/revisions/`.

- Confirm original `field_date` revisions values in the database:
  - [x] Execute the following query on your local machines terminal
    - [x] `lando drush sqlc`
    - [x] `select * from node_revision__field_date where entity_id = '9589' and revision_id = '339417';`
    - [x] The `field_date_value` is set to: 2020-11-11T19:11:00 
    - [x] The `field_date_end_value` is set to : 2020-11-11T20:11:00

### Situation Updates

- Only a single content items exist that use the 'Situation Updates' paragraph field. 
- Navigate here: `/node/6922/edit`
- Scroll down to the 'SITUATION UPDATES' group
- Select Edit next to any of the situation updates
- [x] Data already exists in the database for this field since it was entered into PROD by Kevwalsh at a previous point in time.
- Navigate here: `/node/6922/revisions`
- Select the very last revision by selecting the datetime under the revisions column
- [x] Confirm a field 'DATE AND TIME' does not exist.

### Migration

- Confirm the migration of data from `field_date` to the `field_datetime_range_timezone`:
  - [ ] Execute the following query on your local machines terminal
    - [ ] `select count(*) from node_revision__field_date where bundle = 'event'`;
      - [ ] count = 'enter count here'
    - [ ] `select count(*) from node_field_data where type = 'event';`
      - [ ] count = 'enter count here'
    - [ ] `select count(*) from paragraph_r__d38323513b;`
      - [ ] count = 'enter count here'
    - [ ] `select count(*) from paragraph__field_datetime_range_timezone;`
      - [ ] count = 'enter count here'
  - [x] Execute the following script:
    - [x] `lando drush scr ./scripts/content/VACMS-2812-update-timezone-data-2020-11.php`
    - [x] Clear Cache
    - [x] Confirm the following messages appear and that the counts from above are the same as the counts in the message: 

```
SUCCESSFULLY connected to drupal database. Beginning migration...

There are **count** Event revisions with field date to be processed.
There are **count** Event nodes with field date to be processed.

>>> Successfully processed **count** of **count** Event date revision updates.
>>> Successfully processed **count** of **count** node event date updates.

There are **count** Situation Update field date revisions to be processed.
There are **count** Situation Update field date paragraphs to be processed.

>>> Successfully processed **count** of **count** Situation Update field date revision updates.
>>> Successfully processed **count** of **count** Paragraph Situation Update field date updates.
```
- Navigate back to the following pages and confirm the field 'DATE AND TIME' is filled in:
  - [x] `/node/9589/edit`
  - [x] `/node/9589/revisions/339417/view`
  - [x] `/node/6922/edit`
  - [x] `/node/6922/revisions/322479/view`

### Reverting

- [x] Confirm you are able to revert to a past revision and that the field 'DATE AND TIME' is visible and filled in for both 'Event' nodes and 'Situation Update' paragraphs.

### Reports

- Navigate here: /admin/reports/dblog
- Filter by type "va_gov_db"
  - [ ] Confirm a message appears that corresponds the same same messages that appears after running the script locally.


## Definition of Done
- [ ] Documentation has been updated, if applicable.

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
