### PR TITLE
Restore vets-website to use version in composer instead of commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "symfony/config": "^3.4",
         "symfony/finder": "^3",
         "symfony/phpunit-bridge": "^5.1",
-        "va-gov/web": "dev-master#4749648bd8506c6e2432f27d395fa5cfd75c19a1",
+        "va-gov/web": "^0.1",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
         "weitzman/drupal-test-traits": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70578a870d5f91de97b4eda07d106e36",
+    "content-hash": "532f219897616d27df64e2bdfafb49a1",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -18389,16 +18389,16 @@
         },
         {
             "name": "va-gov/web",
-            "version": "dev-master",
+            "version": "v0.1.1174",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/vets-website.git",
-                "reference": "4749648bd8506c6e2432f27d395fa5cfd75c19a1"
+                "reference": "e32b2e277350bad6c8acf82868b7c79dad4636e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/vets-website/zipball/4749648bd8506c6e2432f27d395fa5cfd75c19a1",
-                "reference": "4749648bd8506c6e2432f27d395fa5cfd75c19a1",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/vets-website/zipball/e32b2e277350bad6c8acf82868b7c79dad4636e2",
+                "reference": "e32b2e277350bad6c8acf82868b7c79dad4636e2",
                 "shasum": ""
             },
             "type": "node-project",
@@ -18423,7 +18423,7 @@
                 }
             ],
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/web, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
-            "time": "2020-12-01T17:24:02+00:00"
+            "time": "2020-12-01T18:38:26+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -21093,7 +21093,6 @@
         "drupal/views_tree": 15,
         "drupal/workbench_access": 10,
         "drupal/workflow_assignments": 20,
-        "va-gov/web": 20,
         "weitzman/drupal-test-traits": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
## Description

Restore vets-website to use version in composer instead of commit


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [x] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/3611)
<!-- Reviewable:end -->
