### PR TITLE
Improve content release icon accessibility

### DIFF
--- a/docroot/modules/custom/va_gov_backend/css/toolbar.css
+++ b/docroot/modules/custom/va_gov_backend/css/toolbar.css
@@ -1,10 +1,15 @@
 .toolbar-oriented .toolbar-bar .toolbar-tab.content-release-toolbar-tab,
 .toolbar-oriented .toolbar-bar .toolbar-tab.branch-toolbar-tab {
   float: right;
+  height: 39px;
 }
 
 .toolbar-oriented .toolbar-bar .toolbar-tab.branch-toolbar-tab .toolbar-icon-branch {
   padding-left: 1em;
+}
+
+.toolbar-icon-content-release .button-text {
+  font-size: 0;
 }
 
 .content-release-toolbar-tab {

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1579,13 +1579,12 @@ function va_gov_backend_toolbar() {
     '#type' => 'toolbar_item',
     'tab' => [
       '#type' => 'html_tag',
-      '#tag' => 'div',
-      '#value' => '&nbsp;',
+      '#tag' => 'button',
+      '#value' => '<span class="button-text">Last Content Release Time</span>',
       '#attributes' => [
         'class' => ['toolbar-icon', 'toolbar-icon-content-release'],
         'title' => 'Mouse over to see last content release time',
         'id' => 'content-release-status-icon',
-        'tabindex' => '0',
       ],
     ],
     '#wrapper_attributes' => [


### PR DESCRIPTION
## Description

Follow-on to #3984 - improves accessibility.

## Testing done

Tested with voiceover on a mac, it reads "Last Content Release Time Button" and then the tooltip content.
