### PR TITLE
VACMS-3682 push facility covid service status

### DIFF
--- a/READMES/migrations-facility.md
+++ b/READMES/migrations-facility.md
@@ -6,7 +6,7 @@
       - [VAMC Status](#vamc-status-migration)
    1. VBA (Veterans Benefits Administraion) Facilities
    1. Vet Centers
-1. [Status Changes to Lighthouse](#status-changes-to-lighthouse)
+1. [Status Changes to Lighthouse](vamc-facilities.md#status-changes-to-lighthouse)
 
 ![Facilities updates and actions](images/VA-facilities.png)
 
@@ -29,15 +29,12 @@ to the user "CMS Migrator"
 ### VAMC Status Migration
 VAMC Statuses are updated by a separate migration
 (va_node_health_care_local_facility_status) that runs every hour.  It grabs
-multiple CSV sources (one per system) which are scraped from TeamSite and
-updates the "Operating status" (field_operating_status_facility) and "Operating
-status - more info" (field_operating_status_more_info)
+[multiple CSV sources](../docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml) (one per system) which are
+scraped from TeamSite and updates the "Operating status"
+(field_operating_status_facility) and "Operating status - more info"
+(field_operating_status_more_info)  [Changes to operating status also get pushed
+ to Lighthouse](vamc-facilities.md#status-changes-to-lighthouse).
 
-## Status Changes to Lighthouse
-Whenever any facility has a change of "Operating status" or "Operating status -
-more info" saved in VACMS (whether by an editor, or migration), a change post is
-added to the "post API queue" by module:va_gov_post_api. When cron runs, any
-items in the queue are posted to the Lighthouse API.
 
 
 [Table of Contents](../README.md)

--- a/READMES/vamc-facilities.md
+++ b/READMES/vamc-facilities.md
@@ -1,0 +1,31 @@
+# VAMC Facilities
+
+1. [Facility Migrations](migrations-facilities.md#facility-migrations)
+2. [Status Updates to Lighthouse](#status-changes-to-lighthouse)
+3. [Facility Service Updates to Lighthouse](#facility-service-changes-to-lighthouse)
+
+![Facilities updates and actions](images/VA-facilities.png)
+
+## Status Changes to Lighthouse
+Whenever any facility has a change of "Operating status" or "Operating status -
+more info" saved in VACMS (whether by an editor, or migration), a change post is
+added to the "post API queue" by module:va_gov_post_api. When cron runs, any
+items in the queue are posted to the Lighthouse API.
+
+## Facility Service Changes to Lighthouse
+To meet the need for getting timely information related to COVID-19 Vaccines out
+to the Facility Locator, we are pushing this data to Lighthouse any time a
+"COVID-19 Vaccines" facility service is saved under the following criteria:
+ - New and published
+ - New and draft
+ - Draft of unpublished
+ - Archived
+
+ Drafts of a published service are intentionally not pushed.  A change post is
+added to the "post API queue" by module:va_gov_post_api. When cron runs, any
+items in the queue are posted to the Lighthouse API.  Queueing logic is all
+handled in [PostFacilityService.php](../docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php).  This service is currently only using Covid-19
+Vaccines but is expandable to handle more or eventually all services.
+
+
+[Table of Contents](../README.md)

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.health_care_region_page.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.health_care_region_page.yml
@@ -61,7 +61,7 @@ source:
     -
       path: 'URL alias'
 process:
-  #
+  # Pseudo fields have no real destination but can be processed the same way.
   pseudo_field_parent:
     -
       plugin: concat

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -127,7 +127,6 @@ class PostFacilityService {
       // and the health service taxonomy.
       $this->setFacility();
       $this->setSystemService();
-      $this->setServiceTerm();
 
       if (empty($this->errors) && ($this->isPushable())) {
         // There were no errors gathering data and it is pushable, so proceed.
@@ -239,14 +238,15 @@ class PostFacilityService {
    * Checks to see if this service is slated for pushing.
    */
   private function isPushable() {
-    return in_array($this->serviceTerm->id(), $this->servicesToPush);
+    return (!empty($this->serviceTerm) && in_array($this->serviceTerm->id(), $this->servicesToPush));
   }
 
   /**
    * Load and set the facility node that this service belongs to.
    */
   protected function setFacility() {
-    $facility = $this->facilityService->get('field_facility_location')->referencedEntities();
+    $field = $this->facilityService->get('field_facility_location');
+    $facility = (!empty($field)) ? $field->referencedEntities() : NULL;
     if (!empty($facility)) {
       $this->Facility = reset($facility);
     }
@@ -262,6 +262,7 @@ class PostFacilityService {
     $system_health_service = $this->facilityService->get('field_regional_health_service')->referencedEntities();
     if (!empty($system_health_service)) {
       $this->systemService = reset($system_health_service);
+      $this->setServiceTerm();
     }
     else {
       $this->errors[] = "Unable to load system service. Field 'field_regional_health_service' not set.";
@@ -272,7 +273,9 @@ class PostFacilityService {
    * Load and set the health service taxonomy term for this service.
    */
   protected function setServiceTerm() {
-    $health_service_term = $this->systemService->get('field_service_name_and_descripti')->referencedEntities();
+    $health_service_term_field = $this->systemService->get('field_service_name_and_descripti');
+    $health_service_term = (!empty($health_service_term_field)) ? $health_service_term_field->referencedEntities() : NULL;
+
     if (!empty($health_service_term)) {
       $this->serviceTerm = reset($health_service_term);
     }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -147,7 +147,7 @@ class PostFacilityService {
           $this->postQueue->addToQueue($data, $dedupe);
           // @todo When this is expanded to more than just COVID we may want
           // to remove the messenger as it will be too noisy.
-          $message = t('The facility service data for %serice_name is being sent to the Facility Locator.', ['%serice_name' => $this->facilityService->getTitle()]);
+          $message = t('The facility service data for %service_name is being sent to the Facility Locator.', ['%service_name' => $this->facilityService->getTitle()]);
           $this->messenger->addStatus($message);
         }
       }
@@ -194,7 +194,7 @@ class PostFacilityService {
    *   TRUE if bypass, FALSE if no bypass.
    */
   protected function shouldBypass() {
-    return empty($this->configFactory->get('va_gov_post_api.settings')->get('bypass_data_check')) ? FALSE : TRUE;
+    return !empty($this->configFactory->get('va_gov_post_api.settings')->get('bypass_data_check'));
   }
 
   /**
@@ -239,7 +239,7 @@ class PostFacilityService {
    * Checks to see if this service is slated for pushing.
    */
   private function isPushable() {
-    return (in_array($this->serviceTerm->id(), $this->servicesToPush)) ? TRUE : FALSE;
+    return in_array($this->serviceTerm->id(), $this->servicesToPush);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -149,19 +149,16 @@ class PostFacilityService {
     if (empty($this->errors) && $this->shouldPush()) {
       // @todo set the actual payload for facility service once Lighthouse
       // defines it for us.
+      $service = new \stdClass();
+      $service->name = $this->serviceTerm->getName();
+      $service->active = ($this->facilityService->isPublished()) ? 1 : 0;
+      $service->description_national = $this->serviceTerm->getDescription();
+      $service->description_system = $this->systemService->get('field_body')->value;
+      $service->description_facility = $this->facilityService->get('field_body')->value;
+      $service->health_service_api_id = $this->serviceTerm->get('field_health_service_api_id')->value;
+
       $payload = [
-        'services' => [
-          $this->serviceTerm->getName() => [
-            'name' => $this->serviceTerm->getName(),
-            // @todo will need to align this value with shouldPush logic.
-            'active' => ($this->facilityService->isPublished()) ? 1 : 0,
-            'description_national' => $this->serviceTerm->getDescription(),
-            'description_system' => $this->systemService->get('field_body')->value,
-            'description_facility' => $this->facilityService->get('field_body')->value,
-            // Not sure if we need this.
-            'health_service_api_id' => $this->serviceTerm->get('field_health_service_api_id')->value,
-          ],
-        ],
+        'detailed_services' => [$service],
       ];
     }
 

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Drupal\va_gov_post_api\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\post_api\Service\AddToQueue;
+
+/**
+ * Class PostFacilityService posts specific service info to Lighthouse.
+ */
+class PostFacilityService {
+
+  /**
+   * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * A array of any errors in prepping the data.
+   *
+   * @var array
+   */
+  protected $errors = [];
+
+  /**
+   * The facility service node.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $facilityService;
+
+  /**
+   * The Post queue add service.
+   *
+   * @var \Drupal\post_api\Service\AddToQueue
+   */
+  protected $postQueue;
+
+  /**
+   * The related system service node.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $systemService;
+
+  /**
+   * The related health system taxonomy service term.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $serviceTerm;
+
+  /**
+   * The services that should be pushed to Lighthouse.
+   *
+   * For now we are only pushing covid 19 services. The key is only for
+   * making sense of code, the TID is what is used for comparison.
+   *
+   * @var array
+   */
+  protected $servicesToPush = [
+    // Key: service name (not used) => Value: TID.
+    'COVID-19 vaccines' => 321,
+  ];
+
+  /**
+   * Logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a new PostFacilityService object.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, LoggerChannelFactoryInterface $logger, AddToQueue $post_queue) {
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->logger = $logger;
+    $this->postQueue = $post_queue;
+  }
+
+  /**
+   * Adds facility service data to Post API queue.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   */
+  public function queueFacilityService(EntityInterface $entity) {
+    if (($entity->getEntityTypeId() === 'node') && ($entity->bundle() === 'health_care_local_health_service')) {
+      // This is an appropriate service so begin gathering data to process.
+      $this->facilityService = $entity;
+      // Many service details do not reside with the facility service node.
+      // They must be derived from the facility and system service nodes
+      // and the health service taxonomy.
+      $this->setFacility();
+      $this->setSystemService();
+      $this->setServiceTerm();
+
+      if (empty($this->errors) && ($this->isPushable())) {
+        // There were no errors gathering data and it is pushable, so proceed.
+        $data['nid'] = $this->facilityService->id();
+        // Queue item's Unique ID.
+        $data['uid'] = "facility_service_{$this->Facility->id()}_{$this->facilityService->id()}";
+        $facilityApiId = $this->Facility->hasField('field_facility_locator_api_id') ? $this->Facility->get('field_facility_locator_api_id')->value : NULL;
+        $data['endpoint_path'] = ($facilityApiId) ? "/services/va_facilities/v0/facilities/{$facilityApiId}/cms-overlay" : NULL;
+        $data['payload'] = $this->getPayload();
+
+        // Only add to queue if payload is not empty.
+        // If its empty, it means that there is no new information to send to
+        // endpoint.
+        if (!empty($data['payload']) && !empty($facilityApiId)) {
+          // If bypass_data_check setting is enabled, do not dedupe, just force.
+          $dedupe = !$this->shouldBypass();
+          $this->postQueue->addToQueue($data, $dedupe);
+        }
+      }
+      elseif (!empty($this->errors) && ($this->isPushable())) {
+        // We were supposed to push it, but there was a problem.
+        $errors = implode(' ', $this->errors);
+        $message = sprintf('Post API: attempted to add a system  NID %d to queue, but ran into errors: %s', $this->facilityService->id(), $errors);
+        $this->logger->get('va_gov_post_api')->error($message);
+      }
+    }
+  }
+
+  /**
+   * Compose and return payload array for facility service.
+   *
+   * @return array
+   *   Payload array.
+   */
+  protected function getPayload() {
+    // Default payload is an empty array.
+    $payload = [];
+
+    if (empty($this->errors) && $this->shouldPush()) {
+      // @todo set the actual payload for facility service once Lighthouse
+      // defines it for us.
+      $payload = [
+        'services' => [
+          $this->serviceTerm->getName() => [
+            'name' => $this->serviceTerm->getName(),
+            'active' => ($this->facilityService->isPublished()) ? 1 : 0,
+            'description_national' => $this->serviceTerm->getDescription(),
+            'description_system' => $this->systemService->get('field_body')->value,
+            'description_facility' => $this->facilityService->get('field_body')->value,
+            // Not sure if we need this.
+            'health_service_api_id' => $this->serviceTerm->get('field_health_service_api_id')->value,
+          ],
+        ],
+      ];
+    }
+
+    return $payload;
+  }
+
+  /**
+   * Checks to see if the data checks should be bypassed.
+   *
+   * @return bool
+   *   TRUE if bypass, FALSE if no bypass.
+   */
+  protected function shouldBypass() {
+    return empty($this->configFactory->get('va_gov_post_api.settings')->get('bypass_data_check')) ? FALSE : TRUE;
+  }
+
+  /**
+   * Determines if the data says a payload should be assembled and pushed.
+   *
+   * @return bool
+   *   TRUE if should be pushed, FALSE otherwise.
+   */
+  protected function shouldPush() {
+    $push = FALSE;
+
+    if (isset($this->facilityService->original)
+    && ($this->facilityService->original instanceof EntityInterface)
+    // Temporarily, the need is to just always push, so circumventing here.
+    && (TRUE == FALSE)
+    && (!$this->shouldBypass())) {
+      // Entity is updated. Check if the status changed and needs to be pushed.
+      if ($this->facilityService->status !== $this->facilityService->original->status) {
+        // One of the status values changed. Send the payload.
+        $push = TRUE;
+      }
+    }
+    else {
+      // Entity is new or data bypassed. Send the payload.
+      $push = TRUE;
+    }
+
+    return $push;
+  }
+
+  /**
+   * Checks to see if this service is slated for pushing.
+   */
+  private function isPushable() {
+    return (in_array($this->serviceTerm->id(), $this->servicesToPush)) ? TRUE : FALSE;
+  }
+
+  /**
+   * Load and set the facility node that this service belongs to.
+   */
+  protected function setFacility() {
+    $facility = $this->facilityService->get('field_facility_location')->referencedEntities();
+    if (!empty($facility)) {
+      $this->Facility = reset($facility);
+    }
+    else {
+      $this->errors[] = "Unable to load related facility. Field 'field_facility_location' not set.";
+    }
+  }
+
+  /**
+   * Load and set the system health service node that belongs with this service.
+   */
+  protected function setSystemService() {
+    $system_health_service = $this->facilityService->get('field_regional_health_service')->referencedEntities();
+    if (!empty($system_health_service)) {
+      $this->systemService = reset($system_health_service);
+    }
+    else {
+      $this->errors[] = "Unable to load system service. Field 'field_regional_health_service' not set.";
+    }
+  }
+
+  /**
+   * Load and set the health service taxonomy term for this service.
+   */
+  protected function setServiceTerm() {
+    $health_service_term = $this->systemService->get('field_service_name_and_descripti')->referencedEntities();
+    if (!empty($health_service_term)) {
+      $this->serviceTerm = reset($health_service_term);
+    }
+    else {
+      $this->errors[] = "Unable to load health service term. Field 'field_service_name_and_descripti' not set.";
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -153,6 +153,7 @@ class PostFacilityService {
         'services' => [
           $this->serviceTerm->getName() => [
             'name' => $this->serviceTerm->getName(),
+            // @todo will need to align this value with shouldPush logic.
             'active' => ($this->facilityService->isPublished()) ? 1 : 0,
             'description_national' => $this->serviceTerm->getDescription(),
             'description_system' => $this->systemService->get('field_body')->value,
@@ -192,6 +193,11 @@ class PostFacilityService {
     && (TRUE == FALSE)
     && (!$this->shouldBypass())) {
       // Entity is updated. Check if the status changed and needs to be pushed.
+      // @todo this logic needs to be updated to account for sending:
+      // - published: should be pushed
+      // - draft revision on published node :should not be pushed, even w/bypass
+      // - draft on node that has not been published: should be pushed.
+      // - archived: should be pushed.
       if ($this->facilityService->status !== $this->facilityService->original->status) {
         // One of the status values changed. Send the payload.
         $push = TRUE;

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -14,6 +14,8 @@ use Drupal\Core\Entity\EntityInterface;
  */
 function post_api_entity_insert(EntityInterface $entity) {
   _post_api_add_facility_to_queue($entity);
+  _post_api_add_facility_service_to_queue($entity);
+
 }
 
 /**
@@ -23,6 +25,7 @@ function post_api_entity_insert(EntityInterface $entity) {
  */
 function post_api_entity_update(EntityInterface $entity) {
   _post_api_add_facility_to_queue($entity);
+  _post_api_add_facility_service_to_queue($entity);
 }
 
 /**
@@ -78,7 +81,7 @@ function _post_api_add_facility_to_queue(EntityInterface $entity) {
 }
 
 /**
- * Compose and return payload array.
+ * Compose and return payload array for facility status.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   Entity.
@@ -123,4 +126,16 @@ function _post_api_get_facility_payload(EntityInterface $entity) {
   }
 
   return $payload;
+}
+
+/**
+ * Adds facility service data to Post API queue to update Lighthouse.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity.
+ */
+function _post_api_add_facility_service_to_queue(EntityInterface $entity) {
+  if ($entity->bundle() === 'health_care_local_health_service') {
+    Drupal::service('va_gov_post_api.queue_service_updates')->queueFacilityService($entity);
+  }
 }

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
@@ -12,4 +12,4 @@ services:
       - { name: 'event_subscriber' }
   va_gov_post_api.queue_service_updates:
     class: '\Drupal\va_gov_post_api\Service\PostFacilityService'
-    arguments: ['@config.factory', '@entity_type.manager', '@logger.factory', '@post_api.add_to_queue']
+    arguments: ['@config.factory', '@entity_type.manager', '@logger.factory', '@messenger', '@post_api.add_to_queue']

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
@@ -10,3 +10,6 @@ services:
     arguments: ['@config.factory', '@logger.factory', '@module_handler', '@slack.slack_service']
     tags:
       - { name: 'event_subscriber' }
+  va_gov_post_api.queue_service_updates:
+    class: '\Drupal\va_gov_post_api\Service\PostFacilityService'
+    arguments: ['@config.factory', '@entity_type.manager', '@logger.factory', '@post_api.add_to_queue']


### PR DESCRIPTION
## Description
This PR has been tested against lighthouse sandbox and is working.  

It does not include the moderna data but that can be added at any time the migration run to bring those in.

~This PR is as far as we can take it until Lighthouse tells us the data format they want.~

When a system service node is saved, it checks to see if it belongs to the Covid 19 Vaccines term and if it does, it queues up a delivery to post to lighthouse.
Here is an example from the current code.
![image](https://user-images.githubusercontent.com/5752113/102577864-de2b1600-40c6-11eb-93d8-a3163a0dd5d2.png)

## Testing done

Tested with lighthouse on slack here 
https://dsva.slack.com/archives/C0FQSS30V/p1610129469068600?thread_ts=1607551861.482000&cid=C0FQSS30V


## Screenshots


## QA steps

As an content_admin or admin
- Navigate to `/node/add/health_care_local_health_service` to add a new facility health care service.
   - Under Health Service and Facility Basic Info Choose Facility "Arberdeen VA Clinic"
 (because it is fastest to select)  and for VAMC systeem Health service , select `COVID-19 vaccines at VA Pittsburgh health care` (because it is the only system service already created).
![image](https://user-images.githubusercontent.com/5752113/102923146-3f534080-445d-11eb-8e54-a88a37172ea4.png)
- Set an owner to whatever is easy to select (just because it is required)

- **Saving a new Covid vaccine service should push**
   - Click `Save draft and continue editing` the node in draft state 
   - [x] validate message appears  
![image](https://user-images.githubusercontent.com/5752113/102924770-3021c200-4460-11eb-94aa-78649f925989.png)

- **Saving a new draft of an unpublished should push**
   -  edit the node you just saved and leave as draft  then click `save and continue editing`
   - [x] validate message appears  
![image](https://user-images.githubusercontent.com/5752113/102924770-3021c200-4460-11eb-94aa-78649f925989.png)
- **Saving  as published should push**
   -  edit the node you just saved and change its state to published then click  `save`
   - [x] validate message appears  
![image](https://user-images.githubusercontent.com/5752113/102924770-3021c200-4460-11eb-94aa-78649f925989.png)
- **Saving as a new draft of published should NOT push**
   -  edit the node you just saved and leave as draft  then click `save and continue editing`
   - [x] validate that NO push related message appears.  
- **Saving a new published should push**
   -  edit the node you just saved and change its state to published then click  `save`
   - [x] validate message appears  
![image](https://user-images.githubusercontent.com/5752113/102924770-3021c200-4460-11eb-94aa-78649f925989.png)
- **Saving as Archived should push**
   -  edit the node you just saved and change its state to archived then click  `save`
   - [x] validate message appears  
![image](https://user-images.githubusercontent.com/5752113/102924770-3021c200-4460-11eb-94aa-78649f925989.png)
- **Saving as draft after archived should push**
   -  edit the node you just saved and leave as draft  then click `save and continue editing`
   - [x] validate message appears  
![image](https://user-images.githubusercontent.com/5752113/102924770-3021c200-4460-11eb-94aa-78649f925989.png)
- **Saving as published after archived should push**
-    -  edit the node you just saved and lchange the status to published  then click `save`
   - [x] validate message appears  
![image](https://user-images.githubusercontent.com/5752113/102924770-3021c200-4460-11eb-94aa-78649f925989.png)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [x] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
