### PR TITLE
VACMS-4158: Add content release logs view

### DIFF
--- a/config/sync/views.view.content_release_logs.yml
+++ b/config/sync/views.view.content_release_logs.yml
@@ -1,0 +1,327 @@
+uuid: d3a1dac2-89dd-46b2-928b-c6b0e4be5b13
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.authenticated
+  module:
+    - dblog
+    - user
+id: content_release_logs
+label: 'Content release logs'
+module: views
+description: 'Shows content release job log entries'
+tag: ''
+base_table: watchdog
+base_field: wid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: role
+        options:
+          role:
+            authenticated: authenticated
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+      row:
+        type: fields
+      fields:
+        wid:
+          id: wid
+          table: watchdog
+          field: wid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: WID
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+        timestamp:
+          id: timestamp
+          table: watchdog
+          field: timestamp
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Date
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: medium
+          custom_date_format: ''
+          timezone: ''
+          plugin_id: date
+        message:
+          id: message
+          table: watchdog
+          field: message
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Message
+          exclude: false
+          alter:
+            alter_text: true
+            text: "<pre>\r\n{{ message }}\r\n</pre>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          replace_variables: true
+          plugin_id: dblog_message
+      filters:
+        type:
+          id: type
+          table: watchdog
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            va_gov_web_builder: va_gov_web_builder
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: dblog_types
+      sorts:
+        timestamp:
+          id: timestamp
+          table: watchdog
+          field: timestamp
+          order: DESC
+          entity_type: null
+          entity_field: null
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: 'Content release logs'
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: true
+          content: "Showing log entries generated at or before {{ timestamp }}\r\n<br />\r\nPlease refresh your browser to check for new entries.\r\n<div>&nbsp;</div>"
+          plugin_id: text_custom
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      use_ajax: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.roles
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/deploy/logs
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.roles
+      tags: {  }
+

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/Block/ContentReleaseStatusBlock.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/Block/ContentReleaseStatusBlock.php
@@ -6,7 +6,6 @@ use Drupal\advancedqueue\Job;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
-use Drupal\va_gov_build_trigger\Plugin\AdvancedQueue\JobType\WebBuildJobType;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -73,12 +72,9 @@ class ContentReleaseStatusBlock extends BlockBase implements ContainerFactoryPlu
         $this->t('Frontend Version'),
         $this->t('Started'),
         $this->t('Finished'),
+        $this->t('Logs'),
       ],
     ];
-
-    if ($this->shouldDisplayLogColumn()) {
-      $table['#header'][] = $this->t('Logs');
-    }
 
     $jobs = $this->getCommandRunnerJobs();
 
@@ -126,21 +122,9 @@ class ContentReleaseStatusBlock extends BlockBase implements ContainerFactoryPlu
 
     // The log page will show an error if there are no log messages,
     // so only show it once the job is being processed.
-    if ($this->shouldDisplayLogColumn()) {
-      $row[] = $job->getState() !== Job::STATE_QUEUED ? $this->getLogLink() : '';
-    }
+    $row[] = $job->getState() !== Job::STATE_QUEUED ? $this->getLogLink() : '';
 
     return $row;
-  }
-
-  /**
-   * Determine whether the log column should be displayed.
-   *
-   * @return bool
-   *   Whether or not the log column should be displayed.
-   */
-  protected function shouldDisplayLogColumn() : bool {
-    return in_array('administrator', $this->currentUser->getRoles());
   }
 
   /**
@@ -151,14 +135,11 @@ class ContentReleaseStatusBlock extends BlockBase implements ContainerFactoryPlu
    */
   protected function getLogLink() : array {
     $log_url = Url::fromRoute(
-      "dblog.overview",
+      "view.content_release_logs.page_1",
       [],
       [
         'attributes' => [
           'target' => '_blank',
-        ],
-        'query' => [
-          'type[]' => WebBuildJobType::QUEUE_ID,
         ],
       ]
     );

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -22,6 +22,7 @@ Feature: Views
 | Content served from Drupal | content_served_from_drupal | Content | Enabled | An exportable list of all content served from Drupal |
 | Content entity browsers | content_entity_browsers | Content | Enabled | Collection of Entity Browsers to use for field widgets configuration in form displays. |
 | Content Entity Reference Source | content_entity_reference_source | Content | Enabled |  |
+| Content release logs | content_release_logs | Watchdog | Enabled | Shows content release job log entries |
 | Date fields | date_fields | Content | Enabled |  |
 | Facility Governance | facility_governance | Content | Enabled | Provides facility management tools. |
 | Files | files | Files | Enabled | Find and manage files. |
@@ -92,9 +93,6 @@ Feature: Views
 | Content | Bulk edit content | page_2 | Page |
 | Content | Resources and support | resources_support_dashboard | Page |
 | Content | Resources and support landing page | resources_and_support_landing_page_block | Block |
-| Content served from Drupal | Page | page_1 | Page |
-| Content served from Drupal | Data export | data_export_1 | Data export |
-| Content served from Drupal | Master | default | Master |
 | Content entity browsers | Master | default | Master |
 | Content entity browsers | Event entity browser | event_entity_browser | Entity browser |
 | Content entity browsers | Q&A entity browser | entity_browser_1 | Entity browser |
@@ -105,6 +103,11 @@ Feature: Views
 | Content Entity Reference Source | Entity Reference: News Release Listing | entity_reference_4 | Entity Reference |
 | Custom block library | Master | default | Master |
 | Custom block library | Page | page_1 | Page |
+| Content release logs | Master | default | Master |
+| Content release logs | Page | page_1 | Page |
+| Content served from Drupal | Page | page_1 | Page |
+| Content served from Drupal | Data export | data_export_1 | Data export |
+| Content served from Drupal | Master | default | Master |
 | Date fields | Master | default | Master |
 | Date fields | Page | page_1 | Page |
 | Facility Governance | Master | default | Master |

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -22,7 +22,7 @@ Feature: Views
 | Content served from Drupal | content_served_from_drupal | Content | Enabled | An exportable list of all content served from Drupal |
 | Content entity browsers | content_entity_browsers | Content | Enabled | Collection of Entity Browsers to use for field widgets configuration in form displays. |
 | Content Entity Reference Source | content_entity_reference_source | Content | Enabled |  |
-| Content release logs | content_release_logs | Watchdog | Enabled | Shows content release job log entries |
+| Content release logs | content_release_logs | Log entries | Enabled | Shows content release job log entries |
 | Date fields | date_fields | Content | Enabled |  |
 | Facility Governance | facility_governance | Content | Enabled | Provides facility management tools. |
 | Files | files | Files | Enabled | Find and manage files. |


### PR DESCRIPTION
## Description

See #4158 

## Testing done

Manual testing

## Screenshots

<img width="1648" alt="Screen Shot 2021-02-01 at 3 18 18 PM" src="https://user-images.githubusercontent.com/101649/106525154-c6ee8f00-64a0-11eb-989b-1a46f3b3adb3.png">

## QA steps

As a user with the `content admin` role,
1. Go to the 'release content' page
1. Create a new build
- [ ] A log link is present (after build starts)
- [ ] You may view logs at the link

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
