### PR TITLE
VACMS-0000: Changes KernelTests to ExistingSiteBase tests.

### DIFF
--- a/tests/phpunit/FrontendBuild/Brd/BrdEnvironmentTest.php
+++ b/tests/phpunit/FrontendBuild/Brd/BrdEnvironmentTest.php
@@ -6,77 +6,38 @@ use Aws\MockHandler;
 use Aws\Result;
 use Aws\Ssm\SsmClient;
 use Drupal\Core\Site\Settings;
-use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
+use Drupal\va_gov_build_trigger\Service\BuildTimeRecorderInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Tests of the BRD environment plugin.
  *
  * @coversDefaultClass \Drupal\va_gov_build_trigger\Plugin\VAGov\Environment\BRD
  */
-class BrdEnvironmentTest extends EntityKernelTestBase {
+class BrdEnvironmentTest extends ExistingSiteBase {
 
   /**
-   * {@inheritdoc}
+   * Stash variable to store the original service.
+   *
+   * @var \Drupal\Core\Site\Settings
    */
-  public static $modules = [
-    'advancedqueue',
-    'datetime',
-    'field',
-    'node',
-    'system',
-    'user',
-    'va_gov_build_trigger',
-  ];
+  protected $originalSettings;
+
+  /**
+   * Stash variable to store the original service.
+   *
+   * @var \Aws\Ssm\SsmClient
+   */
+  protected $originalSsmClient;
 
   /**
    * {@inheritdoc}
    */
   public function setUp() {
     parent::setUp();
-
-    // Nodes for testing last-built date update.
-    static::installEntitySchema('node');
-    \Drupal::moduleHandler()
-      ->loadInclude('node', 'install');
-    NodeType::create([
-      'type' => 'build_time_recorder_test_node',
-      'label' => 'Build Time Recorder Test Node',
-    ])
-      ->save();
-    FieldStorageConfig::create([
-      'field_name' => 'field_page_last_built',
-      'entity_type' => 'node',
-      'type' => 'datetime',
-      'settings' => [
-        'datetime_type' => 'datetime',
-      ],
-      'cardinality' => 1,
-    ])
-      ->save();
-    FieldConfig::create([
-      'field_name' => 'field_page_last_built',
-      'entity_type' => 'node',
-      'bundle' => 'build_time_recorder_test_node',
-      'label' => 'Page Last Built',
-    ])
-      ->save();
-    static::createUser([], [
-      'access content',
-      'administer site configuration',
-    ]);
-    $this->node1 = Node::create([
-      'type' => 'build_time_recorder_test_node',
-      'title' => '1',
-      'field_page_last_built' => 1,
-    ])
-      ->save();
 
     // Mock settings.
     $settings['jenkins_build_env'] = 'TEST';
@@ -87,6 +48,8 @@ class BrdEnvironmentTest extends EntityKernelTestBase {
     $settings['jenkins_build_job_path'] = '/job/builds/job/vets-website-content-vagov' . $settings['jenkins_build_env'];
     $settings['jenkins_build_job_params'] = '/buildWithParameters?deploy=true';
     $settings['jenkins_build_job_url'] = $settings['jenkins_build_job_host'] . $settings['jenkins_build_job_path'] . $settings['jenkins_build_job_params'];
+
+    $this->originalSettings = $this->container->get('settings');
     $this->container->set('settings', new Settings($settings));
 
     // Mock the AWS SSM interface.
@@ -113,8 +76,21 @@ class BrdEnvironmentTest extends EntityKernelTestBase {
         'secret' => 'FAKE AWS SECRET KEY',
       ],
     ]);
+    $this->originalSsmClient = $this->container->get('va_gov_build_trigger.aws_ssm_client');
     $this->container->set('va_gov_build_trigger.aws_ssm_client', $ssmClient);
+    $this->originalJenkinsHttpClient = $this->container->get('va_gov_build_trigger.jenkins_http_client');
+    $this->originalBuildTimeRecorder = $this->container->get('va_gov_build_trigger.build_time_recorder');
+  }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function tearDown() {
+    $this->container->set('settings', $this->originalSettings);
+    $this->container->set('va_gov_build_trigger.aws_ssm_client', $this->originalSsmClient);
+    $this->container->set('va_gov_build_trigger.jenkins_http_client', $this->originalJenkinsHttpClient);
+    $this->container->set('va_gov_build_trigger.build_time_recorder', $this->originalBuildTimeRecorder);
+    parent::tearDown();
   }
 
   /**
@@ -131,12 +107,13 @@ class BrdEnvironmentTest extends EntityKernelTestBase {
     $httpClient = $httpClientProphecy->reveal();
     $this->container->set('va_gov_build_trigger.jenkins_http_client', $httpClient);
 
+    $buildTimeRecorderProphecy = $this->prophesize(BuildTimeRecorderInterface::class);
+    $buildTimeRecorderProphecy
+      ->recordBuildTime()
+      ->shouldBeCalled();
+    $this->container->set('va_gov_build_trigger.build_time_recorder', $buildTimeRecorderProphecy->reveal());
     $plugin = $this->container->get('plugin.manager.va_gov.environment')->createInstance('brd');
     $plugin->triggerFrontendBuild();
-
-    // Test that the last-built time of a node has been updated correctly.
-    $node1 = Node::load(1);
-    $this->assertNotEquals($node1->get('field_page_last_built')->getValue()[0]['value'], '1970-01-01T00:00:01');
   }
 
 }

--- a/tests/phpunit/FrontendBuild/Brd/BuildTimeRecorderTest.php
+++ b/tests/phpunit/FrontendBuild/Brd/BuildTimeRecorderTest.php
@@ -2,72 +2,35 @@
 
 namespace tests\phpunit\FrontendBuild\Brd;
 
-use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Tests of the build-time recorder.
  *
  * @coversDefaultClass \Drupal\va_gov_build_trigger\Service\BuildTimeRecorder
  */
-class BuildTimeRecorderTest extends EntityKernelTestBase {
+class BuildTimeRecorderTest extends ExistingSiteBase {
 
   /**
-   * {@inheritdoc}
+   * Test node ID.
+   *
+   * @var int
    */
-  public static $modules = [
-    'advancedqueue',
-    'datetime',
-    'field',
-    'node',
-    'system',
-    'user',
-    'va_gov_build_trigger',
-  ];
+  protected $nodeId;
 
   /**
    * {@inheritdoc}
    */
   public function setUp() {
     parent::setUp();
-    static::installEntitySchema('node');
-    \Drupal::moduleHandler()
-      ->loadInclude('node', 'install');
-    NodeType::create([
-      'type' => 'build_time_recorder_test_node',
-      'label' => 'Build Time Recorder Test Node',
-    ])
-      ->save();
-    FieldStorageConfig::create([
-      'field_name' => 'field_page_last_built',
-      'entity_type' => 'node',
-      'type' => 'datetime',
-      'settings' => [
-        'datetime_type' => 'datetime',
-      ],
-      'cardinality' => 1,
-    ])
-      ->save();
-    FieldConfig::create([
-      'field_name' => 'field_page_last_built',
-      'entity_type' => 'node',
-      'bundle' => 'build_time_recorder_test_node',
-      'label' => 'Page Last Built',
-    ])
-      ->save();
-    static::createUser([], [
-      'access content',
-      'administer site configuration',
-    ]);
-    $this->node1 = Node::create([
-      'type' => 'build_time_recorder_test_node',
-      'title' => '1',
+    $testNode = Node::create([
+      'type' => 'landing_page',
+      'title' => 'PHPUnit Test Landing Page',
       'field_page_last_built' => 1,
-    ])
-      ->save();
+    ]);
+    $testNode->save();
+    $this->nodeId = $testNode->id();
   }
 
   /**
@@ -78,8 +41,8 @@ class BuildTimeRecorderTest extends EntityKernelTestBase {
   public function testRecordBuildTime() {
     $buildTimeRecorder = $this->container->get('va_gov_build_trigger.build_time_recorder');
     $buildTimeRecorder->recordBuildTime(1232);
-    $node1 = Node::load(1);
-    $this->assertEquals($node1->get('field_page_last_built')->getValue()[0]['value'], '1970-01-01T00:20:32');
+    $testNode = Node::load($this->nodeId);
+    $this->assertEquals($testNode->get('field_page_last_built')->getValue()[0]['value'], '1970-01-01T00:20:32');
   }
 
 }

--- a/tests/phpunit/FrontendBuild/Brd/SystemsManagerClientTest.php
+++ b/tests/phpunit/FrontendBuild/Brd/SystemsManagerClientTest.php
@@ -5,22 +5,21 @@ namespace tests\phpunit\FrontendBuild\Brd;
 use Aws\MockHandler;
 use Aws\Result;
 use Aws\Ssm\SsmClient;
-use Drupal\KernelTests\KernelTestBase;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Tests of the Jenkins client.
  *
  * @coversDefaultClass \Drupal\va_gov_build_trigger\Service\SystemsManagerClient
  */
-class SystemsManagerClientTest extends KernelTestBase {
+class SystemsManagerClientTest extends ExistingSiteBase {
 
   /**
-   * {@inheritdoc}
+   * Stash variable to store the original service.
+   *
+   * @var \Aws\Ssm\SsmClient
    */
-  public static $modules = [
-    'datetime',
-    'va_gov_build_trigger',
-  ];
+  protected $originalSsmClient;
 
   /**
    * {@inheritdoc}
@@ -50,7 +49,16 @@ class SystemsManagerClientTest extends KernelTestBase {
         'secret' => 'FAKE AWS SECRET KEY',
       ],
     ]);
+    $this->originalSsmClient = $this->container->get('va_gov_build_trigger.aws_ssm_client');
     $this->container->set('va_gov_build_trigger.aws_ssm_client', $ssmClient);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tearDown() {
+    $this->container->set('va_gov_build_trigger.aws_ssm_client', $this->originalSsmClient);
+    parent::tearDown();
   }
 
   /**


### PR DESCRIPTION
## Description

The kernel tests broke on staging post-deploy tests because the AMI has a too-old version of SQLite installed.

So I changed the tests to ExistingSiteBase tests.

These shouldn't interfere with other tests or the normal operation of the site once the test is completed because the container should be reset in the tearDown() method.

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
