### PR TITLE
VACMS-4604: Change default field_administration to _none

### DIFF
--- a/config/sync/field.field.node.documentation_page.field_administration.yml
+++ b/config/sync/field.field.node.documentation_page.field_administration.yml
@@ -16,9 +16,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: d2799316-7164-43e4-9f2b-090fd62141c8
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.full_width_banner_alert.field_administration.yml
+++ b/config/sync/field.field.node.full_width_banner_alert.field_administration.yml
@@ -6,8 +6,13 @@ dependencies:
     - field.storage.node.field_administration
     - node.type.full_width_banner_alert
     - taxonomy.vocabulary.administration
-  content:
-    - 'taxonomy_term:administration:87832236-1e54-4ce3-8141-8dec27c8a9a7'
+  module:
+    - entity_reference_validators
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: false
 id: node.full_width_banner_alert.field_administration
 field_name: field_administration
 entity_type: node
@@ -16,9 +21,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: 87832236-1e54-4ce3-8141-8dec27c8a9a7
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.nca_facility.field_administration.yml
+++ b/config/sync/field.field.node.nca_facility.field_administration.yml
@@ -16,9 +16,7 @@ label: Owner
 description: 'The health care system that manages this local facility.'
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: d2ebe609-99ab-4f4c-b7bb-b5fa754ef4b6
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.support_service.field_administration.yml
+++ b/config/sync/field.field.node.support_service.field_administration.yml
@@ -16,9 +16,7 @@ label: Owner
 description: 'The VA office or program that owns this content.'
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: 1d2fb45c-58b4-409b-9fef-24d15a56aba7
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.va_form.field_administration.yml
+++ b/config/sync/field.field.node.va_form.field_administration.yml
@@ -16,9 +16,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: 7d7e2e18-f91e-4af0-bca2-52a9af9a7b3e
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.vamc_operating_status_and_alerts.field_administration.yml
+++ b/config/sync/field.field.node.vamc_operating_status_and_alerts.field_administration.yml
@@ -16,9 +16,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: 87832236-1e54-4ce3-8141-8dec27c8a9a7
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.vba_facility.field_administration.yml
+++ b/config/sync/field.field.node.vba_facility.field_administration.yml
@@ -16,9 +16,7 @@ label: Owner
 description: 'The health care system that manages this local facility.'
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: 55a295b5-182a-4f4f-ba62-723bfe8df473
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.vet_center.field_administration.yml
+++ b/config/sync/field.field.node.vet_center.field_administration.yml
@@ -16,9 +16,7 @@ label: Owner
 description: 'The health care system that manages this local facility.'
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: a8b1bb11-67a8-4489-a648-6d35c04be9cb
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.vet_center_facility_health_servi.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_facility_health_servi.field_administration.yml
@@ -23,9 +23,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: a8b1bb11-67a8-4489-a648-6d35c04be9cb
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.vet_center_locations_list.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_locations_list.field_administration.yml
@@ -23,9 +23,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: a8b1bb11-67a8-4489-a648-6d35c04be9cb
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.vet_center_mobile_vet_center.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_mobile_vet_center.field_administration.yml
@@ -23,9 +23,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: a8b1bb11-67a8-4489-a648-6d35c04be9cb
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.node.vet_center_outstation.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_outstation.field_administration.yml
@@ -23,9 +23,7 @@ label: Owner
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    target_uuid: a8b1bb11-67a8-4489-a648-6d35c04be9cb
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -521,6 +521,8 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 
   _va_gov_backend_dropdown_field_access($form, $targets);
 
+  _va_gov_backend_get_owner_section_default($form);
+
   if ($form_id === 'workbench_access_assign_user') {
     $form['#submit'][] = 'va_gov_backend_workbench_assign_user_form_submit';
   }
@@ -1189,6 +1191,31 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
             }
           }
         }
