### PR TITLE
VACMS-4274: Make custom modules Drupal 9 compatible.

### DIFF
--- a/docroot/modules/custom/disable_node_menu_item/disable_node_menu_item.info.yml
+++ b/docroot/modules/custom/disable_node_menu_item/disable_node_menu_item.info.yml
@@ -1,7 +1,7 @@
 name : Disable node menu item
 description : Hide a link within a menu from the add/edit interface
 type: module
-core : 8.x
+core_version_requirement: ^8 || ^9
 configure: disable_node_menu_item.settings
 dependencies:
   - menu_ui

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.info.yml
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.info.yml
@@ -2,7 +2,7 @@ name: 'VA.gov Backend'
 type: module
 description: 'Tools to improve backend user experience for VA.gov'
 configure: va_gov_backend.exclusion_types_admin_form
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   # Depends on webform for tippy.js library.

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.info.yml
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.info.yml
@@ -2,4 +2,4 @@ name: VA.gov Content Release Trigger Module
 description: Creates a content release trigger for releasing content to the frontend.
 package: Custom
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9

--- a/docroot/modules/custom/va_gov_bulk/va_gov_bulk.info.yml
+++ b/docroot/modules/custom/va_gov_bulk/va_gov_bulk.info.yml
@@ -2,4 +2,4 @@ name: Va Gov Bulk
 description: 'Bulk publish and unpublish workflow content'
 package: Custom
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.info.yml
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.info.yml
@@ -6,4 +6,4 @@ dependencies:
   - openapi
 
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9

--- a/docroot/modules/custom/va_gov_content_export/va_gov_content_export.info.yml
+++ b/docroot/modules/custom/va_gov_content_export/va_gov_content_export.info.yml
@@ -1,7 +1,7 @@
 name: 'VA.gov Content Export'
 type: module
 description: 'Export content to JSON files for consumption by frontend build process. Includes Tome (Sync) overrides to massage data.'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - openapi

--- a/docroot/modules/custom/va_gov_db/va_gov_db.info.yml
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.info.yml
@@ -1,7 +1,7 @@
 name: 'VA.gov DB'
 type: module
 description: 'Update and db op tools.'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - redirect_options

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -367,8 +367,8 @@ function va_gov_db_update_8020() {
     }
   }
 
