### PR TITLE
VACMS-4194: Fail the yaml test when va:web:build errors out

### DIFF
--- a/tests.yml
+++ b/tests.yml
@@ -46,13 +46,7 @@ va/web/install:
 
 va/web/build:
   description: Build VA.gov Front-end
-
-  # NOTE: If we used the `va:web:build` command directly, it would throw a false positive if it were to exit 0.
-  # Instead of presuming that it will always exit 0 if unable to read Drupal content, we make sure to check for the error as well.
-  #
-  # So, we decided to keep the "grep" for the Metalsmith error message to ensure that we catch the situation where the
-  # error is shown, but the command exits successfully (exit 0).
-  command: composer va:web:build | tee /dev/stderr | grep "Failed to pipe Drupal content into Metalsmith!" -B1000 -C8 && echo "tests.yml | composer va:web:build included the Drupal/Metalsmith error." && exit 1 || echo "tests.yml | Front end site was built! Check $DRUPAL_ADDRESS/static for raw output!"
+  command: ./tests/scripts/build-web.sh
 
 va/tests/behat:
   description: Behat Tests

--- a/tests/scripts/build-web.sh
+++ b/tests/scripts/build-web.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Prevent tee from masking build failures
+set -eo pipefail
+
+# NOTE: If we used the `va:web:build` command directly, it would throw a false positive if it were to exit 0.
+# Instead of presuming that it will always exit 0 if unable to read Drupal content, we make sure to check for the error as well.
+#
+# So, we decided to keep the "grep" for the Metalsmith error message to ensure that we catch the situation where the
+# error is shown, but the command exits successfully (exit 0).
+TEMPFILE=$( mktemp )
+composer va:web:build | tee ${TEMPFILE}
+grep "Failed to pipe Drupal content into Metalsmith!" -B1000 -C8 ${TEMPFILE} &&
+  echo "tests.yml | composer va:web:build included the Drupal/Metalsmith error." &&
+  exit 1 ||
+    echo "tests.yml | Front end site was built! Check $DRUPAL_ADDRESS/static for raw output!"
+
+exit $?

--- a/tests/scripts/build-web.sh
+++ b/tests/scripts/build-web.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
-# Prevent tee from masking build failures
+# Prevent tee from masking build failures.
 set -eo pipefail
 
-# NOTE: If we used the `va:web:build` command directly, it would throw a false positive if it were to exit 0.
-# Instead of presuming that it will always exit 0 if unable to read Drupal content, we make sure to check for the error as well.
+# NOTE: If we used the `va:web:build` command directly, it would throw a false
+# positive if it were to exit 0. Instead of presuming that it will always exit 0
+# if unable to read Drupal content, we make sure to check for the error as well.
 #
-# So, we decided to keep the "grep" for the Metalsmith error message to ensure that we catch the situation where the
-# error is shown, but the command exits successfully (exit 0).
+# So, we decided to keep the "grep" for the Metalsmith error message to ensure
+# that we catch the situation where the error is shown, but the command exits
+# successfully (exit 0).
 TEMPFILE=$( mktemp )
 composer va:web:build | tee ${TEMPFILE}
 grep "Failed to pipe Drupal content into Metalsmith!" -B1000 -C8 ${TEMPFILE} &&


### PR DESCRIPTION
## Description

`yaml-tests` does not report an error when `composer va:web:build` exits with an error status, due to the use of `tee`. To reproduce the issue:

1. remove a dependency, e.g. `rm -r /web/node_modules/chokidar`
2. run `composer yaml-tests build`

You should see output similar to this:

```
✔ Process Succeeded in 1.272s Output: /path/to/file
✔ GitHub Status: va/web/build: success
```

## Testing done

tested with and without the missing dependency.

## Screenshots


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
