### PR TITLE
VACMS-000 Update call to depricated path.alias_manager.

### DIFF
--- a/docroot/modules/custom/va_gov_user/va_gov_user.module
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.module
@@ -16,7 +16,7 @@ function va_gov_user_user_login($account) {
   $sections = \Drupal::service('va_gov_user.user_perms')->getSections($account);
   $route_name = \Drupal::routeMatch()->getRouteName();
   if (count($sections) === 1 && $route_name === 'user.login') {
-    $alias_manager = \Drupal::service('path.alias_manager');
+    $alias_manager = \Drupal::service('path_alias.manager');
     $alias = $alias_manager->getAliasByPath('/taxonomy/term/' . key($sections));
     $response = new RedirectResponse($alias);
     $response->send();


### PR DESCRIPTION
## Description
path.alias_manager  is now path_alias.manager

causes this error when logging in with a non-admin account who only has one section assigned.

Introduced by https://github.com/department-of-veterans-affairs/va.gov-cms/pull/5752/files

## Testing done
## QA steps
 

1.  https://cms-2tgedegcc2xecvh0jc23exmuhq5yz6ec.ci.cms.va.gov and Login as Ryan.Stubblebine@va.gov
- [ ] Validate that you see no whitescreen with error.

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
