### PR TITLE
VACMS-5081: Refine tests taskfile.

### DIFF
--- a/tests.yml
+++ b/tests.yml
@@ -14,6 +14,7 @@ tasks:
     cmds:
       - |
         cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
           result="\$(composer va:test:accessibility)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
@@ -30,6 +31,7 @@ tasks:
     cmds:
       - |
         cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
           cd tests/behat
           result="\$(behat --colors)"
           exit_code=$?
@@ -47,6 +49,7 @@ tasks:
     cmds:
       - |
         cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
           result="\$(composer va:test:behavioral)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
@@ -63,6 +66,7 @@ tasks:
     cmds:
       - |
         cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
           result="{{ .TASK }}:<br/><br/>\$(./tests/scripts/check-cer.sh)"
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -79,8 +83,8 @@ tasks:
     cmds:
       - |
         cat <<EOF | bash
-          exit_code=0
           : "${SKIP_REPORTING:=0}"
+          exit_code=0
           result="{{ .TASK }}<br/><br/>"
           trap '{ (( exit_code |=\$? )); result+="\$output<br/>"; }' ERR
           output=\$(find docroot/modules/custom docroot/themes -name '*.inc' -print0 | xargs -0 -n1 php -l 2>&1)
@@ -137,6 +141,7 @@ tasks:
     cmds:
       - |
         cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
           lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --severity=2)
           line_count=\$(grep -c "^.+$" <<< $lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
@@ -154,6 +159,7 @@ tasks:
     cmds:
       - |
         cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
           result="\$(./tests/scripts/build-web.sh)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then

--- a/tests.yml
+++ b/tests.yml
@@ -144,7 +144,7 @@ tasks:
         cat <<EOF | bash
           : "${SKIP_REPORTING:=0}"
           lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --severity=2)
-          line_count=\$(grep -c "^.+$" <<< $lines)
+          line_count=\$(grep -c "^.+$" <<< \$lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$line_count" -eq 0 ]; then
               github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success: No Drupal status requirement errors were found.'

--- a/tests.yml
+++ b/tests.yml
@@ -13,58 +13,66 @@ tasks:
     desc: accessibility test with cypress-axe for 508 compliance
     cmds:
       - |
-        result="$(composer va:test:accessibility)"
-        exit_code=$?
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ "$exit_code" -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+        cat <<EOF | bash
+          result="\$(composer va:test:accessibility)"
+          exit_code=\$?
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$exit_code" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+            fi
           fi
-        fi
+        EOF
 
   va/tests/behat:
     desc: Behat Tests
     cmds:
       - |
-        cd tests/behat
-        result="$(behat --colors)"
-        exit_code=$?
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ "$exit_code" -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+        cat <<EOF | bash
+          cd tests/behat
+          result="\$(behat --colors)"
+          exit_code=$?
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$exit_code" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+            fi
           fi
-        fi
+        EOF
 
   va/tests/behavioral:
     desc: behavioral tests with cypress
     cmds:
       - |
-        result="$(composer va:test:behavioral)"
-        exit_code=$?
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ "$exit_code" -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+        cat <<EOF | bash
+          result="\$(composer va:test:behavioral)"
+          exit_code=\$?
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$exit_code" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+            fi
           fi
-        fi
+        EOF
 
   va/tests/check-cer:
     desc: Ensure cer fields exist
     cmds:
       - |
-        result="{{ .TASK }}:<br/><br/>$(./tests/scripts/check-cer.sh)"
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ "$exit_code" -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
-            [ -z "${GITHUB_COMMENT_TYPE}" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="${result}"
+        cat <<EOF | bash
+          result="{{ .TASK }}:<br/><br/>\$(./tests/scripts/check-cer.sh)"
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$exit_code" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+              [ -z "\${GITHUB_COMMENT_TYPE}" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="\${result}"
+            fi
           fi
-        fi
+        EOF
 
   va/tests/phplint:
     desc: PHP Lint
@@ -94,58 +102,68 @@ tasks:
     desc: PHPUnit
     cmds:
       - |
-        result="$(phpunit --exclude-group disabled tests/phpunit --colors=always)"
-        exit_code=$?
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ "$exit_code" -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+        cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
+          result="\$(phpunit --exclude-group disabled tests/phpunit --colors=always)"
+          exit_code=\$?
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$exit_code" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+            fi
           fi
-        fi
+        EOF
 
   va/tests/revision-log:
     desc: Ensure revision log field is present
     cmds:
       - |
-        result="$(./tests/scripts/check-revision-logs.sh)"
-        exit_code=$?
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ "$exit_code" -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+        cat <<EOF | bash
+          : "${SKIP_REPORTING:=0}"
+          result="\$(./tests/scripts/check-revision-logs.sh)"
+          exit_code=\$?
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$exit_code" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+            fi
           fi
-        fi
+        EOF
 
   va/tests/status-error:
     desc: Check for Drupal status errors
     cmds:
       - |
-        lines=$(drush $DRUSH_ALIAS core-requirements --format=list --severity=2)
-        line_count=$(grep -c "^.+$" <<< $lines)
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ $line_count -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success: No Drupal status requirement errors were found.'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description="Failed: ${line_count} Drupal status requirements found."
-            [ -z "${GITHUB_COMMENT_TYPE}" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="{{ .TASK }}:<br /><br />${lines}"
+        cat <<EOF | bash
+          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --severity=2)
+          line_count=\$(grep -c "^.+$" <<< $lines)
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$line_count" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success: No Drupal status requirement errors were found.'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description="Failed: \${line_count} Drupal status requirements found."
+              [ -z "\${GITHUB_COMMENT_TYPE}" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="{{ .TASK }}:<br /><br />\${lines}"
+            fi
           fi
-        fi
+        EOF
 
   va/web/build:
     desc: Build VA.gov Front-end
     cmds:
       - |
-        result="$(./tests/scripts/build-web.sh)"
-        exit_code=$?
-        if [ "$SKIP_REPORTING" -ne 1 ]; then
-          if [ "$exit_code" -eq 0 ]; then
-            github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-          else
-            github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+        cat <<EOF | bash
+          result="\$(./tests/scripts/build-web.sh)"
+          exit_code=\$?
+          if [ "$SKIP_REPORTING" -ne 1 ]; then
+            if [ "\$exit_code" -eq 0 ]; then
+              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
+            else
+              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
+            fi
           fi
-        fi
+        EOF
 
   set-check-status:
     cmds:

--- a/tests.yml
+++ b/tests.yml
@@ -68,6 +68,7 @@ tasks:
         cat <<EOF | bash
           : "${SKIP_REPORTING:=0}"
           result="{{ .TASK }}:<br/><br/>\$(./tests/scripts/check-cer.sh)"
+          exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
               github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'


### PR DESCRIPTION
## Description

See #5081.

The Task task runner does not obey the expected rules for evaluating exit codes, which means the task runner can improperly interpret failed test tasks as having executed successfully.  This is a bad thing.

This PR rewrites all of the tasks in the `tests.yml` file as HEREDOCs and executes them in Bash so that the exit code will be properly interpreted and failed tests will be correctly recognized.

## Testing done

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
