### PR TITLE
VACMS-5250: Standardize Section labels.

### DIFF
--- a/config/sync/core.entity_form_display.block_content.alert.default.yml
+++ b/config/sync/core.entity_form_display.block_content.alert.default.yml
@@ -48,7 +48,7 @@ third_party_settings:
         id: ''
         classes: ''
         required_fields: false
-      label: Governance
+      label: VA.gov Section
       region: content
     group_behaviour_and_placement:
       children:

--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -25,7 +25,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Governance
+      label: VA.gov Section
       region: content
 _core:
   default_config_hash: xFJUl0MccoGPEv1eb_I_XnxzjqvZ8M5HA1G3PBtv9IE

--- a/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -26,7 +26,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Governance
+      label: VA.gov Section
       region: content
 _core:
   default_config_hash: xFJUl0MccoGPEv1eb_I_XnxzjqvZ8M5HA1G3PBtv9IE

--- a/config/sync/core.entity_form_display.media.document_external.default.yml
+++ b/config/sync/core.entity_form_display.media.document_external.default.yml
@@ -28,7 +28,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
     group_edi:
       children: {  }
       parent_name: ''

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -28,7 +28,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Governance
+      label: VA.gov Section
       region: content
 _core:
   default_config_hash: kyoAHlZTGIuGTaQuBblGBk8EhfnVKOl19_0j5WbpQqM

--- a/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -30,7 +30,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Governance
+      label: VA.gov Section
       region: content
 _core:
   default_config_hash: kyoAHlZTGIuGTaQuBblGBk8EhfnVKOl19_0j5WbpQqM

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Governance
+      label: VA.gov Section
       region: content
 _core:
   default_config_hash: OUea_b_jf81XjPvIY9J8KrRUckqz2APuLv4bkxYfdT4

--- a/config/sync/core.entity_form_display.media.video.media_library.yml
+++ b/config/sync/core.entity_form_display.media.video.media_library.yml
@@ -31,7 +31,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Governance
+      label: VA.gov Section
       region: content
 _core:
   default_config_hash: OUea_b_jf81XjPvIY9J8KrRUckqz2APuLv4bkxYfdT4

--- a/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
@@ -63,7 +63,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
@@ -70,7 +70,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
     group_editorial_workflow:
       children:
         - moderation_state

--- a/config/sync/core.entity_form_display.node.centralized_content.default.yml
+++ b/config/sync/core.entity_form_display.node.centralized_content.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 10
-      label: Governance
+      label: VA.gov Section
     group_editorial_workflow:
       children:
         - moderation_state

--- a/config/sync/core.entity_form_display.node.checklist.default.yml
+++ b/config/sync/core.entity_form_display.node.checklist.default.yml
@@ -69,7 +69,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_include_alert:
       children:

--- a/config/sync/core.entity_form_display.node.documentation_page.default.yml
+++ b/config/sync/core.entity_form_display.node.documentation_page.default.yml
@@ -44,7 +44,7 @@ third_party_settings:
         required_fields: '1'
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
 id: node.documentation_page.default
 targetEntityType: node

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -48,7 +48,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_location:
       children:

--- a/config/sync/core.entity_form_display.node.event_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.event_listing.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.faq_multiple_q_a.default.yml
+++ b/config/sync/core.entity_form_display.node.faq_multiple_q_a.default.yml
@@ -56,7 +56,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -35,7 +35,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_edi:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -48,7 +48,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
@@ -40,7 +40,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: hidden
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -43,7 +43,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_appointments:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.inline_entity_form.yml
@@ -36,7 +36,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: hidden
 id: node.health_care_local_health_service.inline_entity_form
 targetEntityType: node

--- a/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
@@ -38,7 +38,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -45,7 +45,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.health_services_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.health_services_listing.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_right_rail:
       children:

--- a/config/sync/core.entity_form_display.node.leadership_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.leadership_listing.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.locations_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.locations_listing.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.media_list_images.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_images.default.yml
@@ -83,7 +83,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_categories:
       children:

--- a/config/sync/core.entity_form_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_videos.default.yml
@@ -69,7 +69,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.nca_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.nca_facility.default.yml
@@ -57,7 +57,7 @@ third_party_settings:
         open: 1
         required_fields: 1
         weight: '-10'
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.news_story.default.yml
+++ b/config/sync/core.entity_form_display.node.news_story.default.yml
@@ -36,7 +36,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editor:
       children:

--- a/config/sync/core.entity_form_display.node.office.default.yml
+++ b/config/sync/core.entity_form_display.node.office.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_meta_tags:
       children:

--- a/config/sync/core.entity_form_display.node.outreach_asset.default.yml
+++ b/config/sync/core.entity_form_display.node.outreach_asset.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         id: ''
         classes: ''
         required_fields: false
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -41,7 +41,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_include_crisis_alert:
       children:

--- a/config/sync/core.entity_form_display.node.person_profile.default.yml
+++ b/config/sync/core.entity_form_display.node.person_profile.default.yml
@@ -42,7 +42,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_e:
       children:

--- a/config/sync/core.entity_form_display.node.person_profile.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.person_profile.inline_entity_form.yml
@@ -37,7 +37,7 @@ third_party_settings:
         open: 1
         required_fields: 1
         weight: '-10'
-      label: Governance
+      label: VA.gov Section
       region: content
     group_e:
       children:

--- a/config/sync/core.entity_form_display.node.press_release.default.yml
+++ b/config/sync/core.entity_form_display.node.press_release.default.yml
@@ -38,7 +38,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.press_releases_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.press_releases_listing.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.publication_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.publication_listing.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.q_a.default.yml
+++ b/config/sync/core.entity_form_display.node.q_a.default.yml
@@ -67,7 +67,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_in:
       children:

--- a/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
+++ b/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
@@ -29,7 +29,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.step_by_step.default.yml
+++ b/config/sync/core.entity_form_display.node.step_by_step.default.yml
@@ -83,7 +83,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_inc:
       children:

--- a/config/sync/core.entity_form_display.node.story_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.story_listing.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
@@ -84,7 +84,7 @@ third_party_settings:
         open: 1
         required_fields: 1
         weight: '-10'
-      label: Governance
+      label: VA.gov Section
       region: content
     group_include_toc:
       children:

--- a/config/sync/core.entity_form_display.node.support_service.default.yml
+++ b/config/sync/core.entity_form_display.node.support_service.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
 id: node.support_service.default
 targetEntityType: node

--- a/config/sync/core.entity_form_display.node.va_form.default.yml
+++ b/config/sync/core.entity_form_display.node.va_form.default.yml
@@ -52,7 +52,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_online_tool:
       children:

