### PR TITLE
VACMS-000 Add dependency to va_gov_graphql.

### DIFF
--- a/docroot/modules/custom/va_gov_graphql/va_gov_graphql.info.yml
+++ b/docroot/modules/custom/va_gov_graphql/va_gov_graphql.info.yml
@@ -3,3 +3,6 @@ type: module
 description: 'Helper functionality for GraphQL integration'
 core: 8.x
 package: 'Custom'
+dependencies:
+  - basic_auth
+  - graphql


### PR DESCRIPTION
## Description

va_gov_graphql uses basic_auth but did not declare its dependency.  THis remedies that so no detective work is needed. 

## Testing done
![image](https://user-images.githubusercontent.com/5752113/107706158-e00bf280-6c8d-11eb-946b-268ea7a0b98e.png)


![image](https://user-images.githubusercontent.com/5752113/107706867-f5355100-6c8e-11eb-924a-0268f2b7c75f.png)



## Screenshots


## QA steps

As admin  
1. go to /admin/modules
2. filter for "graph"
  - [ ] validate VA.gov GraphQL required basic_auth AND graphql



### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`


