### PR TITLE
VACMS-5491: Memcache out of memory fix, 1GB container image

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -164,7 +164,7 @@ services:
         - find "${DOCROOT}/vendor/va-gov/content-build/script" -type f -exec chmod +x {} \+
 
   memcache:
-    image: tugboatqa/memcached:1.6
+    image: tugboatqa/memcached:1.6.6
 
   # What to call the service hosting MySQL. This name also acts as the
   # hostname to access the service by from the php service.

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -164,7 +164,7 @@ services:
         - find "${DOCROOT}/vendor/va-gov/content-build/script" -type f -exec chmod +x {} \+
 
   memcache:
-    image: tugboatqa/memcached:1.6.6
+    image: vacmsbot/docker-memcached-tugboat:1.6.6
 
   # What to call the service hosting MySQL. This name also acts as the
   # hostname to access the service by from the php service.


### PR DESCRIPTION
## Description
- Match Tugboat Memcached version to Elasticache version
- Use custom vacmsbot/docker-memcached-tugboat:1.6.6 image with 1GB ram.

See #5491 

## Testing done
Tested by rebuilding a base image from this branch on the Tugboat CMS-TEST Project and making 15 pull requests using the new image. 

No more out of memory errors.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/1504756/121272497-f95b2f00-c87a-11eb-9e78-d9ea9551c3be.png)

After:
![image](https://user-images.githubusercontent.com/1504756/121272511-011ad380-c87b-11eb-90b3-b02fe9f84742.png)



## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
