### PR TITLE
VACMS-5447: Update content release perms.

### DIFF
--- a/config/sync/user.role.content_publisher.yml
+++ b/config/sync/user.role.content_publisher.yml
@@ -143,7 +143,6 @@ permissions:
   - 'use text format rich_text'
   - 'use text format rich_text_limited'
   - 'use workbench access'
-  - 'va gov deploy content build'
   - 'view all media revisions'
   - 'view all revisions'
   - 'view any unpublished content'

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -619,7 +619,6 @@ class RolesPermissionsTest extends ExistingSiteBase {
           'use text format rich_text',
           'use text format rich_text_limited',
           'use workbench access',
-          'va gov deploy content build',
           'view all media revisions',
           'view all revisions',
           'view any unpublished content',


### PR DESCRIPTION
## Description
See #5447

## Testing done
Visual / phpunit

## QA steps
- Login as `user/34` and visually verify the content release button no longer appears in admin content menu.
- Visit `admin/content/deploy` and visually verify you see an access denied page.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
