### PR TITLE
VACMS-4104: Remove first service location removal button.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/script.es6.js
+++ b/docroot/modules/custom/va_gov_backend/js/script.es6.js
@@ -58,6 +58,23 @@
     },
   };
 
+  Drupal.behaviors.vaGovServiceLocationRemoveButton = {
+    attach() {
+      // Don't show remove button on first instance.
+      const removeButtons = document.querySelectorAll(
+        '.field--name-field-service-location .paragraphs-dropbutton-wrapper input[value="Remove"]'
+      );
+
+      if (removeButtons.length > 0) {
+        removeButtons.forEach((button, i) => {
+          if (i < 1) {
+            button.style.display = "none";
+          }
+        });
+      }
+    },
+  };
+
   Drupal.behaviors.vaGovAlertSingleComponent = {
     attach() {
       const reusableAlertRemovedIds = [];

--- a/docroot/modules/custom/va_gov_backend/js/script.js
+++ b/docroot/modules/custom/va_gov_backend/js/script.js
@@ -42,6 +42,20 @@
     }
   };
 
+  Drupal.behaviors.vaGovServiceLocationRemoveButton = {
+    attach: function attach() {
+      var removeButtons = document.querySelectorAll('.field--name-field-service-location .paragraphs-dropbutton-wrapper input[value="Remove"]');
+
+      if (removeButtons.length > 0) {
+        removeButtons.forEach(function (button, i) {
+          if (i < 1) {
+            button.style.display = "none";
+          }
+        });
+      }
+    }
+  };
+
   Drupal.behaviors.vaGovAlertSingleComponent = {
     attach: function attach() {
       var reusableAlertRemovedIds = [];


### PR DESCRIPTION
## Description
See #4104 

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/106317612-8b538b00-623c-11eb-87b1-95aeebf4f731.png)

## QA steps
- As and administrator, go to `node/add/health_care_local_health_service` and visually verify that the first service location does not have a remove button above.
- Add a second service location, and visually verify that a remove button appears above it.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