-  $entity_manager = \Drupal::entityManager();
-  $previous_storage_definitions = $entity_manager->getLastInstalledFieldStorageDefinitions('node');
+  $schema_repository = \Drupal::service('entity.last_installed_schema.repository');
+  $previous_storage_definitions = $schema_repository->getLastInstalledFieldStorageDefinitions('node');
   if (!empty($previous_storage_definitions['field_health_services_local_info'])) {
     $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
     $definition_update_manager->uninstallFieldStorageDefinition(

--- a/docroot/modules/custom/va_gov_flags/va_gov_flags.info.yml
+++ b/docroot/modules/custom/va_gov_flags/va_gov_flags.info.yml
@@ -1,7 +1,7 @@
 name: 'va_gov_flags'
 type: module
 description: 'Provides flags for frontend build'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - feature_toggle

--- a/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.info.yml
+++ b/docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.info.yml
@@ -2,6 +2,6 @@ name: VA GovDelivery
 description: Provides customization to send bulletins through GovDelivery.
 package: 'Custom'
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - govdelivery_bulletins:govdelivery_bulletins

--- a/docroot/modules/custom/va_gov_graphql/va_gov_graphql.info.yml
+++ b/docroot/modules/custom/va_gov_graphql/va_gov_graphql.info.yml
@@ -1,7 +1,7 @@
 name: 'VA.gov GraphQL'
 type: module
 description: 'Helper functionality for GraphQL integration'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - basic_auth

--- a/docroot/modules/custom/va_gov_help_center/va_gov_help_center.info.yml
+++ b/docroot/modules/custom/va_gov_help_center/va_gov_help_center.info.yml
@@ -1,5 +1,5 @@
 name: 'VA.gov Help Center'
 type: module
 description: 'Tools to improve user experience for the CMS Help Center'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'

--- a/docroot/modules/custom/va_gov_login/va_gov_login.info.yml
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.info.yml
@@ -1,8 +1,7 @@
 name: 'VA.gov Login'
 type: module
 description: 'Helper functionality for VA.gov Login process'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
-
 dependencies:
   - simplesamlphp_auth:simplesamlphp_auth

--- a/docroot/modules/custom/va_gov_migrate/va_gov_migrate.info.yml
+++ b/docroot/modules/custom/va_gov_migrate/va_gov_migrate.info.yml
@@ -1,7 +1,7 @@
 name: 'VA.gov Migrate'
 type: module
 description: 'Migrate content from va.gov'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - migration_tools

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.info.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.info.yml
@@ -2,7 +2,7 @@ name: VA Post API
 description: Provides implementation of Post API.
 package: 'Custom'
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:post_api
   - drupal:slack

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.info.yml
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.info.yml
@@ -5,6 +5,6 @@ description: Provide content editors a Preview experience.
 
 package: custom
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:serialization

--- a/docroot/modules/custom/va_gov_resources_and_support/va_gov_resources_and_support.info.yml
+++ b/docroot/modules/custom/va_gov_resources_and_support/va_gov_resources_and_support.info.yml
@@ -1,5 +1,5 @@
 name: 'VA.gov Resources and Support'
 type: module
 description: 'Custom logic for Resources and Support'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'

--- a/docroot/modules/custom/va_gov_user/va_gov_user.info.yml
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.info.yml
@@ -2,4 +2,4 @@ name: 'VA.gov User Profile'
 description: 'Provides blocks and other functionality for user profiles.'
 package: 'Custom'
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9

--- a/docroot/modules/custom/va_gov_workflow_assignments/va_gov_workflow_assignments.info.yml
+++ b/docroot/modules/custom/va_gov_workflow_assignments/va_gov_workflow_assignments.info.yml
@@ -4,4 +4,4 @@ package: 'Custom'
 type: module
 dependencies:
   - va_gov_backend
-core: 8.x
+core_version_requirement: ^8 || ^9

--- a/docroot/modules/custom/zippylib/zippylib.info.yml
+++ b/docroot/modules/custom/zippylib/zippylib.info.yml
@@ -1,9 +1,7 @@
 name: Zippy Composer Package Wrapper
 description: A Drupal Services wrapper for the Zippy library (https://packagist.org/packages/alchemy/zippy)
-
 type: module
-core: 8.x
-core_version_requirement: ^8
+core_version_requirement: ^8 || ^9
 dependencies:
   - 'drupal:file'
   - 'zippylib:zippylib'


### PR DESCRIPTION
## Description

See #4274. 

## Testing done
This issue has two main AC's.

The first of which is that we need to ensure that the line `core_version_requirement: ^8 || ^9` replaces `core: 8.x` in all custom modules.

This can be tested by running the following commands from the repo root:
1.  `grep -L "core_version_requirement" docroot/modules/custom/*/*.info.yml` -- search for files matching the latter pattern that _don't_ contain the new string -- this should return no results.
2. `grep "core:" docroot/modules/custom/*/*.info.yml` -- search for files that _do_ contain the old string -- this also should return no results.

The second is that we need to ensure the absence of any deprecated code.  This is not practical without [some static analysis system](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/4231) or [module](https://www.drupal.org/project/upgrade_status).  Guess I'll add this to QA steps.

The only deprecated code in `va_gov_db` (some deprecated code exists in other modules and is handled by separate issues) is the following:
<img width="1036" alt="Screen Shot 2021-02-16 at 10 07 23 AM" src="https://user-images.githubusercontent.com/1318579/108081329-d6440f80-703e-11eb-8089-562426c6d1c6.png">

in this code:

```php
$entity_manager = \Drupal::entityManager();
$previous_storage_definitions = $entity_manager->getLastInstalledFieldStorageDefinitions('node');
```

The `$entity_manager` variable is used only in the following call, and `getLastInstalledFieldStorageDefinitions()` should instead be called on the `entity.last_installed_schema.repository` service, so it's a trivial fix.

## Screenshots
<img width="979" alt="Screen Shot 2021-02-16 at 9 26 26 AM" src="https://user-images.githubusercontent.com/1318579/108076087-0f798100-7039-11eb-8330-449575795d88.png">

<img width="908" alt="Screen Shot 2021-02-16 at 10 10 35 AM" src="https://user-images.githubusercontent.com/1318579/108081710-40f54b00-703f-11eb-95d4-c63a269e06e9.png">

## QA steps
1.  Go [here](https://pr4321-4tlphne45bmhzeaz1oeswpte7yfvyrd0.ci.cms.va.gov/admin/reports/upgrade-status).
2. Verify that the ACs are met:
    - [ ] All custom modules should have the above line added to their .info.yml files if it is not already present.
    - [ ] Custom module are not using deprecated methods (except for the `vagovadmin` theme, which is handled in a separate issue, none of our custom modules should show up under a "Fix With Rector" or "Fix Manually" header).

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review
- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?
- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner
- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
