### PR TITLE
VACMS-4629: Prevent empty resources panel on node view.

### DIFF
--- a/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
@@ -442,10 +442,11 @@ content:
       closed_mode: summary
       autocollapse: none
       closed_mode_threshold: 0
-      add_mode: dropdown
+      add_mode: button
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
       features:
+        add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
@@ -563,6 +564,7 @@ content:
       placeholder_url: ''
       placeholder_title: ''
       linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
     type: linkit
     region: content

--- a/config/sync/core.entity_view_display.node.campaign_landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.campaign_landing_page.default.yml
@@ -263,7 +263,7 @@ content:
     region: content
   field_clp_faq_cta:
     type: entity_reference_revisions_entity_view
-    weight: 12
+    weight: 20
     label: above
     settings:
       view_mode: default
@@ -272,7 +272,7 @@ content:
     region: content
   field_clp_faq_paragraphs:
     type: entity_reference_revisions_entity_view
-    weight: 11
+    weight: 19
     label: hidden
     settings:
       view_mode: default
@@ -282,7 +282,7 @@ content:
   field_clp_resources:
     type: entity_reference_entity_view
     weight: 17
-    label: above
+    label: hidden
     settings:
       view_mode: default
       link: false
@@ -293,7 +293,7 @@ content:
     weight: 18
     label: above
     settings:
-      view_mode: default
+      view_mode: preview
       link: ''
     third_party_settings: {  }
     region: content


### PR DESCRIPTION
## Description
See #4629 

## Testing done
Visual / behat

## QA steps
- Go to `/node/add/campaign_landing_page` and create a clp, sand Downloadable resources.
- Save, and visually verify that an empty Downloadable resources panel does not appear.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
