### PR TITLE
VACMS-3840: Appt Intro Select Logic Fix

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -627,13 +627,13 @@ function va_gov_backend_entity_view_alter(array &$build, EntityInterface $entity
  *   Fields that should be unset.
  */
 function _va_gov_backend_unset_fields(EntityInterface $entity) {
-  $appt_intro_select = $entity->get('field_hservice_appt_intro_select')->getValue();
-  if ($appt_intro_select[0]['value'] === 'default_intro_text') {
+  $appt_intro_select = $entity->field_hservice_appt_intro_select->value;
+  if ($appt_intro_select === 'default_intro_text') {
     return [
       'field_hservice_appt_leadin',
     ];
   }
-  elseif ($appt_intro_select[0]['value'] === 'custom_intro_text') {
+  elseif ($appt_intro_select === 'custom_intro_text') {
     return [
       'field_hservices_lead_in_default',
     ];


### PR DESCRIPTION
…n a more defensive way

## Description

See _issueid_. https://app.zenhub.com/workspaces/vagov-cms-team-5c0e7b864b5806bc2bfc2087/issues/department-of-veterans-affairs/va.gov-cms/3840

## Testing done


## Screenshots


## QA steps
- Login to preview environment
- Navigate here: `/node/add/health_care_local_health_service`
- Fill out required fields
- Leave Appointment Intro Text selection as : `Use default appointments intro text`
- [ ] Confirm you can see the default intro text below the selections as   _Contact us to schedule, reschedule, or cancel your
  appointment. If a referral is required, you’ll need to
  contact your primary care provider first._
- Save

- Confirm the following on the preview:
- [ ] APPOINTMENT INTRO TEXT
Use default appointments intro text
- [ ] APPOINTMENT LEAD-IN DEFAULT
  Contact us to schedule, reschedule, or cancel your
  appointment. If a referral is required, you’ll need to
  contact your primary care provider first.

- Navigate here: `/node/add/health_care_local_health_service`
- Fill out required fields
- Select Appointment Intro Text selection as : `Customize appointments intro text`
- [ ] Confirm you can see an empty input field
- Save without filling the field out.
- Confirm the following error message on save: `1 error has been found: Appointment lead-in text`
- Fill out of the empty field: `test`
- Save

- Confirm the following on the preview:
- [ ] APPOINTMENT INTRO TEXT
Customize appointments intro text
- [ ] APPOINTMENT LEAD-IN TEXT
test

- Navigate here: `/node/add/health_care_local_health_service`
- Fill out required fields
- Change Appointment Intro Text selection as : `No appointments intro text`
- [ ] Confirm that the default appt intro text hides and that you cannot see the following text: _Contact us to schedule, reschedule, or cancel your
  appointment. If a referral is required, you’ll need to
  contact your primary care provider first._
- Save

- Confirm the following on the preview:
- [ ] APPOINTMENT INTRO TEXT
No appointments intro text

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
