### PR TITLE
VACMS-3324: Fix paragraph and Node being out of sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -253,6 +253,9 @@
             "drupal/entity_clone": {
                 "Cloning child references to nodes has potential to cause memory resource issues": "https://www.drupal.org/files/issues/2020-02-10/entity_clone-child-node-system-drain-3112577-1.patch"
             },
+            "drupal/entity_reference_revisions": {
+                "2984027 Incorrect manipulation of default revision flag": "https://www.drupal.org/files/issues/2019-05-17/entity_reference_revisions-default_revision-2984027-7.patch"
+            },
             "drupal/govdelivery_bulletins": {
                 "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -254,7 +254,7 @@
                 "Cloning child references to nodes has potential to cause memory resource issues": "https://www.drupal.org/files/issues/2020-02-10/entity_clone-child-node-system-drain-3112577-1.patch"
             },
             "drupal/entity_reference_revisions": {
-                "2984027 Incorrect manipulation of default revision flag": "https://www.drupal.org/files/issues/2019-05-17/entity_reference_revisions-default_revision-2984027-7.patch"
+                "2984027 Incorrect manipulation of default revision flag": "https://www.drupal.org/files/issues/2020-09-03/entity_reference_revisions-default_revision-2984027-10.patch"
             },
             "drupal/govdelivery_bulletins": {
                 "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch"

--- a/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
+++ b/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
@@ -132,18 +132,3 @@ function updateParagraphs($paragraphs) {
     $query->execute();
   }
 }
-
-function updateNodeForNewParagraph(\Drupal\node\Entity\Node $node) {
-  // Make this change a new revision.
-  $node->setNewRevision(TRUE);
-
-  // Set revision author to uid 1317 (CMS Migrator user).
-  $node->setRevisionAuthorId(1317);
-  $node->setChangedTime(time());
-  $node->setRevisionCreationTime(time());
-  $node->setOwnerId(1317);
-
-  // Set revision log message.
-  $node->setRevisionLogMessage('Resaved to fix out of sync data.');
-  $node->save();
-}

--- a/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
+++ b/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @file
+ * One-time migration for fixing the default revision for paragraphs.
+ *
+ * We are accessing the database tables directly instead of using the Field Storage API
+ * so
+ */
+
+$sandbox = ['#finished' => 0];
+do {
+  print(run($sandbox));
+} while ($sandbox['#finished'] < 1);
+
+function run(&$sandbox) {
+  if (!isset($sandbox['total'])) {
+    $sandbox['total'] = getParagraphCount();
+    $sandbox['paragraph_ids'] = getAllParagraphIds();
+    $sandbox['current'] = 0;
+  }
+
+  $limit = 25;
+  $paragraph_ids = array_slice($sandbox['paragraph_ids'], $sandbox['current'], $limit, TRUE);
+  runRange($paragraph_ids);
+
+  $sandbox['current'] += count($paragraph_ids);
+
+  // Log the processed nodes.
+  Drupal::logger('va_gov_db')
+    ->info('Paragraph %current saved to fix revision ids. Paragraphs processed: %paragraph_ids', [
+      '%current' => $sandbox['current'],
+      '%paragraph_ids' => implode(', ', $paragraph_ids),
+    ]);
+
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+  // Log the all-finished notice.
+  if ($sandbox['#finished'] == 1) {
+    Drupal::logger('va_gov_db')->info('RE-saving all %count paragraphs completed.', [
+      '%count' => $sandbox['total'],
+    ]);
+    return "Paragraph revision fix complete. {$sandbox['current']} / {$sandbox['total']}\n";
+  }
+
+  return "Processing paragraphs...{$sandbox['current']} / {$sandbox['total']}\n";
+}
+
+function runRange($paragraph_ids) {
+  $connection = \Drupal::database();
+  $transaction = $connection->startTransaction();
+
+  try {
+    $paragraphs = getParagraphData($paragraph_ids);
+    foreach ($paragraphs as $paragraph) {
+
+      if (shouldWeUpdateThisParagraph($paragraph)) {
+        updateNodeForNewParagraph($paragraph->getParentEntity());
+      }
+    }
+  }
+  catch (\Exception $e) {
+    $transaction->rollBack();
+    \Drupal::logger('va_gov_db')
+      ->error('Exception during paragraph migration');
+
+    watchdog_exception('va_gov_db', $e);
+  }
+}
+
+function getParagraphCount() : int {
+  return \Drupal::entityQuery('paragraph')->count()->execute();
+}
+
+function getAllParagraphIds() {
+  $query = \Drupal::entityQuery('paragraph');
+  return $query->execute();
+}
+
+/**
+ * @return \Drupal\paragraphs\Entity\Paragraph[]
+ */
+function getParagraphData(array $pids) : array {
+  return \Drupal::entityTypeManager()->getStorage('paragraph')->loadMultiple($pids);
+}
+
+function shouldWeUpdateThisParagraph(\Drupal\paragraphs\Entity\Paragraph $paragraph) : bool {
+  if ($paragraph->parent_type->value !== 'node') {
+    return FALSE;
+  }
+
+  $parent = $paragraph->getParentEntity();
+  $field_name = $paragraph->parent_field_name;
+
+  if ($parent === NULL || $field_name === NULL) {
+    return FALSE;
+  }
+
+  // Get the data for the field
+  $paragraph_field_items = $parent->get($field_name->value);
+  $paragraph_field_item = $paragraph_field_items->filter(function($item) use ($paragraph) {
+    return $item->target_id === $paragraph->id() && $paragraph->getRevisionId() !== $item->target_revision_id;
+  });
+
+  return count($paragraph_field_item) > 0;
+}
+
+function updateNodeForNewParagraph(\Drupal\node\Entity\Node $node) {
+  // Make this change a new revision.
+  $node->setNewRevision(TRUE);
+
+  // Set revision author to uid 1317 (CMS Migrator user).
+  $node->setRevisionAuthorId(1317);
+  $node->setChangedTime(time());
+  $node->setRevisionCreationTime(time());
+  $node->setOwnerId(1317);
+
+  // Set revision log message.
+  $node->setRevisionLogMessage('Resaved to fix out of sync data.');
+  $node->save();
+}

