### PR TITLE
VACMS-4147: Add new fields to vha vocab.

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -8,6 +8,10 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id
     - field.field.taxonomy_term.health_care_service_taxonomy.field_owner
     - field.field.taxonomy_term.health_care_service_taxonomy.field_service_type_of_care
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_com_conditions
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_friendly_name
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_service_descrip
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_type_of_care
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode
     - taxonomy.vocabulary.health_care_service_taxonomy
   module:
@@ -20,7 +24,7 @@ third_party_settings:
       children:
         - field_owner
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details_sidebar
       format_settings:
         weight: 0
@@ -30,6 +34,23 @@ third_party_settings:
         open: false
       label: Governance
       region: hidden
+    group_vet_center:
+      children:
+        - field_vet_center_type_of_care
+        - field_vet_center_friendly_name
+        - field_vet_center_com_conditions
+        - field_vet_center_service_descrip
+      parent_name: ''
+      weight: 7
+      format_type: details
+      region: content
+      format_settings:
+        description: 'Add content to these fields if you want to "override" how the service is described on Vet Center pages.'
+        required_fields: true
+        id: ''
+        classes: ''
+        open: false
+      label: 'Vet Center'
 id: taxonomy_term.health_care_service_taxonomy.default
 targetEntityType: taxonomy_term
 bundle: health_care_service_taxonomy
@@ -37,14 +58,14 @@ mode: default
 content:
   description:
     type: text_textarea
-    weight: 6
+    weight: 5
     region: content
     settings:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
   field_also_known_as:
-    weight: 4
+    weight: 3
     settings:
       size: 60
       placeholder: ''
@@ -52,7 +73,7 @@ content:
     type: string_textfield
     region: content
   field_commonly_treated_condition:
-    weight: 5
+    weight: 4
     settings:
       size: 60
       placeholder: ''
@@ -60,7 +81,7 @@ content:
     type: string_textfield
     region: content
   field_health_service_api_id:
-    weight: 2
+    weight: 1
     settings:
       size: 60
       placeholder: ''
@@ -68,13 +89,43 @@ content:
     type: string_textfield
     region: content
   field_service_type_of_care:
-    weight: 1
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_vet_center_com_conditions:
+    weight: 10
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_vet_center_friendly_name:
+    weight: 9
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_vet_center_service_descrip:
+    weight: 11
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_vet_center_type_of_care:
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_vha_healthservice_stopcode:
-    weight: 3
+    weight: 2
     settings:
       placeholder: ''
     third_party_settings: {  }
@@ -90,7 +141,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -8,6 +8,10 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id
     - field.field.taxonomy_term.health_care_service_taxonomy.field_owner
     - field.field.taxonomy_term.health_care_service_taxonomy.field_service_type_of_care
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_com_conditions
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_friendly_name
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_service_descrip
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_type_of_care
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode
     - taxonomy.vocabulary.health_care_service_taxonomy
   module:
@@ -51,6 +55,36 @@ content:
     region: content
   field_service_type_of_care:
     weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_vet_center_com_conditions:
+    weight: 8
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_vet_center_friendly_name:
+    weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_vet_center_service_descrip:
+    weight: 9
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_vet_center_type_of_care:
+    weight: 6
     label: above
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_com_conditions.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_com_conditions.yml
@@ -1,0 +1,19 @@
+uuid: 2fee2e92-7d42-4c89-872e-fa360ca5c836
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_vet_center_com_conditions
+    - taxonomy.vocabulary.health_care_service_taxonomy
+id: taxonomy_term.health_care_service_taxonomy.field_vet_center_com_conditions
+field_name: field_vet_center_com_conditions
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Common conditions'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_friendly_name.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_friendly_name.yml
@@ -1,0 +1,19 @@
+uuid: ea65efd8-d6b1-499e-b100-c7bffb47321c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_vet_center_friendly_name
+    - taxonomy.vocabulary.health_care_service_taxonomy
+id: taxonomy_term.health_care_service_taxonomy.field_vet_center_friendly_name
+field_name: field_vet_center_friendly_name
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Patient friendly name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_service_descrip.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_service_descrip.yml
@@ -1,0 +1,19 @@
+uuid: 1edd09e4-6497-4b09-aca7-347a2253061d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_vet_center_service_descrip
+    - taxonomy.vocabulary.health_care_service_taxonomy
+id: taxonomy_term.health_care_service_taxonomy.field_vet_center_service_descrip
+field_name: field_vet_center_service_descrip
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Service description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_type_of_care.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_type_of_care.yml
@@ -1,0 +1,21 @@
+uuid: cd5a4729-c2fa-40e6-aaa4-92ced5f500f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_vet_center_type_of_care
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - options
+id: taxonomy_term.health_care_service_taxonomy.field_vet_center_type_of_care
+field_name: field_vet_center_type_of_care
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Type of Care'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.taxonomy_term.field_vet_center_com_conditions.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vet_center_com_conditions.yml
@@ -1,0 +1,21 @@
+uuid: e9eb478a-30a3-4092-85dd-d107c7e7c497
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_vet_center_com_conditions
+field_name: field_vet_center_com_conditions
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_vet_center_friendly_name.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vet_center_friendly_name.yml
@@ -1,0 +1,21 @@
+uuid: 811c5ee4-2c93-4483-8084-198c3bc4054d
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_vet_center_friendly_name
+field_name: field_vet_center_friendly_name
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_vet_center_service_descrip.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vet_center_service_descrip.yml
@@ -1,0 +1,19 @@
+uuid: 52a78239-acd2-4c35-ba73-bf224d85c704
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_vet_center_service_descrip
+field_name: field_vet_center_service_descrip
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_vet_center_type_of_care.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vet_center_type_of_care.yml
@@ -1,0 +1,30 @@
+uuid: a2009998-ce26-4d56-8ea3-534e40022ad4
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - taxonomy
+id: taxonomy_term.field_vet_center_type_of_care
+field_name: field_vet_center_type_of_care
+entity_type: taxonomy_term
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: counselling
+      label: 'Counselling services'
+    -
+      value: referral
+      label: 'Referral services'
+    -
+      value: other
+      label: 'Other services'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -24,3 +24,8 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Type of care | field_service_type_of_care | List (text) |  | 1 | Select list |  |
 | Vocabulary | VHA health service taxonomy | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |
+| Vocabulary | VHA health service taxonomy | Common conditions | field_vet_center_com_conditions  | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VHA health service taxonomy | Patient friendly name | field_vet_center_friendly_name | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VHA health service taxonomy | Service description | field_vet_center_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Vocabulary | VHA health service taxonomy | Type of Care | field_vet_center_type_of_care | List (text) |  | 1 | Select list |  |
+


### PR DESCRIPTION
## Description
See #4147 

## Testing done
Visual / Behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/108396384-c7975d00-71e4-11eb-8d13-d88a4f8846b6.png)
![image](https://user-images.githubusercontent.com/2404547/108396398-cbc37a80-71e4-11eb-8f2a-899b5fb33195.png)

## QA steps
- As an administrator, go to `admin/structure/taxonomy/manage/health_care_service_taxonomy/add` and visually verify new fieldset and fields appear as in above screenshot.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