+      }
+    }
+  }
+}
+
+/**
+ * For setting the default owner section in dropdown.
+ *
+ * @param array $form
+ *   The entity form.
+ */
+function _va_gov_backend_get_owner_section_default(array &$form) {
+  if (!empty($form['field_administration']['widget'])) {
+    $user = \Drupal::currentUser();
+    $admin_roles = [
+      'administrator',
+      'content_admin',
+    ];
+    $role_count = array_intersect($admin_roles, $user->getRoles());
+    // User is admin, so try to set a default section in the dropdown.
+    if ($role_count > 0) {
+      $perms_service = \Drupal::service('va_gov_user.user_perms');
+      // If only 1, make default, otherwise defaults to Select prompt.
+      if ($default = $perms_service->getDefault($user)) {
+        $form['field_administration']['widget']['#default_value'] = $default;
       }
     }
   }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1204,19 +1204,10 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
  */
 function _va_gov_backend_get_owner_section_default(array &$form) {
   if (!empty($form['field_administration']['widget'])) {
-    $user = \Drupal::currentUser();
-    $admin_roles = [
-      'administrator',
-      'content_admin',
-    ];
-    $role_count = array_intersect($admin_roles, $user->getRoles());
-    // User is admin, so try to set a default section in the dropdown.
-    if ($role_count > 0) {
-      $perms_service = \Drupal::service('va_gov_user.user_perms');
-      // If only 1, make default, otherwise defaults to Select prompt.
-      if ($default = $perms_service->getDefault($user)) {
-        $form['field_administration']['widget']['#default_value'] = $default;
-      }
+    $perms_service = \Drupal::service('va_gov_user.user_perms');
+    // If only 1, make default, otherwise defaults to Select prompt.
+    if ($default = $perms_service->getDefault(TRUE)) {
+      $form['field_administration']['widget']['#default_value'] = $default;
     }
   }
 }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -521,8 +521,6 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 
   _va_gov_backend_dropdown_field_access($form, $targets);
 
-  _va_gov_backend_set_owner_section_default($form, $form_state);
-
   if ($form_id === 'workbench_access_assign_user') {
     $form['#submit'][] = 'va_gov_backend_workbench_assign_user_form_submit';
   }
@@ -1197,6 +1195,13 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
 }
 
 /**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function va_gov_backend_form_node_form_alter(array &$form, FormStateInterface &$form_state) {
+  _va_gov_backend_set_owner_section_default($form, $form_state);
+}
+
+/**
  * For setting the default owner section in dropdown.
  *
  * @param array $form
@@ -1204,19 +1209,18 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
  * @param Drupal\Core\Form\FormStateInterface $form_state
  *   The entity form state.
  */
-function _va_gov_backend_set_owner_section_default(array &$form, FormStateInterface $form_state) {
+function _va_gov_backend_set_owner_section_default(array &$form, FormStateInterface &$form_state) {
   if (!empty($form['field_administration']['widget'])) {
-    // See if there is already a value set on the entity for this field.
-    $field_administration_value = NULL;
+    // No value set, so run default value set logic.
     if ($form_state->getFormObject() instanceof EntityFormInterface) {
-      $field_administration_value = $form_state->getFormObject()->getEntity()->field_administration->getString();
-    }
-    // There isn't a target id, so set a default using perms service.
-    if (!$field_administration_value) {
-      $perms_service = \Drupal::service('va_gov_user.user_perms');
-      // If only 1, make default, otherwise defaults to Select prompt.
-      if ($default = $perms_service->getDefault(TRUE)) {
-        $form['field_administration']['widget']['#default_value'] = $default;
+      $entity = $form_state->getFormObject()->getEntity();
+
+      if ($entity->isNew()) {
+        $perms_service = \Drupal::service('va_gov_user.user_perms');
+        // If only 1, make default, otherwise defaults to Select prompt.
+        if ($default = $perms_service->getDefault(TRUE)) {
+          $form['field_administration']['widget']['#default_value'] = $default;
+        }
       }
     }
   }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -521,7 +521,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 
   _va_gov_backend_dropdown_field_access($form, $targets);
 
-  _va_gov_backend_get_owner_section_default($form);
+  _va_gov_backend_set_owner_section_default($form);
 
   if ($form_id === 'workbench_access_assign_user') {
     $form['#submit'][] = 'va_gov_backend_workbench_assign_user_form_submit';
@@ -1202,7 +1202,7 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
  * @param array $form
  *   The entity form.
  */
-function _va_gov_backend_get_owner_section_default(array &$form) {
+function _va_gov_backend_set_owner_section_default(array &$form) {
   if (!empty($form['field_administration']['widget'])) {
     $perms_service = \Drupal::service('va_gov_user.user_perms');
     // If only 1, make default, otherwise defaults to Select prompt.

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -521,7 +521,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 
   _va_gov_backend_dropdown_field_access($form, $targets);
 
-  _va_gov_backend_set_owner_section_default($form);
+  _va_gov_backend_set_owner_section_default($form, $form_state);
 
   if ($form_id === 'workbench_access_assign_user') {
     $form['#submit'][] = 'va_gov_backend_workbench_assign_user_form_submit';
@@ -1201,13 +1201,23 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
  *
  * @param array $form
  *   The entity form.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   The entity form state.
  */
-function _va_gov_backend_set_owner_section_default(array &$form) {
+function _va_gov_backend_set_owner_section_default(array &$form, FormStateInterface $form_state) {
   if (!empty($form['field_administration']['widget'])) {
-    $perms_service = \Drupal::service('va_gov_user.user_perms');
-    // If only 1, make default, otherwise defaults to Select prompt.
-    if ($default = $perms_service->getDefault(TRUE)) {
-      $form['field_administration']['widget']['#default_value'] = $default;
+    // See if there is already a value set on the entity for this field.
+    $field_administration_value = NULL;
+    if ($form_state->getFormObject() instanceof EntityFormInterface) {
+      $field_administration_value = $form_state->getFormObject()->getEntity()->field_administration->getString();
+    }
+    // There isn't a target id, so set a default using perms service.
+    if (!$field_administration_value) {
+      $perms_service = \Drupal::service('va_gov_user.user_perms');
+      // If only 1, make default, otherwise defaults to Select prompt.
+      if ($default = $perms_service->getDefault(TRUE)) {
+        $form['field_administration']['widget']['#default_value'] = $default;
+      }
     }
   }
 }

--- a/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
@@ -77,6 +77,9 @@ class UserPermsService {
    *
    * @param \Drupal\Core\Session\AccountInterface $user
    *   User object.
+   * @param bool $admin_bypass
+   *   Determines whether we get all sections or just ones
+   *   selected on workbench access form.
    *
    * @return array
    *   Array of user sections where keys are term ids and values are term names.
@@ -84,7 +87,7 @@ class UserPermsService {
    *   NOTE: consumers of this method will have to take care of array key
    *   'administration' according to their use case.
    */
-  public function getSections(AccountInterface $user) {
+  public function getSections(AccountInterface $user, bool $admin_bypass = FALSE) {
     $sections = [];
     $entity_storage = $this->entityTypeManager->getStorage('taxonomy_term');
 
@@ -94,8 +97,8 @@ class UserPermsService {
     $query->condition('sau.user_id_target_id', $user->id());
     $query->fields('sa', ['section_id']);
     $results = $query->execute()->fetchCol();
-
-    if (($key = array_search('administration', $results)) !== FALSE || $user->hasPermission('bypass workbench access')) {
+    $key = array_search('administration', $results);
+    if ((!$admin_bypass) && ($key !== FALSE || $user->hasPermission('bypass workbench access'))) {
       unset($results[$key]);
       $tree = $entity_storage->loadTree('administration');
       foreach ($tree as $term) {
@@ -109,6 +112,24 @@ class UserPermsService {
     $this->addSections($sections, $terms);
 
     return $sections;
+  }
+
+  /**
+   * Get the user's default workbench access section id.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   User object.
+   *
+   * @return mixed
+   *   Returns default user section key or NULL.
+   */
+  public function getDefault(AccountInterface $user) {
+    $user_sections = $this->getSections($user, TRUE);
+    // If only 1 found, return it.
+    if (count($user_sections) === 1) {
+      return key($user_sections);
+    }
+    return NULL;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
@@ -121,7 +121,7 @@ class UserPermsService {
    *   Determines whether or not we return all options (admin default) or
    *   restrict to items selected on workbench access form.
    *
-   * @return mixed
+   * @return int|null
    *   Returns default user section key or NULL.
    */
   public function getDefault(bool $admin_bypass = FALSE) {

--- a/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
@@ -117,14 +117,15 @@ class UserPermsService {
   /**
    * Get the user's default workbench access section id.
    *
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   User object.
+   * @param bool $admin_bypass
+   *   Determines whether or not we return all options (admin default) or
+   *   restrict to items selected on workbench access form.
    *
    * @return mixed
    *   Returns default user section key or NULL.
    */
-  public function getDefault(AccountInterface $user) {
-    $user_sections = $this->getSections($user, TRUE);
+  public function getDefault(bool $admin_bypass = FALSE) {
+    $user_sections = $this->getSections($this->currentUser, $admin_bypass);
     // If only 1 found, return it.
     if (count($user_sections) === 1) {
       return key($user_sections);

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -155,7 +155,7 @@ Feature: CMS Users may effectively create & edit content
     And I should see "City" in the "#edit-field-address-0" element
     And I should see "State" in the "#edit-field-address-0" element
 
-@content_editing
+@content_editing @et
   Scenario: Log in and confirm that System-wide alerts can be created and edited
     When I am logged in as a user with the "content_admin" role
 
@@ -163,6 +163,7 @@ Feature: CMS Users may effectively create & edit content
     Then I am at "node/add/vamc_operating_status_and_alerts"
     And I press "Add new banner alert"
     And I select "Information" from "Alert type"
+    And I select "Veterans Affairs" from "edit-field-administration"
     And I fill in "Title" with "BeHat Alert title"
     And I fill in "Alert body" with "BeHat Alert body"
     And I press "Save draft and continue editing"

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -155,7 +155,7 @@ Feature: CMS Users may effectively create & edit content
     And I should see "City" in the "#edit-field-address-0" element
     And I should see "State" in the "#edit-field-address-0" element
 
-@content_editing @et
+@content_editing
   Scenario: Log in and confirm that System-wide alerts can be created and edited
     When I am logged in as a user with the "content_admin" role
 

--- a/tests/behavioral/cypress/integration/common/i_create_a_node.js
+++ b/tests/behavioral/cypress/integration/common/i_create_a_node.js
@@ -7,6 +7,7 @@ const creators = {
     cy.scrollTo('top');
     cy.findAllByLabelText('Page title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
     cy.findAllByLabelText('Page introduction').type(faker.lorem.sentence(), { force: true });
+    cy.findAllByLabelText('Owner').select('Veterans Affairs', { force: true });
     return cy.get('form.node-form').find('input#edit-submit').click();
   },
   office: () => {


### PR DESCRIPTION
## Description
See #4604 
##AC's  
- [x] Editors with only one workbench access section should see their section pre-populated in field_administration
- [x] Editors with more than one workbench access section should be forced to choose

## Testing done
Visual

## QA steps
- [x] As an administrator, go to `user/34/roles` and assign the `Content admin` role
- [x] Login as user 34 (Ryan.Stubblebine@va.gov), and go to any node form add page.
- [x] Visually verify that the `field_administration` field is set to `Pittsburgh Health Care`
- [x] Change the `field_administration` value, complete the form and save.
- [ ] Visit the edit page for the node you just saved, and visually verify the `field_administration` you set appears as the default value.
- [ ] As an administrator, go to `user/34/workbench_access` and assign at least one more additional section.
- [ ]  Login as user 34 (Ryan.Stubblebine@va.gov), and go to any node form add page.
- [x] Visually verify that the `field_administration` field is set to `Select a value`
- [ ] Change the `field_administration` value, complete the form and save.
- [x] Visit the edit page for the node you just saved, and visually verify the `field_administration` value you set appears as the default value.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