--- a/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
+++ b/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
@@ -95,16 +95,6 @@ function shouldWeUpdateThisParagraph(\Drupal\paragraphs\Entity\Paragraph $paragr
   return count($paragraph_field_items) > 0;
 }
 
-function updateNodes($nids) {
-  /** @var \Drupal\node\NodeStorage $node_storage */
-  $node_storage = Drupal::entityTypeManager()->getStorage('node');
-  foreach ($nids as $nid) {
-    print($nid . PHP_EOL);
-    $vid = $node_storage->getLatestRevisionId($nid);
-    updateNodeForNewParagraph(node_revision_load($vid));
-  }
-}
-
 function updateParagraphs($paragraphs) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   foreach ($paragraphs as $paragraph) {
@@ -117,7 +107,6 @@ function updateParagraphs($paragraphs) {
     });
 
     $paragraph_field_item = $paragraph_field_items->first();
-    $vid = $paragraph_field_item->target_revision_id;
     $vid = $paragraph_field_item->target_revision_id;
 
     print('Updating paragraph ' . $paragraph->id() . ' on node ' . $nid . ' to use vid ' . $vid . PHP_EOL);

--- a/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
+++ b/scripts/content/VACMS-3325_paragraph_revision-2020-10.php
@@ -23,9 +23,9 @@ function run() {
   do {
     getVidsToUpdate($sandbox);
     print('.');
-  } while ($sandbox['current'] / $sandbox['total'] >= 1);
+  } while ($sandbox['total'] - $sandbox['current'] > 0);
 
-  print('Re-saving nodes');
+  print(PHP_EOL . 'Re-saving nodes' . PHP_EOL);
 
   updateNodes($sandbox['nids']);
 }


### PR DESCRIPTION
## Description

See #3325.  This fix adds a patch to fix the underlining issue of the paragraph always saving the `latest` revision as the `default` revision.  This was causing issues when the `paragraph` is loaded outside the context of the field.  The specific issue is with CMS export.

Looking at the data from the field we can see the revision paragraph ids.  These are used to test the script and verify the results.  The selection of the node came from the reported issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15321

