### PR TITLE
VACMS-4988 Menu Governance

### DIFF
--- a/config/sync/va_gov_menu_access.settings.yml
+++ b/config/sync/va_gov_menu_access.settings.yml
@@ -1,3 +1,3 @@
 va_gov_menu_access:
-  paths: "%-health-care/work-with-us~\r\n%-health-care/work-with-us/internships-and-fellowships\r\n%-health-care/work-with-us/doing-business-with-us\r\n%-health-care/programs\r\n%-health-care/research\r\n\r\n\r\n\r\n"
+  paths: "%-health-care/work-with-us~\r\n%-health-care/work-with-us/internships-and-fellowships\r\n%-health-care/work-with-us/doing-business-with-us\r\n%-health-care/work-with-us/jobs-and-careers\r\n%-health-care/work-with-us/volunteer-or-donate\r\n%-health-care/programs\r\n%-health-care/research\r\n\r\n\r\n\r\n"
   locked_paths: '%-health-care*'

--- a/config/sync/va_gov_menu_access.settings.yml
+++ b/config/sync/va_gov_menu_access.settings.yml
@@ -1,3 +1,3 @@
 va_gov_menu_access:
-  paths: "%-health-care/work-with-us~\r\n%-health-care/work-with-us/internships-fellowships\r\n%-health-care/work-with-us/doing-business-with-us\r\n%-health-care/programs\r\n%-health-care/research\r\n\r\n\r\n\r\n"
+  paths: "%-health-care/work-with-us~\r\n%-health-care/work-with-us/internships-and-fellowships\r\n%-health-care/work-with-us/doing-business-with-us\r\n%-health-care/programs\r\n%-health-care/research\r\n\r\n\r\n\r\n"
   locked_paths: '%-health-care*'

