### PR TITLE
VACMS-3555: Limit tz choices.

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -187,13 +187,22 @@ content:
     weight: 1
     region: content
     settings:
+      default_tz: ''
+      custom_tz: America/New_York
+      allowed_timezones:
+        - America/Anchorage
+        - America/Chicago
+        - America/Denver
+        - America/Los_Angeles
+        - America/New_York
+        - America/Phoenix
+        - Pacific/Guam
+        - Pacific/Honolulu
+        - Pacific/Saipan
       modal: false
       default_duration: 60
       default_duration_increments: "30\n60|1 hour\n90\n120|2 hours\ncustom"
       show_extra: true
-      default_tz: ''
-      custom_tz: ''
-      allowed_timezones: {  }
     third_party_settings: {  }
   field_description:
     weight: 3

--- a/config/sync/core.entity_form_display.paragraph.situation_update.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.situation_update.default.yml
@@ -21,13 +21,22 @@ content:
     weight: 1
     region: content
     settings:
+      default_tz: user
+      custom_tz: America/New_York
+      allowed_timezones:
+        - America/Anchorage
+        - America/Chicago
+        - America/Denver
+        - America/Los_Angeles
+        - America/New_York
+        - America/Phoenix
+        - Pacific/Guam
+        - Pacific/Honolulu
+        - Pacific/Saipan
       modal: false
       default_duration: 60
       default_duration_increments: "30\n60|1 hour\n90\n120|2 hours\ncustom"
       show_extra: true
-      default_tz: ''
-      custom_tz: ''
-      allowed_timezones: {  }
     third_party_settings: {  }
   field_send_email_to_subscribers:
     weight: 0


### PR DESCRIPTION
## Description
See #3555 

## Testing done
Visual / behat

## QA steps
As an admin, go to `node/7825/edit` and visually verify that the timezone choices only include the following:
```Americas
- Anchorage
- Chicago
- Denver
- Los Angeles
- New York
- Phoenix
Pacific
- Guam
- Honolulu
- Saipan
```

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