--- a/config/sync/core.entity_form_display.node.vamc_operating_status_and_alerts.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_operating_status_and_alerts.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.vamc_system_policies_page.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_system_policies_page.default.yml
@@ -37,7 +37,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Governance
+      label: VA.gov Section
     group_editorial_workflow:
       children:
         - status

--- a/config/sync/core.entity_form_display.node.vba_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.vba_facility.default.yml
@@ -57,7 +57,7 @@ third_party_settings:
         open: 1
         required_fields: 1
         weight: '-10'
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -66,7 +66,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Governance
+      label: VA.gov Section
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.vet_center_cap.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_cap.default.yml
@@ -40,7 +40,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
     group_editorial_workflow:
       children:
         - moderation_state

--- a/config/sync/core.entity_form_display.node.vet_center_cap.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_cap.inline_entity_form.yml
@@ -33,7 +33,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
     group_health_service_and_facilit:
       children:
         - field_regional_health_service

--- a/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.default.yml
@@ -43,7 +43,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
 id: node.vet_center_facility_health_servi.default
 targetEntityType: node
 bundle: vet_center_facility_health_servi

--- a/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.inline_entity_form.yml
@@ -43,7 +43,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
 id: node.vet_center_facility_health_servi.inline_entity_form
 targetEntityType: node
 bundle: vet_center_facility_health_servi

--- a/config/sync/core.entity_form_display.node.vet_center_locations_list.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_locations_list.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
     group_ed:
       children:
         - moderation_state

--- a/config/sync/core.entity_form_display.node.vet_center_mobile_vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_mobile_vet_center.default.yml
@@ -63,7 +63,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
     group_facility_name:
       children:
         - group_page_title_tooltip

--- a/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
@@ -53,7 +53,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Governance
+      label: VA.gov Section
     group_facility_name:
       children:
         - group_page_title_tooltip

--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
         id: ''
         classes: ''
         open: false
-      label: Governance
+      label: VA.gov Section
       region: hidden
     group_vet_center:
       children:

--- a/config/sync/field.field.block_content.alert.field_owner.yml
+++ b/config/sync/field.field.block_content.alert.field_owner.yml
@@ -10,8 +10,8 @@ id: block_content.alert.field_owner
 field_name: field_owner
 entity_type: block_content
 bundle: alert
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.block_content.promo.field_owner.yml
+++ b/config/sync/field.field.block_content.promo.field_owner.yml
@@ -10,8 +10,8 @@ id: block_content.promo.field_owner
 field_name: field_owner
 entity_type: block_content
 bundle: promo
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.media.document.field_owner.yml
+++ b/config/sync/field.field.media.document.field_owner.yml
@@ -10,8 +10,8 @@ id: media.document.field_owner
 field_name: field_owner
 entity_type: media
 bundle: document
-label: Owner
-description: 'Only members of the section you select here will be able to make changes to this document.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.media.document_external.field_owner.yml
+++ b/config/sync/field.field.media.document_external.field_owner.yml
@@ -16,8 +16,8 @@ id: media.document_external.field_owner
 field_name: field_owner
 entity_type: media
 bundle: document_external
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.media.image.field_owner.yml
+++ b/config/sync/field.field.media.image.field_owner.yml
@@ -10,8 +10,8 @@ id: media.image.field_owner
 field_name: field_owner
 entity_type: media
 bundle: image
-label: Owner
-description: 'Only members of the section you select here will be able to make changes to this image.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.media.video.field_owner.yml
+++ b/config/sync/field.field.media.video.field_owner.yml
@@ -10,8 +10,8 @@ id: media.video.field_owner
 field_name: field_owner
 entity_type: media
 bundle: video
-label: Owner
-description: 'Only members of the section you select here will be able to make changes to this video.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.basic_landing_page.field_administration.yml
+++ b/config/sync/field.field.node.basic_landing_page.field_administration.yml
@@ -10,8 +10,8 @@ id: node.basic_landing_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: basic_landing_page
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.campaign_landing_page.field_administration.yml
+++ b/config/sync/field.field.node.campaign_landing_page.field_administration.yml
@@ -16,8 +16,8 @@ id: node.campaign_landing_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: campaign_landing_page
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.centralized_content.field_administration.yml
+++ b/config/sync/field.field.node.centralized_content.field_administration.yml
@@ -16,8 +16,8 @@ id: node.centralized_content.field_administration
 field_name: field_administration
 entity_type: node
 bundle: centralized_content
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.checklist.field_administration.yml
+++ b/config/sync/field.field.node.checklist.field_administration.yml
@@ -10,8 +10,8 @@ id: node.checklist.field_administration
 field_name: field_administration
 entity_type: node
 bundle: checklist
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.documentation_page.field_administration.yml
+++ b/config/sync/field.field.node.documentation_page.field_administration.yml
@@ -12,8 +12,8 @@ id: node.documentation_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: documentation_page
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.event.field_administration.yml
+++ b/config/sync/field.field.node.event.field_administration.yml
@@ -10,8 +10,8 @@ id: node.event.field_administration
 field_name: field_administration
 entity_type: node
 bundle: event
-label: Owner
-description: 'Select the VA section that will manage this event content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.event_listing.field_administration.yml
+++ b/config/sync/field.field.node.event_listing.field_administration.yml
@@ -10,8 +10,8 @@ id: node.event_listing.field_administration
 field_name: field_administration
 entity_type: node
 bundle: event_listing
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.faq_multiple_q_a.field_administration.yml
+++ b/config/sync/field.field.node.faq_multiple_q_a.field_administration.yml
@@ -10,8 +10,8 @@ id: node.faq_multiple_q_a.field_administration
 field_name: field_administration
 entity_type: node
 bundle: faq_multiple_q_a
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.full_width_banner_alert.field_administration.yml
+++ b/config/sync/field.field.node.full_width_banner_alert.field_administration.yml
@@ -12,8 +12,8 @@ id: node.full_width_banner_alert.field_administration
 field_name: field_administration
 entity_type: node
 bundle: full_width_banner_alert
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.health_care_local_facility.field_administration.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_administration.yml
@@ -10,8 +10,8 @@ id: node.health_care_local_facility.field_administration
 field_name: field_administration
 entity_type: node
 bundle: health_care_local_facility
