### PR TITLE
[WIP] VACMS-4077: Remove CC Field Labels

### DIFF
--- a/config/sync/field.field.node.vamc_system_policies_page.field_cc_bottom_of_page_content.yml
+++ b/config/sync/field.field.node.vamc_system_policies_page.field_cc_bottom_of_page_content.yml
@@ -11,7 +11,7 @@ id: node.vamc_system_policies_page.field_cc_bottom_of_page_content
 field_name: field_cc_bottom_of_page_content
 entity_type: node
 bundle: vamc_system_policies_page
-label: 'National bottom of page content'
+label: ''
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.vamc_system_policies_page.field_cc_gen_visitation_policy.yml
+++ b/config/sync/field.field.node.vamc_system_policies_page.field_cc_gen_visitation_policy.yml
@@ -11,7 +11,7 @@ id: node.vamc_system_policies_page.field_cc_gen_visitation_policy
 field_name: field_cc_gen_visitation_policy
 entity_type: node
 bundle: vamc_system_policies_page
-label: 'National general visitation policy'
+label: ''
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.vamc_system_policies_page.field_cc_intro_text.yml
+++ b/config/sync/field.field.node.vamc_system_policies_page.field_cc_intro_text.yml
@@ -11,7 +11,7 @@ id: node.vamc_system_policies_page.field_cc_intro_text
 field_name: field_cc_intro_text
 entity_type: node
 bundle: vamc_system_policies_page
-label: 'National intro text'
+label: ''
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.vamc_system_policies_page.field_cc_top_of_page_content.yml
+++ b/config/sync/field.field.node.vamc_system_policies_page.field_cc_top_of_page_content.yml
@@ -11,7 +11,7 @@ id: node.vamc_system_policies_page.field_cc_top_of_page_content
 field_name: field_cc_top_of_page_content
 entity_type: node
 bundle: vamc_system_policies_page
-label: 'National top of page content'
+label: ''
 description: ''
 required: false
 translatable: false

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -189,10 +189,10 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Operating Status | Facility operating statuses | field_facility_operating_status | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
 | Content type | VAMC System Operating Status | VAMC system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Policies Page | Fieldset Markup | field_fieldset_markup | Markup |  | 1 | Markup |  |
-| Content type | VAMC System Policies Page | National bottom of page content | field_cc_bottom_of_page_content | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
-| Content type | VAMC System Policies Page | National general visitation policy | field_cc_gen_visitation_policy | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
-| Content type | VAMC System Policies Page | National intro text | field_cc_intro_text | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
-| Content type | VAMC System Policies Page | National top of page content | field_cc_top_of_page_content | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
+| Content type | VAMC System Policies Page | | field_cc_bottom_of_page_content | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
+| Content type | VAMC System Policies Page | | field_cc_gen_visitation_policy | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
+| Content type | VAMC System Policies Page | | field_cc_intro_text | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
+| Content type | VAMC System Policies Page | | field_cc_top_of_page_content | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
 | Content type | VAMC System Policies Page | Other policies | field_vamc_other_policies | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | VAMC System Policies Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Policies Page | Related health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |


### PR DESCRIPTION
## Description

See _issueid_. https://app.zenhub.com/workspaces/vagov-cms-team-5c0e7b864b5806bc2bfc2087/issues/department-of-veterans-affairs/va.gov-cms/4077

## Testing done

1. `Go to node/add/vamc_system_policies_page`
2. You should not see the following field labels:
- [ ] National bottom of page content
- [ ] National general visitation policy 
- [ ] National intro text
- [ ] National top of page content

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