--- a/docroot/modules/custom/va_gov_menu_access/src/Form/VaGovMenuAccessConfigForm.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Form/VaGovMenuAccessConfigForm.php
@@ -76,7 +76,7 @@ class VaGovMenuAccessConfigForm extends ConfigFormBase {
       '#type' => 'textarea',
       '#title' => $this->t('Allow children menu items for "Detail Page" nodes on these URL paths'),
       '#default_value' => $config->get('va_gov_menu_access.paths'),
-      '#description' => $this->t('Put each path on its own line. Available wildcards: "%" = all occurences. "~" = disabled with children. "~" = disabled no children.'),
+      '#description' => $this->t('Put each path on its own line. Available wildcards: "%" = all occurences. "!" = disabled but allow children. "~" = disabled no children allowed.'),
     ];
 
     $form['va_gov_menu_access_paths']['locked_paths'] = [

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -256,7 +256,6 @@ class MenuReductionService {
       ->getStorage('menu_link_content')
       ->loadByProperties([
         'uuid' => array_keys($parent_options_menu_ids),
-        'enabled' => 1,
       ]);
 
     // Loop through them, and decide whether it should be allowed in options.

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -129,10 +129,10 @@ class MenuReductionService {
       'menu_parent',
     ]);
     $this->originalMenuParentOptions = $form['menu']['link']['menu_parent']['#options'] ?? [];
-    $this->setEmptyMenuParentSelector($form);
 
     if ($this->userPermsService->hasAdminRole()) {
       // User is an admin so no menu reduction needed.
+      $this->setEmptyMenuParentSelector($form);
       $this->nuke();
       return;
     }
@@ -150,6 +150,7 @@ class MenuReductionService {
     }
 
     $this->applyVamcMenuRulesForDetailPage($form);
+    $this->setEmptyMenuParentSelector($form);
     $this->nuke();
   }
 

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -568,9 +568,12 @@ class MenuReductionService {
    *   The form array by reference.
    */
   protected function preventUnintendedChangeOfParent(array &$form) {
-    // Check to see if the current parent exists in the reduced form.
-    if (!isset($form['menu']['link']['menu_parent']['#options'][$this->currentMenuParent]) &&
-    !$this->formState->getFormObject()->getEntity()->isNew()) {
+    if ($this->formState->getFormObject()->getEntity()->isNew()) {
+      // Reapply the value that was set when submitted.
+      $form['menu']['link']['menu_parent']['#value'] = $this->currentMenuParent;
+    }
+    // This is not new so check the current parent exists in the reduced form.
+    elseif (!isset($form['menu']['link']['menu_parent']['#options'][$this->currentMenuParent])) {
       // Parent does not exist in reduced form, Put the original parent options
       // back to prevent data loss. The existing menu setting should not be
       // allowed, but it exists, so allow it to persist. It may have been

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -5,6 +5,7 @@ namespace Drupal\va_gov_menu_access\Service;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\NodeForm;
 use Drupal\path_alias\AliasManagerInterface;
 use Drupal\va_gov_user\Service\UserPermsService;
@@ -13,6 +14,8 @@ use Drupal\va_gov_user\Service\UserPermsService;
  * Class MenuReductionService a service for reducing possible menu items.
  */
 class MenuReductionService {
+
+  use StringTranslationTrait;
 
   /**
    * Possible states for the type of menu item.
@@ -551,8 +554,12 @@ class MenuReductionService {
       // allowed, but it exists, so allow it to persist. It may have been
       // created and approved by a content_admin.
       $form['menu']['link']['menu_parent']['#options'] = $this->originalMenuParentOptions;
-      // The menu form itself should be hidden for non-admins.
-      $form['menu']['#attributes'] = ['style' => 'display:none'];
+      // Lock it so the parent can not be changed.
+      $form['menu']['link']['menu_parent']['#attributes']['disabled'] = TRUE;
+      $title = $form['menu']['link']['menu_parent']['#title'];
+      $can_not_change = $this->t('Can not be changed.');
+      $title .= " ($can_not_change)";
+      $form['menu']['link']['menu_parent']['#title'] = $title;
     }
   }
 

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -446,7 +446,7 @@ class MenuReductionService {
   }
 
   /**
-   * Gets the meny type based on the alias.
+   * Gets the menu type based on the alias.
    *
    * @param string $alias
    *   The alias to check.
@@ -544,7 +544,8 @@ class MenuReductionService {
    */
   protected function preventUnintendedChangeOfParent(array &$form) {
     // Check to see if the current parent exists in the reduced form.
-    if (!in_array($this->currentMenuParent, $form['menu']['link']['menu_parent']['#options'])) {
+    if (!in_array($this->currentMenuParent, $form['menu']['link']['menu_parent']['#options']) &&
+    !$this->formState->getFormObject()->getEntity()->isNew()) {
       // Parent does not exist in reduced form, Put the original parent options
       // back to prevent data loss. The existing menu setting should not be
       // allowed, but it exists, so allow it to persist. It may have been

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -251,13 +251,7 @@ class MenuReductionService {
     $enabled_count = 0;
 
     $parent_options_menu_ids = $this->extractMenuIds($form['menu']['link']['menu_parent']['#options']);
-
-    // Load up all our menu items at once.
-    $parent_menu_items = $this->entityTypeManager
-      ->getStorage('menu_link_content')
-      ->loadByProperties([
-        'uuid' => array_keys($parent_options_menu_ids),
-      ]);
+    $parent_menu_items = $this->loadParentMenuItems($parent_options_menu_ids);
 
     // Loop through them, and decide whether it should be allowed in options.
     foreach ($parent_menu_items as $key => $menu_item) {
@@ -282,6 +276,27 @@ class MenuReductionService {
       $form['menu']['link']['menu_parent']['#attributes']['class'][] = 'no-available-menu-targets';
     }
     $this->preventUnintendedChangeOfParent($form);
+  }
+
+  /**
+   * Loads and returns the entities for all menu parents.
+   *
+   * @param array $parent_options_menu_ids
+   *   Menu ids.
+   *
+   * @return array
+   *   An array of menu entities loaded.
+   */
+  protected function loadParentMenuItems(array $parent_options_menu_ids) {
+    $parent_menu_items = [];
+    if (!empty($parent_options_menu_ids)) {
+      $parent_menu_items = $this->entityTypeManager
+        ->getStorage('menu_link_content')
+        ->loadByProperties([
+          'uuid' => array_keys($parent_options_menu_ids),
+        ]);
+    }
+    return $parent_menu_items;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -128,14 +128,6 @@ class MenuReductionService {
     $this->originalMenuParentOptions = $form['menu']['link']['menu_parent']['#options'] ?? [];
     $this->setEmptyMenuParentSelector($form);
 
-    // @todo Remove this nonsense check to activate the remainder of this logic
-    // when the other issues in #2427 have paved the way for adjusting and
-    // testing this logic.
-    if (TRUE) {
-      $this->nuke();
-      return;
-    }
-    // End of @todo removal.  Nothing below this point will run.
     if ($this->userPermsService->hasAdminRole()) {
       // User is an admin so no menu reduction needed.
       $this->nuke();

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -569,12 +569,17 @@ class MenuReductionService {
    *   The form array by reference.
    */
   protected function preventUnintendedChangeOfParent(array &$form) {
+    $current_menu_item_is_present = isset($form['menu']['link']['menu_parent']['#options'][$this->currentMenuParent]);
     if ($this->formState->getFormObject()->getEntity()->isNew()) {
       // Reapply the value that was set when submitted.
       $form['menu']['link']['menu_parent']['#value'] = $this->currentMenuParent;
     }
+    // Check for rare possibility that menu parent is the default menu root.
+    elseif ($this->currentMenuParent === "pittsburgh-health-care:") {
+      return;
+    }
     // This is not new so check the current parent exists in the reduced form.
-    elseif (!isset($form['menu']['link']['menu_parent']['#options'][$this->currentMenuParent])) {
+    elseif (!$current_menu_item_is_present || $this->isCurrentMenuSettingDisabled($form)) {
       // Parent does not exist in reduced form, Put the original parent options
       // back to prevent data loss. The existing menu setting should not be
       // allowed, but it exists, so allow it to persist. It may have been
@@ -587,6 +592,25 @@ class MenuReductionService {
       $title .= " ($can_not_change)";
       $form['menu']['link']['menu_parent']['#title'] = $title;
     }
+  }
+
+  /**
+   * Checks to see if the current menu parent is disabled.
+   *
+   * @param array $form
+   *   The form array.
+   *
+   * @return bool
+   *   TRUE if the current menu parent is disabled.  FALSE otherwise.
+   */
+  protected function isCurrentMenuSettingDisabled(array $form) : bool {
+    $is_disabled = FALSE;
+    $current_menu_setting = $form['menu']['link']['menu_parent']['#options'][$this->currentMenuParent] ?? '';
+    if (strpos($current_menu_setting, 'Disabled no-link') !== FALSE) {
+      $is_disabled = TRUE;
+    }
+
+    return $is_disabled;
   }
 
   /**


### PR DESCRIPTION
## Description

Closes #4988. 

## Testing done
### As Ryan S
-  [x] i shouldn't be able to add or edit menu items for content types other than Detail Pages
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/event
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/press_release
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/person_profile
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/news_story
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/health_care_local_health_service
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/full_width_banner_alert
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/regional_health_care_service_des
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/event
-  [x]  i should be able to place individual menu items of Detail Page content type, using the Menu settings in the right rail, but only with certain parents eligible:
   - [x] %-health-care/work-with-us~  (can only place grandchildren of  this) 
   - [x] %-health-care/work-with-us/internships-and-fellowships  
   - [x] %-health-care/work-with-us/doing-business-with-us  [pittsburgh does not have this, but albany does.   use Peter.Potter ]
   - [x] %-health-care/programs
   - [x] %-health-care/research
in the UI parent item selector, when creating a health_care_region_detail_page, i should be able to see: 
   -  [x]  any menu item that is eligible to have children (and its children, which should also be eligible to have children)
   -  [x]  the ancestors of any menu item that is eligible to have children (except the top level, which is always the Health Care System, and is redundant)
   -  [x] When editing an existing detail page, I should be able to pick a new menu parent from the allowed list, and have it persist after save.
   -  [x] When adding a new detail page I should be forced to choose a menu parent and it should persist on save.

### As an content_admin
- [x] validate that I can always set menu parent on a detail page.
- [x] validate that if I set a menu parent that is not allowed, it will persist after save.
   - [x] validate that when RS edits this page, he will not be able to see the menu parent options
   - [x] validate that as RS can not change the parent, but I can see what parent is selected AND it displays 'Can not be changed.'
![image](https://user-images.githubusercontent.com/5752113/125512410-7b89f726-6481-444b-b89c-5765fee6fe94.png)
   - [x] validate that when RS saves this page its parent will persist when edited by a content_admin
   
## QA steps
### As Ryan S
-  [x] i shouldn't be able to add or edit menu items for content types other than Detail Pages
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/event
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/press_release
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/person_profile
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/news_story
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/health_care_local_health_service
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/full_width_banner_alert
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/regional_health_care_service_des
   - [x] validate no menu options appear on https://pr5648-cebnmfzeip2qe1sje8ewy9pjmt4dboqf.ci.cms.va.gov/node/add/event
-  [x]  i should be able to place individual menu items of Detail Page content type, using the Menu settings in the right rail, but only with certain parents eligible:
   - [x] %-health-care/work-with-us~  (can only place grandchildren of  this) 
   - [x] %-health-care/work-with-us/internships-and-fellowships  
   - [x] %-health-care/work-with-us/doing-business-with-us  [pittsburgh does not have this, but albany does.   use Peter.Potter ]
   - [x] %-health-care/programs
   - [x] %-health-care/research
in the UI parent item selector, when creating a health_care_region_detail_page, i should be able to see: 
   -  [x]  any menu item that is eligible to have children (and its children, which should also be eligible to have children)
   -  [x]  the ancestors of any menu item that is eligible to have children (except the top level, which is always the Health Care System, and is redundant)
   -  [x] When editing an existing detail page, I should be able to pick a new menu parent from the allowed list, and have it persist after save.
   -  [ ] When adding a new detail page I should be forced to choose a menu parent and it should persist on save.

### As an content_admin
- [x] validate that I can always set menu parent on a detail page.
- [x] validate that if I set a menu parent that is not allowed, it will persist after save.
   - [x] validate that when RS edits this page, he will not be able to see the menu parent options
   - [x] validate that as RS can not change the parent, but I can see what parent is selected AND it displays 'Can not be changed.'
![image](https://user-images.githubusercontent.com/5752113/125512410-7b89f726-6481-444b-b89c-5765fee6fe94.png)
   - [ ] validate that when RS saves this page its parent will persist when edited by a content_admin


## Screenshots


## QA steps



### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
