### PR TITLE
VACMS-3485: QA Standalone Fix

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -310,6 +310,14 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 }
 
 /**
+ * Implements hook_field_group_build_pre_render_alter().
+ */
+function va_gov_backend_field_group_form_process_build_alter(array $form, FormStateInterface $form_state, &$element) {
+  // Toggle group Q&A component visibility.
+  $form['group_q_a_page_components']['#states']['visible']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+}
+
+/**
  * Implements hook_form_FORM_ID_alter() for field_config_edit_form.
  */
 function va_gov_backend_form_field_config_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
…andalone Page checkbox

## Description

See _issueid_. https://app.zenhub.com/workspaces/vagov-cms-team-5c0e7b864b5806bc2bfc2087/issues/department-of-veterans-affairs/va.gov-cms/3485

## Testing done


## Screenshots


## QA steps

- Login to preview environment

### QA Standalone field
- Navigate to QA node add page here : `/node/add/q_a`
- [ ] Confirm you see a new boolean (checkbox) field called **Enable standalone page** 
- Do NOT check **Enable standalone page** and fill out the fields within the **Question & Answer** group at the very top
- Fill out the fields within the **Question & Answer** group at the very top
- Select an owner from the sidebar within Governance.
- [ ] Select SAVE and confirm the node saves.
- [ ] Scroll down on preview and confirm the **Enable standalone page** exists and underneath it says **No standalone page**

- Navigate to QA node add page here : `/node/add/q_a`
- [ ] Confirm you see a new boolean (checkbox) field called **Enable standalone page** 
- CHECK the **Enable standalone page**
- [ ] Confirm all the fields within the **Q&A PAGE COMPONENTS** is now visible
- Fill out all required fields.
- Select an owner from the sidebar within Governance.
- [ ] Select SAVE and confirm the node saves.
- [ ] Scroll down on preview and confirm the **Enable standalone page** exists and underneath it says **Standalone page**

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
