### PR TITLE
VACMS-2457: Updates TableField caption help text.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -315,7 +315,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 function va_gov_backend_form_field_config_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $widget_type = $form['default_value']['widget'][0]['#type'] ?? NULL;
   if ($widget_type === 'tablefield') {
-    $form['default_value']['widget'][0]['caption']['#description'] = 'This brief caption will be associated with the table, rendered as a table heading in bold and will help screen reader better describe the content within.';
+    $form['default_value']['widget'][0]['caption']['#description'] = t('This brief caption will be associated with the table, rendered as a table heading in bold and will help screen reader better describe the content within.');
   }
 }
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -310,6 +310,16 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter() for field_config_edit_form.
+ */
+function va_gov_backend_form_field_config_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $widget_type = $form['default_value']['widget'][0]['#type'] ?? NULL;
+  if ($widget_type === 'tablefield') {
+    $form['default_value']['widget'][0]['caption']['#description'] = 'This brief caption will be associated with the table, rendered as a table heading in bold and will help screen reader better describe the content within.';
+  }
+}
+
+/**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter() for moderation_state widgets.
  */
 function va_gov_backend_field_widget_moderation_state_default_form_alter(&$element, FormStateInterface $form_state, $context) {


### PR DESCRIPTION
## Description

See #2457. 

## Testing done
Checked the field settings form for a couple of fields.

## Screenshots
<img width="1008" alt="Screen Shot 2020-11-09 at 2 30 28 PM" src="https://user-images.githubusercontent.com/1318579/98593026-32590400-2298-11eb-80ec-b466f5fae11b.png">

## QA steps
As an administrator:
- [ ] The settings form for [a TableField field on a given content type](http://va-gov-cms.lndo.site/admin/structure/types/manage/health_care_local_facility/fields/node.health_care_local_facility.field_facility_hours) should read `This brief caption will be associated with the table, rendered as a table heading in bold and will help screen reader better describe the content within.`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
