### PR TITLE
VACMS-4847: Set default menu item to --none--

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -669,6 +669,7 @@ function _va_gov_backend_alter_parent_menus(array $form, FormStateInterface $for
   if (!empty($form['menu']['link']['menu_parent']['#options'])) {
     array_unshift($form['menu']['link']['menu_parent']['#options'], '- Select a value -');
     unset($form['menu']['link']['menu_parent']['#value']);
+    $form['menu']['link']['menu_parent']['#required'] = TRUE;
     $form['menu']['link']['menu_parent']['#default_value'] = '- Select a value-';
     $form['#validate'][] = '_va_gov_backend_parent_menu_selected_validation';
   }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -412,14 +412,14 @@ function _va_gov_backend_allowed_formats_remove_textarea_help(array $form_elemen
 }
 
 /**
- * Sets the owner field to a select option prompt.
+ * Sets the parent menu to a select option prompt.
  *
  * @param array $form
  *   The exposed widget form array.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
  */
-function _va_gov_backend_set_default_option_on_new_nodes(array &$form, FormStateInterface $form_state) {
+function _va_gov_backend_remove_menu_parent_on_new_nodes(array &$form, FormStateInterface $form_state) {
   // Don't set parent menu item on new nodes.
   $form_object = $form_state->getFormObject();
   $form_operation = ($form_state->getFormObject() instanceof EntityFormInterface) ? $form_object->getOperation() : NULL;
@@ -454,8 +454,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
   // Require message on revision.
   _va_gov_vet_center_require_revision_message($form, $form_state, $form_id);
 
-  // Default owner field element handling.
-  _va_gov_backend_set_default_option_on_new_nodes($form, $form_state);
+  _va_gov_backend_remove_menu_parent_on_new_nodes($form, $form_state);
 
   // Don't allow wysiwyg on core taxonomy description field.
   if ($form_id === 'taxonomy_term_health_care_service_taxonomy_form') {
@@ -669,7 +668,6 @@ function _va_gov_backend_alter_parent_menus(array $form, FormStateInterface $for
   if (!empty($form['menu']['link']['menu_parent']['#options'])) {
     array_unshift($form['menu']['link']['menu_parent']['#options'], '- Select a value -');
     unset($form['menu']['link']['menu_parent']['#value']);
-    $form['menu']['link']['menu_parent']['#required'] = TRUE;
     $form['menu']['link']['menu_parent']['#default_value'] = '- Select a value-';
     $form['#validate'][] = '_va_gov_backend_parent_menu_selected_validation';
   }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -667,9 +667,9 @@ function _va_gov_backend_validate_required_revision_message(array $form, FormSta
  */
 function _va_gov_backend_alter_parent_menus(array $form, FormStateInterface $form_state) {
   if (!empty($form['menu']['link']['menu_parent']['#options'])) {
-    array_unshift($form['menu']['link']['menu_parent']['#options'], '---none---');
+    array_unshift($form['menu']['link']['menu_parent']['#options'], '- Select a value -');
     unset($form['menu']['link']['menu_parent']['#value']);
-    $form['menu']['link']['menu_parent']['#default_value'] = '---none---';
+    $form['menu']['link']['menu_parent']['#default_value'] = '- Select a value-';
     $form['#validate'][] = '_va_gov_backend_parent_menu_selected_validation';
   }
   return $form;

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -412,6 +412,23 @@ function _va_gov_backend_allowed_formats_remove_textarea_help(array $form_elemen
 }
 
 /**
+ * Sets the owner field to a select option prompt.
+ *
+ * @param array $form
+ *   The exposed widget form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function _va_gov_backend_set_default_option_on_new_nodes(array &$form, FormStateInterface $form_state) {
+  // Don't set parent menu item on new nodes.
+  $form_object = $form_state->getFormObject();
+  $form_operation = ($form_state->getFormObject() instanceof EntityFormInterface) ? $form_object->getOperation() : NULL;
+  if ($form_operation === 'default' && $form_object->getEntity()->getEntityType()->id() === 'node') {
+    $form['#after_build'][] = '_va_gov_backend_alter_parent_menus';
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -437,10 +454,8 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
   // Require message on revision.
   _va_gov_vet_center_require_revision_message($form, $form_state, $form_id);
 
-  // Don't set parent menu item on new events.
-  if ($form_id === 'node_event_form') {
-    $form['#after_build'][] = '_va_gov_backend_alter_parent_menus';
-  }
+  // Default owner field element handling.
+  _va_gov_backend_set_default_option_on_new_nodes($form, $form_state);
 
   // Don't allow wysiwyg on core taxonomy description field.
   if ($form_id === 'taxonomy_term_health_care_service_taxonomy_form') {
@@ -651,10 +666,12 @@ function _va_gov_backend_validate_required_revision_message(array $form, FormSta
  *   The altered form.
  */
 function _va_gov_backend_alter_parent_menus(array $form, FormStateInterface $form_state) {
-  array_unshift($form['menu']['link']['menu_parent']['#options'], '---none---');
-  unset($form['menu']['link']['menu_parent']['#value']);
-  $form['menu']['link']['menu_parent']['#default_value'] = '---none---';
-  $form['#validate'][] = '_va_gov_backend_parent_menu_selected_validation';
+  if (!empty($form['menu']['link']['menu_parent']['#options'])) {
+    array_unshift($form['menu']['link']['menu_parent']['#options'], '---none---');
+    unset($form['menu']['link']['menu_parent']['#value']);
+    $form['menu']['link']['menu_parent']['#default_value'] = '---none---';
+    $form['#validate'][] = '_va_gov_backend_parent_menu_selected_validation';
+  }
   return $form;
 }
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -433,8 +433,15 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
       '#markup' => t('Add a photo of the facility'),
     ];
   }
+
   // Require message on revision.
   _va_gov_vet_center_require_revision_message($form, $form_state, $form_id);
+
+  // Don't set parent menu item on new events.
+  if ($form_id === 'node_event_form') {
+    $form['#after_build'][] = '_va_gov_backend_alter_parent_menus';
+  }
+
   // Don't allow wysiwyg on core taxonomy description field.
   if ($form_id === 'taxonomy_term_health_care_service_taxonomy_form') {
     // We need to manipulate the html prior to after_build.
@@ -629,6 +636,39 @@ function _va_gov_backend_validate_required_revision_message(array $form, FormSta
   // Add revision log validation.
   if ($form_state->isValueEmpty(['revision_log', '0', 'value'])) {
     $form_state->setErrorByName('revision_log][0][value', t('Revision log message is required'));
+  }
+}
+
+/**
+ * Returns form with empty option set for parent menu item.
+ *
+ * @param array $form
+ *   The node form array.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   Instance of FormStateInterface.
+ *
+ * @return array
+ *   The altered form.
+ */
+function _va_gov_backend_alter_parent_menus(array $form, FormStateInterface $form_state) {
+  array_unshift($form['menu']['link']['menu_parent']['#options'], '---none---');
+  unset($form['menu']['link']['menu_parent']['#value']);
+  $form['menu']['link']['menu_parent']['#default_value'] = '---none---';
+  $form['#validate'][] = '_va_gov_backend_parent_menu_selected_validation';
+  return $form;
+}
+
+/**
+ * Validates that menu parent item is selected.
+ *
+ * @param array $form
+ *   The node form array.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   Instance of FormStateInterface.
+ */
+function _va_gov_backend_parent_menu_selected_validation(array $form, FormStateInterface $form_state) {
+  if ($form_state->getValue('menu')['menu_parent'] === '0') {
+    $form_state->setErrorByName('menu][menu_parent', t('Menu parent item cannot be empty.'));
   }
 }
 


### PR DESCRIPTION
## Description
See #4847

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/113428537-f63c5200-93a4-11eb-880c-53696f6fd931.png)

## QA steps
- As an administrator, go to `node/add/event` and visually verify that parent menu item is set to `---none---`
- Set parent to something else, and confirm form saves as expected.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
