### PR TITLE
VACMS-5739: Set vamc and vc terms to 0 in hook and in subsequnt saves.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1918,7 +1918,30 @@ function va_gov_backend_entity_presave(EntityInterface $entity) {
     _va_gov_backend_disable_autopath_alias($entity);
   }
 
+  if ($entity instanceof TermInterface) {
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    $term = $entity;
+    _va_gov_backend_set_term_weight($term);
+  }
+
   _va_gov_backend_apply_filter_to_tablefield_cells($entity);
+}
+
+/**
+ * Sets administration child term weights to 0 if child of vamc or vc.
+ *
+ * @param \Drupal\Taxonomy\TermInterface $term
+ *   The term on which to perform weight setting operation.
+ */
+function _va_gov_backend_set_term_weight(TermInterface $term) {
+  if ($term->bundle() === 'administration') {
+    /** @var \Drupal\taxonomy\TermStorage $storage */
+    $storage = \Drupal::service('entity_type.manager')->getStorage('taxonomy_term');
+    $parents = $storage->loadAllParents($term->id());
+    if (array_key_exists(8, $parents) || array_key_exists(190, $parents)) {
+      $term->setWeight(0);
+    }
+  }
 }
 
 /**

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1918,10 +1918,8 @@ function va_gov_backend_entity_presave(EntityInterface $entity) {
     _va_gov_backend_disable_autopath_alias($entity);
   }
 
-  if ($entity instanceof TermInterface) {
-    /** @var \Drupal\taxonomy\TermInterface $term */
-    $term = $entity;
-    _va_gov_backend_set_term_weight($term);
+  if ($entity->getEntityTypeId() === 'taxonomy_term') {
+    _va_gov_backend_set_term_weight($entity);
   }
 
   _va_gov_backend_apply_filter_to_tablefield_cells($entity);
@@ -1930,16 +1928,15 @@ function va_gov_backend_entity_presave(EntityInterface $entity) {
 /**
  * Sets administration child term weights to 0 if child of vamc or vc.
  *
- * @param \Drupal\Taxonomy\TermInterface $term
+ * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The term on which to perform weight setting operation.
  */
-function _va_gov_backend_set_term_weight(TermInterface $term) {
-  if ($term->bundle() === 'administration') {
-    /** @var \Drupal\taxonomy\TermStorage $storage */
+function _va_gov_backend_set_term_weight(EntityInterface $entity) {
+  if ($entity->getVocabularyId() === 'administration') {
     $storage = \Drupal::service('entity_type.manager')->getStorage('taxonomy_term');
-    $parents = $storage->loadAllParents($term->id());
+    $parents = $storage->loadAllParents($entity->id());
     if (array_key_exists(8, $parents) || array_key_exists(190, $parents)) {
-      $term->setWeight(0);
+      $entity->set('weight', 0);
     }
   }
 }

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -525,3 +525,43 @@ function va_gov_db_update_8027(&$sandbox) {
     '%count' => $count,
   ]);
 }
+
+/**
+ * Set vamc term children to 0 weight for proper sorting.
+ */
+function va_gov_db_update_8028(&$sandbox) {
+  // Grab our terms and set the count.
+  $vamc_items = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('administration', 8, NULL, TRUE);
+  foreach ($vamc_items as $vamc_term) {
+    $vamc_term->set('weight', 0);
+    $vamc_term->save();
+
+  }
+
+  // Tell drupal we processed vamc terms.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'VAMC terms processed: %count', [
+      '%count' => count($vamc_items),
+    ]);
+
+}
+
+/**
+ * Set vc term children to 0 weight for proper sorting.
+ */
+function va_gov_db_update_8029(&$sandbox) {
+  // Grab our terms and set the count.
+  $vc_items = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('administration', 190, NULL, TRUE);
+  foreach ($vc_items as $vc_term) {
+    $vc_term->set('weight', 0);
+    $vc_term->save();
+
+  }
+
+  // Tell drupal we processed vc terms.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'VC terms processed: %count', [
+      '%count' => count($vc_items),
+    ]);
+
+}


### PR DESCRIPTION
## Description
See #5739

## Testing done
Visual, updb

## QA steps
As an admin, go to `/admin/structure/taxonomy/manage/administration/overview` and visually verify that all children of vamc and vc have weight set to 0.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
