### PR TITLE
VACMS-5696 remove Erie operating status endpoint.

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -56,7 +56,6 @@ source:
     - 'https://www.detroit.va.gov/locations/facilities.asp'
     - 'https://www.dublin.va.gov/locations/facilities.asp'
     - 'https://www.elpaso.va.gov/locations/facilities.asp'
-    - 'https://www.erie.va.gov/locations/facilities.asp'
     - 'https://www.fayettevillear.va.gov/locations/facilities.asp'
     - 'https://www.fayettevillenc.va.gov/locations/facilities.asp'
     - 'https://www.fresno.va.gov/locations/facilities.asp'

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -57,7 +57,6 @@ source:
     - https://www.detroit.va.gov/locations/facilities.asp
     - https://www.dublin.va.gov/locations/facilities.asp
     - https://www.elpaso.va.gov/locations/facilities.asp
-    - https://www.erie.va.gov/locations/facilities.asp
     - https://www.fayettevillear.va.gov/locations/facilities.asp
     - https://www.fayettevillenc.va.gov/locations/facilities.asp
     - https://www.fresno.va.gov/locations/facilities.asp


### PR DESCRIPTION
## Description
See #5696
This is a followup to https://github.com/department-of-veterans-affairs/va.gov-cms/pull/5749#pullrequestreview-698247868 = it removes Erie endpoint.

This is on hold until VAMC Erie is ready for full launch, pending a new PAO training.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
