### PR TITLE
VACMS-3449: Forces paragraphs to clone and hides their checkboxes on the clone form.

### DIFF
--- a/config/sync/entity_clone.settings.yml
+++ b/config/sync/entity_clone.settings.yml
@@ -75,15 +75,11 @@ form_settings:
     hidden: true
     default_value: false
     disable: false
-  workflow_participants:
-    hidden: true
-    default_value: false
-    disable: false
   menu_link_content:
     hidden: true
     default_value: false
     disable: false
   paragraph:
     default_value: true
-    disable: false
-    hidden: false
+    disable: true
+    hidden: true


### PR DESCRIPTION
## Description

See #3449. 

## Testing done
Attempted to clone a node with paragraphs and noted that the form no longer contains checkboxes for the paragraph children of the original node.  Clone completed successfully and verified in Views that this created new paragraphs whose parents were the newly cloned node.

## Screenshots
<img width="514" alt="Screen Shot 2020-11-13 at 8 17 47 AM" src="https://user-images.githubusercontent.com/1318579/99081703-d38dd600-2588-11eb-86d4-8d8823e12bbe.png">

## QA steps
As any user with the permission to clone a node:
1. Clone [a node with paragraphs](http://va-gov-cms.lndo.site/entity_clone/node/2768)
1. Verify that:
  - [ ] the clone form does not give the option to avoid cloning the paragraphs
  - [ ] the clone operation succeeds and the new node has paragraphs that are distinct from the paragraphs of the original node

## Definition of Done
It's just a config update.

### CMS user-facing announcement
Is an announcement needed to let editors know of this change? 
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