-label: Owner
-description: 'Select the health care system that manages this facility.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.health_care_local_health_service.field_administration.yml
+++ b/config/sync/field.field.node.health_care_local_health_service.field_administration.yml
@@ -10,8 +10,8 @@ id: node.health_care_local_health_service.field_administration
 field_name: field_administration
 entity_type: node
 bundle: health_care_local_health_service
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.health_care_region_detail_page.field_administration.yml
+++ b/config/sync/field.field.node.health_care_region_detail_page.field_administration.yml
@@ -10,8 +10,8 @@ id: node.health_care_region_detail_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: health_care_region_detail_page
-label: Owner
-description: 'The health care system that manages this local page.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.health_care_region_page.field_administration.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_administration.yml
@@ -10,8 +10,8 @@ id: node.health_care_region_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: health_care_region_page
-label: Owner
-description: 'The health care system or VISN.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.health_services_listing.field_administration.yml
+++ b/config/sync/field.field.node.health_services_listing.field_administration.yml
@@ -10,8 +10,8 @@ id: node.health_services_listing.field_administration
 field_name: field_administration
 entity_type: node
 bundle: health_services_listing
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.landing_page.field_administration.yml
+++ b/config/sync/field.field.node.landing_page.field_administration.yml
@@ -10,8 +10,8 @@ id: node.landing_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: landing_page
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.leadership_listing.field_administration.yml
+++ b/config/sync/field.field.node.leadership_listing.field_administration.yml
@@ -10,8 +10,8 @@ id: node.leadership_listing.field_administration
 field_name: field_administration
 entity_type: node
 bundle: leadership_listing
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.locations_listing.field_administration.yml
+++ b/config/sync/field.field.node.locations_listing.field_administration.yml
@@ -10,8 +10,8 @@ id: node.locations_listing.field_administration
 field_name: field_administration
 entity_type: node
 bundle: locations_listing
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.media_list_images.field_administration.yml
+++ b/config/sync/field.field.node.media_list_images.field_administration.yml
@@ -10,8 +10,8 @@ id: node.media_list_images.field_administration
 field_name: field_administration
 entity_type: node
 bundle: media_list_images
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.media_list_videos.field_administration.yml
+++ b/config/sync/field.field.node.media_list_videos.field_administration.yml
@@ -10,8 +10,8 @@ id: node.media_list_videos.field_administration
 field_name: field_administration
 entity_type: node
 bundle: media_list_videos
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.nca_facility.field_administration.yml
+++ b/config/sync/field.field.node.nca_facility.field_administration.yml
@@ -12,8 +12,8 @@ id: node.nca_facility.field_administration
 field_name: field_administration
 entity_type: node
 bundle: nca_facility
-label: Owner
-description: 'The health care system that manages this local facility.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.news_story.field_administration.yml
+++ b/config/sync/field.field.node.news_story.field_administration.yml
@@ -10,8 +10,8 @@ id: node.news_story.field_administration
 field_name: field_administration
 entity_type: node
 bundle: news_story
-label: Owner
-description: 'Select the VA section that will manage this story content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.office.field_administration.yml
+++ b/config/sync/field.field.node.office.field_administration.yml
@@ -10,8 +10,8 @@ id: node.office.field_administration
 field_name: field_administration
 entity_type: node
 bundle: office
-label: Owner
-description: 'The health care system that manages this local page.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.outreach_asset.field_administration.yml
+++ b/config/sync/field.field.node.outreach_asset.field_administration.yml
@@ -10,8 +10,8 @@ id: node.outreach_asset.field_administration
 field_name: field_administration
 entity_type: node
 bundle: outreach_asset
-label: Owner
-description: 'The office that owns this outreach asset.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.page.field_administration.yml
+++ b/config/sync/field.field.node.page.field_administration.yml
@@ -10,8 +10,8 @@ id: node.page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: page
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.person_profile.field_administration.yml
+++ b/config/sync/field.field.node.person_profile.field_administration.yml
@@ -10,8 +10,8 @@ id: node.person_profile.field_administration
 field_name: field_administration
 entity_type: node
 bundle: person_profile
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.press_release.field_administration.yml
+++ b/config/sync/field.field.node.press_release.field_administration.yml
@@ -10,8 +10,8 @@ id: node.press_release.field_administration
 field_name: field_administration
 entity_type: node
 bundle: press_release
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.press_releases_listing.field_administration.yml
+++ b/config/sync/field.field.node.press_releases_listing.field_administration.yml
@@ -10,8 +10,8 @@ id: node.press_releases_listing.field_administration
 field_name: field_administration
 entity_type: node
 bundle: press_releases_listing
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.publication_listing.field_administration.yml
+++ b/config/sync/field.field.node.publication_listing.field_administration.yml
@@ -10,8 +10,8 @@ id: node.publication_listing.field_administration
 field_name: field_administration
 entity_type: node
 bundle: publication_listing
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.q_a.field_administration.yml
+++ b/config/sync/field.field.node.q_a.field_administration.yml
@@ -10,8 +10,8 @@ id: node.q_a.field_administration
 field_name: field_administration
 entity_type: node
 bundle: q_a
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.regional_health_care_service_des.field_administration.yml
+++ b/config/sync/field.field.node.regional_health_care_service_des.field_administration.yml
@@ -10,8 +10,8 @@ id: node.regional_health_care_service_des.field_administration
 field_name: field_administration
 entity_type: node
 bundle: regional_health_care_service_des
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.step_by_step.field_administration.yml
+++ b/config/sync/field.field.node.step_by_step.field_administration.yml
@@ -10,8 +10,8 @@ id: node.step_by_step.field_administration
 field_name: field_administration
 entity_type: node
 bundle: step_by_step
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.story_listing.field_administration.yml
+++ b/config/sync/field.field.node.story_listing.field_administration.yml
@@ -10,8 +10,8 @@ id: node.story_listing.field_administration
 field_name: field_administration
 entity_type: node
 bundle: story_listing
-label: Owner
-description: 'Select the VA section that will manage this story list.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.support_resources_detail_page.field_administration.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_administration.yml
@@ -10,8 +10,8 @@ id: node.support_resources_detail_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: support_resources_detail_page
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.support_service.field_administration.yml
+++ b/config/sync/field.field.node.support_service.field_administration.yml
@@ -12,8 +12,8 @@ id: node.support_service.field_administration
 field_name: field_administration
 entity_type: node
 bundle: support_service
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.va_form.field_administration.yml
+++ b/config/sync/field.field.node.va_form.field_administration.yml
@@ -12,8 +12,8 @@ id: node.va_form.field_administration
 field_name: field_administration
 entity_type: node
 bundle: va_form
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.vamc_operating_status_and_alerts.field_administration.yml
+++ b/config/sync/field.field.node.vamc_operating_status_and_alerts.field_administration.yml
@@ -12,8 +12,8 @@ id: node.vamc_operating_status_and_alerts.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vamc_operating_status_and_alerts
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.vamc_system_policies_page.field_administration.yml
+++ b/config/sync/field.field.node.vamc_system_policies_page.field_administration.yml
@@ -16,8 +16,8 @@ id: node.vamc_system_policies_page.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vamc_system_policies_page
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.vba_facility.field_administration.yml
+++ b/config/sync/field.field.node.vba_facility.field_administration.yml
@@ -12,8 +12,8 @@ id: node.vba_facility.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vba_facility
-label: Owner
-description: 'The health care system that manages this local facility.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.vet_center.field_administration.yml
+++ b/config/sync/field.field.node.vet_center.field_administration.yml
@@ -12,8 +12,8 @@ id: node.vet_center.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vet_center
-label: Owner
-description: 'The health care system that manages this local facility.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.vet_center_cap.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_cap.field_administration.yml
@@ -16,8 +16,8 @@ id: node.vet_center_cap.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vet_center_cap
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.node.vet_center_facility_health_servi.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_facility_health_servi.field_administration.yml
@@ -19,8 +19,8 @@ id: node.vet_center_facility_health_servi.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vet_center_facility_health_servi
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.vet_center_locations_list.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_locations_list.field_administration.yml
@@ -19,8 +19,8 @@ id: node.vet_center_locations_list.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vet_center_locations_list
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.vet_center_mobile_vet_center.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_mobile_vet_center.field_administration.yml
@@ -19,8 +19,8 @@ id: node.vet_center_mobile_vet_center.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vet_center_mobile_vet_center
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.node.vet_center_outstation.field_administration.yml
+++ b/config/sync/field.field.node.vet_center_outstation.field_administration.yml
@@ -19,8 +19,8 @@ id: node.vet_center_outstation.field_administration
 field_name: field_administration
 entity_type: node
 bundle: vet_center_outstation
