### PR TITLE
Fix tablefield sanitize function for caption

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1746,19 +1746,16 @@ function _va_gov_backend_apply_filter_to_tablefield_cells(EntityInterface $entit
         $format = $entity->get($field_name)->format ?? 'plain_text';
         if (!empty($raw_table) && is_array($raw_table)) {
           foreach ($raw_table as $row_key => $row_item) {
-            if ($row_key === 'caption') {
-              // Tablefield caption does not support html.
-              $sanitized_items['caption'] = strip_tags($row_item);
-            }
-            else {
-              if (is_array($row_item)) {
-                foreach ($row_item as $cell_key => $cell_item) {
-                  $clean_html = check_markup($cell_item, $format, '', ['autop']);
-                  $sanitized_items['value'][$row_key][$cell_key] = (string) $clean_html;
-                }
+            if (is_array($row_item)) {
+              foreach ($row_item as $cell_key => $cell_item) {
+                $clean_html = check_markup($cell_item, $format, '', ['autop']);
+                $sanitized_items['value'][$row_key][$cell_key] = (string) $clean_html;
               }
             }
           }
+
+          // Tablefield caption does not support html.
+          $sanitized_items['caption'] = strip_tags(trim($entity->get($field_name)->caption));
           $sanitized_items['format'] = $format;
           $entity->$field_name->setValue($sanitized_items);
         }


### PR DESCRIPTION
## Description

Fix tablefield sanitize function for caption

## Testing done
Saved node which has a paragraph with a table field with a caption.
Make sure the caption still exists on edit after save!
Did this on video call with @swirtSJW and @ndouglas

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/va.gov-cms/4181)
<!-- Reviewable:end -->
