### PR TITLE
VACMS-4541: Prevent non admin user from editing administration.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1108,7 +1108,7 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
       foreach ($form[$target]['widget']['#options'] as $header_key => $option_header) {
         // Field_listing is an exception. It is a one level field and doesn't
         // have opt groups.
-        if ($target === 'field_listing' && !is_array($option_header) && !empty($option_header)) {
+        if (!is_array($option_header) && !empty($option_header)) {
           // If not in the allowed items array, take it out.
           if (!in_array($header_key, $allowed_options)) {
             unset($form[$target]['widget']['#options'][$header_key]);

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
@@ -5,6 +5,7 @@
  * Contains va_gov_vet_center.module.
  */
 
+use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -111,6 +112,40 @@ function va_gov_vet_center_form_alter(&$form, FormStateInterface $form_state, $f
     $form['field_facility_hours']['widget']['#after_build'][] = 'va_gov_vet_center_vc_cap_hours_hide_caption_after_build';
   }
 
+  _va_gov_vet_center_office_selection_modify($form, $form_state, $form_id);
+
+}
+
+/**
+ * Determine when and how to display office select field on node forms.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return string
+ *   The altered office select field.
+ */
+function _va_gov_vet_center_office_selection_modify(array &$form, FormStateInterface $form_state, $form_id) {
+  // Only prevent user from changing on these three edit forms.
+  $vc_target_bundles = [
+    'node_vet_center_locations_list_edit_form',
+    'node_vet_center_outstation_edit_form',
+    'node_vet_center_mobile_vet_center_edit_form',
+  ];
+  if (in_array($form_id, $vc_target_bundles)) {
+    $user_roles = \Drupal::currentUser()->getRoles();
+    $admin_roles = ['content_admin', 'administrator'];
+    // User isn't an admin, so logic is applied.
+    if (empty(array_intersect($user_roles, $admin_roles))) {
+      $form_object = $form_state->getFormObject();
+      if ($form_object instanceof ContentEntityForm) {
+        $form['field_administration']['#disabled'] = TRUE;
+      }
+    }
+  }
+  return $form;
 }
 
 /**


### PR DESCRIPTION
## Description
See #4541

## Testing done
Visual / Behat

## QA steps
- As an administrator, add Content publisher and Content creator - Vet Center roles to `vanessa.luxen@va.gov` account
- Add Create perms on main perms page for Vet Center Locations List, Vet Center Outstation and Vet Center Mobile Vet Center content types for Content creator - Vet Center role
- Assign `vanessa.luxen@va.gov` account all Vet Center sections.
- Add a VC Cap, and visually verify that all vc's are available in Owner dropdown
- Edit an existing Vet Center Outstation, and visually verify that the Owner dropdown is disabled.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
