### PR TITLE
VACMS-5764: Restore moderation widget on op status form.

### DIFF
--- a/config/sync/core.entity_form_display.node.vamc_operating_status_and_alerts.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_operating_status_and_alerts.default.yml
@@ -13,8 +13,10 @@ dependencies:
     - field.field.node.vamc_operating_status_and_alerts.field_office
     - field.field.node.vamc_operating_status_and_alerts.field_operating_status_emerg_inf
     - node.type.vamc_operating_status_and_alerts
+    - workflows.workflow.editorial
   module:
     - allow_only_one
+    - content_moderation
     - field_group
     - ief_table_view_mode
     - linkit
@@ -25,7 +27,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 7
+      weight: 8
       format_type: details_sidebar
       format_settings:
         description: ''
@@ -38,6 +40,7 @@ third_party_settings:
       region: content
     group_editorial_workflow:
       children:
+        - moderation_state
         - revision_log
       parent_name: ''
       weight: 6
@@ -140,6 +143,12 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0
@@ -151,7 +160,6 @@ content:
 hidden:
   created: true
   field_meta_tags: true
-  moderation_state: true
   path: true
   promote: true
   status: true


### PR DESCRIPTION
## Description
See #5764 

## Testing done
Visual / behat

## QA steps
 - Go to `node/2370/edit` and visually verify presence of moderation widget 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
