### PR TITLE
VACMS-000 configure xdebug3 and connect to VScode.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -42,7 +42,7 @@ services:
       # cypress-axe dependencies - https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
       - "apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -y"
       - .lando/scripts/blackfire-init.sh
-    xdebug: false
+    xdebug: true
     config:
       php: .lando/zzz-lando-my-custom.ini
     build:

--- a/.lando/zzz-lando-my-custom.ini
+++ b/.lando/zzz-lando-my-custom.ini
@@ -20,7 +20,7 @@ xdebug.force_display_errors = 1
 xdebug.force_error_reporting = 1
 xdebug.mode = debug,trace,develop,
 xdebug.start_with_request = yes
-;xdebug.client_port = 9000
+xdebug.client_port = 9003
 xdebug.log = /tmp/xdebug.log
 
 [blackfire]

--- a/.lando/zzz-lando-my-custom.ini
+++ b/.lando/zzz-lando-my-custom.ini
@@ -20,7 +20,7 @@ xdebug.force_display_errors = 1
 xdebug.force_error_reporting = 1
 xdebug.mode = debug,trace,develop,
 xdebug.start_with_request = yes
-xdebug.client_port = 9000
+;xdebug.client_port = 9000
 xdebug.log = /tmp/xdebug.log
 
 [blackfire]

--- a/.lando/zzz-lando-my-custom.ini
+++ b/.lando/zzz-lando-my-custom.ini
@@ -10,24 +10,18 @@ memory_limit = 4G
 ; Xdebug
 xdebug.max_nesting_level = 256
 xdebug.show_exception_trace = 0
-xdebug.collect_params = 0
 ; Extra custom Xdebug setting for debug to work in VSCode.
-xdebug.remote_enable = 1
-xdebug.remote_autostart = 1
-xdebug.remote_host = ${LANDO_HOST_IP}
-xdebug.remote_connect_back = 1
-xdebug.remote_log = /tmp/xdebug.log
+xdebug.client_host = ${LANDO_HOST_IP}
+xdebug.discover_client_host = 1
 
 ; xdebug3 config.  See https://xdebug.org/docs/upgrade_guide
-xdebug.collect_assignments=1
-xdebug.collect_includes=1
-xdebug.collect_vars=1
-xdebug.force_display_errors=1
-xdebug.force_error_reporting=1
-
-xdebug.mode=debug,trace,develop
-xdebug.start_with_request=yes
-xdebug.client_port=9001
+xdebug.collect_assignments = 1
+xdebug.force_display_errors = 1
+xdebug.force_error_reporting = 1
+xdebug.mode = debug,trace,develop,
+xdebug.start_with_request = yes
+xdebug.client_port = 9000
+xdebug.log = /tmp/xdebug.log
 
 [blackfire]
 ; Enterprise does not have the option to update Blackfire  settings via .platform.app.yaml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for XDebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9000,
+      "log": true,
+      "pathMappings": {
+        "/app/": "${workspaceFolder}",
+        "/opt/drush/8/drush/drush": "${env:HOME}/.config/composer/vendor/drush/drush",
+      }
+    },
+    {
+      "name": "Launch currently open script",
+      "type": "php",
+      "request": "launch",
+      "program": "${file}",
+      "cwd": "${fileDirname}",
+      "port": 9000
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Listen for XDebug",
       "type": "php",
       "request": "launch",
-      "port": 9000,
+      "port": 9003,
       "log": true,
       "pathMappings": {
         "/app/": "${workspaceFolder}",
@@ -18,7 +18,7 @@
       "request": "launch",
       "program": "${file}",
       "cwd": "${fileDirname}",
-      "port": 9000
+      "port": 9003
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,19 +6,11 @@
       "type": "php",
       "request": "launch",
       "port": 9003,
-      "log": true,
+      "log": false,
       "pathMappings": {
         "/app/": "${workspaceFolder}",
         "/opt/drush/8/drush/drush": "${env:HOME}/.config/composer/vendor/drush/drush",
       }
-    },
-    {
-      "name": "Launch currently open script",
-      "type": "php",
-      "request": "launch",
-      "program": "${file}",
-      "cwd": "${fileDirname}",
-      "port": 9003
     }
   ]
 }