-label: Owner
-description: ''
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: true
 default_value:

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_owner.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_owner.yml
@@ -12,8 +12,8 @@ id: taxonomy_term.health_care_service_taxonomy.field_owner
 field_name: field_owner
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
-label: Owner
-description: 'The VA office or program that owns this content.'
+label: Section
+description: 'Choose what part of VA.gov this content belongs to.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -460,7 +460,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -678,7 +678,7 @@ display:
           exposed: true
           expose:
             operator_id: taxonomy_entity_index_tid_depth_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: taxonomy_entity_index_tid_depth_op
@@ -902,7 +902,7 @@ display:
           exposed: true
           expose:
             operator_id: taxonomy_entity_index_tid_depth_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: taxonomy_entity_index_tid_depth_op
@@ -1283,7 +1283,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -1707,7 +1707,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -2130,7 +2130,7 @@ display:
           exposed: true
           expose:
             operator_id: owner
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_administration_target_id_op
@@ -2371,7 +2371,7 @@ display:
           exposed: true
           expose:
             operator_id: taxonomy_entity_index_tid_depth_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: taxonomy_entity_index_tid_depth_op
@@ -2724,7 +2724,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -3062,7 +3062,7 @@ display:
           exposed: true
           expose:
             operator_id: taxonomy_entity_index_tid_depth_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: taxonomy_entity_index_tid_depth_op
@@ -3398,7 +3398,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false

--- a/config/sync/views.view.content_entity_browsers.yml
+++ b/config/sync/views.view.content_entity_browsers.yml
@@ -370,7 +370,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -440,7 +440,7 @@ display:
           exposed: true
           expose:
             operator_id: field_administration_target_id_op
-            label: 'Owner (field_administration)'
+            label: 'Section'
             description: ''
             use_operator: false
             operator: field_administration_target_id_op
@@ -794,7 +794,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -868,7 +868,7 @@ display:
           exposed: true
           expose:
             operator_id: field_administration_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_administration_target_id_op
@@ -1297,7 +1297,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false

--- a/config/sync/views.view.content_served_from_drupal.yml
+++ b/config/sync/views.view.content_served_from_drupal.yml
@@ -252,7 +252,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -506,7 +506,7 @@ display:
           exposed: true
           expose:
             operator_id: field_administration_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_administration_target_id_op

--- a/config/sync/views.view.custom_block_entity_browsers.yml
+++ b/config/sync/views.view.custom_block_entity_browsers.yml
@@ -530,7 +530,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -654,7 +654,7 @@ display:
           exposed: true
           expose:
             operator_id: field_owner_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_owner_target_id_op
@@ -876,7 +876,7 @@ display:
           exposed: true
           expose:
             operator_id: field_owner_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_owner_target_id_op
@@ -1176,7 +1176,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false

--- a/config/sync/views.view.facility_governance.yml
+++ b/config/sync/views.view.facility_governance.yml
@@ -497,7 +497,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -1003,7 +1003,7 @@ display:
           exposed: true
           expose:
             operator_id: taxonomy_entity_index_tid_depth_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: taxonomy_entity_index_tid_depth_op

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -1029,7 +1029,7 @@ display:
           exposed: true
           expose:
             operator_id: field_owner_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_owner_target_id_op
@@ -1393,7 +1393,7 @@ display:
           exposed: true
           expose:
             operator_id: field_owner_target_id_op
-            label: 'Owner (field_owner)'
+            label: 'Section'
             description: ''
             use_operator: false
             operator: field_owner_target_id_op

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -884,7 +884,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false

--- a/config/sync/views.view.va_blocks_admin.yml
+++ b/config/sync/views.view.va_blocks_admin.yml
@@ -406,7 +406,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -769,7 +769,7 @@ display:
           exposed: true
           expose:
             operator_id: field_owner_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_owner_target_id_op
@@ -1259,7 +1259,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -1742,7 +1742,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false

--- a/config/sync/views.view.vamc_alerts_and_operating_statuses.yml
+++ b/config/sync/views.view.vamc_alerts_and_operating_statuses.yml
@@ -410,7 +410,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -835,7 +835,7 @@ display:
           exposed: true
           expose:
             operator_id: field_administration_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_administration_target_id_op

--- a/config/sync/views.view.vamc_operating_statuses.yml
+++ b/config/sync/views.view.vamc_operating_statuses.yml
@@ -279,7 +279,7 @@ display:
           exposed: true
           expose:
             operator_id: field_administration_target_id_op
-            label: Owner
+            label: Section
             description: ''
             use_operator: false
             operator: field_administration_target_id_op

--- a/config/sync/views.view.vamc_top_task_pages.yml
+++ b/config/sync/views.view.vamc_top_task_pages.yml
@@ -356,7 +356,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Owner
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -609,7 +609,7 @@ display:
           exposed: true
           expose:
             operator_id: field_administration_target_id_op
-            label: 'Owner (field_administration)'
+            label: 'Section'
             description: ''
             use_operator: false
             operator: field_administration_target_id_op

--- a/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
@@ -15,7 +15,7 @@ Feature: Content model: Benefits hubs Content Type fields
 | Content type | Benefits Detail Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter |  |
 | Content type | Benefits Detail Page | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- |  |
 | Content type | Benefits Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter |  |
-| Content type | Benefits Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Benefits Detail Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Benefits Detail Page | Page introduction | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | Benefits Detail Page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  |
 | Content type | Benefits Detail Page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | -- Disabled -- |  |
