### PR TITLE
 VACMS-5194: Change content-build repo to use source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,7 @@
         "symfony/finder": "^3",
         "symfony/phpunit-bridge": "^5.1",
         "traviscarden/behat-table-comparison": "~0.2",
-        "va-gov/content-build": "^0.0.72",
+        "va-gov/content-build": "^0.0.78",
         "vlucas/phpdotenv": "^5.3",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
@@ -235,7 +235,7 @@
         },
         "preferred-install": {
             "drupal/core": "source",
-            "va-gov/web": "source",
+            "va-gov/content-build": "source",
             "*": "dist"
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be09ed86ee690ac550ad38414695e2fc",
+    "content-hash": "406cb3725d638844aa78979eaecc547c",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -19107,7 +19107,7 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.72",
+            "version": "v0.0.78",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
@@ -19143,7 +19143,7 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/web, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.72"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.78"
             },
             "time": "2021-05-07T15:24:24+00:00"
         },

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/Block/ContentReleaseStatusBlock.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/Block/ContentReleaseStatusBlock.php
@@ -191,12 +191,12 @@ class ContentReleaseStatusBlock extends BlockBase implements ContainerFactoryPlu
       return ['data' => ['#markup' => '[default]']];
     }
 
-    if (preg_match('/origin\/([^\/ ]*)$/', $payload->commands[1], $matches)) {
+    if (preg_match('/origin\/([^\/ ]*)$/', $payload->commands[2], $matches)) {
       $branch = $matches[1];
       return ['data' => ['#markup' => "Branch: {$branch}"]];
     }
 
-    if (preg_match('/git fetch origin pull\/([0-9]*)\/head/', $payload->commands[1], $matches)) {
+    if (preg_match('/git fetch origin pull\/([0-9]*)\/head/', $payload->commands[2], $matches)) {
       $pr = $matches[1];
       return ['data' => ['#markup' => "Pull request: #{$pr}"]];
     }


### PR DESCRIPTION
## Description

See #5194.   The `content-build` repo needs to use source so the branch changes work correctly.

## Testing done

Search for a branch

![image](https://user-images.githubusercontent.com/121603/117982713-498ab400-b304-11eb-8104-5e61001116ef.png)

Auto-complete PR:

![image](https://user-images.githubusercontent.com/121603/117982894-74750800-b304-11eb-88d7-3e25b72c0c64.png)


Full Build

![image](https://user-images.githubusercontent.com/121603/117985294-92dc0300-b306-11eb-840c-dcd80cd60d6d.png)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
