### PR TITLE
VACMS-3508: Use revision creation time for right sidebar view sort

### DIFF
--- a/config/sync/views.view.right_sidebar_latest_revision.yml
+++ b/config/sync/views.view.right_sidebar_latest_revision.yml
@@ -324,21 +324,21 @@ display:
           plugin_id: field
       filters: {  }
       sorts:
-        changed:
-          id: changed
-          table: node_field_revision
-          field: changed
-          order: DESC
-          entity_type: node
-          entity_field: changed
-          plugin_id: date
+        revision_timestamp:
+          id: revision_timestamp
+          table: node_revision
+          field: revision_timestamp
           relationship: none
           group_type: group
           admin_label: ''
+          order: DESC
           exposed: false
           expose:
             label: ''
           granularity: second
+          entity_type: node
+          entity_field: revision_timestamp
+          plugin_id: date
       title: ''
       header: {  }
       footer: {  }


### PR DESCRIPTION
## Description

See #3508

## Testing done

Confirmed that sort is correct on revision sidebar and revisions tab.

## Screenshots

<img width="422" alt="Screen Shot 2020-11-23 at 2 19 16 PM" src="https://user-images.githubusercontent.com/101649/100016704-10cb4280-2d97-11eb-8730-ecb0a36d0755.png">

## QA steps

As a user with the 'Content Admin' role
1. Perform several moderation actions on a node during the same clock minute
1. Then validate Acceptance Criteria from issue:
- [ ] Revisions are sorted in order performed on the right sidebar block
- [ ] Revisions are sorted in order performed on the revisions tab

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