@@ -28,7 +28,7 @@ Feature: Content model: Benefits hubs Content Type fields
 | Content type | Benefits Hub Landing Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Benefits Hub Landing Page | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Benefits Hub Landing Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Benefits Hub Landing Page | Owner | field_administration | Entity reference | Required | 1 | Select list |  |
+| Content type | Benefits Hub Landing Page | Section | field_administration | Entity reference | Required | 1 | Select list |  |
 | Content type | Benefits Hub Landing Page | Page introduction | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
 | Content type | Benefits Hub Landing Page | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
 | Content type | Benefits Hub Landing Page | Plain language Certified Date | field_plainlanguage_date | Date |  | 1 | -- Disabled -- | Translatable |
@@ -40,11 +40,11 @@ Feature: Content model: Benefits hubs Content Type fields
 | Content type | Landing Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
 | Content type | Landing Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Landing Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Landing Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Landing Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Landing Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Landing Page | Product | field_product | Entity reference | Required | 1 | Select list |  |
 | Content type | Support Service | Link | field_link | Link |  | 1 | Linkit |  |
-| Content type | Support Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Support Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Support Service | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
 | Content type | Support Service | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number |  |
 | Content type | Support Service | Related office | field_office | Entity reference | Required | 1 | Select list | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_campaign_landing_page_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_campaign_landing_page_content_type_fields.feature
@@ -37,7 +37,7 @@ Feature: Content model: Campaign Landing Page Content Type fields
 | Content type | Campaign Landing Page | Introduction | field_clp_why_this_matters | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter |  |
 | Content type | Campaign Landing Page | Links with summaries | field_clp_spotlight_link_teasers | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
 | Content type | Campaign Landing Page | Optional Spotlight cta | field_clp_spotlight_cta | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
-| Content type | Campaign Landing Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Campaign Landing Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Campaign Landing Page | Page introduction | field_hero_blurb | Text (plain) |  | 1 | Textfield with counter |  |
 | Content type | Campaign Landing Page | Primary call to action | field_primary_call_to_action | Entity reference revisions | Required | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Campaign Landing Page | Resources | field_clp_resources | Entity reference |  | 3 | Inline entity form - Complex - Table View Mode |  |

--- a/tests/behat/drupal-spec-tool/content_model_custom_block_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_custom_block_fields.feature
@@ -13,11 +13,11 @@ Feature: Content model: Custom Block fields
 | Custom block type | Alert | Alert title | field_alert_title | Text (plain) | Required | 1 | Textfield |  |
 | Custom block type | Alert | Alert Type | field_alert_type | List (text) | Required | 1 | Select list |  |
 | Custom block type | Alert | Banner or in-page alert? | field_is_this_a_header_alert_ | List (text) |  | 1 | Select list |  |
-| Custom block type | Alert | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
+| Custom block type | Alert | Section | field_owner | Entity reference | Required | 1 | Select list |  |
 | Custom block type | Alert | Persistence (for dismissable alerts only) | field_alert_frequency | List (text) | Required | 1 | Select list |  |
 | Custom block type | Alert | Reusability | field_reusability | List (text) | Required | 1 | -- Disabled -- |  |
 | Custom block type | Alert | Scope | field_node_reference | Entity reference |  | Unlimited | Autocomplete |  |
 | Custom block type | Promo | Image | field_image | Entity reference | Required | 1 | Media library |  |
 | Custom block type | Promo | Link | field_promo_link | Entity reference revisions |  | 1 | Inline entity form - Simple |  |
-| Custom block type | Promo | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
+| Custom block type | Promo | Section | field_owner | Entity reference | Required | 1 | Select list | Translatable |
 

--- a/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
@@ -15,7 +15,7 @@ Feature: Content model: LC Content Type fields
 | Content type | Checklist | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Checklist | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Checklist | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | Checklist | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Checklist | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Checklist | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Checklist | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Checklist | Primary category | field_primary_category | Entity reference | Required | 1 | Select list |  |
@@ -25,7 +25,7 @@ Feature: Content model: LC Content Type fields
 | Content type | FAQ - multiple Q&As | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic | Translatable |
 | Content type | FAQ - multiple Q&As | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | FAQ - multiple Q&As | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | FAQ - multiple Q&As | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | FAQ - multiple Q&As | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | FAQ - multiple Q&As | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | FAQ - multiple Q&As | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | FAQ - multiple Q&As | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
@@ -36,7 +36,7 @@ Feature: Content model: LC Content Type fields
 | Content type | FAQ - multiple Q&As | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table | Translatable |
 | Content type | Resources and support Detail Page | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Resources and support Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | Resources and support Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Resources and support Detail Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Resources and support Detail Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Resources and support Detail Page | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Resources and support Detail Page | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
@@ -55,7 +55,7 @@ Feature: Content model: LC Content Type fields
 | Content type | Media list - Images | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Media list - Images | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Media list - Images | Media list - Images | field_media_list_images | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
-| Content type | Media list - Images | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Media list - Images | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Media list - Images | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Media list - Images | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Media list - Images | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
@@ -67,7 +67,7 @@ Feature: Content model: LC Content Type fields
 | Content type | Media list - Videos | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Media list - Videos | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | Media list - Videos | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | Media list - Videos | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Media list - Videos | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Media list - Videos | Page introduction | field_intro_text_limited_html | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Media list - Videos | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Media list - Videos | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
@@ -79,7 +79,7 @@ Feature: Content model: LC Content Type fields
 | Content type | Q&A | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Content type | Q&A | Enable standalone Resources and support page for this Q&A. | field_standalone_page | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | Q&A | CTA buttons | field_buttons | Entity reference revisions | Required | 2 | Paragraphs Classic | Translatable |
-| Content type | Q&A | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Q&A | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Q&A | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Q&A | Primary category | field_primary_category | Entity reference |  | 1 | Select list | Translatable |
 | Content type | Q&A | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Classic |  |
@@ -90,7 +90,7 @@ Feature: Content model: LC Content Type fields
 | Content type | Step-by-Step | Alert | field_alert_single | Entity reference revisions | Required | 1 | Paragraphs Classic | Translatable |
 | Content type | Step-by-Step | Page introduction | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Step-by-Step | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
-| Content type | Step-by-Step | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Step-by-Step | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Step-by-Step | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Step-by-Step | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | Step-by-Step | Step-by-step | field_steps | Entity reference revisions | Required | Unlimited | Paragraphs Classic |  |

--- a/tests/behat/drupal-spec-tool/content_model_media_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_media_fields.feature
@@ -10,22 +10,22 @@ Feature: Content model: Media fields
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Media type | Document | Document | field_document | File | Required | 1 | File |  |
 | Media type | Document | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup |  |
