### PR TITLE
VACMS-4056: Add logic to restrict elements to certain roles on centralized content.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/script.es6.js
+++ b/docroot/modules/custom/va_gov_backend/js/script.es6.js
@@ -35,6 +35,59 @@
   };
 
   /**
+   * Behaviors for hiding elements when user shouldn't have access.
+   * */
+  Drupal.behaviors.nationalDataHideDelete = {
+    attach(context) {
+      const adminRoles = ["administrator"];
+      // If national content and user isn't admin, start operating.
+      if (
+        drupalSettings.gtm_data.contentType === "centralized_content" &&
+        !adminRoles.some((item) =>
+          drupalSettings.gtm_data.userRoles.includes(item)
+        )
+      ) {
+        const inputs = context.querySelectorAll(
+          "#field-content-block-values input"
+        );
+        const buttons = context.querySelectorAll(
+          "#field-content-block-values button"
+        );
+        const drags = context.querySelectorAll(
+          "#field-content-block-values .field-multiple-drag"
+        );
+        const weightToggles = context.querySelectorAll(
+          ".tabledrag-toggle-weight-wrapper"
+        );
+        // Hide paragraph deletes.
+        inputs.forEach((item) => {
+          if (item.value && item.value === "Remove") {
+            item.style.display = "none";
+          }
+        });
+        // Hide options.
+        buttons.forEach((item) => {
+          if (item && item.classList.contains("paragraphs-dropdown-toggle")) {
+            item.style.display = "none";
+          }
+        });
+        // Hide drags.
+        drags.forEach((item) => {
+          if (item) {
+            item.style.display = "none";
+          }
+        });
+        // Hide weight toggles.
+        weightToggles.forEach((item) => {
+          if (item) {
+            item.style.display = "none";
+          }
+        });
+      }
+    },
+  };
+
+  /**
    * Behaviors for manipulating vast output on node forms.
    * */
   Drupal.behaviors.vastDataNodeOutputManipulation = {

--- a/docroot/modules/custom/va_gov_backend/js/script.js
+++ b/docroot/modules/custom/va_gov_backend/js/script.js
@@ -25,6 +25,45 @@
     }
   };
 
+  Drupal.behaviors.nationalDataHideDelete = {
+    attach: function attach(context) {
+      var adminRoles = ["administrator"];
+
+      if (drupalSettings.gtm_data.contentType === "centralized_content" && !adminRoles.some(function (item) {
+        return drupalSettings.gtm_data.userRoles.includes(item);
+      })) {
+        var inputs = context.querySelectorAll("#field-content-block-values input");
+        var buttons = context.querySelectorAll("#field-content-block-values button");
+        var drags = context.querySelectorAll("#field-content-block-values .field-multiple-drag");
+        var weightToggles = context.querySelectorAll(".tabledrag-toggle-weight-wrapper");
+
+        inputs.forEach(function (item) {
+          if (item.value && item.value === "Remove") {
+            item.style.display = "none";
+          }
+        });
+
+        buttons.forEach(function (item) {
+          if (item && item.classList.contains("paragraphs-dropdown-toggle")) {
+            item.style.display = "none";
+          }
+        });
+
+        drags.forEach(function (item) {
+          if (item) {
+            item.style.display = "none";
+          }
+        });
+
+        weightToggles.forEach(function (item) {
+          if (item) {
+            item.style.display = "none";
+          }
+        });
+      }
+    }
+  };
+
   Drupal.behaviors.vastDataNodeOutputManipulation = {
     attach: function attach(context) {
       if (context.querySelectorAll(".admin-help-email-tpl").length) {


### PR DESCRIPTION
## Description
See #4056

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/123676390-e3091900-d811-11eb-8638-d052f982ea5e.png)

## QA steps
As an administrator, visit `/node/16142/edit` and visually verify that deletes, actions (the three vertical dots elements), row drags, and `Show row weights` action link appear.
Log in as a user who is not a content admin / admin, visit `/node/16142/edit` and visually verify that deletes, actions (the three vertical dots elements), row drags, and `Show row weights` action link do not appear.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
