### PR TITLE
VACMS-3840: Add new leadin field to services.

### DIFF
--- a/config/sync/core.entity_form_display.node.support_service.default.yml
+++ b/config/sync/core.entity_form_display.node.support_service.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.support_service.field_administration
+    - field.field.node.support_service.field_health_service_appt_leadin
     - field.field.node.support_service.field_link
     - field.field.node.support_service.field_office
     - field.field.node.support_service.field_page_last_built
@@ -17,6 +18,7 @@ dependencies:
     - link
     - path
     - telephone
+    - textfield_counter
 third_party_settings:
   field_group:
     group_editorial_workflow:
@@ -25,7 +27,7 @@ third_party_settings:
         - revision_log
         - field_page_last_built
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         id: ''
@@ -39,14 +41,14 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: details_sidebar
       format_settings:
         id: ''
         classes: ''
-        open: 1
-        required_fields: 1
-        weight: '-10'
+        open: true
+        required_fields: true
+        weight: -10
       label: Governance
       region: content
 id: node.support_service.default
@@ -59,6 +61,19 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_select
+    region: content
+  field_health_service_appt_leadin:
+    weight: 4
+    settings:
+      rows: 5
+      placeholder: ''
+      maxlength: 200
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining.'
+    third_party_settings: {  }
+    type: string_textarea_with_counter
     region: content
   field_link:
     weight: 3
@@ -81,7 +96,7 @@ content:
     type: datetime_default
     region: content
   field_phone_number:
-    weight: 4
+    weight: 5
     settings:
       placeholder: ''
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.support_service.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.support_service.inline_entity_form.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.node.inline_entity_form
     - field.field.node.support_service.field_administration
+    - field.field.node.support_service.field_health_service_appt_leadin
     - field.field.node.support_service.field_link
     - field.field.node.support_service.field_office
     - field.field.node.support_service.field_page_last_built
@@ -63,6 +64,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_health_service_appt_leadin: true
   field_page_last_built: true
   moderation_state: true
   path: true

--- a/config/sync/core.entity_view_display.node.support_service.default.yml
+++ b/config/sync/core.entity_view_display.node.support_service.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.support_service.field_administration
+    - field.field.node.support_service.field_health_service_appt_leadin
     - field.field.node.support_service.field_link
     - field.field.node.support_service.field_office
     - field.field.node.support_service.field_page_last_built
@@ -18,6 +19,13 @@ targetEntityType: node
 bundle: support_service
 mode: default
 content:
+  field_health_service_appt_leadin:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
   field_link:
     weight: 0
     label: above

--- a/config/sync/core.entity_view_display.node.support_service.support_services_listing.yml
+++ b/config/sync/core.entity_view_display.node.support_service.support_services_listing.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.support_services_listing
     - field.field.node.support_service.field_administration
+    - field.field.node.support_service.field_health_service_appt_leadin
     - field.field.node.support_service.field_link
     - field.field.node.support_service.field_office
     - field.field.node.support_service.field_page_last_built
@@ -33,6 +34,7 @@ content:
 hidden:
   content_moderation_control: true
   field_administration: true
+  field_health_service_appt_leadin: true
   field_link: true
   field_office: true
   field_page_last_built: true

--- a/config/sync/core.entity_view_display.node.support_service.teaser.yml
+++ b/config/sync/core.entity_view_display.node.support_service.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.support_service.field_administration
+    - field.field.node.support_service.field_health_service_appt_leadin
     - field.field.node.support_service.field_link
     - field.field.node.support_service.field_office
     - field.field.node.support_service.field_page_last_built
@@ -25,6 +26,7 @@ content:
 hidden:
   content_moderation_control: true
   field_administration: true
+  field_health_service_appt_leadin: true
   field_link: true
   field_office: true
   field_page_last_built: true

--- a/config/sync/field.field.node.support_service.field_health_service_appt_leadin.yml
+++ b/config/sync/field.field.node.support_service.field_health_service_appt_leadin.yml
@@ -1,0 +1,19 @@
+uuid: 7365b876-ef58-42b8-9eec-558ebd04ecc8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_health_service_appt_leadin
+    - node.type.support_service
+id: node.support_service.field_health_service_appt_leadin
+field_name: field_health_service_appt_leadin
+entity_type: node
+bundle: support_service
+label: 'Appointment lead-in text'
+description: 'You can change to provide additional context about appointments.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.storage.node.field_health_service_appt_leadin.yml
+++ b/config/sync/field.storage.node.field_health_service_appt_leadin.yml
@@ -1,0 +1,19 @@
+uuid: f24e7ca7-37eb-4d6c-aa2b-a532664456ce
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_health_service_appt_leadin
+field_name: field_health_service_appt_leadin
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
@@ -4,7 +4,7 @@ Feature: Content model: Benefits hubs Content Type fields
   As a content editor
   I want to have content type fields that reflect my content model.
 
-  @dst @field_type @content_type_fields @dstfields                                                                                                                                                               
+  @dst @field_type @content_type_fields @dstfields
      Scenario: Fields
        Then exactly the following fields should exist for bundles "page,landing_page,basic_landing_page,support_service" of entity type node
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
@@ -44,6 +44,7 @@ Feature: Content model: Benefits hubs Content Type fields
 | Content type | Landing Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Landing Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Landing Page | Product | field_product | Entity reference | Required | 1 | Select list |  |
+| Content type | Support Service | Appointment lead-in text | field_health_service_appt_leadin | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | Support Service | Link | field_link | Link |  | 1 | Link |  |
 | Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Support Service | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |


### PR DESCRIPTION
## Description
See #3840 

## FE Implementation
Attn: @mmiddaugh @kevwalsh @mpelzsherman @brangi 
- Add `fieldHealthServiceApptLeadin` to `src/site/stages/build/drupal/graphql/supportService.graphql.js`
- Update templates that use services data (e.g.: `src/site/facilities/health_service.drupal.liquid`, etc.) to include `fieldHealthServiceApptLeadin` - add check so that when field is empty, output this default text: `Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you’ll need to contact your primary care provider first.`

## Testing done
Visual/Behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/102816537-2f275c80-439c-11eb-8f9d-62a38eb2f7dd.png)

## QA steps
As an administrator, go to `admin/structure/types/manage/support_service/form-display` and visually verify that `Appointment lead-in text` appears identical to screenshot (when cog is clicked)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
