### PR TITLE
VACMS-4553 Update entity_field_fetch to use ids.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "drupal/entity_browser_table": "^1.2",
         "drupal/entity_clone": "^1.0@beta",
         "drupal/entity_embed": "^1.0",
-        "drupal/entity_field_fetch": "^1.0@beta",
+        "drupal/entity_field_fetch": "^1.0-beta2",
         "drupal/entity_reference_revisions": "^1.7",
         "drupal/entity_reference_unpublished": "^1.1",
         "drupal/entity_reference_validators": "^1.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb1639600c8e267698219ec93c01ce33",
+    "content-hash": "e7f235fc867fa3865332473108b549f0",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5572,17 +5572,17 @@
         },
         {
             "name": "drupal/entity_field_fetch",
-            "version": "1.0.0-beta1",
+            "version": "1.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_field_fetch.git",
-                "reference": "1.0.0-beta1"
+                "reference": "1.0.0-beta2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_field_fetch-1.0.0-beta1.zip",
-                "reference": "1.0.0-beta1",
-                "shasum": "a71b1c6da63bba15fa2e9dde0b87e1cdc04d95da"
+                "url": "https://ftp.drupal.org/files/projects/entity_field_fetch-1.0.0-beta2.zip",
+                "reference": "1.0.0-beta2",
+                "shasum": "880ec8840a91835509980f767814790f7d0c8a81"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -5590,8 +5590,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.0-beta1",
-                    "datestamp": "1612817790",
+                    "version": "1.0.0-beta2",
+                    "datestamp": "1615610578",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -22614,7 +22614,6 @@
         "drupal/content_lock": 15,
         "drupal/entity_block": 10,
         "drupal/entity_clone": 10,
-        "drupal/entity_field_fetch": 10,
         "drupal/entity_reference_validators": 15,
         "drupal/entityqueue": 10,
         "drupal/fast_404": 20,


### PR DESCRIPTION
## Description

See #4553 

THis PR gets a necessary entity id to the FE team, but requires a re-save of all existing VAMC System policy node pages (currently there is only 1 :) 
/admin/content/bulk?title=&type=vamc_system_policies_page&moderation_state=All&taxonomy_entity_index_tid_depth=All

The also removed the theme errors we have been seeing related to entity_filed_fetch

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
