### PR TITLE
VACMS-3904 Remove deploy steps from tests.yml & change order of deploy steps to match `drush deploy`

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -7,15 +7,17 @@ config:
 
 events:
   post-db-import:
-    # @TODO: Change to `composer yaml-tests va/deploy` once the "filter argument" feature is in place.
-    - appserver: cd $LANDO_WEBROOT && /app/bin/drush cache-rebuild -y
-    - appserver: cd $LANDO_WEBROOT && /app/bin/drush updatedb -y
-    - appserver: cd $LANDO_WEBROOT && /app/bin/drush cache-rebuild -y
-    - appserver: cd $LANDO_WEBROOT && /app/bin/drush config:import -y
-    - appserver: cd $LANDO_WEBROOT && /app/bin/drush cache-rebuild -y
+    # Follows `drush deploy` sequence recommendations - https://www.drush.org/latest/deploycommand/
+    # Replace with `drush deploy` once Drush 10 is upgraded
+    # If updated, also update in devops:post-deploy-tasks.yml and .tugboat/config.yml
+    - appserver: cd $LANDO_WEBROOT && drush updatedb --cache-clear=0 -y
+    - appserver: cd $LANDO_WEBROOT && drush cache-rebuild -y
+    - appserver: cd $LANDO_WEBROOT && drush config:import -y
+    - appserver: cd $LANDO_WEBROOT && drush cache-rebuild -y
 
   # Runs composer install after app starts
   post-start:
+    # Composer options are in composer.json, 'config' key.
     - appserver: cd $LANDO_MOUNT && composer install
     # Pulled from https://github.com/AaronFeledy/lando-examples/tree/master/landofile-changed-alert.
     # Alert user if landofile and current environment are out of sync.
@@ -23,8 +25,10 @@ events:
 
   # After code changes
   post-update:
+    # Composer options are in composer.json, 'config' key.
     - appserver: cd $LANDO_MOUNT && composer install
-    - appserver: cd $LANDO_WEBROOT && drush updb -y &&  drush cr -y
+    - appserver: cd $LANDO_WEBROOT && drush updatedb --cache-clear=0 -y
+    - appserver: cd $LANDO_WEBROOT && drush cache:rebuild -y
 
 services:
   appserver:
@@ -104,7 +108,7 @@ tooling:
     cmd: /app/scripts/lando-precommit.sh
 
   test:
-    description: Run all VA.gov tests, as defined in tests.yml. Add arguments to run subsets of tests. For example. "lando test deploy" will run all of the "va/deploy/*" tests.
+    description: Run all VA.gov tests, as defined in tests.yml. Add arguments to run subsets of tests. For example. "lando test web" will run all of the "va/web/*" tests.
     service: appserver
     cmd: composer yaml-tests
 

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -84,7 +84,8 @@ services:
       # already be present.
       update:
         # Install/update packages managed by composer, including drush.
-        - composer install --optimize-autoloader --apcu-autoloader
+        # Composer options are in composer.json, 'config' key.
+        - composer install
         - composer va:web:install
 
         - curl --remote-name https://dsva-vagov-prod-cms-backup-sanitized.s3-us-gov-west-1.amazonaws.com/files/cms-prod-files-latest.tgz
@@ -111,11 +112,14 @@ services:
         - j2 "${TUGBOAT_ROOT}/.tugboat/.env.j2" -o "${TUGBOAT_ROOT}/.env"
         # This command is shared by the clone and build stages, make sure to update both stages.
         - j2 "${TUGBOAT_ROOT}/.web/403-error-document.j2.html" -o "${TUGBOAT_ROOT}/.web/403-error-document.html"
-        - composer install --optimize-autoloader --apcu-autoloader
+        - composer install
         - composer va:web:install
+        # Follows `drush deploy` sequence recommendations - https://www.drush.org/latest/deploycommand/
+        # Replace with `drush deploy` once Drush 10 is upgraded
+        # If updated, also update in devops:post-deploy-tasks.yml and .lando.yml
+        - drush updatedb --cache-clear=0 -y
         - drush cache:rebuild
         - drush config:import -y
-        - drush updatedb --cache-clear=0 -y
         - drush cache:rebuild
 
         # Setup background processing service.  This uses runit to keep process up

--- a/tests.yml
+++ b/tests.yml
@@ -5,25 +5,6 @@
 #  command: intentionalFailure
 #  description: Intentional Failure. Uncomment to test CI system failure behavior.
 
-# TODO: These can be removed once the DevShop deploy task runs the install task before it runs the deploy hooks.
-va/deploy/0-composer:
-  description: Composer Install
-  about: Using --dev is actually the default. Putting it here to make it clear this is the way composer should be run right now.
-  # Removing va-gov/web here because composer won't update it, we think... needs more testing.
-  command: rm -rf ./docroot/vendor/va-gov/web && composer install --dev --no-interaction --no-progress --ansi
-
-va/deploy/1-cache:
-  description: Rebuild Drupal caches
-  command: drush $DRUSH_ALIAS cr
-
-va/deploy/2-update:
-  description: Run Drupal Update Hooks
-  command: drush $DRUSH_ALIAS updatedb --yes
-
-va/deploy/3-config:
-  - drush $DRUSH_ALIAS cim --yes
-  - drush $DRUSH_ALIAS cr
-
 va/tests/phplint:
   description: PHP Lint
   command: composer va:test:lint


### PR DESCRIPTION
## Description
1) The deploy steps in tests.yml was only for DevShop to run things because we were using it outside its expected behavior. DevShop is gone now and we don't need these anymore.

2) The deploy steps order is changed to match the `drush deploy` recommendations. See https://www.drush.org/latest/deploycommand/

3) The composer install autoloader options are removed from Tugboat as we have them in composer.json config section. 

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/3904

Deploy steps changes are also in BRD here > https://github.com/department-of-veterans-affairs/devops/pull/8557

## Testing done
- Tested locally on Lando
- Tested on Tugboat, this PR - passed
- Testing on BRD now, build works and doing a DEV deploy now and then tests should run and pass too