### PR TITLE
VACMS-4484 and 4901 Send covid appointment data to lighthouse.

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php
@@ -4,11 +4,12 @@ namespace Drupal\va_gov_post_api\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\Entity\Node;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class VaGovFacilityForceQueueForm.
+ * Form to force queuing content for posting to Lighthouse.
  */
 class VaGovFacilityForceQueueForm extends FormBase {
 
@@ -18,6 +19,32 @@ class VaGovFacilityForceQueueForm extends FormBase {
    * @var string Config settings
    */
   const SETTINGS = 'va_gov_post_api.settings';
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -39,9 +66,13 @@ class VaGovFacilityForceQueueForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    // Queries to get total number of facilities for each type for reference.
+    // Queries to get total number of nodes for each type for reference.
     $health_care_local_facility = \Drupal::entityQuery('node')
       ->condition('type', 'health_care_local_facility')
+      ->execute();
+
+    $health_care_facility_service = \Drupal::entityQuery('node')
+      ->condition('type', 'health_care_local_health_service')
       ->execute();
 
     $nca_facility = \Drupal::entityQuery('node')
@@ -58,15 +89,16 @@ class VaGovFacilityForceQueueForm extends FormBase {
 
     $form['description'] = [
       '#type' => 'markup',
-      '#markup' => $this->t('This form queues ALL facilities of selected type for sync to Lighthouse.'),
+      '#markup' => $this->t('This form queues ALL items of a selected type for sync to Lighthouse.'),
     ];
 
     $form['facility_type'] = [
       '#type' => 'radios',
-      '#title' => $this->t('Facility type'),
-      '#description' => t('Select a facility type to queue.'),
+      '#title' => $this->t('Content type'),
+      '#description' => t('Select a content type to queue.'),
       '#options' => [
         'health_care_local_facility' => $this->t('VAMC facilities') . ' (' . count($health_care_local_facility) . ')',
+        'health_care_local_health_service' => ' - ' . $this->t('VAMC facility services') . ' (' . count($health_care_facility_service) . ')',
         'nca_facility' => $this->t('NCA facilities') . ' (' . count($nca_facility) . ')',
         'vba_facility' => $this->t('VBA facilities') . ' (' . count($vba_facility) . ')',
         'vet_center' => $this->t('Vet Centers') . ' (' . count($vet_center) . ')',
@@ -76,7 +108,7 @@ class VaGovFacilityForceQueueForm extends FormBase {
 
     $form['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Force-Queue Selected Facilities'),
+      '#value' => $this->t('Force-Queue Selected Items'),
     ];
 
     return $form;
@@ -86,7 +118,7 @@ class VaGovFacilityForceQueueForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $facility_type = $form_state->getValue('facility_type');
+    $bundle = $form_state->getValue('facility_type');
 
     // Enable force update.
     $this->configFactory()
@@ -95,7 +127,7 @@ class VaGovFacilityForceQueueForm extends FormBase {
       ->save();
 
     $sandbox['nids'] = \Drupal::entityQuery('node')
-      ->condition('type', $facility_type)
+      ->condition('type', $bundle)
       ->execute();
 
     if (!empty($sandbox['nids'])) {
@@ -107,41 +139,46 @@ class VaGovFacilityForceQueueForm extends FormBase {
           // Run through a batch of 50.
           $nids = array_slice($sandbox['nids'], $sandbox['current'], 50, FALSE);
 
-          $nodes = Node::loadMultiple($nids);
+          $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
           foreach ($nodes as $node) {
-            _post_api_add_facility_to_queue($node);
+            if ($bundle === 'health_care_local_health_service') {
+              _post_api_add_facility_service_to_queue($node);
+            }
+            else {
+              _post_api_add_facility_to_queue($node);
+            }
           }
 
           $sandbox['current'] = $sandbox['current'] + count($nids);
 
           $this->logger('va_gov_post_api')
             ->log(LogLevel::INFO, 'VA.gov Post API: %current of %total %type nodes queued for sync to Lighthouse.', [
-              '%type' => $facility_type,
+              '%type' => $bundle,
               '%current' => $sandbox['current'],
               '%total' => count($sandbox['nids']),
             ]);
         }
 
-        $this->messenger()->addStatus(sprintf('%d %s nodes queued for sync to Lighthouse.', count($sandbox['nids']), $facility_type));
+        $this->messenger()->addStatus(sprintf('%d %s nodes queued for sync to Lighthouse.', count($sandbox['nids']), $bundle));
       }
       catch (\Exception $e) {
         $this->logger('va_gov_post_api')
-          ->log(LogLevel::ERROR, 'VA.gov Post API: Failed queuing facilities of type %type. %e', [
-            '%type' => $facility_type,
+          ->log(LogLevel::ERROR, 'VA.gov Post API: Failed queuing items of type %type. %e', [
+            '%type' => $bundle,
             '%e' => $e->getMessage(),
           ]);
 
-        $this->messenger()->addError(sprintf('Failed queuing facilities of type %s. Check log and try again.', $facility_type));
+        $this->messenger()->addError(sprintf('Failed queuing items of type %s. Check log and try again.', $bundle));
       }
     }
     else {
       // Didn't find facilities to process. Houston, we have a problem!
       $this->logger('va_gov_post_api')
-        ->log(LogLevel::ERROR, 'VA.gov Post API: Found 0 facilities of type %type! This is a serious issue that requires immediate attention!', [
-          '%type' => $facility_type,
+        ->log(LogLevel::ERROR, 'VA.gov Post API: Found 0 items of type %type! This is a serious issue that requires immediate attention!', [
+          '%type' => $bundle,
         ]);
 
-      $this->messenger()->addError(sprintf('Found 0 facilities of type %s! This is a serious issue that requires immediate attention!', $facility_type));
+      $this->messenger()->addError(sprintf('Found 0 items of type %s! This is a serious issue that requires immediate attention!', $bundle));
     }
 
     // Disable force update.

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -172,11 +172,15 @@ class PostFacilityService {
     if (empty($this->errors) && $this->shouldPush()) {
       $service = new \stdClass();
       $service->name = $this->serviceTerm->getName();
-      $service->active = ($this->facilityService->isPublished()) ? 1 : 0;
+      $service->active = ($this->facilityService->isPublished()) ? TRUE : FALSE;
       $service->description_national = $this->serviceTerm->getDescription();
       $service->description_system = $this->systemService->get('field_body')->value;
       $service->description_facility = $this->facilityService->get('field_body')->value;
       $service->health_service_api_id = $this->serviceTerm->get('field_health_service_api_id')->value;
+      $service->appointment_leadin = $this->getAppointmentLeadin();
+      $service->appointment_phones = $this->getPhones();
+      $service->referral_required = $this->getReferralRequired();
+      $service->walk_ins_accepted = $this->getWalkInsAccepted();
 
       $payload = [
         'detailed_services' => [$service],
@@ -184,6 +188,110 @@ class PostFacilityService {
     }
 
     return $payload;
+  }
+
+  /**
+   * Assembles the phone data and returns an array of objects.
+   *
+   * @return array
+   *   An array of objects with propertied type, label, number, extension.
+   */
+  protected function getPhones() {
+    $assembled_phones = [];
+    // Grab phones from the facility service.
+    $phones = $this->facilityService->get('field_phone_numbers_paragraph')->referencedEntities();
+    if (empty($phones)) {
+      // The service has no phones, so use the facility's as fallback.
+      $phone_w_ext = $this->Facility->get('field_phone_number')->value;
+      // This field may have extension present like 555-555-1212 x 444.
+      $phone_split = explode('x', $phone_w_ext);
+      $assembledPhone = new \stdClass();
+      $assembledPhone->type = 'tel';
+      $assembledPhone->label = "Main phone";
+      $assembledPhone->number = !empty($phone_split[0]) ? trim($phone_split[0]) : NULL;
+      $assembledPhone->extension = !empty($phone_split[1]) ? trim($phone_split[1]) : NULL;
+      $assembled_phones[] = $assembledPhone;
+    }
+    else {
+      // Process the phones from the facility health service.
+      foreach ($phones as $phone) {
+        $assembledPhone = new \stdClass();
+        $assembledPhone->type = $phone->get('field_phone_number_type')->value;
+        $assembledPhone->label = $phone->get('field_phone_label')->value;
+        $assembledPhone->number = $phone->get('field_phone_number')->value;
+        $assembledPhone->extension = $phone->get('field_phone_extension')->value;
+        $assembled_phones[] = $assembledPhone;
+      }
+    }
+
+    return $assembled_phones;
+  }
+
+  /**
+   * Gets the appropriate appointment intro text.
+   *
+   * @return string
+   *   The mapped values of the field.  True, False, not applicable, NULL.
+   */
+  protected function getAppointmentLeadin() {
+    $selection = $this->facilityService->get('field_hservice_appt_intro_select')->value;
+
+    switch ($selection) {
+      case 'custom_intro_text':
+        $text = $this->facilityService->get('field_hservice_appt_leadin')->value;
+        break;
+
+      case 'no_intro_text':
+        $text = NULL;
+        break;
+
+      case 'default_intro_text':
+      default:
+        $markupField = $this->facilityService->get('field_hservices_lead_in_default');
+        $text = $markupField->getSetting('markup')['value'] ?? NULL;
+
+        break;
+    }
+
+    return $text;
+  }
+
+  /**
+   * Maps and returns the value of referral required.
+   *
+   * @return string
+   *   The mapped values of the field.  True, False, not applicable, NULL.
+   */
+  protected function getReferralRequired() {
+    $raw = $this->facilityService->get('field_referral_required')->value;
+    $map = [
+      // Value => Return.
+      // Lighthouse decided to receive these as strings since non-bool options.
+      '0' => 'false',
+      '1' => 'true',
+      'not_applicable' => 'not applicable',
+    ];
+
+    return $map[$raw] ?? NULL;
+  }
+
+  /**
+   * Maps and returns the value of walk ins accepted.
+   *
+   * @return string
+   *   The mapped values of the field.  True, False, not applicable, NULL.
+   */
+  protected function getWalkInsAccepted() {
+    $raw = $this->facilityService->get('field_walk_ins_accepted')->value;
+    $map = [
+      // Value => Return.
+      // Lighthouse decided to receive these as strings since non-bool options.
+      '0' => 'false',
+      '1' => 'true',
+      'not_applicable' => 'not applicable',
+    ];
+
+    return $map[$raw] ?? NULL;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -119,6 +119,7 @@ class PostFacilityService {
    *   Entity.
    */
   public function queueFacilityService(EntityInterface $entity) {
+    $this->errors = [];
     if (($entity->getEntityTypeId() === 'node') && ($entity->bundle() === 'health_care_local_health_service')) {
       // This is an appropriate service so begin gathering data to process.
       $this->facilityService = $entity;
@@ -194,7 +195,7 @@ class PostFacilityService {
    * Assembles the phone data and returns an array of objects.
    *
    * @return array
-   *   An array of objects with propertied type, label, number, extension.
+   *   An array of objects with properties type, label, number, extension.
    */
   protected function getPhones() {
     $assembled_phones = [];
@@ -333,6 +334,14 @@ class PostFacilityService {
 
       case ($defaultRevisionIsPublished && !$thisRevisionIsPublished):
         // Draft revision on published node, should not push, even w/bypass.
+        $push = FALSE;
+        break;
+
+      case ($this->shouldBypass()):
+        // Bypass is activated.
+        $push = TRUE;
+        break;
+
       default:
         // Anything that makes it this far should not be pushed.
         $push = FALSE;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -117,6 +117,9 @@ class PostFacilityService {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   Entity.
+   *
+   * @return int
+   *   The count of the number of items queued (1,0).
    */
   public function queueFacilityService(EntityInterface $entity) {
     $this->errors = [];
@@ -149,6 +152,7 @@ class PostFacilityService {
           // to remove the messenger as it will be too noisy.
           $message = t('The facility service data for %service_name is being sent to the Facility Locator.', ['%service_name' => $this->facilityService->getTitle()]);
           $this->messenger->addStatus($message);
+          return 1;
         }
       }
       elseif (!empty($this->errors) && ($this->isPushable())) {
@@ -156,6 +160,8 @@ class PostFacilityService {
         $errors = implode(' ', $this->errors);
         $message = sprintf('Post API: attempted to add a system  NID %d to queue, but ran into errors: %s', $this->facilityService->id(), $errors);
         $this->logger->get('va_gov_post_api')->error($message);
+
+        return 0;
       }
     }
   }

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -33,6 +33,9 @@ function post_api_entity_update(EntityInterface $entity) {
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   Entity.
+ *
+ * @return int
+ *   The count of the number of items queued (1,0).
  */
 function _post_api_add_facility_to_queue(EntityInterface $entity) {
   $facility_types = [
@@ -42,6 +45,7 @@ function _post_api_add_facility_to_queue(EntityInterface $entity) {
     'vet_center',
     'vet_center_outstation',
   ];
+  $queued_count = 0;
 
   if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $facility_types)) {
     $queue = Drupal::service('post_api.add_to_queue');
@@ -72,11 +76,13 @@ function _post_api_add_facility_to_queue(EntityInterface $entity) {
       // If bypass_data_check setting is enabled, do not dedupe, just force.
       $dedupe = !empty($config->get('bypass_data_check')) ? FALSE : TRUE;
       $queue->addToQueue($data, $dedupe);
+      return 1;
     }
     elseif (empty($facility_id)) {
       // Log error on empty Facility Locator API ID.
       $message = sprintf('Post API: attempted to add an item with NID %d to queue, but it had no Facility API ID.', $entity->id());
       Drupal::logger('va_gov_post_api')->error($message);
+      return 0;
     }
   }
 }
@@ -139,9 +145,14 @@ function _post_api_get_facility_payload(EntityInterface $entity) {
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   Entity.
+ *
+ * @return int
+ *   The count of the number of items queued (1,0).
  */
 function _post_api_add_facility_service_to_queue(EntityInterface $entity) {
   if ($entity->bundle() === 'health_care_local_health_service') {
-    Drupal::service('va_gov_post_api.queue_service_updates')->queueFacilityService($entity);
+    return Drupal::service('va_gov_post_api.queue_service_updates')->queueFacilityService($entity);
   }
-}
+
+  return 0;
+}q


### PR DESCRIPTION
## Description

See #4484 and #4901

## QA steps

As admin
### 4484 (single item push)
1. Visit here https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/admin/config/post-api/queue  The api queue should either be empty or have one item in it matching `"uid":"facility_status_vha_999999"`  which is an artifact from automated testing.  Pressing the "Process queue" button should cause the list to empty.
2. Visit https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/node/15380/edit  and save the node as draft
3.  visit https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/admin/config/post-api/queue
   - [x] validate there is nothing in the queue (saving a draft to a published node, should cause no push).
4. Visit https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/node/15380/edit and save the node as published
5.  visit https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/admin/config/post-api/queue
   - [x] validate there is one item in the queue (saving a draft to a published node, should cause no push).
   - [x] Press the "Process queue" button and validate that the queue comes back empty.
6. Visit https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/admin/reports/dblog?type%5B%5D=post_api
   - [x] validate there are no errors related to the time you processed the queue (there might be some related to attempts during automated testing.
 7. Contact lighthouse team
   - [x] validate they received and processed.   Confirmed here https://dsva.slack.com/archives/C0FQSS30V/p1617302734401300?thread_ts=1615912371.013800&cid=C0FQSS30V

```
    "detailed_services": [
      {
        "name": "COVID-19 vaccines",
        "active": true,
        "description_national": "<p>We provide COVID-19 vaccines for eligible veterans and staff. VA has a limited amount of this vaccine to start. Your VA health care team will contact you if you’re eligible to get a vaccine during this time.</p>\r\n",
        "description_system": "<h3>Care we provide at VA Iowa City health care</h3><ul><li>COVID-19 vaccines for eligible Veterans and staff</li></ul><p><a href=\"/health-care/covid-19-vaccine\">Learn more about COVID-19 vaccines at VA</a></p>",
        "description_facility": null,
        "health_service_api_id": null,
        "appointment_leadin": "Contact us to schedule, reschedule, or cancel your appointment.",
        "appointment_phones": [
          {
            "type": "tel",
            "label": "COVID-19 vaccination appointments",
            "number": "319-688-3511",
            "extension": null
          }
        ],
        "referral_required": "false",
        "walk_ins_accepted": "not applicable"
      }
    ]
```
 
###4901 Bulk Push.
 1. Visit https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/admin/config/va-gov-post-api/facility-force-queue
   - [x] validate that an option is available to queue facility services 
![image](https://user-images.githubusercontent.com/5752113/113374279-c48ea100-933a-11eb-8e75-47fcb0abd40e.png)

2. Select "VAMC facility services (4994)" and press the "Force-Queue Selected Items"
  - [x] Validate that the page returns with a long list of Covid Vaccine items listed and that over 4000 items had been processed and ~200 queued.
![image](https://user-images.githubusercontent.com/5752113/113375940-8c895d00-933e-11eb-8601-65e1ac974613.png)


3. Visit Visit here https://pr4889-7odr5cgaf5xv5bptmu1suz5d0srncuqk.ci.cms.va.gov/admin/config/post-api/queue
  - [x] Validate there are roughly 200 items in the queue.


   


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
