### PR TITLE
VACMS-5390 Remove buttons validation logic.

### DIFF
--- a/config/sync/core.entity_form_display.node.vet_center_locations_list.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_locations_list.default.yml
@@ -71,10 +71,10 @@ content:
     settings:
       entity_browser: mobile_vet_centers
       field_widget_display: label
-      field_widget_edit: '1'
       field_widget_remove: '1'
       open: '1'
       selection_mode: selection_append
+      field_widget_edit: 0
       field_widget_replace: 0
       field_widget_display_settings: {  }
     third_party_settings:
@@ -87,11 +87,11 @@ content:
     settings:
       entity_browser: vet_centers
       field_widget_display: label
-      field_widget_edit: '1'
-      field_widget_remove: '1'
-      open: '1'
+      field_widget_remove: true
+      open: true
       selection_mode: selection_append
-      field_widget_replace: 0
+      field_widget_edit: false
+      field_widget_replace: false
       field_widget_display_settings: {  }
     third_party_settings:
       limited_field_widgets:
@@ -110,13 +110,6 @@ content:
     settings: {  }
     region: content
     third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 7
-    region: content
-    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0
@@ -125,14 +118,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  url_redirects:
-    weight: 8
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   created: true
   path: true
   promote: true
+  status: true
   sticky: true
   uid: true
+  url_redirects: true

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -613,6 +613,18 @@ function _va_gov_vet_center_require_revision_message(array &$form, FormStateInte
   ];
   // Vet centers need to have revision log messages on edit.
   if (in_array($form_id, $vc_types)) {
+    $widget_fields = [
+      'field_nearby_vet_centers',
+      'field_nearby_mobile_vet_centers',
+    ];
+    foreach ($widget_fields as $widget_field) {
+      // We don't want the node form validation to fire on the removal buttons.
+      foreach ($form[$widget_field]['widget']['current'] as $key => $button) {
+        if (is_numeric($key)) {
+          $form[$widget_field]['widget']['current'][$key]['actions']['remove_button']['#limit_validation_errors'] = [['field_nearby_vet_centers']];
+        }
+      }
+    }
     $form['revision_log']['#required'] = TRUE;
     $form['revision_log']['widget']['#required'] = TRUE;
     $form['revision_log']['widget'][0]['#required'] = TRUE;


### PR DESCRIPTION
## Description
See #5390

## Testing done
Visual

## QA steps
As an administrator, go to `/node/16478/edit` and visually verify that you can remove nearby locations from either of the tables, without adding a revision message.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
