### PR TITLE
VACMS-3487 remove system fields step 3 of 3

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -52,7 +52,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       parent_name: ''
       weight: 13
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -52,6 +52,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 13
       format_type: fieldset

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.install
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.install
@@ -373,3 +373,22 @@ function va_gov_backend_update_8008() {
     }
   }
 }
+
+/**
+ * Remove fields from VAMC system.
+ */
+function va_gov_backend_update_8009() {
+  $vamc_system_fields = [
+    'field_featured_content_healthser',
+    'field_press_release_blurb',
+  ];
+
+  foreach ($vamc_system_fields as $system_field) {
+    if ($field = FieldConfig::loadByName('node', 'health_care_region_page', $system_field)) {
+      $field->delete();
+      Drupal::logger('va_gov_backend')->log(LogLevel::INFO, 'Deleted "%system_field" from health_care_region_page.', [
+        '%system_field' => $system_field,
+      ]);
+    }
+  }
+}


### PR DESCRIPTION
## Description
See #3487 
Step 3 of 3. (Step 1 = remove fields from vets-web, Step 3 = remove fields from db in update hook)
Do not merge until https://github.com/department-of-veterans-affairs/va.gov-cms/pull/3523 is merged

## Testing done
VIsual / Behat (will need to update tests before changing from draft to ready for review)

## Screenshots
![disabled_fields](https://user-images.githubusercontent.com/2404547/99669772-92d90580-2a3d-11eb-90a3-45e3656efb5f.png)
![removed_fields](https://user-images.githubusercontent.com/2404547/99669773-93719c00-2a3d-11eb-8df7-adf545be661d.png)

## QA steps
- As as admin, go to `admin/structure/types/manage/health_care_region_page/form-display` and visually verify that `Regional Health Service Offerings.` is disabled
- As an admin, go to `admin/structure/types/manage/health_care_region_page/fields` and visually verify that Featured content and Press release blurbs fields have been removed.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review
- [ ] `Core Application Team`
- [x] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
