### PR TITLE
VACMS-5436: Restrict field_media to field_administration value context on node forms.

### DIFF
--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -15,6 +15,7 @@ dependencies:
     - media_library
     - taxonomy
     - user
+    - workbench_access
 id: media_library
 label: 'Media library'
 module: views
@@ -497,6 +498,7 @@ display:
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
         - 'config:core.entity_view_display.media.video.thumbnail'
+        - 'config:core.entity_view_display.media.video.user_guides'
   page:
     display_plugin: page
     id: page
@@ -810,6 +812,7 @@ display:
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
         - 'config:core.entity_view_display.media.video.thumbnail'
+        - 'config:core.entity_view_display.media.video.user_guides'
   widget:
     display_plugin: page
     id: widget
@@ -928,6 +931,8 @@ display:
         arguments: false
         header: false
         css_class: false
+        relationships: false
+        exposed_form: false
       display_description: ''
       access:
         type: perm
@@ -1016,26 +1021,26 @@ display:
           entity_type: media
           entity_field: name
           plugin_id: string
-        field_owner_target_id:
-          id: field_owner_target_id
-          table: media__field_owner
-          field: field_owner_target_id
+        workbench_access_section__section_1:
+          id: workbench_access_section__section_1
+          table: media
+          field: workbench_access_section__section
           relationship: none
           group_type: group
           admin_label: ''
-          operator: or
+          operator: in
           value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: field_owner_target_id_op
+            operator_id: workbench_access_section__section_1_op
             label: Section
             description: ''
             use_operator: false
-            operator: field_owner_target_id_op
+            operator: workbench_access_section__section_1_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_owner_target_id
+            identifier: workbench_access_section__section_1
             required: false
             remember: false
             multiple: false
@@ -1044,7 +1049,10 @@ display:
               anonymous: '0'
               content_api_consumer: '0'
               content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
               vamc_content_creator: '0'
+              content_creator_vet_center: '0'
               content_editor: '0'
               content_reviewer: '0'
               content_publisher: '0'
@@ -1052,7 +1060,7 @@ display:
               redirect_administrator: '0'
               admnistrator_users: '0'
               administrator: '0'
-            reduce: false
+            reduce: 1
           is_grouped: false
           group_info:
             label: ''
@@ -1065,13 +1073,11 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: administration
-          hierarchy: true
-          error_message: true
-          plugin_id: taxonomy_index_tid
+          reduce_duplicates: 0
+          section_filter:
+            show_hierarchy: 1
+          entity_type: media
+          plugin_id: workbench_access_section
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -1129,9 +1135,8 @@ display:
             title: All
           title_enable: false
           title: ''
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
+          default_argument_type: current_user
+          default_argument_options: {  }
           default_argument_skip_url: false
           summary_options:
             base_path: ''
@@ -1181,6 +1186,19 @@ display:
           plugin_id: display_link
       css_class: ''
       rendering_language: '***LANGUAGE_language_interface***'
+      relationships: {  }
+      exposed_form:
+        type: input_required
+        options:
+          submit_button: 'Apply filters'
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: false
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: rich_text
     cache_metadata:
       max-age: -1
       contexts:
@@ -1206,6 +1224,7 @@ display:
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
         - 'config:core.entity_view_display.media.video.thumbnail'
+        - 'config:core.entity_view_display.media.video.user_guides'
   widget_table:
     display_plugin: page
     id: widget_table


### PR DESCRIPTION
## Description
See #5436

## Testing done
Visual

## QA steps
- As a non administrator, go to `node/3731/edit` and click the `Add media` button - visually verify Section select in modal only contains values available to user from options selected in user profile workbench access sections.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
