### PR TITLE
Hard Code Composer version for lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -3,6 +3,7 @@ recipe: drupal8
 config:
   webroot: docroot
   php: "7.1"
+  composer_version: '1.10.1'
 
 events:
   post-db-import:


### PR DESCRIPTION
## Description

Lando now includes a `composer_version:` setting which defaults to composer 2 and our site doesn't work on composer 2.  This PR hard codes the version to 1.10.1