### PR TITLE
VACMS-3405 Temporarily disable content alias locking.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -328,7 +328,7 @@ function va_gov_backend_field_widget_moderation_state_default_form_alter(&$eleme
  */
 function _va_gov_backend_get_locked_alias_bundles() {
 
-  return [
+  $bundles_to_lock = [
     'basic_landing_page',
     'checklist',
     'faq_multiple_q_a',
@@ -339,6 +339,10 @@ function _va_gov_backend_get_locked_alias_bundles() {
     'support_resources_detail_page',
     'va_form',
   ];
+
+  // @TODO restore return of $bundles_to_lock when ready to engage locking.
+  // Returning empty for now as this is preventing alias updating.
+  return [];
 }
 
 /**


### PR DESCRIPTION
## Description

See _issueid_. 

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

## Definition of Done
- [ ] Documentation has been updated, if applicable.

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
