### PR TITLE
VACMS-4204: Add patch to prevent deletion of fetched entities.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -335,6 +335,9 @@
             "drupal/entity_clone": {
                 "Cloning child references to nodes has potential to cause memory resource issues": "https://www.drupal.org/files/issues/2020-02-10/entity_clone-child-node-system-drain-3112577-1.patch"
             },
+            "drupal/entity_field_fetch": {
+                "3193585 - Prevent deletion of fetched entities": "https://www.drupal.org/files/issues/2021-06-30/prevent-deletion-of-eff-3193585-2.patch"
+            },
             "drupal/entity_reference_revisions": {
                 "2984027 Incorrect manipulation of default revision flag": "https://www.drupal.org/files/issues/2020-09-03/entity_reference_revisions-default_revision-2984027-10.patch"
             },


### PR DESCRIPTION
## Description
See #4204 

## Testing done
Visual

## QA steps
As an administrator, go to `node/15588/delete` (an entity whose content has been fetched) and visually verify `Access denied` message.

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/124041691-573fea00-d9d5-11eb-9bb2-7bd96e51637d.png)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
