### PR TITLE
VACMS-5847: Hide labels from fields in paragraphs in Knowledge Base.

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.address.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.address.user_guides.yml
@@ -1,0 +1,29 @@
+uuid: 41f1e6dd-f8b1-4788-b103-bcf46de20b1a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.address.field_address
+    - paragraphs.paragraphs_type.address
+  module:
+    - address
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.address.user_guides
+targetEntityType: paragraph
+bundle: address
+mode: user_guides
+content:
+  field_address:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: address_default
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.alert.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.alert.user_guides.yml
@@ -1,0 +1,59 @@
+uuid: 19a12110-204e-4ca9-bdca-c0c6eaa4b047
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.alert.field_alert_block_reference
+    - field.field.paragraph.alert.field_alert_heading
+    - field.field.paragraph.alert.field_alert_type
+    - field.field.paragraph.alert.field_va_paragraphs
+    - paragraphs.paragraphs_type.alert
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - options
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.alert.user_guides
+targetEntityType: paragraph
+bundle: alert
+mode: user_guides
+content:
+  field_alert_block_reference:
+    weight: 0
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_alert_heading:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_alert_type:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_va_paragraphs:
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.basic_accordion.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.basic_accordion.user_guides.yml
@@ -1,21 +1,27 @@
-uuid: 05e99e8d-eee9-40c5-bfaf-548e87a5cbfc
+uuid: b1f83928-259c-4c04-8f8a-9d5e81b59df6
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.paragraph.user_guides
     - field.field.paragraph.basic_accordion.field_header
     - field.field.paragraph.basic_accordion.field_rich_wysiwyg
     - paragraphs.paragraphs_type.basic_accordion
   module:
+    - layout_builder
     - text
-id: paragraph.basic_accordion.default
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.basic_accordion.user_guides
 targetEntityType: paragraph
 bundle: basic_accordion
