### PR TITLE
Add mailhog service to Lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -62,6 +62,11 @@ services:
         BLACKFIRE_CLIENT_TOKEN: ~
         BLACKFIRE_SERVER_ID: ~
         BLACKFIRE_SERVER_TOKEN: ~
+  mailhog:
+    type: mailhog
+    portforward: true
+    hogfrom:
+      - appserver
 
   # Uncomment this to work on site build triggers, then export ENV vars below, then `lando rebuild`.
   # Must use lando 3.0.0-rc9+

--- a/READMES/local.md
+++ b/READMES/local.md
@@ -7,11 +7,22 @@
 
 
     ### Lando Commands (commonly used ones.  See Lando docs for more.)
-    * `lando start -y`
-    * `lando rebuild -y`
-    * `lando composer nuke`  Destroy the vendor directory so it can be rebuilt
-        properly.
-    * `lando xdebug-on` | `lando xdebug-off` Turns [xdebug](debugging.md) on or off.
+    | Command | Description |
+    | --- | --- |
+    | `lando start -y` | Start the application |
+    | `lando rebuild -y` | Rebuild the application and re-run the setup commands |
+    | `lando composer nuke` | Destroy the vendor directory so it can be rebuilt properly. |
+    | `lando xdebug-on` / `lando xdebug-off` | Turns [xdebug](debugging.md) on or off. |
+    | `lando info` | View service URLs and ports |
+    
+    ### Mailhog
+    
+    [Mailhog](https://github.com/mailhog/MailHog) is an email testing tool that has two main functions:
+    
+    1. captures outgoing email from the application
+    2. provides a web UI for viewing outgoing emails
+
+    To access the UI, run `lando info` to see the mailhog URL and visit the service URL.
 
     ### Troubleshooting:
     * Sometimes after initial setup or `lando start`, Drush is not found. Running `lando rebuild -y` once or twice usually cures, if not, see: https://github.com/lando/lando/issues/580#issuecomment-354490298


### PR DESCRIPTION
## Description

As a developer, I want to be able to easily capture and view emails sent by the system, in order to easily debug mail-sending issues.

## Screenshots

<img width="1175" alt="Screen Shot 2021-02-17 at 9 51 47 AM" src="https://user-images.githubusercontent.com/101649/108238027-c2171580-7105-11eb-8b8c-effeff84674b.png">

## QA steps

1. `lando rebuild`
2. run `lando info` to get the mailhog URL
3. generate an email, e.g. by creating a new user account
- [ ] the email is viewable in the mailhog UI

### Definition of Done

- [x] Documentation has been updated, if applicable.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`