### PR TITLE
VACMS-3439: Patch govdelivery_bulletins to allow creating test queue items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -257,7 +257,8 @@
                 "2984027 Incorrect manipulation of default revision flag": "https://www.drupal.org/files/issues/2020-09-03/entity_reference_revisions-default_revision-2984027-10.patch"
             },
             "drupal/govdelivery_bulletins": {
-                "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch"
+                "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch",
+                "Adding a test queue item does not work": "https://www.drupal.org/files/issues/2020-11-13/govdelivery_bulletins-fix_test_validation-3182474-2.patch"
             },
             "drupal/graphql": {
                 "PHP 7.4 Notices (https://github.com/drupal-graphql/graphql/pull/989)": "https://patch-diff.githubusercontent.com/raw/drupal-graphql/graphql/pull/989.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68a5e56d45bd9fe801e76a01a442b8ec",
+    "content-hash": "4493e1cdcf59b444b4f956dac370343f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5390,7 +5390,8 @@
                     }
                 },
                 "patches_applied": {
-                    "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch"
+                    "Use default lease time in claimItem()": "https://www.drupal.org/files/issues/2020-04-16/default-claim-time-3128425-2.patch",
+                    "Adding a test queue item does not work": "https://www.drupal.org/files/issues/2020-11-13/govdelivery_bulletins-fix_test_validation-3182474-2.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",


### PR DESCRIPTION
## Description

See #3439. In order to test govdelivery_bulletins with the new endpoints on a production-like environment, we need to be able to create test queue items. This PR patches govdelivery_bulletins with a fix.

## Testing done

Added test queue items according to the govdelivery_bulletins README.

## QA steps

As a developer:
1. Add a test queue item
- [ ] Validate that it is added to the queue table with no errors

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
