### PR TITLE
VACMS-4972: Vet-Center-Office-Hours-Opt-In

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -416,11 +416,6 @@ function _va_gov_backend_allowed_formats_remove_textarea_help(array $form_elemen
  */
 function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
-  // We want to trigger the office hours field on/off.
-  if (($form_id === 'node_vet_center_cap_edit_form') || ($form_id === 'node_vet_center_cap_form')) {
-    _va_gov_backend_cap_hours_opt_in($form);
-  }
-
   // List of forms to modify media library widget help text.
   $media_widget_content_form_ids = [
     'node_vet_center_cap_form',
@@ -635,23 +630,6 @@ function _va_gov_backend_validate_required_revision_message(array $form, FormSta
   // Add revision log validation.
   if ($form_state->isValueEmpty(['revision_log', '0', 'value'])) {
     $form_state->setErrorByName('revision_log][0][value', t('Revision log message is required'));
-
-/**  
- * Determines whether or not user can edit community access point office hours.
- *
- * @param array $form
- *   The node form array.
- */
-function _va_gov_backend_cap_hours_opt_in(array &$form) {
-  $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node instanceof NodeInterface) {
-    if (($node->hasField('field_office_hours')) && ($node->hasField('field_vetcenter_cap_hours_opt_in'))) {
-      $form['field_office_hours']['#states'] = [
-        'visible' => [
-          ':input[name="field_vetcenter_cap_hours_opt_in"]' => ['value' => '1'],
-        ],
-      ];
-    }
   }
 }
 
@@ -743,14 +721,6 @@ function va_gov_backend_entity_view_alter(array &$build, EntityInterface $entity
     }
   };
 
-  // Check if correct content bundle and unset office hours if opted out.
-  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'vet_center_cap') {
-    $office_hours_opt_in_select = $entity->field_vetcenter_cap_hours_opt_in->value;
-    if ($office_hours_opt_in_select === '0') {
-      unset($entity->field_office_hours);
-      unset($build['field_office_hours']);
-    }
-  };
 }
 
 /**

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -707,7 +707,6 @@ function va_gov_backend_entity_view_alter(array &$build, EntityInterface $entity
         'field_tags',
       ];
       foreach ($standalone_only_fields as $standalone_only_field) {
-        unset($entity->$standalone_only_field);
         unset($build[$standalone_only_field]);
       }
     }
@@ -716,7 +715,6 @@ function va_gov_backend_entity_view_alter(array &$build, EntityInterface $entity
   // Check if correct content bundle and unset fields.
   if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'health_care_local_health_service') {
     foreach (_va_gov_backend_unset_fields($entity) as $appt_intro_field) {
-      unset($entity->$appt_intro_field);
       unset($build[$appt_intro_field]);
     }
   };

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -415,6 +415,12 @@ function _va_gov_backend_allowed_formats_remove_textarea_help(array $form_elemen
  * Implements hook_form_alter().
  */
 function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // We want to trigger the office hours field on/off.
+  if (($form_id === 'node_vet_center_cap_edit_form') || ($form_id === 'node_vet_center_cap_form')) {
+    _va_gov_backend_cap_hours_opt_in($form);
+  }
+
   // List of forms to modify media library widget help text.
   $media_widget_content_form_ids = [
     'node_vet_center_cap_form',
@@ -629,6 +635,23 @@ function _va_gov_backend_validate_required_revision_message(array $form, FormSta
   // Add revision log validation.
   if ($form_state->isValueEmpty(['revision_log', '0', 'value'])) {
     $form_state->setErrorByName('revision_log][0][value', t('Revision log message is required'));
+
+/**  
+ * Determines whether or not user can edit community access point office hours.
+ *
+ * @param array $form
+ *   The node form array.
+ */
+function _va_gov_backend_cap_hours_opt_in(array &$form) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof NodeInterface) {
+    if (($node->hasField('field_office_hours')) && ($node->hasField('field_vetcenter_cap_hours_opt_in'))) {
+      $form['field_office_hours']['#states'] = [
+        'visible' => [
+          ':input[name="field_vetcenter_cap_hours_opt_in"]' => ['value' => '1'],
+        ],
+      ];
+    }
   }
 }
 
@@ -717,6 +740,15 @@ function va_gov_backend_entity_view_alter(array &$build, EntityInterface $entity
     foreach (_va_gov_backend_unset_fields($entity) as $appt_intro_field) {
       unset($entity->$appt_intro_field);
       unset($build[$appt_intro_field]);
+    }
+  };
+
+  // Check if correct content bundle and unset office hours if opted out.
+  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'vet_center_cap') {
+    $office_hours_opt_in_select = $entity->field_vetcenter_cap_hours_opt_in->value;
+    if ($office_hours_opt_in_select === '0') {
+      unset($entity->field_office_hours);
+      unset($build['field_office_hours']);
     }
   };
 }

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
@@ -111,6 +111,59 @@ function va_gov_vet_center_form_alter(&$form, FormStateInterface $form_state, $f
     $form['field_facility_hours']['widget']['#after_build'][] = 'va_gov_vet_center_vc_cap_hours_hide_caption_after_build';
   }
 
