### PR TITLE
VACMS-4102: do not cache graphql query

### DIFF
--- a/docroot/modules/custom/va_gov_graphql/src/QueueProcessor.php
+++ b/docroot/modules/custom/va_gov_graphql/src/QueueProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\va_gov_graphql;
+
+use Drupal\graphql\GraphQL\Execution\QueryProcessor;
+use GraphQL\Executor\Promise\PromiseAdapter;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Server\OperationParams;
+use GraphQL\Server\ServerConfig;
+
+/**
+ * A Queue processor class to override default behavior of caching.
+ */
+class QueueProcessor extends QueryProcessor {
+
+  /**
+   * Override Caching operation to not cache.
+   *
+   * @param \GraphQL\Executor\Promise\PromiseAdapter $adapter
+   *   Adapter.
+   * @param \GraphQL\Server\ServerConfig $config
+   *   Serverconfig.
+   * @param \GraphQL\Server\OperationParams $params
+   *   Operation Params.
+   * @param \GraphQL\Language\AST\DocumentNode $document
+   *   Documetn Node.
+   * @param bool $validate
+   *   Should validate?
+   *
+   * @return \GraphQL\Executor\Promise\Promise|mixed
+   *   The promise.
+   */
+  protected function executeCacheableOperation(PromiseAdapter $adapter, ServerConfig $config, OperationParams $params, DocumentNode $document, $validate = TRUE) {
+    return $this->executeUncachableOperation($adapter, $config, $params, $document, $validate);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_graphql/va_gov_graphql.services.yml
+++ b/docroot/modules/custom/va_gov_graphql/va_gov_graphql.services.yml
@@ -3,3 +3,12 @@ services:
     class: Drupal\va_gov_graphql\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+  va_gov_graphql.queue_processor:
+    decorates: graphql.query_processor
+    class: Drupal\va_gov_graphql\QueueProcessor
+    arguments:
+      - '@cache_contexts_manager'
+      - '@plugin.manager.graphql.schema'
+      - '@cache.graphql.results'
+      - '@request_stack'
+


### PR DESCRIPTION
## Description

See #4102 . 

## Testing done

* Ran build locally without change.  Saw the cache table with resuilts.
* Ran the build with changes and saw the cache table empty.
### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/4111)
<!-- Reviewable:end -->
