### PR TITLE
VACMS-000 Fix source of php notice_va_gov_vet_center_require_revision_message

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -618,7 +618,8 @@ function _va_gov_vet_center_require_revision_message(array &$form, FormStateInte
     ];
     foreach ($widget_fields as $widget_field) {
       // We don't want the node form validation to fire on the removal buttons.
-      foreach ($form[$widget_field]['widget']['current'] as $key => $button) {
+      $current_widgets = $form[$widget_field]['widget']['current'] ?? [];
+      foreach ($current_widgets as $key => $button) {
         if (is_numeric($key)) {
           $form[$widget_field]['widget']['current'][$key]['actions']['remove_button']['#limit_validation_errors'] = [['field_nearby_vet_centers']];
         }


### PR DESCRIPTION

## Description
On editing a vet_center  the following php notices are seen
![image](https://user-images.githubusercontent.com/5752113/122596473-eba26800-d037-11eb-84c8-5188229d313e.png)

```
Notice: Undefined index: field_nearby_vet_centers in _va_gov_vet_center_require_revision_message() (line 621 of modules/custom/va_gov_backend/va_gov_backend.module).
Warning: Invalid argument supplied for foreach() in _va_gov_vet_center_require_revision_message() (line 621 of modules/custom/va_gov_backend/va_gov_backend.module).
```

There are cases where that value is not present and should not be treated as an array.


## Testing done


## Screenshots


## QA steps

As user admin
1. visit `/node/3612/edit`
- [ ] Validate that the php notices seen above, do not appear on the page.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
