### PR TITLE
VACMS-1268: Install and enable menu_force module for Detail Page.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "drupal/memcache_admin": "^2.3",
         "drupal/menu_breadcrumb": "^1.8",
         "drupal/menu_export": "^1.2",
+        "drupal/menu_force": "^1.2",
         "drupal/menu_item_extras": "^2.7",
         "drupal/menu_link_attributes": "^1.2",
         "drupal/menu_normalizer": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f116d0946abca4540637bb568c8d64da",
+    "content-hash": "6228445f2a9f3276d55b32a5e55f43b4",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -6623,6 +6623,58 @@
             "homepage": "https://www.drupal.org/project/menu_export",
             "support": {
                 "source": "https://git.drupalcode.org/project/menu_export"
+            }
+        },
+        {
+            "name": "drupal/menu_force",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/menu_force.git",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/menu_force-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "96036cf057002223ee08d1f03e494cbad25439ac"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1593463689",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "BarisW",
+                    "homepage": "https://www.drupal.org/user/107229"
+                },
+                {
+                    "name": "perennial.sky",
+                    "homepage": "https://www.drupal.org/user/2622667"
+                },
+                {
+                    "name": "scuba_fly",
+                    "homepage": "https://www.drupal.org/user/953390"
+                }
+            ],
+            "description": "Makes sure a node gets added to the menu system on specific content types",
+            "homepage": "https://www.drupal.org/project/menu_force",
+            "support": {
+                "source": "https://git.drupalcode.org/project/menu_force"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -191,6 +191,7 @@ module:
   workbench_menu_access: 0
   workflows: 0
   limited_field_widgets: 1
+  menu_force: 1
   menu_link_content: 1
   pathauto: 1
   disable_node_menu_item: 10

--- a/config/sync/node.type.health_care_region_detail_page.yml
+++ b/config/sync/node.type.health_care_region_detail_page.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - menu_force
     - menu_ui
     - node_revision_delete
     - node_title_help_text
@@ -158,6 +159,9 @@ third_party_settings:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0
     when_to_delete: 0
+  menu_force:
+    menu_force: 1
+    menu_force_parent: 0
 name: 'Detail Page'
 type: health_care_region_detail_page
 description: 'For static pages where there''s not another content type already available.'


### PR DESCRIPTION
## Description

See #1268. 

This is the contrib module approach, but it has the right UX. We could reproduce this UX in our custom menu module. 

One advantage with contrib is that we could apply it to other content types, like Benefits Hub Detail Pages. 

## Testing done

Manual.

## Screenshots

![Create_Detail_Page___VA_gov_CMS](https://user-images.githubusercontent.com/643678/119527008-e8c09a00-bd4d-11eb-8f81-fd90a7c409d1.png)

## QA steps

As user Victor.A.MCtest
1. Go to /node/add/health_care_region_detail_page
2. Create a page and note that your menu item is required. 
3. Go to /node/add/person_profile
4. Note that menu item is not required

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
