### PR TITLE
Update va-gov/web (v0.1.1217 => v0.1.1227)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5324,10 +5324,6 @@
                     "homepage": "https://www.drupal.org/user/761344"
                 },
                 {
-                    "name": "hideaway",
-                    "homepage": "https://www.drupal.org/user/741876"
-                },
-                {
                     "name": "joaogarin",
                     "homepage": "https://www.drupal.org/user/612814"
                 },
@@ -5372,10 +5368,6 @@
                 {
                     "name": "fubhy",
                     "homepage": "https://www.drupal.org/user/761344"
-                },
-                {
-                    "name": "hideaway",
-                    "homepage": "https://www.drupal.org/user/741876"
                 },
                 {
                     "name": "joaogarin",
@@ -6007,7 +5999,7 @@
                     "homepage": "https://www.drupal.org/user/409554"
                 },
                 {
-                    "name": "markhalliwell",
+                    "name": "markcarver",
                     "homepage": "https://www.drupal.org/user/501638"
                 }
             ],
@@ -18725,16 +18717,16 @@
         },
         {
             "name": "va-gov/web",
-            "version": "v0.1.1217",
+            "version": "v0.1.1227",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/vets-website.git",
-                "reference": "ec884b84135ffc89141afe95010e3b029b1074fd"
+                "reference": "aa415acfd1bbde176ff723fc4c4c1cd2e6876efc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/vets-website/zipball/ec884b84135ffc89141afe95010e3b029b1074fd",
-                "reference": "ec884b84135ffc89141afe95010e3b029b1074fd",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/vets-website/zipball/aa415acfd1bbde176ff723fc4c4c1cd2e6876efc",
+                "reference": "aa415acfd1bbde176ff723fc4c4c1cd2e6876efc",
                 "shasum": ""
             },
             "type": "node-project",
@@ -18759,7 +18751,7 @@
                 }
             ],
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/web, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
-            "time": "2021-01-08T17:45:33+00:00"
+            "time": "2021-01-13T17:26:43+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description

This update includes https://github.com/department-of-veterans-affairs/vets-website/pull/15601 which dramatically reduces build memory consumption and shaves ca. 30s off the build time. (Every little bit counts...)