### PR TITLE
VACMS-4252_4253_4254_4255_4256_4257_4314 module removal and patch update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
         "drupal/migrate_source_ui": "^1.0@RC",
         "drupal/migrate_tools": "^4.0",
         "drupal/migration_tools": "^2.1",
-        "drupal/module_missing_message_fixer": "^1.1",
         "drupal/node_link_report": "^1.14",
         "drupal/node_revision_delete": "^1.0",
         "drupal/node_title_help_text": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "drupal/better_field_descriptions": "^1.4",
         "drupal/blazy": "^2.0@RC",
         "drupal/block_content_permissions": "^1.6",
-        "drupal/block_visibility_groups": "^1.3",
         "drupal/cer": "^4.0@alpha",
         "drupal/coder": "^8.3",
         "drupal/components": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "drupal/block_content_permissions": "^1.6",
         "drupal/cer": "^4.0@alpha",
         "drupal/coder": "^8.3",
-        "drupal/components": "^1.0",
         "drupal/computed_field": "^2.0",
         "drupal/config_ignore": "^2.1",
         "drupal/config_override_warn": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -349,7 +349,7 @@
                 "Fix revision uncaught type error by extending class.": "https://www.drupal.org/files/issues/2019-08-16/workflow_participants-revision-error-3075426-1.patch"
             },
             "traviscarden/behat-table-comparison": {
-                "Throw meaningful message for duplicate entry.": "https://patch-diff.githubusercontent.com/raw/TravisCarden/behat-table-comparison/pull/7.patch"
+                "Throw meaningful message for duplicate entry. See https://github.com/TravisCarden/behat-table-comparison/pull/7": "patches/duplicate-row-message.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,6 @@
         "drupal/textfield_counter": "^2.0",
         "drupal/tome": "1.3",
         "drupal/toolbar_menu": "^2.1",
-        "drupal/tour_ui": "^1.0@beta",
         "drupal/user_history": "^1.0@alpha",
         "drupal/uswds": "^1.0@beta",
         "drupal/video_embed_media": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,6 @@
         "drupal/tome": "1.3",
         "drupal/toolbar_menu": "^2.1",
         "drupal/user_history": "^1.0@alpha",
-        "drupal/uswds": "^1.0@beta",
         "drupal/video_embed_media": "^2.2",
         "drupal/views_bulk_edit": "^2.3",
         "drupal/views_bulk_operations": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,6 @@
         "drupal/textfield_counter": "^2.0",
         "drupal/tome": "1.3",
         "drupal/toolbar_menu": "^2.1",
-        "drupal/toolbar_menu_clean": "^1.0",
         "drupal/tour_ui": "^1.0@beta",
         "drupal/user_history": "^1.0@alpha",
         "drupal/uswds": "^1.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2d8d4e87ff087e2d1c26d1119fe1be3",
+    "content-hash": "b0dd3225ac49b3945707e43e919dbf06",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -21193,7 +21193,7 @@
             "type": "library",
             "extra": {
                 "patches_applied": {
-                    "Throw meaningful message for duplicate entry.": "https://patch-diff.githubusercontent.com/raw/TravisCarden/behat-table-comparison/pull/7.patch"
+                    "Throw meaningful message for duplicate entry. See https://github.com/TravisCarden/behat-table-comparison/pull/7": "patches/duplicate-row-message.patch"
                 }
             },
             "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2dd86427ab64c7e23fd5a59e666d89f7",
+    "content-hash": "b7acfb958ffd7c7a98f89d6c0a4668b1",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -9114,51 +9114,6 @@
             "homepage": "https://www.drupal.org/project/toolbar_menu",
             "support": {
                 "source": "https://git.drupalcode.org/project/toolbar_menu"
-            }
-        },
-        {
-            "name": "drupal/toolbar_menu_clean",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/toolbar_menu_clean.git",
-                "reference": "8.x-1.2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/toolbar_menu_clean-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "8adbd1be7cc4065fbb717dab969a8e35817483cc"
-            },
-            "require": {
-                "drupal/core": "~8.0",
-                "drupal/toolbar_menu": "*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1568775486",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "zipme_hkt",
-                    "homepage": "https://www.drupal.org/user/368236"
-                }
-            ],
-            "description": "Clean up Toolbar menu for user",
-            "homepage": "https://www.drupal.org/project/toolbar_menu_clean",
-            "support": {
-                "source": "https://git.drupalcode.org/project/toolbar_menu_clean"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7acfb958ffd7c7a98f89d6c0a4668b1",
+    "content-hash": "520601edcfafaf0c619152b0d46f3edd",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -9114,58 +9114,6 @@
             "homepage": "https://www.drupal.org/project/toolbar_menu",
             "support": {
                 "source": "https://git.drupalcode.org/project/toolbar_menu"
-            }
-        },
-        {
-            "name": "drupal/tour_ui",
-            "version": "1.0.0-beta2",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/tour_ui.git",
-                "reference": "8.x-1.0-beta2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/tour_ui-8.x-1.0-beta2.zip",
-                "reference": "8.x-1.0-beta2",
-                "shasum": "d861fe1d0d2aafb3aad74c2ab87829911e740f93"
-            },
-            "require": {
-                "drupal/core": "^8"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.0-beta2",
-                    "datestamp": "1541254684",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "GoZ",
-                    "homepage": "https://www.drupal.org/user/226961"
-                },
-                {
-                    "name": "clemens.tolboom",
-                    "homepage": "https://www.drupal.org/user/125814"
-                },
-                {
-                    "name": "nick_schuch",
-                    "homepage": "https://www.drupal.org/user/1412036"
-                }
-            ],
-            "description": "Provides a UI to manage guided tours.",
-            "homepage": "https://www.drupal.org/project/tour_ui",
-            "support": {
-                "source": "https://git.drupalcode.org/project/tour_ui"
             }
         },
         {
@@ -21523,7 +21471,6 @@
         "drupal/pathologic": 15,
         "drupal/role_delegation": 15,
         "drupal/site_alert": 20,
-        "drupal/tour_ui": 10,
         "drupal/user_history": 15,
         "drupal/uswds": 10,
         "drupal/views_data_export": 10,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81d29233fadd9ca5089e13a31042245a",
+    "content-hash": "2dd86427ab64c7e23fd5a59e666d89f7",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -6926,60 +6926,6 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/migration_tools",
                 "issues": "https://www.drupal.org/project/issues/migration_tools"
-            }
-        },
-        {
-            "name": "drupal/module_missing_message_fixer",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/module_missing_message_fixer.git",
-                "reference": "8.x-1.2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/module_missing_message_fixer-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "bff669790857d9a7e9f55d30b97215a6addb299b"
-            },
-            "require": {
-                "drupal/core": "~8"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1585919601",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "drush": {
-                    "services": {
-                        "drush.services.yml": "^9"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "John Ouellet",
-                    "homepage": "https://www.drupal.org/u/labboy0276",
-                    "role": "Developer"
-                }
-            ],
-            "description": "This module displays a list of missing modules that appear on your site and lets you fix the entries",
-            "homepage": "https://www.drupal.org/project/module_missing_message_fixer",
-            "keywords": [
-                "Drupal"
-            ],
-            "support": {
-                "source": "http://cgit.drupalcode.org/module_missing_message_fixer",
-                "issues": "https://www.drupal.org/project/issues/module_missing_message_fixer"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c6fd40946a60c0000e26f3deb8cdf92",
+    "content-hash": "e6b7b5fee12fad88ebe810aa42f21ce9",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -741,6 +741,16 @@
                 "stream",
                 "stream_filter_append",
                 "stream_filter_register"
+            ],
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
             ],
             "time": "2019-04-09T12:31:48+00:00"
         },