-mode: default
+mode: user_guides
 content:
   field_header:
     weight: 0
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.paragraph.button.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.button.user_guides.yml
@@ -1,0 +1,43 @@
+uuid: 8ffe72f8-d008-4380-a119-db5cdc71fc42
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.button.field_button_label
+    - field.field.paragraph.button.field_button_link
+    - paragraphs.paragraphs_type.button
+  module:
+    - layout_builder
+    - link
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.button.user_guides
+targetEntityType: paragraph
+bundle: button
+mode: user_guides
+content:
+  field_button_label:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_button_link:
+    weight: 1
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.checklist.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.checklist.user_guides.yml
@@ -1,0 +1,31 @@
+uuid: 93dca02a-e55e-4674-ba88-4434618af0c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.checklist.field_checklist_sections
+    - paragraphs.paragraphs_type.checklist
+  module:
+    - entity_reference_revisions
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.checklist.user_guides
+targetEntityType: paragraph
+bundle: checklist
+mode: user_guides
+content:
+  field_checklist_sections:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.checklist_item.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.checklist_item.user_guides.yml
@@ -1,0 +1,46 @@
+uuid: 2c718e2d-2e81-46c1-9e7f-d9767f717902
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.checklist_item.field_checklist_items
+    - field.field.paragraph.checklist_item.field_section_header
+    - field.field.paragraph.checklist_item.field_section_intro
+    - paragraphs.paragraphs_type.checklist_item
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.checklist_item.user_guides
+targetEntityType: paragraph
+bundle: checklist_item
+mode: user_guides
+content:
+  field_checklist_items:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_section_header:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_section_intro:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.collapsible_panel.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.collapsible_panel.user_guides.yml
@@ -1,0 +1,37 @@
+uuid: 72869d7a-0e1f-449a-b297-d8b7db7a387e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.collapsible_panel.field_collapsible_panel_bordered
+    - field.field.paragraph.collapsible_panel.field_collapsible_panel_expand
+    - field.field.paragraph.collapsible_panel.field_collapsible_panel_multi
+    - field.field.paragraph.collapsible_panel.field_va_paragraphs
+    - paragraphs.paragraphs_type.collapsible_panel
+  module:
+    - entity_reference_revisions
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.collapsible_panel.user_guides
+targetEntityType: paragraph
+bundle: collapsible_panel
+mode: user_guides
+content:
+  field_va_paragraphs:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+hidden:
+  field_collapsible_panel_bordered: true
+  field_collapsible_panel_expand: true
+  field_collapsible_panel_multi: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.collapsible_panel_item.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.collapsible_panel_item.user_guides.yml
@@ -1,0 +1,49 @@
+uuid: 1a86c83d-b117-488d-9a4e-ce5848f5360f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.collapsible_panel_item.field_title
+    - field.field.paragraph.collapsible_panel_item.field_va_paragraphs
+    - field.field.paragraph.collapsible_panel_item.field_wysiwyg
+    - paragraphs.paragraphs_type.collapsible_panel_item
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.collapsible_panel_item.user_guides
+targetEntityType: paragraph
+bundle: collapsible_panel_item
+mode: user_guides
+content:
+  field_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_va_paragraphs:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  field_wysiwyg:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.contact_information.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.contact_information.user_guides.yml
@@ -1,0 +1,78 @@
+uuid: fdf6e9bb-a1df-41e9-bc0e-b7d86a793c7f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.contact_information.field_additional_contact
+    - field.field.paragraph.contact_information.field_benefit_hub_contacts
+    - field.field.paragraph.contact_information.field_contact_default
+    - field.field.paragraph.contact_information.field_contact_info_switch
+    - field.field.paragraph.contact_information.field_markup
+    - paragraphs.paragraphs_type.contact_information
+  module:
+    - entity_reference_revisions
+    - field_group
+    - layout_builder
+    - options
+third_party_settings:
+  field_group:
+    group_contact_information:
+      children:
+        - field_contact_default
+        - field_benefit_hub_contacts
+        - field_additional_contact
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: 'Contact information'
+      region: content
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.contact_information.user_guides
+targetEntityType: paragraph
+bundle: contact_information
+mode: user_guides
+content:
+  field_additional_contact:
+    type: entity_reference_revisions_entity_view
+    weight: 4
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_benefit_hub_contacts:
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: support_services_listing
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_contact_default:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: support_services_listing
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_contact_info_switch:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+hidden:
+  field_markup: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.email_contact.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.email_contact.user_guides.yml
@@ -1,0 +1,52 @@
+uuid: f0952ced-461e-43a3-8cd6-1d6c8bac7fc8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.email_contact.field_email_address
+    - field.field.paragraph.email_contact.field_email_label
+    - paragraphs.paragraphs_type.email_contact
+  module:
+    - field_group
+    - layout_builder
+third_party_settings:
+  field_group:
+    group_email_contact:
+      children:
+        - field_email_address
+        - field_email_label
+      parent_name: ''
+      weight: 0
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: 'Email contact'
+      region: content
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.email_contact.user_guides
+targetEntityType: paragraph
+bundle: email_contact
+mode: user_guides
+content:
+  field_email_address:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_email_label:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.featured_content.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.featured_content.user_guides.yml
@@ -1,0 +1,52 @@
+uuid: e638088e-c6c8-4602-8674-052b4509d135
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.featured_content.field_cta
+    - field.field.paragraph.featured_content.field_description
+    - field.field.paragraph.featured_content.field_section_header
+    - paragraphs.paragraphs_type.featured_content
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - string_field_formatter
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.featured_content.user_guides
+targetEntityType: paragraph
+bundle: featured_content
+mode: user_guides
+content:
+  field_cta:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_description:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_section_header:
+    weight: 0
+    label: hidden
+    settings:
+      wrap_tag: h3
+      wrap_class: ''
+      link_to_entity: false
+    third_party_settings: {  }
+    type: plain_string_formatter
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.link_teaser_with_image.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.link_teaser_with_image.user_guides.yml
@@ -1,0 +1,43 @@
+uuid: f9c9258d-d99c-4c37-99dc-ddf37e91f256
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.link_teaser_with_image.field_link_teaser
+    - field.field.paragraph.link_teaser_with_image.field_media
+    - image.style.3_2_medium_thumbnail
+    - paragraphs.paragraphs_type.link_teaser_with_image
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - media
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.link_teaser_with_image.user_guides
+targetEntityType: paragraph
+bundle: link_teaser_with_image
+mode: user_guides
+content:
+  field_link_teaser:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_media:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: 3_2_medium_thumbnail
+      image_link: ''
+    third_party_settings: {  }
+    type: media_thumbnail
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.media.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.media.user_guides.yml
@@ -1,0 +1,34 @@
+uuid: ab71e742-2c0a-4b78-84c3-c728401797aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.media.field_allow_clicks_on_this_image
+    - field.field.paragraph.media.field_markup
+    - field.field.paragraph.media.field_media
+    - paragraphs.paragraphs_type.media
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.media.user_guides
+targetEntityType: paragraph
+bundle: media
+mode: user_guides
+content:
+  field_media:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: embedded
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_allow_clicks_on_this_image: true
+  field_markup: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.media_list_images.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.media_list_images.user_guides.yml
@@ -1,0 +1,39 @@
+uuid: a73fa3f1-9c53-4e57-ae5f-5f714825717e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.media_list_images.field_images
+    - field.field.paragraph.media_list_images.field_section_header
+    - paragraphs.paragraphs_type.media_list_images
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.media_list_images.user_guides
+targetEntityType: paragraph
+bundle: media_list_images
+mode: user_guides
+content:
+  field_images:
+    type: entity_reference_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_section_header:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.process.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.process.user_guides.yml
@@ -1,0 +1,29 @@
+uuid: 5e028214-e1ea-4535-8899-91389206103e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.process.field_steps
+    - paragraphs.paragraphs_type.process
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.process.user_guides
+targetEntityType: paragraph
+bundle: process
+mode: user_guides
+content:
+  field_steps:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.q_a.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.q_a.user_guides.yml
@@ -1,0 +1,43 @@
+uuid: b38f7d78-9fba-450d-b8d5-21a13ee8bde0
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.q_a.field_answer
+    - field.field.paragraph.q_a.field_question
+    - paragraphs.paragraphs_type.q_a
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - string_field_formatter
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.q_a.user_guides
+targetEntityType: paragraph
+bundle: q_a
+mode: user_guides
+content:
+  field_answer:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  field_question:
+    weight: 0
+    label: hidden
+    settings:
+      wrap_tag: h3
+      wrap_class: ''
+      link_to_entity: false
+    third_party_settings: {  }
+    type: plain_string_formatter
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.q_a_group.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.q_a_group.user_guides.yml
@@ -1,0 +1,49 @@
+uuid: 3b88f810-69c0-4667-922b-480b4af8d3f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.q_a_group.field_accordion_display
+    - field.field.paragraph.q_a_group.field_q_as
+    - field.field.paragraph.q_a_group.field_section_header
+    - paragraphs.paragraphs_type.q_a_group
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.q_a_group.user_guides
+targetEntityType: paragraph
+bundle: q_a_group
+mode: user_guides
+content:
+  field_accordion_display:
+    weight: 1
+    label: hidden
+    settings:
+      format: custom
+      format_custom_true: 'Q&A''s in this section will display as accordions'
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_q_as:
+    weight: 2
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_section_header:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.q_a_section.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.q_a_section.user_guides.yml
@@ -1,0 +1,50 @@
+uuid: de94d107-1d56-4b1a-8754-8ada302f7e61
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.q_a_section.field_accordion_display
+    - field.field.paragraph.q_a_section.field_questions
+    - field.field.paragraph.q_a_section.field_section_header
+    - field.field.paragraph.q_a_section.field_section_intro
+    - paragraphs.paragraphs_type.q_a_section
+  module:
+    - entity_reference_revisions
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.q_a_section.user_guides
+targetEntityType: paragraph
+bundle: q_a_section
+mode: user_guides
+content:
+  field_questions:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: visually_hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_section_header:
+    weight: 0
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_section_intro:
+    weight: 1
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  field_accordion_display: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.spanish_translation_summary.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.spanish_translation_summary.user_guides.yml
@@ -1,0 +1,38 @@
+uuid: 130af877-8079-4eb4-84c2-b4b6b903c3ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.spanish_translation_summary.field_text_expander
+    - field.field.paragraph.spanish_translation_summary.field_wysiwyg
+    - paragraphs.paragraphs_type.spanish_translation_summary
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.spanish_translation_summary.user_guides
+targetEntityType: paragraph
+bundle: spanish_translation_summary
+mode: user_guides
+content:
+  field_text_expander:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_wysiwyg:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.table.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.table.user_guides.yml
@@ -1,0 +1,31 @@
+uuid: ffcdc4ab-596e-482d-ade8-cc4e26081632
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.table.field_table
+    - paragraphs.paragraphs_type.table
+  module:
+    - layout_builder
+    - tablefield
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.table.user_guides
+targetEntityType: paragraph
+bundle: table
+mode: user_guides
+content:
+  field_table:
+    weight: 0
+    label: hidden
+    settings:
+      row_header: true
+      column_header: false
+    third_party_settings: {  }
+    type: tablefield
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.wysiwyg.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.wysiwyg.user_guides.yml
@@ -1,0 +1,29 @@
+uuid: 1d30e484-5e1d-4e11-81d7-b01eed5cde6e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.user_guides
+    - field.field.paragraph.wysiwyg.field_wysiwyg
+    - paragraphs.paragraphs_type.wysiwyg
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.wysiwyg.user_guides
+targetEntityType: paragraph
+bundle: wysiwyg
+mode: user_guides
+content:
+  field_wysiwyg:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_mode.paragraph.user_guides.yml
+++ b/config/sync/core.entity_view_mode.paragraph.user_guides.yml
@@ -5,6 +5,6 @@ dependencies:
   module:
     - paragraphs
 id: paragraph.user_guides
-label: 'User guides'
+label: 'Knowledge Base'
 targetEntityType: paragraph
 cache: true


### PR DESCRIPTION
## Description
Closes #5847

## Testing done
Visual / behat

## QA steps
Gonna need @kevwalsh to have a look - I looked at a handful of help pages on prod, and didn't find any examples of paragraph labels appearing in the output.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
