### PR TITLE
VACMS-5086: Add redirect on login for one section users.

### DIFF
--- a/docroot/modules/custom/va_gov_user/va_gov_user.module
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.module
@@ -4,3 +4,21 @@
  * @file
  * Contains va_gov_user.module.
  */
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Redirect user to section on login if they only have one section assigned.
+ *
+ * Implements hook_user_user_login().
+ */
+function va_gov_user_user_login($account) {
+  $sections = \Drupal::service('va_gov_user.user_perms')->getSections($account);
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if (count($sections) === 1 && $route_name === 'user.login') {
+    $alias_manager = \Drupal::service('path.alias_manager');
+    $alias = $alias_manager->getAliasByPath('/taxonomy/term/' . key($sections));
+    $response = new RedirectResponse($alias);
+    $response->send();
+  }
+}


### PR DESCRIPTION
## Description
See #5086

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/124128723-08cd3280-da4b-11eb-8bfc-fbf02095b7b9.png)

## QA steps
Login as `vanessa.luxen@va.gov` and visually verify you are redirected to Butler section page.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