-| Media type | Document | Owner | field_owner | Entity reference | Required | 1 | Select list |  |
+| Media type | Document | Section | field_owner | Entity reference | Required | 1 | Select list |  |
 | Media type | Document | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable |
 | Media type | Document - External | External File URL | field_media_external_file | Link | Required | 1 | Link | Translatable |
 | Media type | Document - External | File type | field_mime_type | Text (plain) |  | 1 | -- Disabled -- |  |
-| Media type | Document - External | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
+| Media type | Document - External | Section | field_owner | Entity reference | Required | 1 | Select list | Translatable |
 | Media type | Document - External | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable |
 | Media type | Document - External | Description | field_description | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Media type | Image | Description | field_description | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Media type | Image | Image | image | Image | Required | 1 | ImageWidget crop |  |
 | Media type | Image | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable |
-| Media type | Image | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
+| Media type | Image | Section | field_owner | Entity reference | Required | 1 | Select list | Translatable |
 | Media type | Image | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- |  |
 | Media type | Video | Description | field_description | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Media type | Video | Duration | field_duration | Hours Minutes and Seconds |  | 1 | Hour Minutes and Seconds |  |
 | Media type | Video | Media submission guidelines | field_media_submission_guideline | Markup |  | 1 | Markup | Translatable |
-| Media type | Video | Owner | field_owner | Entity reference | Required | 1 | Select list | Translatable |
+| Media type | Video | Section | field_owner | Entity reference | Required | 1 | Select list | Translatable |
 | Media type | Video | Reusable | field_media_in_library | Boolean |  | 1 | -- Disabled -- | Translatable |
 | Media type | Video | Video URL | field_media_video_embed_field | Video Embed | Required | 1 | Video Textfield | Translatable |
 | Media type | Video | Publication date | field_publication_date | Date |  | 1 | Date and time |  |

--- a/tests/behat/drupal-spec-tool/content_model_nca_facility_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_nca_facility_content_type_fields.feature
@@ -4,11 +4,11 @@ Feature: Content model: NCA facility Content Type fields
   As a content editor
   I want to have content type fields that reflect my content model.
 
-  @dst @field_type @content_type_fields @dstfields                                                                                                                                                               
+  @dst @field_type @content_type_fields @dstfields
      Scenario: Fields
        Then exactly the following fields should exist for bundles "nca_facility" of entity type node
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Content type | NCA Facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | NCA Facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
 | Content type | NCA Facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | NCA Facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | NCA Facility | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_outreach_hub_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_outreach_hub_content_type_fields.feature
@@ -4,7 +4,7 @@ Feature: Content model: Outreach hub Content Type fields
   As a content editor
   I want to have content type fields that reflect my content model.
 
-  @dst @field_type @content_type_fields @dstfields                                                                                                                                                               
+  @dst @field_type @content_type_fields @dstfields
      Scenario: Fields
        Then exactly the following fields should exist for bundles "office,outreach_asset,publication_listing" of entity type node
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
@@ -12,17 +12,17 @@ Feature: Content model: Outreach hub Content Type fields
 | Content type | Office | Meta description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Office | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Office | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Office | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Publication | File or video | field_media | Entity reference |  | 1 | Media library |  |
 | Content type | Publication | Format | field_format | List (text) | Required | 1 | Select list |  |
 | Content type | Publication | Meta description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Publication | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
-| Content type | Publication | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Publication | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Publication | Publication listing | field_listing | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Publication | Related Benefits | field_benefits | List (text) |  | 1 | Select list |  |
 | Content type | Publication Listing Page | Intro text | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Publication Listing Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Publication Listing Page | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Publication Listing Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Publication Listing Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Publication Listing Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Publication Listing Page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
@@ -4,7 +4,7 @@ Feature: Content model: User guides Content Type fields
   As a content editor
   I want to have content type fields that reflect my content model.
 
-  @dst @field_type @content_type_fields @dstfields                                                                                                                                                               
+  @dst @field_type @content_type_fields @dstfields
      Scenario: Fields
        Then exactly the following fields should exist for bundles "documentation_page" of entity type node
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
@@ -12,4 +12,4 @@ Feature: Content model: User guides Content Type fields
 | Content type | CMS Help Page | Related user guides | field_related_user_guides | Entity reference |  | 5 | Autocomplete |  |
 | Content type | CMS Help Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | -- Disabled -- | Translatable |
 | Content type | CMS Help Page | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
-| Content type | CMS Help Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | CMS Help Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_va_common_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_va_common_content_type_fields.feature
@@ -9,5 +9,5 @@ Feature: Content model: VA Common Content Type fields
        Then exactly the following fields should exist for bundles "centralized_content" of entity type node
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Content type | Centralized Content | Content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser Classic | Translatable |
-| Content type | Centralized Content | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Centralized Content | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Centralized Content | Purpose and Scope | body | Text (formatted, long, with summary) |  | 1 | Text area with a summary | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_va_forms_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_va_forms_content_type_fields.feature
@@ -24,7 +24,7 @@ Feature: Content model: VA Forms Content Type fields
 | Content type | VA Form | Link to online tool | field_va_form_tool_url | Link |  | 1 | Linkit |  |
 | Content type | VA Form | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | VA Form | Number of pages | field_va_form_num_pages | Number (integer) |  | 1 | Number field |  |
-| Content type | VA Form | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VA Form | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VA Form | Related forms | field_va_form_related_forms | Entity reference |  | Unlimited | Autocomplete |  |
 | Content type | VA Form | Revision date | field_va_form_revision_date | Date |  | 1 | Date and time |  |
 | Content type | VA Form | Row ID | field_va_form_row_id | Number (integer) |  | 1 | Number field |  |

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -15,7 +15,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Detail Page | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Detail Page | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Detail Page | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Detail Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Detail Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Detail Page | Page introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Detail Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | Detail Page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
@@ -33,7 +33,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Event | Teaser description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Event | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Event | Order | field_order | List (integer) |  | 1 | Select list |  |
-| Content type | Event | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Event | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Event | Registration required | field_event_registrationrequired | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | Event | Label | field_event_cta | List (text) |  | 1 | Select list |  |
 | Content type | Event | URL | field_link | Link |  | 1 | Linkit | Translatable |
@@ -41,27 +41,27 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Events List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Events List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Events List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Events List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Events List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Events List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Events List | Office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Health Services List | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic | Translatable |
 | Content type | Health Services List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Health Services List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Health Services List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Health Services List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Health Services List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Health Services List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Health Services List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Leadership List | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete | Translatable |
 | Content type | Leadership List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Leadership List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Leadership List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Leadership List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Leadership List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Leadership List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Leadership List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Locations List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | VAMC System Locations List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | VAMC System Locations List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | VAMC System Locations List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System Locations List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Locations List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC System Locations List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | News Release | Full text of the Press Release | field_press_release_fulltext | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
