### PR TITLE
VACMS-4240: Upgrade Tugboat from Mysql to MariaDB 10.5

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -3,9 +3,6 @@ recipe: drupal8
 config:
   webroot: docroot
   php: "7.1"
-  # Match with terraform-aws-vsp-cms/rds.tf (another repo)
-  # Match with .tugboat/config.yml (this repo)
-  database: mariadb:10.5
   composer_version: '1.10.1'
 
 events:

--- a/.lando.yml
+++ b/.lando.yml
@@ -3,6 +3,9 @@ recipe: drupal8
 config:
   webroot: docroot
   php: "7.1"
+  # Match with terraform-aws-vsp-cms/rds.tf (another repo)
+  # Match with .tugboat/config.yml (this repo)
+  database: mariadb:10.5
   composer_version: '1.10.1'
 
 events:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -154,7 +154,7 @@ services:
     commands:
       init:
         - printf '[mysqld]\ninnodb_log_file_size = 50331648\nmax_allowed_packet = 128M\n' > /etc/mysql/conf.d/zzz.cnf
-        - sv restart mysql
+        - sv restart mariadb
         # Give MySQL some time to restart.
         - sleep 5
       # Commands that import files, databases,  or other assets. When an

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -146,8 +146,9 @@ services:
   # What to call the service hosting MySQL. This name also acts as the
   # hostname to access the service by from the php service.
   mysql:
-    # Use the latest available 5.x version of MySQL
-    image: tugboatqa/mysql:5
+    # Match with terraform-aws-vsp-cms/rds.tf (another repo)
+    # Match with .lando.yml (this repo)
+    image: tugboatqa/mariadb:10.5
 
     # A set of commands to run while building this service
     commands:


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/4240

## Testing done
Tested a base build w/no preview on this branch. Works. 


## Screenshots

See the 10.5.8 here. 

![image](https://user-images.githubusercontent.com/1504756/107832968-b1058780-6d46-11eb-8dc6-291f483265f5.png)

