### PR TITLE
VACMS-5361: Fixes user-loading in behavioral test.

### DIFF
--- a/tests/behavioral/cypress/support/commands.js
+++ b/tests/behavioral/cypress/support/commands.js
@@ -121,7 +121,7 @@ Cypress.Commands.add('unsetWorkbenchAccessSections', () => {
   return cy.get('@uid')
     .then((uid) => {
       const command = `
-        $user = user_load(${uid});
+        $user = \\Drupal\\user\\Entity\\User::load(${uid});
         $section_scheme = \\Drupal::entityTypeManager()->getStorage('access_scheme')->load('section');
         $section_storage = \\Drupal::service('workbench_access.user_section_storage');
         $current_sections = $section_storage->getUserSections($section_scheme, $user);
@@ -138,7 +138,7 @@ Cypress.Commands.add('setWorkbenchAccessSections', (value) => {
     .then(() => cy.get('@uid'))
     .then((uid) => {
       const command = `
-        $user = user_load(${uid});
+        $user = \\Drupal\\user\\Entity\\User::load(${uid});
         $section_scheme = \\Drupal::entityTypeManager()->getStorage('access_scheme')->load('section');
         $section_storage = \\Drupal::service('workbench_access.user_section_storage');
         $section_storage->addUser($section_scheme, $user, explode(',', '${value}'));


### PR DESCRIPTION
## Description

See #5361.  Used a deprecated function which will bite us in D9.  This is good to merge provided tests pass, as the code is only used in the tests that it breaks in D9.

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
