### PR TITLE
VACMS-5625: Add viewport_width image style.

### DIFF
--- a/config/sync/image.style.viewport_width.yml
+++ b/config/sync/image.style.viewport_width.yml
@@ -1,0 +1,15 @@
+uuid: b57e48b0-15a3-4fe1-80cb-9b486f164295
+langcode: en
+status: true
+dependencies: {  }
+name: viewport_width
+label: 'Viewport width'
+effects:
+  4924be55-3577-41df-aa98-f5b59a2d2a22:
+    uuid: 4924be55-3577-41df-aa98-f5b59a2d2a22
+    id: image_scale
+    weight: 1
+    data:
+      width: 2500
+      height: null
+      upscale: false

--- a/tests/behat/drupal-spec-tool/media.feature
+++ b/tests/behat/drupal-spec-tool/media.feature
@@ -27,6 +27,7 @@ Feature: Media
 | Linkit result thumbnail  | linkit_result_thumbnail  |
 | Original | original |
 | 2:3 medium thumbnail  | 2_3_medium_thumbnail  |
+| Viewport width | viewport_width |
 
   @dst @image_effects
      Scenario: Image effects
@@ -57,3 +58,4 @@ Feature: Media
 | Medium (220×220) | Scale | 220×220   |
 | Original | Manual crop | uses Original crop type |
 | Thumbnail (100×100) | Scale | 100×100 |
+| Viewport width | Scale | width 2500 |


### PR DESCRIPTION
## Description
See #5625
Once this is merged / depoloyed, @kelsonic will able to apply to clp templates.

## Testing done
Behat

## QA steps
- As and administrator, go to `admin/config/media/image-styles/manage/viewport_width` and visually verify `Scale width 2500` is set

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
