### PR TITLE
VACMS-5296: Add three domains to link check whitelist.

### DIFF
--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -4,7 +4,7 @@ display_on_node_view: node_view
 display_on_node_edit: node_edit
 display_on_node_preview: node_preview
 additional_domains_as_internal: www.va.gov
-domains_to_skip: "charlesajudge.com\nhamptoninn3.hilton.com\nhiltongardeninn3.hilton.com\nwww.choicehotels.com\nwww.hilton.com\nwww.instagram.com\nwww.linkedin.com\nwww.marriott.com\nwww.portauthority.org/\nwww.qualityinn.com\nwww.redroof.com\nwww.youtube.com"
+domains_to_skip: "charlesajudge.com\ndatabus.org\nhamptoninn3.hilton.com\nhiltongardeninn3.hilton.com\nvawww.va.gov\nwebex.com\nwww.choicehotels.com\nwww.hilton.com\nwww.instagram.com\nwww.linkedin.com\nwww.marriott.com\nwww.portauthority.org/\nwww.qualityinn.com\nwww.redroof.com\nwww.youtube.com"
 enable_reporting_skipped_links: 1
 user_agent: 'VA.gov CMS link checker'
 path_patterns_to_skip: "/block/*\n/node/*/edit\n/section/*\n/user/*\nmedia/*\nmedia/*/edit"


### PR DESCRIPTION
## Description
See #5296 

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/118797269-69712900-b86a-11eb-9ed2-92331a5c2c08.png)

## QA steps
As an administrator, go to `admin/config/content/node_link_report` and visually verify that three whitelist domains have been added to exemption list, per screenshot.

### Select Team for PR review

- [x] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
