### PR TITLE
VACMS 3955: Reverts changes to Jenkins API fetching to unbork main branch.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
@@ -81,7 +81,7 @@ class BRD extends EnvironmentPluginBase {
    */
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE): void {
     $va_cms_bot_github_username = Settings::get('va_cms_bot_github_username');
-    $va_cms_bot_jenkins_auth_token = $this->getJenkinsApiToken();
+    $va_cms_bot_jenkins_auth_token = Settings::get('va_cms_bot_jenkins_auth_token');
     $jenkins_build_job_host = Settings::get('jenkins_build_job_host');
     $jenkins_build_job_path = Settings::get('jenkins_build_job_path');
     $jenkins_build_job_url = Settings::get('jenkins_build_job_url');
@@ -206,7 +206,7 @@ class BRD extends EnvironmentPluginBase {
    *   The value of the value of ssm param named
    *   '/cms/va-cms-bot/jenkins-api-token', or '' if not found.
    */
-  private function getJenkinsApiToken() {
+  private function getJenkinsApiToken(): string {
     $cmd = 'aws ssm get-parameter --name "/cms/va-cms-bot/jenkins-api-token" --with-decryption --query Parameter.Value --output text';
     $value = exec($cmd, $output, $status);
     if ($status !== 0) {

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -109,6 +109,7 @@ $settings['jenkins_build_job_host'] = 'http://jenkins.vfs.va.gov';
 // Authorized to the Jenkins API via GitHub login.
 $settings['va_cms_bot_github_username'] = 'va-cms-bot';
 $settings['va_cms_bot_github_auth_token'] = getenv('CMS_GITHUB_VA_CMS_BOT_TOKEN') ?: FALSE;
+$settings['va_cms_bot_jenkins_auth_token'] = getenv('CMS_JENKINS_VA_CMS_BOT_TOKEN') ?: FALSE;
 
 // Environment settings
 $settings['va_gov_composer_home'] = getenv('COMPOSER_HOME');


### PR DESCRIPTION
## Description
The `exec()` call in #4149 didn't succeed, and then the attempt to log the output failed catastrophically.  This reverts the calls while leaving the function itself intact.

## Testing done
None.

## Screenshots


## QA steps

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
