### PR TITLE
VACMS-4077 Hide field labels and source data for entity field fetch fields.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "drupal/entity_browser_table": "^1.2",
         "drupal/entity_clone": "^1.0@beta",
         "drupal/entity_embed": "^1.0",
-        "drupal/entity_field_fetch": "1.0.0-alpha1",
+        "drupal/entity_field_fetch": "^1.0@beta",
         "drupal/entity_reference_revisions": "^1.7",
         "drupal/entity_reference_unpublished": "^1.1",
         "drupal/entity_reference_validators": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40021010edca97250b4bef8dab29a76c",
+    "content-hash": "d7e84c02320b1ac6dc643270838eb8db",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -741,16 +741,6 @@
                 "stream",
                 "stream_filter_append",
                 "stream_filter_register"
-            ],
-            "funding": [
-                {
-                    "url": "https://clue.engineering/support",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
-                }
             ],
             "time": "2019-04-09T12:31:48+00:00"
         },
@@ -4726,29 +4716,29 @@
         },
         {
             "name": "drupal/entity_field_fetch",
-            "version": "1.0.0-alpha1",
+            "version": "1.0.0-beta1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_field_fetch.git",
-                "reference": "1.0.0-alpha1"
+                "reference": "1.0.0-beta1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_field_fetch-1.0.0-alpha1.zip",
-                "reference": "1.0.0-alpha1",
-                "shasum": "34ade8fb465488047ca0006da7b55a072aae59b2"
+                "url": "https://ftp.drupal.org/files/projects/entity_field_fetch-1.0.0-beta1.zip",
+                "reference": "1.0.0-beta1",
+                "shasum": "a71b1c6da63bba15fa2e9dde0b87e1cdc04d95da"
             },
             "require": {
-                "drupal/core": "~8.0"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.0-alpha1",
-                    "datestamp": "1611172233",
+                    "version": "1.0.0-beta1",
+                    "datestamp": "1612817790",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -21706,6 +21696,7 @@
         "drupal/content_lock": 15,
         "drupal/entity_block": 10,
         "drupal/entity_clone": 10,
+        "drupal/entity_field_fetch": 10,
         "drupal/entityqueue": 10,
         "drupal/fast_404": 15,
         "drupal/fieldhelptext": 10,

--- a/config/sync/core.entity_form_display.node.vamc_system_policies_page.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_system_policies_page.default.yml
@@ -108,25 +108,37 @@ content:
     region: content
   field_cc_bottom_of_page_content:
     weight: 5
-    settings: {  }
+    settings:
+      show_source_updated_date: '1'
+      show_field_label: 0
+      show_link_to_source: 0
     third_party_settings: {  }
     type: entity_field_fetch_widget
     region: content
   field_cc_gen_visitation_policy:
     weight: 3
-    settings: {  }
+    settings:
+      show_source_updated_date: '1'
+      show_field_label: 0
+      show_link_to_source: 0
     third_party_settings: {  }
     type: entity_field_fetch_widget
     region: content
   field_cc_intro_text:
     weight: 28
-    settings: {  }
+    settings:
+      show_field_label: 0
+      show_link_to_source: 0
+      show_source_updated_date: 0
     third_party_settings: {  }
     type: entity_field_fetch_widget
     region: content
   field_cc_top_of_page_content:
     weight: 29
-    settings: {  }
+    settings:
+      show_source_updated_date: '1'
+      show_field_label: 0
+      show_link_to_source: 0
     third_party_settings: {  }
     type: entity_field_fetch_widget
     region: content

--- a/config/sync/core.entity_view_display.node.vamc_system_policies_page.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_policies_page.default.yml
@@ -66,28 +66,28 @@ mode: default
 content:
   field_cc_bottom_of_page_content:
     weight: 6
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: entity_field_fetch
     region: content
   field_cc_gen_visitation_policy:
     weight: 3
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: entity_field_fetch
     region: content
   field_cc_intro_text:
     weight: 9
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: entity_field_fetch
     region: content
   field_cc_top_of_page_content:
     weight: 10
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: entity_field_fetch


### PR DESCRIPTION
## Description

See #4077 and #4138.



## QA steps

As user _uid_ with _user_role_
1. As an admin go to https://pr4224-0d61wv7bdc2wtwjdqvqwb9r4mdg3qbrt.ci.cms.va.gov/node/add/vamc_system_policies_page
- [x] Validate the field labels are NOT showing  on the entity_field_fetch fields.
![image](https://user-images.githubusercontent.com/5752113/107288232-1c8ee280-6a31-11eb-9dbb-3bf118175660.png)
- [x] validate that the source data is not showing.
![image](https://user-images.githubusercontent.com/5752113/107288751-f4ec4a00-6a31-11eb-90e6-a5c3dc34dac5.png)

- [x] Validate that the updated date is showing.
![image](https://user-images.githubusercontent.com/5752113/107288672-d0906d80-6a31-11eb-8711-37abd6fb4a20.png)

- [ ] Go to node view for the sample you created in prior steps.  Validate that the field labels for centralized content are not present.
![image](https://user-images.githubusercontent.com/5752113/107385412-ded99a80-6ac0-11eb-83a9-875b11edcb32.png)


### Definition of Done


- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`


### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