The update script updates the revision on the paragraph tables to the correct revision.  Originally I attempted to re-save the node to update the revision but this solution only worked if there weren't any draft node revisions.  

These queries show the data out of sync between the field storage and paragraph storage

```
select field_content_block_target_id, field_content_block_target_revision_id from node__field_content_block where entity_id=255;
```

| field_content_block_target_id | field_content_block_target_revision_id |
|-------------------------------|----------------------------------------|
| 3784                          | 35659                                  |
| 3805                          | 35660                                  |
| 3807                          | 35661                                  |
| 3809                          | 35662                                  |
| 5510                          | 35663                                  |

```
SELECT id, revision_id
FROM paragraphs_item 
WHERE id in (3784, 3805, 3807, 3809, 5510);
```

| id   | revision_id |
|------|-------------|
| 3784 | 37275       |
| 3805 | 37276       |
| 3807 | 37277       |
| 3809 | 37278       |
| 5510 | 372791      |


## Testing done

Ran the test against the known node which has the issue:

```
$paragraph_ids = [3784, 3805, 3807, 3809, 5510];
$new_nids = runRange($paragraph_ids);
updateParagraphs($new_nids);
```

**Before Data Locally**

```
SELECT t.*
FROM drupal8.paragraphs_item_field_data t
WHERE id in (3784, 3805, 3807, 3809, 5510);
```

| id   | revision_id |
|------|-------------|
| 3784 | 37275       |
| 3805 | 37276       |
| 3807 | 37277       |
| 3809 | 37278       |
| 5510 | 372791      |

**After Data Locally**

| id   | revision_id |
|------|-------------|
| 3784 | 35659       |
| 3805 | 35660       |
| 3807 | 35661       |
| 3809 | 35662       |
| 5510 | 35663       |

The revisions are back in sync with the field data.

**Full Script Run**
This lists all of the nodes to be updated

```
❯ lando drush scr ../scripts/content/VACMS-3325_paragraph_revision-2020-10.php
Finding Nodes which need to be updated...
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Updating Paragraphs
Updating paragraph 3784 on node 255 to use vid 35659
Updating paragraph 3805 on node 255 to use vid 35660
Updating paragraph 3807 on node 255 to use vid 35661
Updating paragraph 3809 on node 255 to use vid 35662
Updating paragraph 5510 on node 255 to use vid 35663
Updating paragraph 5598 on node 78 to use vid 47011
Updating paragraph 2852 on node 201 to use vid 86961
Updating paragraph 9892 on node 284 to use vid 131971
Updating paragraph 7011 on node 284 to use vid 131972
Updating paragraph 4487 on node 720 to use vid 97105
Updating paragraph 4489 on node 720 to use vid 97106
Updating paragraph 4491 on node 720 to use vid 97111
Updating paragraph 4484 on node 720 to use vid 97113
Updating paragraph 3547 on node 67 to use vid 156524
Updating paragraph 11552 on node 6454 to use vid 161405
Updating paragraph 6984 on node 952 to use vid 80491
Updating paragraph 6986 on node 952 to use vid 80492
Updating paragraph 6988 on node 952 to use vid 80499
Updating paragraph 6979 on node 952 to use vid 80501
Updating paragraph 6981 on node 952 to use vid 80503
Updating paragraph 12572 on node 637 to use vid 157706
Updating paragraph 12575 on node 637 to use vid 157709
Updating paragraph 12578 on node 637 to use vid 157712
Updating paragraph 13477 on node 8471 to use vid 161974
Updating paragraph 13478 on node 8471 to use vid 161975
Updating paragraph 13479 on node 8471 to use vid 161976
Updating paragraph 13481 on node 8471 to use vid 161978
Updating paragraph 14016 on node 8471 to use vid 161979
```

## Testing the Patch

To test the patch we save a node in `draft` status which has a previously published revision.  Node 255, 720 and 952 all fit into this category.   After running the data migration script, resave the node while staying in draft status.  Then look at the `paragraphs_item_field_data` for the paragraph revisions to make sure they didn't change.  Using 255 is the easiest since the paragraph ids are already mentioned in this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/3409)
<!-- Reviewable:end -->