@@ -71,13 +71,13 @@ Feature: Content model: VAMC Content Type fields
 | Content type | News Release | Media Contact(s) | field_press_release_contact | Entity reference |  | Unlimited | Autocomplete | Translatable |
 | Content type | News Release | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | News Release | News releases listing | field_listing | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | News Release | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | News Release | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | News Release | PDF of Press Release | field_pdf_version | Entity reference |  | 1 | Media library |  |
 | Content type | News Release | Release date | field_release_date | Date |  | 1 | Date and time |  |
 | Content type | News Releases List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | News Releases List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | News Releases List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | News Releases List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | News Releases List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | News Releases List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | News Releases List | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | News Releases List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
@@ -90,7 +90,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Staff Profile | Last name | field_last_name | Text (plain) |  | 1 | Textfield |  |
 | Content type | Staff Profile | Job title | field_description | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Staff Profile | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
-| Content type | Staff Profile | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Staff Profile | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Staff Profile | Phone Number | field_phone_number | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | Staff Profile | Photo | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Content type | Staff Profile | Related office or health care region | field_office | Entity reference | Required | 1 | Select list | Translatable |
@@ -103,13 +103,13 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Story | First sentence (lede) | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Story | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Story | Order | field_order | List (integer) |  | 1 | Select list | Translatable |
-| Content type | Story | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Story | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Story | Where should the story be listed? | field_listing | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Stories List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Stories List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Stories List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Stories List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Stories List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Stories List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Stories List | Office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility | Address | field_address | Address |  | 1 | Address | Translatable |
 | Content type | VAMC Facility | Classification | field_facility_classification | List (text) |  | 1 | Select list |  |
@@ -127,12 +127,12 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility | Mobile | field_mobile | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC Facility | Status | field_operating_status_facility | List (text) | Required | 1 | Select list |  |
 | Content type | VAMC Facility | Details | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
-| Content type | VAMC Facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC Facility | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | VAMC Facility | What health care system does the facility belong to? | field_region_page | Entity reference | Required | 1 | Select list |  |
 | Content type | VAMC Facility Health Service | Facility | field_facility_location | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility Health Service | Facility description of service | field_body | Text (formatted, long) |  | 1 | -- Disabled -- | Translatable |
-| Content type | VAMC Facility Health Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC Facility Health Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility Health Service | Service locations | field_service_location | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
 | Content type | VAMC Facility Health Service | VAMC system health service | field_regional_health_service | Entity reference | Required | 1 | Select list |  |
 | Content type | VAMC Facility Health Service | Is online scheduling available for this service? | field_online_scheduling_availabl | List (text) | Required | 1 | Select list |  |
@@ -154,7 +154,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | VAMC System | Operating status | field_operating_status | Link |  | 1 | Linkit |  |
 | Content type | VAMC System | Other VA Locations | field_other_va_locations | Text (plain) |  | Unlimited | Textfield |  |
-| Content type | VAMC System | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System | Page introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | VAMC System | Regional Health Service Offerings. | field_clinical_health_services | Entity reference |  | Unlimited | -- Disabled -- |  |
 | Content type | VAMC System | Twitter | field_twitter | Link |  | 1 | Linkit | Translatable |
@@ -167,12 +167,12 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Banner Alert with Situation Updates | Display "Get updates on affected services and facilities" link | field_alert_operating_status_cta | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC System Banner Alert with Situation Updates | Display "Subscribe to email updates" link? | field_alert_email_updates_button | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC System Banner Alert with Situation Updates | Limit banner display to the home and the Operating Status page(s) | field_alert_inheritance_subpages | Boolean |  | 1 | Single on/off checkbox |  |
-| Content type | VAMC System Banner Alert with Situation Updates | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System Banner Alert with Situation Updates | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Banner Alert with Situation Updates | Send email update on this situation | field_operating_status_sendemail | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Content type | VAMC System Banner Alert with Situation Updates | Situation updates | field_situation_updates | Entity reference revisions |  | Unlimited | Paragraphs EXPERIMENTAL |  |
 | Content type | VAMC System Banner Alert with Situation Updates | Pages for the following VAMC systems | field_banner_alert_vamcs | Entity reference | Required | Unlimited | Check boxes/radio buttons |  |
 | Content type | VAMC System Health Service | Facility services | field_local_health_care_service_ | Entity reference |  | Unlimited | -- Disabled -- |  |
-| Content type | VAMC System Health Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System Health Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Health Service | VAMC system | field_region_page | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Health Service | VAMC system description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC System Health Service | Service | field_service_name_and_descripti | Entity reference | Required | 1 | Select list |  |
@@ -183,7 +183,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Operating Status | Patient resources | field_operating_status_emerg_inf | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | VAMC System Operating Status | Local emergency resources | field_links | Link |  | Unlimited | Linkit | Translatable |
 | Content type | VAMC System Operating Status | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
-| Content type | VAMC System Operating Status | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System Operating Status | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Operating Status | Facility operating statuses | field_facility_operating_status | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
 | Content type | VAMC System Operating Status | VAMC system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Policies Page | Fieldset Markup | field_fieldset_markup | Markup |  | 1 | Markup |  |
@@ -192,6 +192,6 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Policies Page | National intro text | field_cc_intro_text | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
 | Content type | VAMC System Policies Page | National top of page content | field_cc_top_of_page_content | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
 | Content type | VAMC System Policies Page | Other policies | field_vamc_other_policies | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
-| Content type | VAMC System Policies Page | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System Policies Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Policies Page | Related health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Policies Page | Visitation policy | field_vamc_visitation_policy | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |

--- a/tests/behat/drupal-spec-tool/content_model_vba_facility_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vba_facility_content_type_fields.feature
@@ -4,11 +4,11 @@ Feature: Content model: VBA facility Content Type fields
   As a content editor
   I want to have content type fields that reflect my content model.
 
-  @dst @field_type @content_type_fields @dstfields                                                                                                                                                               
+  @dst @field_type @content_type_fields @dstfields
      Scenario: Fields
        Then exactly the following fields should exist for bundles "vba_facility" of entity type node
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Content type | VBA Facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | VBA Facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
 | Content type | VBA Facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | VBA Facility | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VBA Facility | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
@@ -11,7 +11,7 @@ Feature: Content model: Vet Center Content Type fields
 | Content type | Vet Center | Facility ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Vet Center | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
 | Content type | Vet Center | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Vet Center | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Vet Center | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center | Main location address  | field_address | Address |  | 1 | Address | Translatable |
 | Content type | Vet Center | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) |  |
 | Content type | Vet Center | Facility photo | field_media | Entity reference |  | 1 | Media library | Translatable |