+  // We want to trigger the office hours field on/off.
+  _va_gov_vet_center_cap_hours_opt_in($form, $form_state, $form_id);
+
+}
+
+/**
+ * Determine whether or not user can edit community access point office hours.
+ *
+ * @param array $form
+ *   The node form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ * @param string $form_id
+ *   The form id.
+ */
+function _va_gov_vet_center_cap_hours_opt_in(array &$form, FormStateInterface $form_state, $form_id) {
+
+  if (($form_id === 'node_vet_center_cap_edit_form') || ($form_id === 'node_vet_center_cap_form')) {
+
+    $node = $form_state->getformObject()->getEntity();
+
+    if (($node->hasField('field_office_hours')) && ($node->hasField('field_vetcenter_cap_hours_opt_in'))) {
+      $form['field_office_hours']['#states'] = [
+        'visible' => [
+          ':input[name="field_vetcenter_cap_hours_opt_in"]' => ['value' => '1'],
+        ],
+      ];
+    }
+
+  }
+}
+
+/**
+ * Implements hook_entity_view_alter().
+ */
+function va_gov_vet_center_entity_view_alter(array &$build, EntityInterface $entity) {
+
+  // Toggles the office hours field based on trigger field.
+  _va_gov_vet_center_unset_cap_hours($build, $entity);
+}
+
+/**
+ * Unset field_office_hours on proofing page based on trigger field.
+ */
+function _va_gov_vet_center_unset_cap_hours(&$build, $entity) {
+
+  // Check if correct content bundle and unset office hours if opted out.
+  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'vet_center_cap') {
+    $office_hours_opt_in_select = $entity->field_vetcenter_cap_hours_opt_in->value;
+    if ($office_hours_opt_in_select === '0') {
+      unset($build['field_office_hours']);
+    }
+  };
 }
 
 /**

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
@@ -111,7 +111,6 @@ function va_gov_vet_center_form_alter(&$form, FormStateInterface $form_state, $f
     $form['field_facility_hours']['widget']['#after_build'][] = 'va_gov_vet_center_vc_cap_hours_hide_caption_after_build';
   }
 
-  // We want to trigger the office hours field on/off.
   _va_gov_vet_center_cap_hours_opt_in($form, $form_state, $form_id);
 
 }
@@ -120,7 +119,7 @@ function va_gov_vet_center_form_alter(&$form, FormStateInterface $form_state, $f
  * Determine whether or not user can edit community access point office hours.
  *
  * @param array $form
- *   The node form array.
+ *   The form array.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
  * @param string $form_id
@@ -132,6 +131,8 @@ function _va_gov_vet_center_cap_hours_opt_in(array &$form, FormStateInterface $f
 
     $node = $form_state->getformObject()->getEntity();
 
+    // We want to implement the states logic only if the field_office_hours
+    // and the field_vetcenter_cap_hours_opt_in are available.
     if (($node->hasField('field_office_hours')) && ($node->hasField('field_vetcenter_cap_hours_opt_in'))) {
       $form['field_office_hours']['#states'] = [
         'visible' => [
@@ -148,14 +149,18 @@ function _va_gov_vet_center_cap_hours_opt_in(array &$form, FormStateInterface $f
  */
 function va_gov_vet_center_entity_view_alter(array &$build, EntityInterface $entity) {
 
-  // Toggles the office hours field based on trigger field.
   _va_gov_vet_center_unset_cap_hours($build, $entity);
 }
 
 /**
  * Unset field_office_hours on proofing page based on trigger field.
+ *
+ * @param array &$build
+ *   A renderable array representing the entity content.
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity object being rendered.
  */