@@ -2700,62 +2710,6 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/block_content_permissions",
                 "issues": "https://www.drupal.org/project/issues/block_content_permissions"
-            }
-        },
-        {
-            "name": "drupal/block_visibility_groups",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/block_visibility_groups.git",
-                "reference": "8.x-1.3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/block_visibility_groups-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "3c42377fcf6b849e8509b4b993a750cbc1a90a9b"
-            },
-            "require": {
-                "drupal/core": "^8"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1536509886",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "joelpittet",
-                    "homepage": "https://www.drupal.org/user/160302"
-                },
-                {
-                    "name": "mlncn",
-                    "homepage": "https://www.drupal.org/user/64383"
-                },
-                {
-                    "name": "tedbow",
-                    "homepage": "https://www.drupal.org/user/240860"
-                }
-            ],
-            "description": "My Awesome Module",
-            "homepage": "http://drupal.org/project/block_visibility_groups",
-            "keywords": [
-                "Drupal"
-            ],
-            "support": {
-                "source": "http://cgit.drupalcode.org/block_visibility_groups",
-                "issues": "http://drupal.org/project/issues/block_visibility_groups"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "520601edcfafaf0c619152b0d46f3edd",
+    "content-hash": "d2d8d4e87ff087e2d1c26d1119fe1be3",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -9163,59 +9163,6 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/user_history",
                 "issues": "https://www.drupal.org/project/issues/user_history"
-            }
-        },
-        {
-            "name": "drupal/uswds",
-            "version": "1.0.0-beta3",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/uswds.git",
-                "reference": "8.x-1.0-beta3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/uswds-8.x-1.0-beta3.zip",
-                "reference": "8.x-1.0-beta3",
-                "shasum": "f220e5edc916417c9215a54ac8fcd4247669a855"
-            },
-            "require": {
-                "drupal/core": "~8.0"
-            },
-            "type": "drupal-theme",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.0-beta3",
-                    "datestamp": "1515004684",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Irisibk",
-                    "homepage": "https://www.drupal.org/user/1175178"
-                },
-                {
-                    "name": "JayDarnell",
-                    "homepage": "https://www.drupal.org/user/667566"
-                },
-                {
-                    "name": "brockfanning",
-                    "homepage": "https://www.drupal.org/user/709486"
-                }
-            ],
-            "description": "Drupal theme for the U.S. Web Design Standards library.",
-            "homepage": "https://www.drupal.org/project/uswds",
-            "support": {
-                "source": "http://cgit.drupalcode.org/uswds",
-                "issues": "https://www.drupal.org/project/issues/uswds?categories=All"
             }
         },
         {
@@ -21472,7 +21419,6 @@
         "drupal/role_delegation": 15,
         "drupal/site_alert": 20,
         "drupal/user_history": 15,
-        "drupal/uswds": 10,
         "drupal/views_data_export": 10,
         "drupal/views_tree": 15,
         "drupal/workbench_access": 10,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6b7b5fee12fad88ebe810aa42f21ce9",
+    "content-hash": "81d29233fadd9ca5089e13a31042245a",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2809,54 +2809,6 @@
                 "standards"
             ],
             "time": "2020-05-08T10:20:59+00:00"