@@ -32,15 +32,15 @@ Feature: Content model: Vet Center Content Type fields
 | Content type | Vet Center - Community Access Point | Access point name | field_geographical_identifier | Text (plain) | Required | 1 | Textfield |  |
 | Content type | Vet Center - Community Access Point | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) | Translatable |
 | Content type | Vet Center - Community Access Point | Facility photo | field_media | Entity reference |  | 1 | Media library | Translatable |
-| Content type | Vet Center - Community Access Point | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Vet Center - Community Access Point | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Community Access Point | Main Vet Center location | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Community Access Point | Table of contents | field_table_of_contents | Markup |  | 1 | Markup | Translatable |
 | Content type | Vet Center - Community Access Point | How should CAP hours be communicated? | field_vetcenter_cap_hours_opt_in | Boolean | Required | 1 | Check boxes/radio buttons |  |
 | Content type | Vet Center - Facility Health Service | Description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
-| Content type | Vet Center - Facility Health Service | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Vet Center - Facility Health Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Facility Health Service | Service | field_service_name_and_descripti | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Facility Health Service | Vet Center | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Vet Center - Locations List | Owner | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Vet Center - Locations List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Locations List | Page introduction | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
 | Content type | Vet Center - Locations List | Nearby Mobile Vet Centers | field_nearby_mobile_vet_centers | Entity reference |  | Unlimited | Entity Browser - Table |  |
 | Content type | Vet Center - Locations List | Nearby Vet Centers and Outstations | field_nearby_vet_centers | Entity reference |  | Unlimited | Entity Browser - Table |  |

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -20,7 +20,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | Sections | URL | field_email_updates_url | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VHA health service taxonomy | Owner | field_owner | Entity reference | Required | 1 | -- Disabled -- |  |
+| Vocabulary | VHA health service taxonomy | Section | field_owner | Entity reference | Required | 1 | -- Disabled -- |  |
 | Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Type of care | field_service_type_of_care | List (text) |  | 1 | Select list |  |
 | Vocabulary | VHA health service taxonomy | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -70,7 +70,7 @@ Feature: CMS Users may effectively create & edit content
     # Create an office node with a menu link.
     And I fill in "Name" with "Test Office - BeHaT"
     And I fill in "Meta title tag" with "Test Office - BeHaT | Veterans Affairs"
-    And I fill in "Owner" with "5"
+    And I fill in "Section" with "5"
     And I check "Provide a menu link"
     And I fill in "Menu link title" with "Test Office - BeHat"
     And I uncheck "Enable in menu"
@@ -105,7 +105,7 @@ Feature: CMS Users may effectively create & edit content
     # Create an office node.
     And I fill in "Name" with "Test Office - BeHaT"
     And I fill in "Meta title tag" with "Test Office - BeHaT | Veterans Affairs"
-    And I fill in "Owner" with "5"
+    And I fill in "Section" with "5"
     And I press "Save"
 
     # Confirm that the va.gov url is not shown for nodes without a published revision.

--- a/tests/behat/features/personal_content_flags.feature
+++ b/tests/behat/features/personal_content_flags.feature
@@ -12,7 +12,7 @@ Feature: Personal Content Flags indicate a user's relationship to content.
 
     And I fill in "Name" with "Behat Edited Flag Test"
     And I fill in "Meta title tag" with "Just a Test | Veterans Affairs"
-    And I fill in "Owner" with "7"
+    And I fill in "Section" with "7"
     And I press "Save"
     Then I should see "Behat Edited Flag Test"
     And the "edited" flag for node "Behat Edited Flag Test" should be set for me

--- a/tests/behavioral/cypress/integration/common/i_create_a_media.js
+++ b/tests/behavioral/cypress/integration/common/i_create_a_media.js
@@ -7,7 +7,7 @@ const creators = {
     cy.scrollTo('top');
     cy.findAllByLabelText('Name').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
     cy.findAllByLabelText('Description').type(faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Owner').select('Veterans Affairs');
+    cy.findAllByLabelText('Section').select('Veterans Affairs');
     cy.get('#edit-image-0-upload').attachFile('images/polygon_image.png').wait(1000);
     cy.findAllByLabelText('Alternative text').type(faker.lorem.sentence(), { force: true });
     const resizePoint = cy.get('span.cropper-face.cropper-move');

--- a/tests/behavioral/cypress/integration/common/i_create_a_node.js
+++ b/tests/behavioral/cypress/integration/common/i_create_a_node.js
@@ -14,7 +14,7 @@ const creators = {
     cy.scrollTo('top');
     cy.findAllByLabelText('Name').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
     cy.findAllByLabelText('Meta title tag').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Owner').select('Veterans Affairs', { force: true });
+    cy.findAllByLabelText('Section').select('Veterans Affairs', { force: true });
     cy.findAllByLabelText('Provide a menu link').check({ force: true });
     cy.findAllByLabelText('Menu link title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
     cy.findAllByLabelText('Enable in menu').uncheck({ force: true });
@@ -28,7 +28,7 @@ const creators = {
     // Enter text into page intro ckeditor.
     cy.type_ckeditor("edit-field-intro-text-limited-html-0-value", faker.lorem.sentence());
 
-    cy.findAllByLabelText('Owner').select('Veterans Affairs', { force: true });
+    cy.findAllByLabelText('Section').select('Veterans Affairs', { force: true });
     cy.findAllByLabelText('Button Link').type('https://va.gov/', { force: true });
     cy.findAllByLabelText('Button Label').type('va.gov', { force: true });
     cy.findAllByLabelText('Section Header').type(faker.lorem.word(), { force: true });

--- a/tests/behavioral/cypress/integration/google_tag_manager.feature
+++ b/tests/behavioral/cypress/integration/google_tag_manager.feature
@@ -36,7 +36,7 @@ Feature: Google Tag Manager dataLayer values are correct
     And I click the edit tab
     And I fill in "Name" with "[Test Data] My Test Office"
     And I fill in "Meta title tag" with "[Test Data] My Meta title tag"
-    And I select option "--Outreach Hub" from dropdown "Owner"
+    And I select option "--Outreach Hub" from dropdown "Section"
     And I save the node
     Then the GTM data layer value for "contentTitle" should be set to "[Test Data] My Test Office"
     Then the GTM data layer value for "pageTitle" should be set to "[Test Data] My Test Office"


### PR DESCRIPTION
## Description

See #5088 ... the decision to standardize around "Section" instead of "Owner" or Governance.

This PR updates all the field labels, fieldset labels, and views column headers.  

It shouldn't be merged until it has been tested with some users and we have an CMS announcement queued to go out with this change, and updated user guide.

## Testing done

Behat (not done yet)

## Screenshots


## QA steps

Go to any /node/add form and check out the right sidebar. 



### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [x] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