-function _va_gov_vet_center_unset_cap_hours(&$build, $entity) {
+function _va_gov_vet_center_unset_cap_hours(array &$build, Drupal\Core\Entity\EntityInterface $entity) {
 
   // Check if correct content bundle and unset office hours if opted out.
   if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'vet_center_cap') {

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
@@ -160,7 +160,7 @@ function va_gov_vet_center_entity_view_alter(array &$build, EntityInterface $ent
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The entity object being rendered.
  */
-function _va_gov_vet_center_unset_cap_hours(array &$build, Drupal\Core\Entity\EntityInterface $entity) {
+function _va_gov_vet_center_unset_cap_hours(array &$build, EntityInterface $entity) {
 
   // Check if correct content bundle and unset office hours if opted out.
   if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'vet_center_cap') {


### PR DESCRIPTION
…n another field, added logic to unset the build of the office hours field on proofing page if the choice was to hide the office hours field

## Description

See _issueid_. #4972 

## Testing done


## Screenshots


## QA steps

- Login to preview environment
- Navigate to an existing vet center community access point form:
  - `/node/16626/edit`
  - `/node/16624/edit`
  - `/node/16625/edit`
- [x] Confirm that you can toggle the following field and that the Hours field can toggle on and off like the images below:
![image](https://user-images.githubusercontent.com/56809719/114462819-92d6cf00-9bb1-11eb-9478-f498d3017ded.png)
![image](https://user-images.githubusercontent.com/56809719/114462846-9ff3be00-9bb1-11eb-8c92-3ae593d1e692.png)
- [x] Confirm that saving with the first radio button (Veterans should call main Vet Center for hours) doesn't display the office hours on proofing page.
- [x] Confirm that saving with the second radio button (Provide CAP hours online) does display the office hours on proofing page.

## Additional Regression Testing **

### Q_A Form
- Navigate here: node/16585/edit
- [x] Confirm that if you uncheck this field: `Enable standalone Resources and support page for this Q&A.` and select save, on the proofing page all the fields within the Q&A Page Components is NOT visible.
- [x] Confirm re-selecting the field and saving the node now shows all the fields on the proofing page. 

### VAMC Facility Health Service Form
- Navigate here: `/node/add/health_care_local_health_service`
- Fill out required fields
- Leave Appointment Intro Text selection as : `Use default appointments intro text`
- [x] Confirm you can see the default intro text below the selections as   _Contact us to schedule, reschedule, or cancel your
  appointment. If a referral is required, you’ll need to
  contact your primary care provider first._
- Save

- Confirm the following on the preview:
- [x] APPOINTMENT INTRO TEXT
Use default appointments intro text
- [x] APPOINTMENT LEAD-IN DEFAULT
  Contact us to schedule, reschedule, or cancel your
  appointment. If a referral is required, you’ll need to
  contact your primary care provider first.

- Navigate here: `/node/add/health_care_local_health_service`
- Fill out required fields
- Select Appointment Intro Text selection as : `Customize appointments intro text`
- [x] Confirm you can see an empty input field
- Save without filling the field out.
- Confirm the following error message on save: `1 error has been found: Appointment lead-in text`
- Fill out of the empty field: `test`
- Save

- Confirm the following on the preview:
- [x] APPOINTMENT INTRO TEXT
Customize appointments intro text
- [x] APPOINTMENT LEAD-IN TEXT
test

- Navigate here: `/node/add/health_care_local_health_service`
- Fill out required fields
- Change Appointment Intro Text selection as : `No appointments intro text`
- [x] Confirm that the default appt intro text hides and that you cannot see the following text: _Contact us to schedule, reschedule, or cancel your
  appointment. If a referral is required, you’ll need to
  contact your primary care provider first._
- Save

- Confirm the following on the preview:
- [x] APPOINTMENT INTRO TEXT
No appointments intro text

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