-        },
-        {
-            "name": "drupal/components",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/components.git",
-                "reference": "8.x-1.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/components-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "72af8ff1ca842556ee4b95335595c24703acdb75"
-            },
-            "require": {
-                "drupal/core": "~8.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1556870881",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "JohnAlbin",
-                    "homepage": "https://www.drupal.org/user/32095"
-                },
-                {
-                    "name": "RobLoach",
-                    "homepage": "https://www.drupal.org/user/61114"
-                }
-            ],
-            "description": "Registers “component libraries” defined in modules and themes with the Twig system",
-            "homepage": "https://www.drupal.org/project/components",
-            "support": {
-                "source": "https://git.drupalcode.org/project/components"
-            }
         },
         {
             "name": "drupal/computed_field",

--- a/patches/duplicate-row-message.patch
+++ b/patches/duplicate-row-message.patch
@@ -1,0 +1,29 @@
+From a5607ababaeabb10ef8258788caca5bcc548fff7 Mon Sep 17 00:00:00 2001
+From: Ethan Teague <metrowebz@gmail.com>
+Date: Wed, 5 Aug 2020 18:45:15 -0400
+Subject: [PATCH] Check for duplicate entries in feature file
+
+Throws Exception message indicating duplicate line in file.
+---
+ src/BehatTableComparison/TableEqualityAssertion.php | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/BehatTableComparison/TableEqualityAssertion.php b/src/BehatTableComparison/TableEqualityAssertion.php
+index 84310b2..32d198f 100644
+--- a/src/BehatTableComparison/TableEqualityAssertion.php
++++ b/src/BehatTableComparison/TableEqualityAssertion.php
+@@ -299,6 +299,14 @@ protected function generateMessageForPostSortDifferences(array $expected_rows, a
+      */
+     protected function addArrayDiffMessageLines(array &$message, array $left, array $right, $label)
+     {
++        $duplicates = array_diff_key($right, array_unique($right, SORT_REGULAR));
++        if (!empty($duplicates)) {
++            foreach ($duplicates as $duplicate) {
++                $dupe_str = implode(' | ', $duplicate);
++                $message = PHP_EOL . '~~~ Duplicate entry detected: ' . PHP_EOL . $dupe_str;
++                throw new \LogicException($message);
++            }
++        }
+         $differences = array_filter($right, function (array $row) use ($left) {
+             return !in_array($row, $left);
+         });


### PR DESCRIPTION
## Description
Removes a bunch of unused modules, and moves a remote diff based patch to our local patches dir. All modules were previously disabled, so this just ensures that they aren't sucked in by composer. I checked for orphaned tables, unused variables / config in settings files, etc.
Also checked that the local patch applies cleanly.
See:
#4252 
#4253 
#4254 
#4255 
#4256 
#4257 
#4314 

## Testing done
Build, log checks, spot checks

## Screenshots
N/A

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
