### PR TITLE
Update lando for vets-website install/make dependencies.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -30,7 +30,7 @@ services:
   appserver:
     run_as_root:
       - "apt-get update -y"
-      - "apt-get install build-essential chrpath libssl-dev libxft-dev libfreetype6-dev libfreetype6 libfontconfig1-dev libfontconfig1 -y"
+      - "apt-get install build-essential chrpath libssl-dev libxft-dev libfreetype6-dev libfreetype6 libfontconfig1-dev libfontconfig1 python -y"
       - .lando/scripts/blackfire-init.sh
     xdebug: false
     config:

--- a/composer.json
+++ b/composer.json
@@ -346,8 +346,7 @@
             "cp -r 'simplesamlphp-config-metadata/config' 'simplesamlphp-config-metadata/metadata' 'docroot/vendor/simplesamlphp/simplesamlphp/'",
             "echo 'Removing deleted .git/hooks/commit-msg file, no longer used.'",
             "rm -f .git/hooks/commit-msg",
-            "git update-index --skip-worktree samlsessiondb.sq3",
-            "@va:web:install"
+            "git update-index --skip-worktree samlsessiondb.sq3"
         ],
         "post-update-cmd": [
             "cp -r 'hooks/git/.' '.git/hooks/'",

--- a/docroot/sites/default/settings.devshop.php
+++ b/docroot/sites/default/settings.devshop.php
@@ -30,6 +30,7 @@ $settings['file_public_base_url'] = $_SERVER['DRUPAL_ADDRESS'] . '/' . $site_pat
 
 // Add devshop level service file for FileSystem overrides
 $settings['file_chmod_directory'] = 02775;
+$settings['skip_permissions_hardening'] = TRUE;
 
 // Restore DevShop's $databases settings.
 $databases  = $devshop_db_settings;

--- a/tests.yml
+++ b/tests.yml
@@ -42,6 +42,10 @@ va/tests/accessibility:
   # Ignore failures so that staging deploys can complete.
   ignore-failure: true
 
+va/web/install:
+  description: Install VA.gov node environment
+  command: composer va:web:install
+
 va/web/build:
   description: Build VA.gov Front-end
 


### PR DESCRIPTION
## Description

#3530 and #3600. 

This is to get Lando working with a composer install which does a yarn install for the latest vets-website. The python dependency gets farther but currently fails on Lando with:

> gyp gyp format was not specified; forcing "make
> gyp ERR! configure error                              
> gyp ERR! stack Error: `gyp` failed with exit code: 1