### PR TITLE
VACMS-3925: Update browser to show r&s hub description info.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -276,7 +276,8 @@
             },
             "drupal/entity_browser_table": {
                 "Table drag doesn't work on new entity form, and sort is lost on ajax": "https://www.drupal.org/files/issues/2020-08-25/fix-sort-loss-and-add-form-3166733-2.patch",
-                "Add moderation status column": "https://www.drupal.org/files/issues/2020-08-24/add-moderation-status-3166953-5.patch"
+                "Add moderation status column": "https://www.drupal.org/files/issues/2020-08-24/add-moderation-status-3166953-5.patch",
+                "Limit validation checks on remove": "https://www.drupal.org/files/issues/2021-01-25/limit-remove-button-validators.patch"
             },
             "drupal/entity_clone": {
                 "Cloning child references to nodes has potential to cause memory resource issues": "https://www.drupal.org/files/issues/2020-02-10/entity_clone-child-node-system-drain-3112577-1.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03dc388f9d648a1a08d5e3d51fdf6641",
+    "content-hash": "5977a54cf2b88aa2025b9a5f4770c18a",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -741,16 +741,6 @@
                 "stream",
                 "stream_filter_append",
                 "stream_filter_register"
-            ],
-            "funding": [
-                {
-                    "url": "https://clue.engineering/support",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
-                }
             ],
             "time": "2019-04-09T12:31:48+00:00"
         },
@@ -4577,7 +4567,8 @@
                 },
                 "patches_applied": {
                     "Table drag doesn't work on new entity form, and sort is lost on ajax": "https://www.drupal.org/files/issues/2020-08-25/fix-sort-loss-and-add-form-3166733-2.patch",
-                    "Add moderation status column": "https://www.drupal.org/files/issues/2020-08-24/add-moderation-status-3166953-5.patch"
+                    "Add moderation status column": "https://www.drupal.org/files/issues/2020-08-24/add-moderation-status-3166953-5.patch",
+                    "Limit validation checks on remove": "https://www.drupal.org/files/issues/2021-01-25/limit-remove-button-validators.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5507,10 +5498,6 @@
                     "homepage": "https://www.drupal.org/user/761344"
                 },
                 {
-                    "name": "hideaway",
-                    "homepage": "https://www.drupal.org/user/741876"
-                },
-                {
                     "name": "joaogarin",
                     "homepage": "https://www.drupal.org/user/612814"
                 },
@@ -5555,10 +5542,6 @@
                 {
                     "name": "fubhy",
                     "homepage": "https://www.drupal.org/user/761344"
-                },
-                {
-                    "name": "hideaway",
-                    "homepage": "https://www.drupal.org/user/741876"
                 },
                 {
                     "name": "joaogarin",
@@ -6238,7 +6221,7 @@
                     "homepage": "https://www.drupal.org/user/409554"
                 },
                 {
-                    "name": "markhalliwell",
+                    "name": "markcarver",
                     "homepage": "https://www.drupal.org/user/501638"
                 }
             ],

--- a/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
@@ -280,9 +280,19 @@ content:
     region: content
   field_benefit_categories:
     weight: 42
-    settings: {  }
-    third_party_settings: {  }
-    type: options_buttons
+    settings:
+      entity_browser: lc_benefit_hubs
+      field_widget_display: label
+      field_widget_remove: '1'
+      selection_mode: selection_append
+      field_widget_edit: 0
+      field_widget_replace: 0
+      open: 0
+      field_widget_display_settings: {  }
+    third_party_settings:
+      limited_field_widgets:
+        limit_values: '2'
+    type: entity_reference_browser_table_widget
     region: content
   field_clp_audience:
     weight: 3

--- a/config/sync/views.view.benefits_hub_categories.yml
+++ b/config/sync/views.view.benefits_hub_categories.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_home_page_hub_label
+    - field.storage.node.field_teaser_text
     - node.type.landing_page
   module:
     - entity_browser
@@ -84,6 +85,69 @@ display:
           id: field_home_page_hub_label
           table: node__field_home_page_hub_label
           field: field_home_page_hub_label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_teaser_text:
+          id: field_teaser_text
+          table: node__field_teaser_text
+          field: field_teaser_text
           relationship: none
           group_type: group
           admin_label: ''
@@ -228,6 +292,7 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_home_page_hub_label'
+        - 'config:field.storage.node.field_teaser_text'
   benefits_hub_categories:
     display_plugin: entity_browser
     id: benefits_hub_categories
@@ -287,6 +352,69 @@ display:
           use_field_cardinality: false
           entity_type: node
           plugin_id: entity_browser_select
