### PR TITLE
VACMS-5371: Toughen entity reference validation behavioral test.

### DIFF
--- a/tests/behavioral/cypress/integration/common/i_select_the_benefits_hub.js
+++ b/tests/behavioral/cypress/integration/common/i_select_the_benefits_hub.js
@@ -3,15 +3,16 @@ import { Given } from "cypress-cucumber-preprocessor/steps";
 Given(`I select the {string} benefits hub`, (text) => {
   cy.contains("Select Benefit Hub(s)").click({ force: true });
   cy.get(".entity-browser-modal iframe").should("exist");
-  cy.wait(2000);
+  cy.wait(3000);
 
   cy.get(".entity-browser-modal iframe").iframe().within(() => {
-    cy.get("tr").contains(text).should("exist");
     cy.get("tr")
       .contains(text)
+      .should("exist")
       .parent()
       .find("[type='checkbox']")
       .check({ force: true });
     cy.get("#edit-submit").click({ force: true });
   });
+  cy.get(".entity-browser-modal iframe").should("not.exist");
 });

--- a/tests/behavioral/cypress/integration/entity_reference_validation.feature
+++ b/tests/behavioral/cypress/integration/entity_reference_validation.feature
@@ -9,9 +9,9 @@ Feature: Entity Reference Validation
     And I create a "step_by_step" node
     And I click the edit tab
     And I select the "VA Careers and employment" benefits hub
-    And I wait "2" seconds
+    And I wait "3" seconds
     And I select the "VA Careers and employment" benefits hub
-    And I wait "2" seconds
+    And I wait "3" seconds
     And I save the node
     Then I should see "1 error has been found"
     Then I should see "The value Careers and employment"


### PR DESCRIPTION
## Description

See #5371.  I ran a total of about 120 trials of this and it failed twice in that time, for two different reasons -- one because the delay to wait for the iframe to complete loading was insufficient, and once because the delay between selecting benefit hubs wasn't long enough to allow Drupal to finish processing the side effects of the first selection.

I'd love to find an intelligent way of dealing with these issues, but there's a cost/benefit ratio to consider here.

## Testing done
Ran _a lot_ of tests.

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
