### PR TITLE
VACMS-000: Add tugboat-grant-all-users-all-projects.sh crontab script.

### DIFF
--- a/.tugboat/tugboat-grant-all-users-all-projects.sh  
+++ b/.tugboat/tugboat-grant-all-users-all-projects.sh  
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+projects=$(tugboat ls projects --quiet)
+user_ids=$(tugboat ls keys children=false --quiet | tr "[:space:]" "," | sed 's/,*$//g')
+
+for project in $projects
+do
+  tugboat grant "$project" users="$user_ids"
+done


### PR DESCRIPTION
This will be in the DevOps repo eventually. This runs every minute right now.