### PR TITLE
VACMS-4075 Unique validation for content types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/address": "^1.4",
         "drupal/admin_toolbar": "^3.0",
         "drupal/advancedqueue": "^1.0@RC",
-        "drupal/allow_only_one": "1.0.x-dev",
+        "drupal/allow_only_one": "1.0.0-alpha1",
         "drupal/allowed_formats": "^1.3",
         "drupal/auto_entitylabel": "^3.0-beta3",
         "drupal/better_field_descriptions": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "drupal/address": "^1.4",
         "drupal/admin_toolbar": "^3.0",
         "drupal/advancedqueue": "^1.0@RC",
+        "drupal/allow_only_one": "1.0.x-dev",
         "drupal/allowed_formats": "^1.3",
         "drupal/auto_entitylabel": "^3.0-beta3",
         "drupal/better_field_descriptions": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -2652,6 +2652,51 @@
             }
         },
         {
+            "name": "drupal/allow_only_one",
+            "version": "dev-1.0.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/allow_only_one.git",
+                "reference": "8603cef6dd5b682dab2ae7d21349f39494f1f7bf"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.0.x": "1.0.x-dev"
+                },
+                "drupal": {
+                    "version": "1.0.x-dev",
+                    "datestamp": "1622000901",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "kaise.lafrai",
+                    "homepage": "https://www.drupal.org/user/3628898"
+                },
+                {
+                    "name": "swirt",
+                    "homepage": "https://www.drupal.org/user/138230"
+                }
+            ],
+            "description": "The Allow Only One module allows administrators to require that values supplied for specified fields is a unique combination. Validation will throw an error if another content item exists with the same field value combination.",
+            "homepage": "https://www.drupal.org/project/allow_only_one",
+            "support": {
+                "source": "https://git.drupalcode.org/project/allow_only_one"
+            }
+        },
+        {
             "name": "drupal/allowed_formats",
             "version": "1.3.0",
             "source": {
@@ -21558,6 +21603,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/advancedqueue": 5,
+        "drupal/allow_only_one": 20,
         "drupal/blazy": 5,
         "drupal/cer": 20,
         "drupal/content_lock": 15,

--- a/composer.lock
+++ b/composer.lock
@@ -2653,26 +2653,29 @@
         },
         {
             "name": "drupal/allow_only_one",
-            "version": "dev-1.0.x",
+            "version": "1.0.0-alpha1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/allow_only_one.git",
-                "reference": "8603cef6dd5b682dab2ae7d21349f39494f1f7bf"
+                "reference": "1.0.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/allow_only_one-1.0.0-alpha1.zip",
+                "reference": "1.0.0-alpha1",
+                "shasum": "c0d680668bcc8365e552eaed31a0a358d42dffcf"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.0.x": "1.0.x-dev"
-                },
                 "drupal": {
-                    "version": "1.0.x-dev",
-                    "datestamp": "1622000901",
+                    "version": "1.0.0-alpha1",
+                    "datestamp": "1622133534",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "message": "Alpha releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -21603,7 +21606,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/advancedqueue": 5,
-        "drupal/allow_only_one": 20,
         "drupal/blazy": 5,
         "drupal/cer": 20,
         "drupal/content_lock": 15,

--- a/config/sync/core.entity_form_display.block_content.alert.default.yml
+++ b/config/sync/core.entity_form_display.block_content.alert.default.yml
@@ -48,7 +48,7 @@ third_party_settings:
         id: ''
         classes: ''
         required_fields: false
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_behaviour_and_placement:
       children:

--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -25,7 +25,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Section settings
+      label: 'Section settings'
       region: content
 _core:
   default_config_hash: xFJUl0MccoGPEv1eb_I_XnxzjqvZ8M5HA1G3PBtv9IE

--- a/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -26,7 +26,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Section settings
+      label: 'Section settings'
       region: content
 _core:
   default_config_hash: xFJUl0MccoGPEv1eb_I_XnxzjqvZ8M5HA1G3PBtv9IE

--- a/config/sync/core.entity_form_display.media.document_external.default.yml
+++ b/config/sync/core.entity_form_display.media.document_external.default.yml
@@ -28,7 +28,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
     group_edi:
       children: {  }
       parent_name: ''

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -28,7 +28,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Section settings
+      label: 'Section settings'
       region: content
 _core:
   default_config_hash: kyoAHlZTGIuGTaQuBblGBk8EhfnVKOl19_0j5WbpQqM

--- a/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -30,7 +30,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Section settings
+      label: 'Section settings'
       region: content
 _core:
   default_config_hash: kyoAHlZTGIuGTaQuBblGBk8EhfnVKOl19_0j5WbpQqM

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Section settings
+      label: 'Section settings'
       region: content
 _core:
   default_config_hash: OUea_b_jf81XjPvIY9J8KrRUckqz2APuLv4bkxYfdT4

--- a/config/sync/core.entity_form_display.media.video.media_library.yml
+++ b/config/sync/core.entity_form_display.media.video.media_library.yml
@@ -31,7 +31,7 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Section settings
+      label: 'Section settings'
       region: content
 _core:
   default_config_hash: OUea_b_jf81XjPvIY9J8KrRUckqz2APuLv4bkxYfdT4

--- a/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.basic_landing_page.default.yml
@@ -63,7 +63,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
@@ -72,7 +72,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
     group_editorial_workflow:
       children:
         - moderation_state

--- a/config/sync/core.entity_form_display.node.centralized_content.default.yml
+++ b/config/sync/core.entity_form_display.node.centralized_content.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 10
-      label: Section settings
+      label: 'Section settings'
     group_editorial_workflow:
       children:
         - moderation_state

--- a/config/sync/core.entity_form_display.node.checklist.default.yml
+++ b/config/sync/core.entity_form_display.node.checklist.default.yml
@@ -69,7 +69,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_include_alert:
       children:

--- a/config/sync/core.entity_form_display.node.documentation_page.default.yml
+++ b/config/sync/core.entity_form_display.node.documentation_page.default.yml
@@ -39,12 +39,12 @@ third_party_settings:
       format_type: details_sidebar
       format_settings:
         description: ''
-        open: '1'
-        weight: '0'
-        required_fields: '1'
+        open: true
+        weight: 0
+        required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
 id: node.documentation_page.default
 targetEntityType: node

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -48,7 +48,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_location:
       children:

--- a/config/sync/core.entity_form_display.node.event_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.event_listing.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.event_listing.field_administration
     - field.field.node.event_listing.field_description
+    - field.field.node.event_listing.field_enforce_unique_combo
     - field.field.node.event_listing.field_intro_text
     - field.field.node.event_listing.field_meta_tags
     - field.field.node.event_listing.field_meta_title
@@ -12,6 +13,7 @@ dependencies:
     - node.type.event_listing
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - field_group
     - path
@@ -22,7 +24,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -31,14 +33,14 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -53,7 +55,7 @@ third_party_settings:
         - title
         - field_intro_text
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         description: ''
@@ -67,7 +69,7 @@ third_party_settings:
         - field_meta_title
         - field_description
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -101,6 +103,13 @@ content:
     third_party_settings: {  }
     type: string_textfield_with_counter
     region: content
+  field_enforce_unique_combo:
+    weight: 0
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_intro_text:
     weight: 3
     settings:
@@ -124,7 +133,7 @@ content:
     type: string_textfield_with_counter
     region: content
   field_office:
-    weight: 0
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -137,7 +146,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.faq_multiple_q_a.default.yml
+++ b/config/sync/core.entity_form_display.node.faq_multiple_q_a.default.yml
@@ -56,7 +56,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -35,7 +35,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_edi:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -48,7 +48,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
@@ -40,7 +40,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: hidden
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.health_care_local_health_service.field_administration
     - field.field.node.health_care_local_health_service.field_appointments_help_text
     - field.field.node.health_care_local_health_service.field_body
+    - field.field.node.health_care_local_health_service.field_enforce_unique_combo
     - field.field.node.health_care_local_health_service.field_facility_location
     - field.field.node.health_care_local_health_service.field_facility_service_loc_help
     - field.field.node.health_care_local_health_service.field_hservice_appt_intro_select
@@ -20,6 +21,7 @@ dependencies:
     - node.type.health_care_local_health_service
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - entity_browser_entity_form
     - field_group
@@ -43,7 +45,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_appointments:
       children:
@@ -133,6 +135,7 @@ third_party_settings:
       region: content
     group_health_service_and_facilit:
       children:
+        - field_enforce_unique_combo
         - field_facility_location
         - field_regional_health_service
       parent_name: ''
@@ -149,7 +152,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       parent_name: ''
       weight: 4
       format_type: fieldset
@@ -177,8 +179,15 @@ content:
     third_party_settings: {  }
     type: markup
     region: content
+  field_enforce_unique_combo:
+    weight: 29
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_facility_location:
-    weight: 0
+    weight: 30
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -246,7 +255,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_regional_health_service:
-    weight: 1
+    weight: 31
     settings: {  }
     third_party_settings: {  }
     type: options_select

--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -152,6 +152,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 4
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.inline_entity_form.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.health_care_local_health_service.field_administration
     - field.field.node.health_care_local_health_service.field_appointments_help_text
     - field.field.node.health_care_local_health_service.field_body
+    - field.field.node.health_care_local_health_service.field_enforce_unique_combo
     - field.field.node.health_care_local_health_service.field_facility_location
     - field.field.node.health_care_local_health_service.field_facility_service_loc_help
     - field.field.node.health_care_local_health_service.field_hservice_appt_intro_select
@@ -36,7 +37,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: hidden
 id: node.health_care_local_health_service.inline_entity_form
 targetEntityType: node
@@ -66,6 +67,7 @@ content:
 hidden:
   created: true
   field_appointments_help_text: true
+  field_enforce_unique_combo: true
   field_facility_service_loc_help: true
   field_hservice_appt_intro_select: true
   field_hservice_appt_leadin: true

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -45,7 +45,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.health_services_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.health_services_listing.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.health_services_listing.field_administration
     - field.field.node.health_services_listing.field_description
+    - field.field.node.health_services_listing.field_enforce_unique_combo
     - field.field.node.health_services_listing.field_featured_content_healthser
     - field.field.node.health_services_listing.field_intro_text
     - field.field.node.health_services_listing.field_meta_tags
@@ -13,6 +14,7 @@ dependencies:
     - node.type.health_services_listing
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - field_group
     - paragraphs
@@ -24,7 +26,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -33,14 +35,13 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         id: ''
@@ -55,7 +56,7 @@ third_party_settings:
         - title
         - field_intro_text
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         description: ''
@@ -68,7 +69,7 @@ third_party_settings:
       children:
         - field_featured_content_healthser
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -82,7 +83,7 @@ third_party_settings:
         - field_meta_title
         - field_description
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -115,6 +116,13 @@ content:
       textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
     type: string_textfield_with_counter
+    region: content
+  field_enforce_unique_combo:
+    weight: 0
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
     region: content
   field_featured_content_healthser:
     weight: 7
@@ -151,7 +159,7 @@ content:
     type: string_textfield_with_counter
     region: content
   field_office:
-    weight: 0
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -164,7 +172,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.health_services_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.health_services_listing.default.yml
@@ -40,6 +40,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 5
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_right_rail:
       children:

--- a/config/sync/core.entity_form_display.node.leadership_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.leadership_listing.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.locations_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.locations_listing.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.locations_listing.field_administration
     - field.field.node.locations_listing.field_description
+    - field.field.node.locations_listing.field_enforce_unique_combo
     - field.field.node.locations_listing.field_intro_text
     - field.field.node.locations_listing.field_meta_tags
     - field.field.node.locations_listing.field_meta_title
@@ -12,6 +13,7 @@ dependencies:
     - node.type.locations_listing
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - field_group
     - path
@@ -22,7 +24,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -31,14 +33,14 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -53,7 +55,7 @@ third_party_settings:
         - title
         - field_intro_text
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         description: ''
@@ -67,7 +69,7 @@ third_party_settings:
         - field_meta_title
         - field_description
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -101,6 +103,13 @@ content:
     third_party_settings: {  }
     type: string_textfield_with_counter
     region: content
+  field_enforce_unique_combo:
+    weight: 0
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_intro_text:
     weight: 3
     settings:
@@ -124,7 +133,7 @@ content:
     type: string_textfield_with_counter
     region: content
   field_office:
-    weight: 0
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -137,7 +146,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.media_list_images.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_images.default.yml
@@ -83,7 +83,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_categories:
       children:

--- a/config/sync/core.entity_form_display.node.media_list_videos.default.yml
+++ b/config/sync/core.entity_form_display.node.media_list_videos.default.yml
@@ -69,7 +69,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.nca_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.nca_facility.default.yml
@@ -54,10 +54,10 @@ third_party_settings:
         id: ''
         classes: ''
         description: ''
-        open: 1
-        required_fields: 1
-        weight: '-10'
-      label: Section settings
+        open: true
+        required_fields: true
+        weight: -10
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.news_story.default.yml
+++ b/config/sync/core.entity_form_display.node.news_story.default.yml
@@ -36,7 +36,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editor:
       children:

--- a/config/sync/core.entity_form_display.node.office.default.yml
+++ b/config/sync/core.entity_form_display.node.office.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_meta_tags:
       children:

--- a/config/sync/core.entity_form_display.node.outreach_asset.default.yml
+++ b/config/sync/core.entity_form_display.node.outreach_asset.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         id: ''
         classes: ''
         required_fields: false
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -41,7 +41,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_include_crisis_alert:
       children:

--- a/config/sync/core.entity_form_display.node.person_profile.default.yml
+++ b/config/sync/core.entity_form_display.node.person_profile.default.yml
@@ -42,7 +42,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_e:
       children:

--- a/config/sync/core.entity_form_display.node.person_profile.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.person_profile.inline_entity_form.yml
@@ -34,10 +34,10 @@ third_party_settings:
       format_settings:
         id: ''
         classes: ''
-        open: 1
-        required_fields: 1
-        weight: '-10'
-      label: Section settings
+        open: true
+        required_fields: true
+        weight: -10
+      label: 'Section settings'
       region: content
     group_e:
       children:

--- a/config/sync/core.entity_form_display.node.press_release.default.yml
+++ b/config/sync/core.entity_form_display.node.press_release.default.yml
@@ -38,7 +38,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.press_releases_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.press_releases_listing.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.press_releases_listing.field_administration
     - field.field.node.press_releases_listing.field_description
+    - field.field.node.press_releases_listing.field_enforce_unique_combo
     - field.field.node.press_releases_listing.field_intro_text
     - field.field.node.press_releases_listing.field_meta_tags
     - field.field.node.press_releases_listing.field_meta_title
@@ -13,6 +14,7 @@ dependencies:
     - node.type.press_releases_listing
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - field_group
     - path
@@ -24,7 +26,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -33,14 +35,14 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         id: ''
@@ -55,7 +57,7 @@ third_party_settings:
         - title
         - field_intro_text
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         description: ''
@@ -68,7 +70,7 @@ third_party_settings:
       children:
         - field_press_release_blurb
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: details
       format_settings:
         id: ''
@@ -83,7 +85,7 @@ third_party_settings:
         - field_meta_title
         - field_description
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -117,6 +119,13 @@ content:
     third_party_settings: {  }
     type: string_textfield_with_counter
     region: content
+  field_enforce_unique_combo:
+    weight: 0
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_intro_text:
     weight: 3
     settings:
@@ -140,7 +149,7 @@ content:
     type: string_textfield_with_counter
     region: content
   field_office:
-    weight: 0
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -161,7 +170,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.publication_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.publication_listing.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.q_a.default.yml
+++ b/config/sync/core.entity_form_display.node.q_a.default.yml
@@ -67,7 +67,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_in:
       children:

--- a/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
+++ b/config/sync/core.entity_form_display.node.regional_health_care_service_des.default.yml
@@ -5,12 +5,14 @@ dependencies:
   config:
     - field.field.node.regional_health_care_service_des.field_administration
     - field.field.node.regional_health_care_service_des.field_body
+    - field.field.node.regional_health_care_service_des.field_enforce_unique_combo
     - field.field.node.regional_health_care_service_des.field_local_health_care_service_
     - field.field.node.regional_health_care_service_des.field_region_page
     - field.field.node.regional_health_care_service_des.field_service_name_and_descripti
     - node.type.regional_health_care_service_des
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - field_group
     - text
@@ -21,7 +23,7 @@ third_party_settings:
         - field_region_page
         - field_administration
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: details_sidebar
       format_settings:
         open: true
@@ -29,14 +31,14 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -58,12 +60,19 @@ content:
     type: options_select
     region: content
   field_body:
-    weight: 1
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_enforce_unique_combo:
+    weight: 0
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
     region: content
   field_region_page:
     weight: 1
@@ -72,7 +81,7 @@ content:
     type: options_select
     region: content
   field_service_name_and_descripti:
-    weight: 0
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: options_select

--- a/config/sync/core.entity_form_display.node.regional_health_care_service_des.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.regional_health_care_service_des.inline_entity_form.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_form_mode.node.inline_entity_form
     - field.field.node.regional_health_care_service_des.field_administration
     - field.field.node.regional_health_care_service_des.field_body
+    - field.field.node.regional_health_care_service_des.field_enforce_unique_combo
     - field.field.node.regional_health_care_service_des.field_local_health_care_service_
     - field.field.node.regional_health_care_service_des.field_region_page
     - field.field.node.regional_health_care_service_des.field_service_name_and_descripti
@@ -51,6 +52,7 @@ content:
 hidden:
   created: true
   field_administration: true
+  field_enforce_unique_combo: true
   field_region_page: true
   moderation_state: true
   path: true

--- a/config/sync/core.entity_form_display.node.step_by_step.default.yml
+++ b/config/sync/core.entity_form_display.node.step_by_step.default.yml
@@ -83,7 +83,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_inc:
       children:

--- a/config/sync/core.entity_form_display.node.story_listing.default.yml
+++ b/config/sync/core.entity_form_display.node.story_listing.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.story_listing.field_administration
     - field.field.node.story_listing.field_description
+    - field.field.node.story_listing.field_enforce_unique_combo
     - field.field.node.story_listing.field_intro_text
     - field.field.node.story_listing.field_meta_tags
     - field.field.node.story_listing.field_meta_title
@@ -12,6 +13,7 @@ dependencies:
     - node.type.story_listing
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - field_group
     - path
@@ -22,7 +24,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details_sidebar
       format_settings:
         id: ''
@@ -31,14 +33,14 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         id: ''
@@ -50,10 +52,11 @@ third_party_settings:
       region: content
     group_meta:
       children:
+        - field_enforce_unique_combo
         - title
         - field_intro_text
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         description: ''
@@ -67,7 +70,7 @@ third_party_settings:
         - field_meta_title
         - field_description
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         id: ''
@@ -101,8 +104,15 @@ content:
     third_party_settings: {  }
     type: string_textfield_with_counter
     region: content
+  field_enforce_unique_combo:
+    weight: 0
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_intro_text:
-    weight: 3
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
@@ -124,7 +134,7 @@ content:
     type: string_textfield_with_counter
     region: content
   field_office:
-    weight: 0
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -137,7 +147,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.support_resources_detail_page.default.yml
@@ -81,10 +81,10 @@ third_party_settings:
         id: ''
         classes: ''
         description: ''
-        open: 1
-        required_fields: 1
-        weight: '-10'
-      label: Section settings
+        open: true
+        required_fields: true
+        weight: -10
+      label: 'Section settings'
       region: content
     group_include_toc:
       children:

--- a/config/sync/core.entity_form_display.node.support_service.default.yml
+++ b/config/sync/core.entity_form_display.node.support_service.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
 id: node.support_service.default
 targetEntityType: node

--- a/config/sync/core.entity_form_display.node.va_form.default.yml
+++ b/config/sync/core.entity_form_display.node.va_form.default.yml
@@ -52,7 +52,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_online_tool:
       children:

--- a/config/sync/core.entity_form_display.node.vamc_operating_status_and_alerts.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_operating_status_and_alerts.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_form_mode.node.inline_entity_form
     - field.field.node.vamc_operating_status_and_alerts.field_administration
     - field.field.node.vamc_operating_status_and_alerts.field_banner_alert
+    - field.field.node.vamc_operating_status_and_alerts.field_enforce_unique_combo
     - field.field.node.vamc_operating_status_and_alerts.field_facility_operating_status
     - field.field.node.vamc_operating_status_and_alerts.field_links
     - field.field.node.vamc_operating_status_and_alerts.field_meta_tags
@@ -13,6 +14,7 @@ dependencies:
     - field.field.node.vamc_operating_status_and_alerts.field_operating_status_emerg_inf
     - node.type.vamc_operating_status_and_alerts
   module:
+    - allow_only_one
     - field_group
     - ief_table_view_mode
     - linkit
@@ -23,7 +25,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: details_sidebar
       format_settings:
         description: ''
@@ -32,13 +34,13 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:
         - revision_log
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         id: ''
@@ -52,7 +54,7 @@ third_party_settings:
         - field_operating_status_emerg_inf
         - field_links
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details
       format_settings:
         description: 'Add general emergency resources relevant to a variety of situations and emergencies. '
@@ -74,7 +76,7 @@ content:
     type: options_select
     region: content
   field_banner_alert:
-    weight: 2
+    weight: 3
     settings:
       form_mode: inline_entity_form
       override_labels: true
@@ -90,8 +92,15 @@ content:
     third_party_settings: {  }
     type: inline_entity_form_complex_table_view_mode
     region: content
+  field_enforce_unique_combo:
+    weight: 1
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_facility_operating_status:
-    weight: 3
+    weight: 4
     settings:
       form_mode: inline_entity_form
       override_labels: true
@@ -112,12 +121,14 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
     type: linkit
     region: content
   field_office:
     type: options_select
-    weight: 1
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.vamc_system_policies_page.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_system_policies_page.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.vamc_system_policies_page.field_cc_gen_visitation_policy
     - field.field.node.vamc_system_policies_page.field_cc_intro_text
     - field.field.node.vamc_system_policies_page.field_cc_top_of_page_content
+    - field.field.node.vamc_system_policies_page.field_enforce_unique_combo
     - field.field.node.vamc_system_policies_page.field_fieldset_markup
     - field.field.node.vamc_system_policies_page.field_office
     - field.field.node.vamc_system_policies_page.field_vamc_other_policies
@@ -15,6 +16,7 @@ dependencies:
     - node.type.vamc_system_policies_page
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - entity_field_fetch
     - field_group
@@ -24,6 +26,7 @@ third_party_settings:
   field_group:
     group_governance:
       children:
+        - field_enforce_unique_combo
         - field_office
         - field_administration
       parent_name: ''
@@ -37,7 +40,7 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Section settings
+      label: 'Section settings'
     group_editorial_workflow:
       children:
         - status
@@ -116,7 +119,7 @@ bundle: vamc_system_policies_page
 mode: default
 content:
   field_administration:
-    weight: 1
+    weight: 32
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -157,6 +160,13 @@ content:
     third_party_settings: {  }
     type: entity_field_fetch_widget
     region: content
+  field_enforce_unique_combo:
+    weight: 30
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_fieldset_markup:
     weight: 26
     settings: {  }
@@ -164,7 +174,7 @@ content:
     type: markup
     region: content
   field_office:
-    weight: 0
+    weight: 31
     settings: {  }
     third_party_settings: {  }
     type: options_select

--- a/config/sync/core.entity_form_display.node.vba_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.vba_facility.default.yml
@@ -54,10 +54,10 @@ third_party_settings:
         id: ''
         classes: ''
         description: ''
-        open: 1
-        required_fields: 1
-        weight: '-10'
-      label: Section settings
+        open: true
+        required_fields: true
+        weight: -10
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -66,7 +66,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: -10
-      label: Section settings
+      label: 'Section settings'
       region: content
     group_editorial_workflow:
       children:

--- a/config/sync/core.entity_form_display.node.vet_center_cap.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_cap.default.yml
@@ -40,7 +40,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
     group_editorial_workflow:
       children:
         - moderation_state

--- a/config/sync/core.entity_form_display.node.vet_center_cap.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_cap.inline_entity_form.yml
@@ -33,7 +33,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
     group_health_service_and_facilit:
       children:
         - field_regional_health_service

--- a/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.default.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - field.field.node.vet_center_facility_health_servi.field_administration
     - field.field.node.vet_center_facility_health_servi.field_body
+    - field.field.node.vet_center_facility_health_servi.field_enforce_unique_combo
     - field.field.node.vet_center_facility_health_servi.field_office
     - field.field.node.vet_center_facility_health_servi.field_service_name_and_descripti
     - node.type.vet_center_facility_health_servi
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - field_group
     - text
@@ -20,7 +22,7 @@ third_party_settings:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       region: content
       format_settings:
@@ -33,7 +35,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details_sidebar
       region: content
       format_settings:
@@ -43,7 +45,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
 id: node.vet_center_facility_health_servi.default
 targetEntityType: node
 bundle: vet_center_facility_health_servi
@@ -56,21 +58,28 @@ content:
     type: options_select
     region: content
   field_body:
-    weight: 3
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
     region: content
-  field_office:
+  field_enforce_unique_combo:
     weight: 1
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
+  field_office:
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_service_name_and_descripti:
-    weight: 2
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -85,7 +94,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 7
     region: content
     third_party_settings: {  }
   title:
@@ -97,7 +106,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.inline_entity_form.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_form_mode.node.inline_entity_form
     - field.field.node.vet_center_facility_health_servi.field_administration
     - field.field.node.vet_center_facility_health_servi.field_body
+    - field.field.node.vet_center_facility_health_servi.field_enforce_unique_combo
     - field.field.node.vet_center_facility_health_servi.field_office
     - field.field.node.vet_center_facility_health_servi.field_service_name_and_descripti
     - node.type.vet_center_facility_health_servi
@@ -43,7 +44,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
 id: node.vet_center_facility_health_servi.inline_entity_form
 targetEntityType: node
 bundle: vet_center_facility_health_servi
@@ -91,6 +92,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_enforce_unique_combo: true
   path: true
   promote: true
   status: true

--- a/config/sync/core.entity_form_display.node.vet_center_locations_list.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_locations_list.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - entity_browser.browser.vet_centers
     - field.field.node.vet_center_locations_list.field_administration
+    - field.field.node.vet_center_locations_list.field_enforce_unique_combo
     - field.field.node.vet_center_locations_list.field_intro_text
     - field.field.node.vet_center_locations_list.field_nearby_mobile_vet_centers
     - field.field.node.vet_center_locations_list.field_nearby_vet_centers
@@ -12,6 +13,7 @@ dependencies:
     - node.type.vet_center_locations_list
     - workflows.workflow.editorial
   module:
+    - allow_only_one
     - content_moderation
     - entity_browser_table
     - field_group
@@ -22,7 +24,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: details_sidebar
       region: content
       format_settings:
@@ -32,13 +34,13 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
     group_ed:
       children:
         - moderation_state
         - revision_log
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       region: content
       format_settings:
@@ -58,8 +60,15 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
+  field_enforce_unique_combo:
+    weight: 1
+    settings:
+      size: 1
+    third_party_settings: {  }
+    type: allow_only_one_widget
+    region: content
   field_intro_text:
-    weight: 2
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
@@ -67,7 +76,7 @@ content:
     type: string_textarea
     region: content
   field_nearby_mobile_vet_centers:
-    weight: 3
+    weight: 4
     settings:
       entity_browser: mobile_vet_centers
       field_widget_display: label
@@ -83,7 +92,7 @@ content:
     type: entity_reference_browser_table_widget
     region: content
   field_nearby_vet_centers:
-    weight: 4
+    weight: 5
     settings:
       entity_browser: vet_centers
       field_widget_display: label
@@ -99,7 +108,7 @@ content:
     type: entity_reference_browser_table_widget
     region: content
   field_office:
-    weight: 1
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     type: options_select

--- a/config/sync/core.entity_form_display.node.vet_center_mobile_vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_mobile_vet_center.default.yml
@@ -63,7 +63,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
     group_facility_name:
       children:
         - group_page_title_tooltip

--- a/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
@@ -53,7 +53,7 @@ third_party_settings:
         open: true
         required_fields: true
         weight: 0
-      label: Section settings
+      label: 'Section settings'
     group_facility_name:
       children:
         - group_page_title_tooltip

--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
         id: ''
         classes: ''
         open: false
-      label: Section settings
+      label: 'Section settings'
       region: hidden
     group_vet_center:
       children:

--- a/config/sync/core.entity_view_display.node.event_listing.default.yml
+++ b/config/sync/core.entity_view_display.node.event_listing.default.yml
@@ -5,12 +5,14 @@ dependencies:
   config:
     - field.field.node.event_listing.field_administration
     - field.field.node.event_listing.field_description
+    - field.field.node.event_listing.field_enforce_unique_combo
     - field.field.node.event_listing.field_intro_text
     - field.field.node.event_listing.field_meta_tags
     - field.field.node.event_listing.field_meta_title
     - field.field.node.event_listing.field_office
     - node.type.event_listing
   module:
+    - allow_only_one
     - field_group
     - user
 third_party_settings:
@@ -66,6 +68,13 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_enforce_unique_combo:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
+    region: content
   field_intro_text:
     weight: 7
     label: above

--- a/config/sync/core.entity_view_display.node.event_listing.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event_listing.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.event_listing.field_administration
     - field.field.node.event_listing.field_description
+    - field.field.node.event_listing.field_enforce_unique_combo
     - field.field.node.event_listing.field_intro_text
     - field.field.node.event_listing.field_meta_tags
     - field.field.node.event_listing.field_meta_title
@@ -27,6 +28,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_description: true
+  field_enforce_unique_combo: true
   field_intro_text: true
   field_meta_tags: true
   field_meta_title: true

--- a/config/sync/core.entity_view_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_health_service.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.health_care_local_health_service.field_administration
     - field.field.node.health_care_local_health_service.field_appointments_help_text
     - field.field.node.health_care_local_health_service.field_body
+    - field.field.node.health_care_local_health_service.field_enforce_unique_combo
     - field.field.node.health_care_local_health_service.field_facility_location
     - field.field.node.health_care_local_health_service.field_facility_service_loc_help
     - field.field.node.health_care_local_health_service.field_hservice_appt_intro_select
@@ -19,6 +20,7 @@ dependencies:
     - field.field.node.health_care_local_health_service.field_walk_ins_accepted
     - node.type.health_care_local_health_service
   module:
+    - allow_only_one
     - entity_reference_revisions
     - field_group
     - markup
@@ -71,6 +73,13 @@ targetEntityType: node
 bundle: health_care_local_health_service
 mode: default
 content:
+  field_enforce_unique_combo:
+    weight: 13
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
+    region: content
   field_hservice_appt_intro_select:
     weight: 4
     label: above

--- a/config/sync/core.entity_view_display.node.health_care_local_health_service.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_health_service.ief_table.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.health_care_local_health_service.field_administration
     - field.field.node.health_care_local_health_service.field_appointments_help_text
     - field.field.node.health_care_local_health_service.field_body
+    - field.field.node.health_care_local_health_service.field_enforce_unique_combo
     - field.field.node.health_care_local_health_service.field_facility_location
     - field.field.node.health_care_local_health_service.field_facility_service_loc_help
     - field.field.node.health_care_local_health_service.field_hservice_appt_intro_select
@@ -46,6 +47,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_appointments_help_text: true
+  field_enforce_unique_combo: true
   field_facility_service_loc_help: true
   field_hservice_appt_intro_select: true
   field_hservice_appt_leadin: true

--- a/config/sync/core.entity_view_display.node.health_care_local_health_service.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_health_service.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.health_care_local_health_service.field_administration
     - field.field.node.health_care_local_health_service.field_appointments_help_text
     - field.field.node.health_care_local_health_service.field_body
+    - field.field.node.health_care_local_health_service.field_enforce_unique_combo
     - field.field.node.health_care_local_health_service.field_facility_location
     - field.field.node.health_care_local_health_service.field_facility_service_loc_help
     - field.field.node.health_care_local_health_service.field_hservice_appt_intro_select
@@ -39,6 +40,7 @@ hidden:
   field_administration: true
   field_appointments_help_text: true
   field_clinical_health_services: true
+  field_enforce_unique_combo: true
   field_facility_location: true
   field_facility_service_loc_help: true
   field_hservice_appt_intro_select: true

--- a/config/sync/core.entity_view_display.node.health_services_listing.default.yml
+++ b/config/sync/core.entity_view_display.node.health_services_listing.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.health_services_listing.field_administration
     - field.field.node.health_services_listing.field_description
+    - field.field.node.health_services_listing.field_enforce_unique_combo
     - field.field.node.health_services_listing.field_featured_content_healthser
     - field.field.node.health_services_listing.field_intro_text
     - field.field.node.health_services_listing.field_meta_tags
@@ -12,6 +13,7 @@ dependencies:
     - field.field.node.health_services_listing.field_office
     - node.type.health_services_listing
   module:
+    - allow_only_one
     - entity_reference_revisions
     - field_group
     - user
@@ -68,6 +70,13 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_enforce_unique_combo:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
+    region: content
   field_featured_content_healthser:
     weight: 2
     label: above

--- a/config/sync/core.entity_view_display.node.health_services_listing.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_services_listing.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.health_services_listing.field_administration
     - field.field.node.health_services_listing.field_description
+    - field.field.node.health_services_listing.field_enforce_unique_combo
     - field.field.node.health_services_listing.field_featured_content_healthser
     - field.field.node.health_services_listing.field_intro_text
     - field.field.node.health_services_listing.field_meta_tags
@@ -28,6 +29,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_description: true
+  field_enforce_unique_combo: true
   field_featured_content_healthser: true
   field_intro_text: true
   field_meta_tags: true

--- a/config/sync/core.entity_view_display.node.locations_listing.default.yml
+++ b/config/sync/core.entity_view_display.node.locations_listing.default.yml
@@ -5,12 +5,14 @@ dependencies:
   config:
     - field.field.node.locations_listing.field_administration
     - field.field.node.locations_listing.field_description
+    - field.field.node.locations_listing.field_enforce_unique_combo
     - field.field.node.locations_listing.field_intro_text
     - field.field.node.locations_listing.field_meta_tags
     - field.field.node.locations_listing.field_meta_title
     - field.field.node.locations_listing.field_office
     - node.type.locations_listing
   module:
+    - allow_only_one
     - field_group
     - user
 third_party_settings:
@@ -66,6 +68,13 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_enforce_unique_combo:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
+    region: content
   field_intro_text:
     weight: 7
     label: above

--- a/config/sync/core.entity_view_display.node.locations_listing.teaser.yml
+++ b/config/sync/core.entity_view_display.node.locations_listing.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.locations_listing.field_administration
     - field.field.node.locations_listing.field_description
+    - field.field.node.locations_listing.field_enforce_unique_combo
     - field.field.node.locations_listing.field_intro_text
     - field.field.node.locations_listing.field_meta_tags
     - field.field.node.locations_listing.field_meta_title
@@ -27,6 +28,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_description: true
+  field_enforce_unique_combo: true
   field_intro_text: true
   field_meta_tags: true
   field_meta_title: true

--- a/config/sync/core.entity_view_display.node.press_releases_listing.default.yml
+++ b/config/sync/core.entity_view_display.node.press_releases_listing.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.press_releases_listing.field_administration
     - field.field.node.press_releases_listing.field_description
+    - field.field.node.press_releases_listing.field_enforce_unique_combo
     - field.field.node.press_releases_listing.field_intro_text
     - field.field.node.press_releases_listing.field_meta_tags
     - field.field.node.press_releases_listing.field_meta_title
@@ -12,6 +13,7 @@ dependencies:
     - field.field.node.press_releases_listing.field_press_release_blurb
     - node.type.press_releases_listing
   module:
+    - allow_only_one
     - field_group
     - text
     - user
@@ -68,6 +70,13 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_enforce_unique_combo:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
+    region: content
   field_intro_text:
     weight: 7
     label: above

--- a/config/sync/core.entity_view_display.node.press_releases_listing.teaser.yml
+++ b/config/sync/core.entity_view_display.node.press_releases_listing.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.press_releases_listing.field_administration
     - field.field.node.press_releases_listing.field_description
+    - field.field.node.press_releases_listing.field_enforce_unique_combo
     - field.field.node.press_releases_listing.field_intro_text
     - field.field.node.press_releases_listing.field_meta_tags
     - field.field.node.press_releases_listing.field_meta_title
@@ -28,6 +29,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_description: true
+  field_enforce_unique_combo: true
   field_intro_text: true
   field_meta_tags: true
   field_meta_title: true

--- a/config/sync/core.entity_view_display.node.regional_health_care_service_des.default.yml
+++ b/config/sync/core.entity_view_display.node.regional_health_care_service_des.default.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - field.field.node.regional_health_care_service_des.field_administration
     - field.field.node.regional_health_care_service_des.field_body
+    - field.field.node.regional_health_care_service_des.field_enforce_unique_combo
     - field.field.node.regional_health_care_service_des.field_local_health_care_service_
     - field.field.node.regional_health_care_service_des.field_region_page
     - field.field.node.regional_health_care_service_des.field_service_name_and_descripti
     - node.type.regional_health_care_service_des
   module:
+    - allow_only_one
     - field_group
     - text
     - user
@@ -64,6 +66,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_enforce_unique_combo:
+    weight: 6
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
     region: content
   field_local_health_care_service_:
     weight: 5

--- a/config/sync/core.entity_view_display.node.regional_health_care_service_des.teaser.yml
+++ b/config/sync/core.entity_view_display.node.regional_health_care_service_des.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.regional_health_care_service_des.field_administration
     - field.field.node.regional_health_care_service_des.field_body
+    - field.field.node.regional_health_care_service_des.field_enforce_unique_combo
     - field.field.node.regional_health_care_service_des.field_local_health_care_service_
     - field.field.node.regional_health_care_service_des.field_region_page
     - field.field.node.regional_health_care_service_des.field_service_name_and_descripti
@@ -64,6 +65,7 @@ content:
 hidden:
   content_moderation_control: true
   field_administration: true
+  field_enforce_unique_combo: true
   field_health_services_local_info: true
   field_local_health_care_service_: true
   field_region_page: true

--- a/config/sync/core.entity_view_display.node.story_listing.default.yml
+++ b/config/sync/core.entity_view_display.node.story_listing.default.yml
@@ -5,12 +5,14 @@ dependencies:
   config:
     - field.field.node.story_listing.field_administration
     - field.field.node.story_listing.field_description
+    - field.field.node.story_listing.field_enforce_unique_combo
     - field.field.node.story_listing.field_intro_text
     - field.field.node.story_listing.field_meta_tags
     - field.field.node.story_listing.field_meta_title
     - field.field.node.story_listing.field_office
     - node.type.story_listing
   module:
+    - allow_only_one
     - field_group
     - user
 third_party_settings:
@@ -66,6 +68,13 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_enforce_unique_combo:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
+    region: content
   field_intro_text:
     weight: 7
     label: above

--- a/config/sync/core.entity_view_display.node.story_listing.teaser.yml
+++ b/config/sync/core.entity_view_display.node.story_listing.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.story_listing.field_administration
     - field.field.node.story_listing.field_description
+    - field.field.node.story_listing.field_enforce_unique_combo
     - field.field.node.story_listing.field_intro_text
     - field.field.node.story_listing.field_meta_tags
     - field.field.node.story_listing.field_meta_title
@@ -27,6 +28,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_description: true
+  field_enforce_unique_combo: true
   field_intro_text: true
   field_meta_tags: true
   field_meta_title: true

--- a/config/sync/core.entity_view_display.node.vamc_operating_status_and_alerts.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_operating_status_and_alerts.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.vamc_operating_status_and_alerts.field_administration
     - field.field.node.vamc_operating_status_and_alerts.field_banner_alert
+    - field.field.node.vamc_operating_status_and_alerts.field_enforce_unique_combo
     - field.field.node.vamc_operating_status_and_alerts.field_facility_operating_status
     - field.field.node.vamc_operating_status_and_alerts.field_links
     - field.field.node.vamc_operating_status_and_alerts.field_meta_tags
@@ -12,6 +13,7 @@ dependencies:
     - field.field.node.vamc_operating_status_and_alerts.field_operating_status_emerg_inf
     - node.type.vamc_operating_status_and_alerts
   module:
+    - allow_only_one
     - link
     - text
     - user
@@ -27,6 +29,13 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_enforce_unique_combo:
+    weight: 5
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
     region: content
   field_facility_operating_status:
     weight: 2

--- a/config/sync/core.entity_view_display.node.vamc_operating_status_and_alerts.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vamc_operating_status_and_alerts.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.vamc_operating_status_and_alerts.field_administration
     - field.field.node.vamc_operating_status_and_alerts.field_banner_alert
+    - field.field.node.vamc_operating_status_and_alerts.field_enforce_unique_combo
     - field.field.node.vamc_operating_status_and_alerts.field_facility_operating_status
     - field.field.node.vamc_operating_status_and_alerts.field_links
     - field.field.node.vamc_operating_status_and_alerts.field_meta_tags
@@ -28,6 +29,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_banner_alert: true
+  field_enforce_unique_combo: true
   field_facility_operating_status: true
   field_links: true
   field_meta_tags: true

--- a/config/sync/core.entity_view_display.node.vamc_system_policies_page.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_policies_page.default.yml
@@ -8,12 +8,14 @@ dependencies:
     - field.field.node.vamc_system_policies_page.field_cc_gen_visitation_policy
     - field.field.node.vamc_system_policies_page.field_cc_intro_text
     - field.field.node.vamc_system_policies_page.field_cc_top_of_page_content
+    - field.field.node.vamc_system_policies_page.field_enforce_unique_combo
     - field.field.node.vamc_system_policies_page.field_fieldset_markup
     - field.field.node.vamc_system_policies_page.field_office
     - field.field.node.vamc_system_policies_page.field_vamc_other_policies
     - field.field.node.vamc_system_policies_page.field_vamc_visitation_policy
     - node.type.vamc_system_policies_page
   module:
+    - allow_only_one
     - entity_field_fetch
     - field_group
     - markup
@@ -106,6 +108,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: entity_field_fetch
+    region: content
+  field_enforce_unique_combo:
+    weight: 11
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
     region: content
   field_fieldset_markup:
     weight: 8

--- a/config/sync/core.entity_view_display.node.vamc_system_policies_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_policies_page.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.vamc_system_policies_page.field_cc_gen_visitation_policy
     - field.field.node.vamc_system_policies_page.field_cc_intro_text
     - field.field.node.vamc_system_policies_page.field_cc_top_of_page_content
+    - field.field.node.vamc_system_policies_page.field_enforce_unique_combo
     - field.field.node.vamc_system_policies_page.field_fieldset_markup
     - field.field.node.vamc_system_policies_page.field_office
     - field.field.node.vamc_system_policies_page.field_vamc_other_policies
@@ -37,6 +38,7 @@ hidden:
   field_cc_gen_visitation_policy: true
   field_cc_intro_text: true
   field_cc_top_of_page_content: true
+  field_enforce_unique_combo: true
   field_fieldset_markup: true
   field_office: true
   field_vamc_other_policies: true

--- a/config/sync/core.entity_view_display.node.vet_center_facility_health_servi.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_facility_health_servi.default.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - field.field.node.vet_center_facility_health_servi.field_administration
     - field.field.node.vet_center_facility_health_servi.field_body
+    - field.field.node.vet_center_facility_health_servi.field_enforce_unique_combo
     - field.field.node.vet_center_facility_health_servi.field_office
     - field.field.node.vet_center_facility_health_servi.field_service_name_and_descripti
     - node.type.vet_center_facility_health_servi
   module:
+    - allow_only_one
     - text
     - user
 id: node.vet_center_facility_health_servi.default
@@ -22,6 +24,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_enforce_unique_combo:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
     region: content
   field_office:
     weight: 1

--- a/config/sync/core.entity_view_display.node.vet_center_facility_health_servi.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_facility_health_servi.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.vet_center_facility_health_servi.field_administration
     - field.field.node.vet_center_facility_health_servi.field_body
+    - field.field.node.vet_center_facility_health_servi.field_enforce_unique_combo
     - field.field.node.vet_center_facility_health_servi.field_office
     - field.field.node.vet_center_facility_health_servi.field_service_name_and_descripti
     - node.type.vet_center_facility_health_servi
@@ -29,6 +30,7 @@ content:
 hidden:
   field_administration: true
   field_body: true
+  field_enforce_unique_combo: true
   field_office: true
   field_service_name_and_descripti: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.vet_center_locations_list.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_locations_list.default.yml
@@ -4,18 +4,27 @@ status: true
 dependencies:
   config:
     - field.field.node.vet_center_locations_list.field_administration
+    - field.field.node.vet_center_locations_list.field_enforce_unique_combo
     - field.field.node.vet_center_locations_list.field_intro_text
     - field.field.node.vet_center_locations_list.field_nearby_mobile_vet_centers
     - field.field.node.vet_center_locations_list.field_nearby_vet_centers
     - field.field.node.vet_center_locations_list.field_office
     - node.type.vet_center_locations_list
   module:
+    - allow_only_one
     - user
 id: node.vet_center_locations_list.default
 targetEntityType: node
 bundle: vet_center_locations_list
 mode: default
 content:
+  field_enforce_unique_combo:
+    weight: 5
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: allow_only_one
+    region: content
   field_intro_text:
     weight: 2
     label: above

--- a/config/sync/core.entity_view_display.node.vet_center_locations_list.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_locations_list.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.vet_center_locations_list.field_administration
+    - field.field.node.vet_center_locations_list.field_enforce_unique_combo
     - field.field.node.vet_center_locations_list.field_intro_text
     - field.field.node.vet_center_locations_list.field_nearby_mobile_vet_centers
     - field.field.node.vet_center_locations_list.field_nearby_vet_centers
@@ -29,6 +30,7 @@ content:
     region: content
 hidden:
   field_administration: true
+  field_enforce_unique_combo: true
   field_intro_text: true
   field_nearby_mobile_vet_centers: true
   field_nearby_vet_centers: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -5,6 +5,7 @@ module:
   admin_toolbar_links_access_filter: 0
   admin_toolbar_tools: 0
   advancedqueue: 0
+  allow_only_one: 0
   allowed_formats: 0
   auto_entitylabel: 0
   basic_auth: 0

--- a/config/sync/field.field.node.event_listing.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.event_listing.field_enforce_unique_combo.yml
@@ -15,7 +15,7 @@ third_party_settings:
     field_meta_tags: 0
     field_meta_title: 0
     field_office: 1
-    title: 1
+    title: 0
     case_sensitive: '0'
 id: node.event_listing.field_enforce_unique_combo
 field_name: field_enforce_unique_combo

--- a/config/sync/field.field.node.event_listing.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.event_listing.field_enforce_unique_combo.yml
@@ -1,0 +1,33 @@
+uuid: 09753d7c-f2e5-49cc-9666-9f54321a90cb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.event_listing
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_description: 0
+    field_intro_text: 0
+    field_meta_tags: 0
+    field_meta_title: 0
+    field_office: 1
+    title: 1
+    case_sensitive: '0'
+id: node.event_listing.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: event_listing
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.health_care_local_health_service.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.health_care_local_health_service.field_enforce_unique_combo.yml
@@ -1,0 +1,41 @@
+uuid: a158f46e-433a-456d-9f00-06fef33e20e6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.health_care_local_health_service
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_appointments_help_text: 0
+    field_body: 0
+    field_facility_location: 1
+    field_facility_service_loc_help: 0
+    field_hservices_lead_in_default: 0
+    field_hservice_appt_intro_select: 0
+    field_hservice_appt_leadin: 0
+    field_online_scheduling_availabl: 0
+    field_phone_numbers_paragraph: 0
+    field_referral_required: 0
+    field_regional_health_service: 1
+    field_service_location: 0
+    field_walk_ins_accepted: 0
+    title: 0
+    case_sensitive: null
+id: node.health_care_local_health_service.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: health_care_local_health_service
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.health_services_listing.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.health_services_listing.field_enforce_unique_combo.yml
@@ -1,0 +1,34 @@
+uuid: d2de5166-3e9a-49f3-bbae-acbf3001e063
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.health_services_listing
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_description: 0
+    field_featured_content_healthser: 0
+    field_intro_text: 0
+    field_meta_tags: 0
+    field_meta_title: 0
+    field_office: 1
+    title: 0
+    case_sensitive: null
+id: node.health_services_listing.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: health_services_listing
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.locations_listing.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.locations_listing.field_enforce_unique_combo.yml
@@ -1,0 +1,33 @@
+uuid: d885b29d-224f-4343-9fd0-93b9568b3c48
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.locations_listing
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_description: 0
+    field_intro_text: 0
+    field_meta_tags: 0
+    field_meta_title: 0
+    field_office: 1
+    title: 0
+    case_sensitive: null
+id: node.locations_listing.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: locations_listing
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.press_releases_listing.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.press_releases_listing.field_enforce_unique_combo.yml
@@ -1,0 +1,34 @@
+uuid: 1deb9d56-422d-4c71-ba66-0ffb69fd2cc9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.press_releases_listing
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_description: 0
+    field_intro_text: 0
+    field_meta_tags: 0
+    field_meta_title: 0
+    field_office: 1
+    field_press_release_blurb: 0
+    title: 0
+    case_sensitive: null
+id: node.press_releases_listing.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: press_releases_listing
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.regional_health_care_service_des.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.regional_health_care_service_des.field_enforce_unique_combo.yml
@@ -1,0 +1,32 @@
+uuid: 6e3c1cc2-8cb0-4c83-a59a-7a04a57b1e48
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.regional_health_care_service_des
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_body: 0
+    field_local_health_care_service_: 0
+    field_region_page: 1
+    field_service_name_and_descripti: 1
+    title: 0
+    case_sensitive: null
+id: node.regional_health_care_service_des.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: regional_health_care_service_des
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.story_listing.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.story_listing.field_enforce_unique_combo.yml
@@ -1,0 +1,33 @@
+uuid: e43e606d-b859-416a-9767-162f565eb600
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.story_listing
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_description: 0
+    field_intro_text: 0
+    field_meta_tags: 0
+    field_meta_title: 0
+    field_office: 1
+    title: 0
+    case_sensitive: null
+id: node.story_listing.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: story_listing
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.vamc_operating_status_and_alerts.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.vamc_operating_status_and_alerts.field_enforce_unique_combo.yml
@@ -1,0 +1,34 @@
+uuid: ad704233-bb29-48ff-b838-cdc1c066d1be
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.vamc_operating_status_and_alerts
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_banner_alert: 0
+    field_facility_operating_status: 0
+    field_links: 0
+    field_meta_tags: 0
+    field_office: 1
+    field_operating_status_emerg_inf: 0
+    title: 0
+    case_sensitive: null
+id: node.vamc_operating_status_and_alerts.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: vamc_operating_status_and_alerts
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.vamc_system_policies_page.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.vamc_system_policies_page.field_enforce_unique_combo.yml
@@ -1,0 +1,36 @@
+uuid: fbd8a530-4e38-4980-9ec5-576bbd194766
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.vamc_system_policies_page
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_cc_bottom_of_page_content: 0
+    field_cc_gen_visitation_policy: 0
+    field_cc_intro_text: 0
+    field_cc_top_of_page_content: 0
+    field_fieldset_markup: 0
+    field_office: 1
+    field_vamc_other_policies: 0
+    field_vamc_visitation_policy: 0
+    title: 0
+    case_sensitive: null
+id: node.vamc_system_policies_page.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: vamc_system_policies_page
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.vet_center_facility_health_servi.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.vet_center_facility_health_servi.field_enforce_unique_combo.yml
@@ -1,0 +1,31 @@
+uuid: d8503843-9484-491f-b00c-7ea625044894
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.vet_center_facility_health_servi
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_body: 0
+    field_office: 1
+    field_service_name_and_descripti: 1
+    title: 0
+    case_sensitive: null
+id: node.vet_center_facility_health_servi.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: vet_center_facility_health_servi
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.node.vet_center_locations_list.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.vet_center_locations_list.field_enforce_unique_combo.yml
@@ -1,0 +1,32 @@
+uuid: 43c41725-88c1-4906-a4ba-fbd0f2b18cbb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.vet_center_locations_list
+  module:
+    - allow_only_one
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_intro_text: 0
+    field_nearby_mobile_vet_centers: 0
+    field_nearby_vet_centers: 0
+    field_office: 1
+    title: 0
+    case_sensitive: null
+id: node.vet_center_locations_list.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: vet_center_locations_list
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.storage.node.field_enforce_unique_combo.yml
+++ b/config/sync/field.storage.node.field_enforce_unique_combo.yml
@@ -1,0 +1,19 @@
+uuid: 69d88a4f-0e19-4c41-bd7e-d297b81d0470
+langcode: en
+status: true
+dependencies:
+  module:
+    - allow_only_one
+    - node
+id: node.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+type: allow_only_one
+settings: {  }
+module: allow_only_one
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.content_entity_browsers.yml
+++ b/config/sync/views.view.content_entity_browsers.yml
@@ -440,7 +440,7 @@ display:
           exposed: true
           expose:
             operator_id: field_administration_target_id_op
-            label: 'Section'
+            label: Section
             description: ''
             use_operator: false
             operator: field_administration_target_id_op
@@ -1148,7 +1148,7 @@ display:
             timezone_override: ''
             format: default
             force_chronological: false
-            add_classes: 0
+            add_classes: false
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -1393,7 +1393,7 @@ display:
           exposed: true
           expose:
             operator_id: field_owner_target_id_op
-            label: 'Section'
+            label: Section
             description: ''
             use_operator: false
             operator: field_owner_target_id_op

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -44,6 +44,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Events List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Events List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Events List | Office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Events List | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | Health Services List | Featured content on health-services page | field_featured_content_healthser | Entity reference revisions |  | 3 | Paragraphs Classic | Translatable |
 | Content type | Health Services List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Health Services List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
@@ -51,6 +52,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Health Services List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Health Services List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Health Services List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Health Services List | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | Leadership List | Leadership team | field_leadership | Entity reference |  | Unlimited | Autocomplete | Translatable |
 | Content type | Leadership List | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Leadership List | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
@@ -64,6 +66,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Locations List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Locations List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC System Locations List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System Locations List | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | News Release | Full text of the Press Release | field_press_release_fulltext | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | News Release | Introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | News Release | Location | field_address | Address |  | 1 | Address | Translatable |
@@ -81,6 +84,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | News Releases List | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | News Releases List | Press Release Blurb | field_press_release_blurb | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | News Releases List | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | News Releases List | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | Staff Profile | Body text | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | Staff Profile | Complete Biography | field_complete_biography | File |  | 1 | File |  |
 | Content type | Staff Profile | Email address | field_email_address | Email |  | 1 | Email |  |
@@ -111,6 +115,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Stories List | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | Stories List | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Stories List | Office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Stories List | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | VAMC Facility | Address | field_address | Address |  | 1 | Address | Translatable |
 | Content type | VAMC Facility | Classification | field_facility_classification | List (text) |  | 1 | Select list |  |
 | Content type | VAMC Facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield |  |
@@ -141,6 +146,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility Health Service | Are walkins accepted? | field_walk_ins_accepted | List (text) | Required | 1 | Select list |  |
 | Content type | VAMC Facility Health Service | Appointments help text | field_appointments_help_text | Markup |  | 1 | Markup |  |
 | Content type | VAMC Facility Health Service | Service locations help text | field_facility_service_loc_help | Markup |  | 1 | Markup |  |
+| Content type | VAMC Facility Health Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget |  |
 | Content type | VAMC System | Appointments can be scheduled and viewed online | field_appointments_online | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC System | Banner image | field_media | Entity reference | Required | 1 | Media library | Translatable |
 | Content type | VAMC System | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
@@ -176,6 +182,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Health Service | VAMC system | field_region_page | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Health Service | VAMC system description of service | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC System Health Service | Service | field_service_name_and_descripti | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC System Health Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | VAMC Facility Health Service | Appointment intro text | field_hservice_appt_intro_select | List (text) | Required | 1 | Check boxes/radio buttons |  |
 | Content type | VAMC Facility Health Service | Appointment lead-in default | field_hservices_lead_in_default | Markup |  | 1 | Markup |  |
 | Content type | VAMC Facility Health Service | Appointment lead-in text | field_hservice_appt_leadin | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
@@ -186,6 +193,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Operating Status | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Operating Status | Facility operating statuses | field_facility_operating_status | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
 | Content type | VAMC System Operating Status | VAMC system | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VAMC System Operating Status | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | VAMC System Policies Page | Fieldset Markup | field_fieldset_markup | Markup |  | 1 | Markup |  |
 | Content type | VAMC System Policies Page | National bottom of page content | field_cc_bottom_of_page_content | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
 | Content type | VAMC System Policies Page | National general visitation policy | field_cc_gen_visitation_policy | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
@@ -195,3 +203,4 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Policies Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Policies Page | Related health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Policies Page | Visitation policy | field_vamc_visitation_policy | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
+| Content type | VAMC System Policies Page | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
@@ -45,3 +45,5 @@ Feature: Content model: Vet Center Content Type fields
 | Content type | Vet Center - Locations List | Nearby Mobile Vet Centers | field_nearby_mobile_vet_centers | Entity reference |  | Unlimited | Entity Browser - Table |  |
 | Content type | Vet Center - Locations List | Nearby Vet Centers and Outstations | field_nearby_vet_centers | Entity reference |  | Unlimited | Entity Browser - Table |  |
 | Content type | Vet Center - Locations List | Vet Center | field_office | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Vet Center - Locations List | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
+| Content type | Vet Center - Facility Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -156,24 +156,19 @@ Feature: CMS Users may effectively create & edit content
     And I should see "City" in the "#edit-field-address-0" element
     And I should see "State" in the "#edit-field-address-0" element
 
-@content_editing
+@content_editing @et
   Scenario: Log in and confirm that System-wide alerts can be created and edited
     When I am logged in as a user with the "content_admin" role
 
     # Create our initial draft
-    Then I am at "node/add/vamc_operating_status_and_alerts"
+    Then I am at "node/1010/edit"
     And I press "Add new banner alert"
     And I select "Information" from "Alert type"
-    And I select "Veterans Affairs" from "edit-field-administration"
     And I fill in "Title" with "BeHat Alert title"
     And I fill in "Alert body" with "BeHat Alert body"
     And I press "Save draft and continue editing"
     Then I should see "Pages for the following VAMC systems"
     And I should not see "BeHat Alert Body"
-
-    # Confirm that paragraph can be edited inline
-    And I press "edit-field-banner-alert-entities-0-actions-ief-entity-edit"
-    Then I should see "BeHat Alert Body"
 
 @content_editing
   Scenario Outline: Confirm that content cannot be published directly from the node view but can from the node edit form.

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -4,7 +4,7 @@ Feature: CMS Users may effectively create & edit content
   As anyone involved in the project
   I need to have certain functionality available
 
-@content_editing
+  @content_editing
   Scenario: Log in and confirm that "Step by step" node edit has the correct field settings
     Given I am logged in as a user with the "administrator" role
     And I am at "node/add/step_by_step"
@@ -22,21 +22,21 @@ Feature: CMS Users may effectively create & edit content
     # Confirm that a user may add unlimited Step-by-step fields.
     And the "#edit-field-steps-add-more-add-more-button-step-by-step" element should exist
 
-@content_editing
+  @content_editing
   Scenario: Log in and confirm that "Checklist" node edit has the correct field settings
     When I am logged in as a user with the "content_admin" role
 
     Given "topics" terms:
-    | name            | parent | description | format     | language |
-    | BeHat - Topic 1 |        |             | plain_text | UND      |
-    | BeHat - Topic 2 |        |             | plain_text | UND      |
-    | BeHat - Topic 3 |        |             | plain_text | UND      |
-    | BeHat - Topic 4 |        |             | plain_text | UND      |
+      | name            | parent | description | format     | language |
+      | BeHat - Topic 1 |        |             | plain_text | UND      |
+      | BeHat - Topic 2 |        |             | plain_text | UND      |
+      | BeHat - Topic 3 |        |             | plain_text | UND      |
+      | BeHat - Topic 4 |        |             | plain_text | UND      |
 
     # Create beneficiaries term.
     Given "audience_beneficiaries" terms:
-    | name                     | parent | description | format     | language |
-    | BeHat - Awesome Veterans |        |             | plain_text | UND      |
+      | name                     | parent | description | format     | language |
+      | BeHat - Awesome Veterans |        |             | plain_text | UND      |
 
     # Create our initial draft
     Then I am at "node/add/checklist"
@@ -61,7 +61,7 @@ Feature: CMS Users may effectively create & edit content
     # Confirm that our custom validation for Audiences & Topics is working.
     Then I should see "No more than 4 Topic/Audience tags may be selected"
 
-@content_editing
+  @content_editing
   Scenario: Confirm that menu link functionality works correctly
     Given I am logged in as a user with the "content_admin" role
     And I am at "node/add/office"
@@ -97,7 +97,7 @@ Feature: CMS Users may effectively create & edit content
     Then I visit the "edit" page for a node with the title "Test Office - BeHaT"
     And the "menu[link_enabled]" checkbox should be checked
 
-@content_editing
+  @content_editing
   Scenario: Confirm that the EWA block URL is shown correctly.
     Given I am logged in as a user with the "administrator" role
     And I am at "node/add/office"
@@ -147,7 +147,7 @@ Feature: CMS Users may effectively create & edit content
     And I should see "Content Type: Office" in the "#block-entitymetadisplay" element
     And I should not see "VA.gov URL" in the "#block-entitymetadisplay" element
 
-@content_editing
+  @content_editing
   Scenario: Confirm that press release country fields are shown correctly
     Given I am logged in as a user with the "content_admin" role
     And I am at "node/add/press_release"
@@ -156,11 +156,14 @@ Feature: CMS Users may effectively create & edit content
     And I should see "City" in the "#edit-field-address-0" element
     And I should see "State" in the "#edit-field-address-0" element
 
-@content_editing
+  @content_editing
   Scenario: Log in and confirm that System-wide alerts can be created and edited
     When I am logged in as a user with the "content_admin" role
 
     # Create our initial draft
+    # We need to target an existing node
+    # ("Operating status - VA Pittsburgh health care")
+    # to prevent unique validation failure.
     Then I am at "node/1010/edit"
     And I press "Add new banner alert"
     And I select "Information" from "Alert type"
@@ -170,7 +173,7 @@ Feature: CMS Users may effectively create & edit content
     Then I should see "Pages for the following VAMC systems"
     And I should not see "BeHat Alert Body"
 
-@content_editing
+  @content_editing
   Scenario Outline: Confirm that content cannot be published directly from the node view but can from the node edit form.
     Given I am logged in as a user with the "content_admin" role
     And I am viewing an <type> with the title <title>
@@ -178,46 +181,46 @@ Feature: CMS Users may effectively create & edit content
     And I visit the "edit" page for a node with the title <title>
     Then "#edit-moderation-state-0-state" should contain "published"
     Examples:
-      | type                                | title                                     |
-      | "page"                              | "page page"                               |
-      | "landing_page"                      | "landing_page page"                       |
-      | "basic_landing_page"                | "basic_landing_page page"                 |
-      | "checklist"                         | "checklist page"                          |
-      | "documentation_page"                | "documentation_page page"                 |
-      | "faq_multiple_q_a"                  | "faq_multiple_q_a page"                   |
-      | "health_services_listing"           | "health_services_listing page"            |
-      | "health_care_region_detail_page"    | "health_care_region_detail_page page"     |
-      | "event"                             | "event page"                              |
-      | "event_listing"                     | "event_listing page"                      |
-      | "health_care_local_facility"        | "health_care_local_facility page"         |
-      | "health_care_region_page"           | "health_care_region_page page"            |
-      | "press_release"                     | "press_release page"                      |
-      | "outreach_asset"                    | "outreach_asset page"                     |
-      | "publication_listing"               | "publication_listing page"                |
-      | "news_story"                        | "news_story page"                         |
-      | "leadership_listing"                | "leadership_listing page"                 |
-      | "locations_listing"                 | "locations_listing page"                  |
-      | "media_list_images"                 | "media_list_images page"                  |
-      | "media_list_videos"                 | "media_list_videos page"                  |
-      | "nca_facility"                      | "nca_facility page"                       |
-      | "office"                            | "office page"                             |
-      | "press_releases_listing"            | "press_releases_listing page"             |
-      | "q_a"                               | "q_a page"                                |
-      | "step_by_step"                      | "step_by_step page"                       |
-      | "story_listing"                     | "story_listing page"                      |
-      | "support_resources_detail_page"     | "support_resources_detail_page page"      |
-      | "support_service"                   | "support_service page"                    |
-      | "va_form"                           | "va_form page"                            |
-      | "vba_facility"                      | "vba_facility page"                       |
-      | "vet_center"                        | "vet_center page"                         |
+      | type                             | title                                 |
+      | "page"                           | "page page"                           |
+      | "landing_page"                   | "landing_page page"                   |
+      | "basic_landing_page"             | "basic_landing_page page"             |
+      | "checklist"                      | "checklist page"                      |
+      | "documentation_page"             | "documentation_page page"             |
+      | "faq_multiple_q_a"               | "faq_multiple_q_a page"               |
+      | "health_services_listing"        | "health_services_listing page"        |
+      | "health_care_region_detail_page" | "health_care_region_detail_page page" |
+      | "event"                          | "event page"                          |
+      | "event_listing"                  | "event_listing page"                  |
+      | "health_care_local_facility"     | "health_care_local_facility page"     |
+      | "health_care_region_page"        | "health_care_region_page page"        |
+      | "press_release"                  | "press_release page"                  |
+      | "outreach_asset"                 | "outreach_asset page"                 |
+      | "publication_listing"            | "publication_listing page"            |
+      | "news_story"                     | "news_story page"                     |
+      | "leadership_listing"             | "leadership_listing page"             |
+      | "locations_listing"              | "locations_listing page"              |
+      | "media_list_images"              | "media_list_images page"              |
+      | "media_list_videos"              | "media_list_videos page"              |
+      | "nca_facility"                   | "nca_facility page"                   |
+      | "office"                         | "office page"                         |
+      | "press_releases_listing"         | "press_releases_listing page"         |
+      | "q_a"                            | "q_a page"                            |
+      | "step_by_step"                   | "step_by_step page"                   |
+      | "story_listing"                  | "story_listing page"                  |
+      | "support_resources_detail_page"  | "support_resources_detail_page page"  |
+      | "support_service"                | "support_service page"                |
+      | "va_form"                        | "va_form page"                        |
+      | "vba_facility"                   | "vba_facility page"                   |
+      | "vet_center"                     | "vet_center page"                     |
 
-@content_editing
+  @content_editing
   Scenario: Confirm that the default time zone when creating an event is set explicitly to Eastern.
     Given I am logged in as a user with the "content_admin" role
     And I am at "node/add/event"
     Then I should see "New York" in the "#edit-field-datetime-range-timezone-0-timezone" element
 
-@content_editing
+  @content_editing
   Scenario: Confirm Generate automatic URL alias is unchecked after node publish.
     When I am logged in as a user with the "administrator" role
     And I am at "node/add/basic_landing_page"
@@ -247,7 +250,7 @@ Feature: CMS Users may effectively create & edit content
     Then I visit the "edit" page for a node with the title "BeHat URL Alias Title Published"
     And the "path[0][pathauto]" checkbox should not be checked
 
-@content_editing
+  @content_editing
   Scenario: Confirm Generate automatic URL alias is unchecked after taxonomy term publish.
     Given I am logged in as a user with the "administrator" role
     And I am at "admin/structure/taxonomy/manage/health_care_service_taxonomy/add"
@@ -258,7 +261,7 @@ Feature: CMS Users may effectively create & edit content
     Then I visit the "edit" page for a term with the title "BeHat URL Alias Term Title Published"
     And the "path[0][pathauto]" checkbox should not be checked
 
-@content_editing
+  @content_editing
   Scenario: Confirm field group is opened and required field is presented to editor on CLP page.
     Given I am logged in as a user with the "content_admin" role
     And I am at "node/add/campaign_landing_page"

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -156,7 +156,7 @@ Feature: CMS Users may effectively create & edit content
     And I should see "City" in the "#edit-field-address-0" element
     And I should see "State" in the "#edit-field-address-0" element
 
-@content_editing @et
+@content_editing
   Scenario: Log in and confirm that System-wide alerts can be created and edited
     When I am logged in as a user with the "content_admin" role
 


### PR DESCRIPTION
## Description
See #4075

## Testing done
Behat

## QA steps
It's probably overkill, but we could create two of each of the content types to which we've added the `field_enforce_unique_combo` field, and duplicate the values in the unique value combo fields, then verify that a notice is created when trying to save the second one. 
We could probably just spot check a few: E.g.: 
- Create two Facility Health Services with the same field_service_name_and_descripti value, and visually verify that a notice is thrown when saving the second. 
- Create two Story Listing nodes with the same field_office value, and visually verify that a notice is thrown when saving the second. 
- Create two Operating Status nodes with the same field_office value, and visually verify that a notice is thrown when saving the second. 
- Create two Locations Listing nodes with the same field_office value, and visually verify that a notice is thrown when saving the second. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
