### PR TITLE
VACMS-3731 Add content newer content types to alert block scope.

### DIFF
--- a/config/sync/field.field.block_content.alert.field_node_reference.yml
+++ b/config/sync/field.field.block_content.alert.field_node_reference.yml
@@ -6,28 +6,40 @@ dependencies:
     - block_content.type.alert
     - field.storage.block_content.field_node_reference
     - node.type.basic_landing_page
+    - node.type.campaign_landing_page
     - node.type.checklist
+    - node.type.documentation_page
     - node.type.event
     - node.type.event_listing
     - node.type.faq_multiple_q_a
     - node.type.health_care_local_facility
     - node.type.health_care_region_detail_page
     - node.type.health_care_region_page
+    - node.type.health_services_listing
     - node.type.landing_page
+    - node.type.leadership_listing
+    - node.type.locations_listing
     - node.type.media_list_images
     - node.type.media_list_videos
+    - node.type.nca_facility
     - node.type.news_story
     - node.type.office
     - node.type.outreach_asset
     - node.type.page
     - node.type.person_profile
     - node.type.press_release
+    - node.type.press_releases_listing
     - node.type.publication_listing
     - node.type.q_a
     - node.type.regional_health_care_service_des
     - node.type.step_by_step
+    - node.type.story_listing
     - node.type.support_resources_detail_page
     - node.type.support_service
+    - node.type.va_form
+    - node.type.vamc_operating_status_and_alerts
+    - node.type.vba_facility
+    - node.type.vet_center
   module:
     - entity_reference_validators
 third_party_settings:
@@ -50,27 +62,39 @@ settings:
     target_bundles:
       page: page
       landing_page: landing_page
+      documentation_page: documentation_page
+      campaign_landing_page: campaign_landing_page
       checklist: checklist
       health_care_region_detail_page: health_care_region_detail_page
       event: event
       event_listing: event_listing
       faq_multiple_q_a: faq_multiple_q_a
+      health_services_listing: health_services_listing
       basic_landing_page: basic_landing_page
+      leadership_listing: leadership_listing
       support_resources_detail_page: support_resources_detail_page
+      locations_listing: locations_listing
       media_list_images: media_list_images
       media_list_videos: media_list_videos
+      nca_facility: nca_facility
       press_release: press_release
+      press_releases_listing: press_releases_listing
       office: office
       outreach_asset: outreach_asset
       publication_listing: publication_listing
       q_a: q_a
       person_profile: person_profile
       step_by_step: step_by_step
+      story_listing: story_listing
       news_story: news_story
       support_service: support_service
+      va_form: va_form
       health_care_local_facility: health_care_local_facility
       health_care_region_page: health_care_region_page
       regional_health_care_service_des: regional_health_care_service_des
+      vamc_operating_status_and_alerts: vamc_operating_status_and_alerts
+      vba_facility: vba_facility
+      vet_center: vet_center
     sort:
       field: title
       direction: ASC


### PR DESCRIPTION
## Description

See #3731 



## QA steps
Visit /admin/structure/block/block-content/manage/alert/fields/block_content.alert.field_node_reference
- [ ] Validate settings match 
![image](https://user-images.githubusercontent.com/5752113/102111967-0daafb80-3e05-11eb-83a1-04f8a3e7d76b.png)



### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