--- a/READMES/debugging.md
+++ b/READMES/debugging.md
@@ -15,7 +15,7 @@
             * Go to Settings > Languages & Frameworks > PHP. Press "..." button next to CLI interpreter to open interpreter settings.
             * If "Additional > Debugger extension" field is empty, add a path to debugger extension manually. Press `i` (Show phpinfo) button next to PHP executable to find debugger extension path. Look for `extension_dir` variable. Add `xdebug.so` and save this value in "Debugger extension" field. E.g. `/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so`.
     * VS Code
-        * Details are here on [lando docs](https://docs.lando.dev/guides/lando-with-vscode.html#getting-started), however, all the php.ini extras have already been added.  And .vscode/launch.json is already configured as part of this repo.
+        * Open debug panel, then select "Listen for XDebug" and click green arrow to start. Add breakpoints as needed and reload Drupal page in browser. VSCode and XDebug settings have been preconfigured according to [Lando docs](https://docs.lando.dev/guides/lando-with-vscode.html#getting-started). Port may need to be [opened](https://docs.lando.dev/guides/lando-with-vscode.html#known-issues) on Debian/Ubuntu.
 
 * Browser:
     * Open index.php and set a test breakpoint on the first line ($autoloader)

--- a/READMES/debugging.md
+++ b/READMES/debugging.md
@@ -2,7 +2,7 @@
 
 ## Xdebug:
 * Setup:
-    * Enable Xdebug by `lando xdebug-on`
+    * Enable Xdebug by `lando xdebug-on` (default)
     * Disable by typing `lando xdebug-off`
 
 * IDEs
@@ -15,35 +15,7 @@
             * Go to Settings > Languages & Frameworks > PHP. Press "..." button next to CLI interpreter to open interpreter settings.
             * If "Additional > Debugger extension" field is empty, add a path to debugger extension manually. Press `i` (Show phpinfo) button next to PHP executable to find debugger extension path. Look for `extension_dir` variable. Add `xdebug.so` and save this value in "Debugger extension" field. E.g. `/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so`.
     * VS Code
-        * Details are here on [lando docs](https://docs.lando.dev/guides/lando-with-vscode.html#getting-started), however, all the php.ini extras have already been added.  The only thing needed is to add the necessary config to .vscode/launch.json
-
-        ```json
-            {
-            "version": "0.2.0",
-            "configurations": [
-                {
-                "name": "Listen for Xdebug",
-                "type": "php",
-                "request": "launch",
-                "port": 9000,
-                "log": true,
-                "pathMappings": {
-                    "/app/": "${workspaceFolder}/",
-                }
-                },
-                {
-                "name": "Launch currently open script",
-                "type": "php",
-                "request": "launch",
-                "program": "${file}",
-                "cwd": "${fileDirname}",
-                "port": 9000
-                }
-            ]
-            }
-
-        ```
-        This file is git ignored so can be additionally modified without affecting others.
+        * Details are here on [lando docs](https://docs.lando.dev/guides/lando-with-vscode.html#getting-started), however, all the php.ini extras have already been added.  And .vscode/launch.json is already configured as part of this repo.
 
 * Browser:
     * Open index.php and set a test breakpoint on the first line ($autoloader)


### PR DESCRIPTION
## Description

See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/4519. 

## Testing done


## Screenshots


## QA steps

1. Pull this PR locally.
2. `lando rebuild -y`
3. close and restart your vscode
3. Set a breakpoint in docroot/sites/default/settings.php
3. Activate "Listen for XDebug" in vscode.
4.  load drupal in your browser
  - [x] validate the breakpoint worked and variables data is visible in vscode
 5. close your browser tab and any other tabs showing lando so sitealert polling does not trigger new requests.
 6. in your terminal `lando drush cr`
 - [x] validate the breakpoint worked and variables data is visible in vscode
 7.  `lando xdebug-off` to disable xdebug.  
 8. Activate "Listen for XDebug" in vscode.
 9.   load drupal in your browser
 - [x] validate the breakpoint did not activate
 10. `lando xdebug-on` to enable xdebug.  
 11. Activate "Listen for XDebug" in vscode.
 12.   load drupal in your browser
 - [x] validate the breakpoint worked and variables data is visible in vscode

### Definition of Done

- [ ] xdebug can be toggled off an on with a command
- [ ] xdebug works in vscode for browser requests
- [ ] xdebug works in vscode for cli drush commands
- [ ] php storm users don't report we broke them.



