### PR TITLE
VACMS-3633: Do not set va build flag on devshop front end builds

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
@@ -101,7 +101,7 @@ class BuildTriggerForm extends FormBase {
         break;
 
       case $environment_type == 'ci':
-        $description = t('A content release for this environment is handled by CMS-CI. You may press this button to trigger a content release. It will take around 45 seconds.');
+        $description = t('A content release for this environment is handled by CMS-CI. You may press this button to trigger a content release.');
         break;
 
       case $environment_type == 'lando':

--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
@@ -89,12 +89,9 @@ class BuildFrontend {
         $vars = [
           '@link' => Link::fromTextAndUrl(t('Deploy Log'), Url::fromUri('http://' . $_SERVER['DEVSHOP_HOSTNAME'] . '/node/' . $task->nid))->toString(),
         ];
-        $message = t('VA Web Rebuild & Deploy has been queued. The process should complete in around 1 minute. @link', $vars);
+        $message = t('VA Web Rebuild & Deploy has been queued. Please see the devshop deploy log for status. @link', $vars);
         $this->messenger->addStatus($message);
         $this->logger->info($message);
-
-        // Save pending state.
-        $this->setPendingState(1);
       }
       else {
         // This has failed due to bad devshop setting.
@@ -110,8 +107,6 @@ class BuildFrontend {
       $message = t('Frontend build would have been triggered. To build with Lando, run the command: @command', $vars);
       $this->messenger->addStatus($message);
       $this->logger->info($message);
-      // Save pending state.
-      $this->setPendingState(1);
     }
     elseif ((!empty($jenkins_build_environment)) && array_key_exists($jenkins_build_environment, self::WEB_ENVIRONMENTS) && (PHP_SAPI !== 'cli')) {
       // This is in a BRD environment.


### PR DESCRIPTION
## Description

See #3633. 

## Testing done

- Trigger web build on `admin/content/deploy` and do not see message `Web Rebuild & Deploy is in progress`
- Verify the build has been queue to run.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/3649)
<!-- Reviewable:end -->
