### PR TITLE
VACMS-4893: Remove deprecated counselling value from field.

### DIFF
--- a/config/sync/field.storage.taxonomy_term.field_vet_center_type_of_care.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vet_center_type_of_care.yml
@@ -12,9 +12,6 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: counselling
-      label: 'deprecated counselling'
-    -
       value: counseling
       label: 'Counseling services'
     -


### PR DESCRIPTION
## Description
See #4893

## Implementation notes
~~1. Create a PR that adds the new key~~
~~2. Release it to prod~~
~~3. Edit the content on prod~~
**4. Create a PR that removes the old key - current PR**
5. Release to prod


### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
