### PR TITLE
VACMS-000: composer require va-gov/web:dev-master#7b4c8725 (fix broken CI builds caused by hyphens in new URL pattern)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
         "symfony/config": "^3.4",
         "symfony/finder": "^3",
         "symfony/phpunit-bridge": "^5.1",
-        "va-gov/web": "^0.1",
+        "va-gov/web": "dev-master#7b4c87257cfc9b5e684c4ba7ddca283efbc4329d",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
         "weitzman/drupal-test-traits": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b1f5373cf1b868a71e63261ae4c0522",
+    "content-hash": "fb1ecb9327c8929e41351e86858a4bda",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -18454,16 +18454,16 @@
         },
         {
             "name": "va-gov/web",
-            "version": "v0.1.1184",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/vets-website.git",
-                "reference": "482d6fa322be32e699c8c6919392c6d85c4aede7"
+                "reference": "7b4c87257cfc9b5e684c4ba7ddca283efbc4329d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/vets-website/zipball/482d6fa322be32e699c8c6919392c6d85c4aede7",
-                "reference": "482d6fa322be32e699c8c6919392c6d85c4aede7",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/vets-website/zipball/7b4c87257cfc9b5e684c4ba7ddca283efbc4329d",
+                "reference": "7b4c87257cfc9b5e684c4ba7ddca283efbc4329d",
                 "shasum": ""
             },
             "type": "node-project",
@@ -18488,7 +18488,7 @@
                 }
             ],
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/web, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
-            "time": "2020-12-10T21:33:47+00:00"
+            "time": "2020-12-12T00:50:19+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -21159,6 +21159,7 @@
         "drupal/views_tree": 15,
         "drupal/workbench_access": 10,
         "drupal/workflow_assignments": 20,
+        "va-gov/web": 20,
         "weitzman/drupal-test-traits": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
This is for an urgent issue to fix the builds on our new CI environments which have hyphens in the URLs

See https://github.com/department-of-veterans-affairs/vets-website/pull/15350

After this commit is tagged in the next release, we need to go back to the tag again with `composer require va-gov/web:^0.1`.