### PR TITLE
VACMS-4988 Prevent notice when Menu form is not present.

### DIFF
--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -230,7 +230,7 @@ class MenuReductionService {
    *   The form array by reference.
    */
   protected function setEmptyMenuParentSelector(array &$form) {
-    if (!empty($form['menu'])) {
+    if (!empty($form['menu']) && !empty($form['menu']['link']['menu_parent'])) {
       // Sets an empty Select prompt on parent menu selector for all node forms.
       $form['menu']['link']['menu_parent']['#options'] = array_merge(['0' => '- Select a value -'], $form['menu']['link']['menu_parent']['#options']);
       // If we don't have a value set, yet, ensure the Select appears first.


### PR DESCRIPTION
## Description
This is to resolve the notices from array merge trying to merge an array with a nothing.

See _issueid_. 

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