+        field_teaser_text:
+          id: field_teaser_text
+          table: node__field_teaser_text
+          field: field_teaser_text
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Hub teaser text'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         field_home_page_hub_label:
           id: field_home_page_hub_label
           table: node__field_home_page_hub_label
@@ -298,7 +426,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: 'VA {{ field_home_page_hub_label }}'
+            text: "VA {{ field_home_page_hub_label }}\r\n<hr>\r\n{{ field_teaser_text }}"
             make_link: false
             path: ''
             absolute: false
@@ -366,9 +494,15 @@ display:
           summary: ''
           description: ''
           columns:
-            field_home_page_hub_label: field_home_page_hub_label
             entity_browser_select: entity_browser_select
+            field_home_page_hub_label: field_home_page_hub_label
+            field_teaser_text: field_teaser_text
           info:
+            entity_browser_select:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             field_home_page_hub_label:
               sortable: false
               default_sort_order: asc
@@ -376,7 +510,9 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-            entity_browser_select:
+            field_teaser_text:
+              sortable: false
+              default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
@@ -400,3 +536,4 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_home_page_hub_label'
+        - 'config:field.storage.node.field_teaser_text'

--- a/tests/behat/drupal-spec-tool/content_model_campaign_landing_page_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_campaign_landing_page_content_type_fields.feature
@@ -40,8 +40,8 @@ Feature: Content model: Campaign Landing Page Content Type fields
 | Content type | Campaign Landing Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Campaign Landing Page | Page introduction | field_hero_blurb | Text (plain) |  | 1 | Textfield with counter |  |
 | Content type | Campaign Landing Page | Primary call to action | field_primary_call_to_action | Entity reference revisions | Required | 1 | Paragraphs EXPERIMENTAL |  |
-| Content type | Campaign Landing Page | Related benefits | field_benefit_categories | Entity reference | Required | Unlimited | Check boxes/radio buttons | Translatable |
 | Content type | Campaign Landing Page | Resources | field_clp_resources | Entity reference |  | 3 | Entity browser |  |
+| Content type | Campaign Landing Page | Related benefits | field_benefit_categories | Entity reference | Required | Unlimited | Entity Browser - Table | Translatable |
 | Content type | Campaign Landing Page | Secondary call to action | field_secondary_call_to_action | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Campaign Landing Page | Video | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Content type | Campaign Landing Page | What you can do promos | field_clp_what_you_can_do_promos | Entity reference | Required | 3 | Entity Browser - Table |  |

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -143,9 +143,6 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility Health Service | Are walkins accepted? | field_walk_ins_accepted | List (text) | Required | 1 | Select list |  |
 | Content type | VAMC Facility Health Service | Appointments help text | field_appointments_help_text | Markup |  | 1 | Markup |  |
 | Content type | VAMC Facility Health Service | Service locations help text | field_facility_service_loc_help | Markup |  | 1 | Markup |  |
-| Content type | VAMC Facility Health Service | Appointment intro text | field_hservice_appt_intro_select | List (text) | Required | 1 | Check boxes/radio buttons |  |
-| Content type | VAMC Facility Health Service | Appointment lead-in default | field_hservices_lead_in_default | Markup |  | 1 | Markup |  |
-| Content type | VAMC Facility Health Service | Appointment lead-in text | field_hservice_appt_leadin | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC System | Appointments can be scheduled and viewed online | field_appointments_online | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC System | Banner image | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Content type | VAMC System | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
@@ -183,6 +180,9 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Health Service | VAMC system | field_region_page | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Health Service | VAMC system description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC System Health Service | VHA service name and description | field_service_name_and_descripti | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC Facility Health Service | Appointment intro text | field_hservice_appt_intro_select | List (text) | Required | 1 | Check boxes/radio buttons |  |
+| Content type | VAMC Facility Health Service | Appointment lead-in default | field_hservices_lead_in_default | Markup |  | 1 | Markup |  |
+| Content type | VAMC Facility Health Service | Appointment lead-in text | field_hservice_appt_leadin | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC System Operating Status | System-wide alerts | field_banner_alert | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
 | Content type | VAMC System Operating Status | Patient resources | field_operating_status_emerg_inf | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | VAMC System Operating Status | Local emergency resources | field_links | Link |  | Unlimited | Linkit | Translatable |


### PR DESCRIPTION
## Description
See #3925 

## Testing done
Visual / behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/105755002-b7a79880-5f18-11eb-8021-36bb49060732.png)
![image](https://user-images.githubusercontent.com/2404547/105755022-bf673d00-5f18-11eb-9dca-10dac05c5fdd.png)

## QA steps
- As an administrator, go to `node/15068/edit`, open up the VA benefits panel, and click Select Benefit hubs button
- Visually verify that all items in browser have a description
- Close browser, and visually verify that selected items are in a sortable table.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
