### PR TITLE
VACMS-5545: Fix GovDelivery Queue Cache issue

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5842,17 +5842,17 @@
         },
         {
             "name": "drupal/govdelivery_bulletins",
-            "version": "1.3.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/govdelivery_bulletins.git",
-                "reference": "8.x-1.3"
+                "reference": "8.x-1.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/govdelivery_bulletins-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "49cb4139bac511925081a18b060afcb233ef42f6"
+                "url": "https://ftp.drupal.org/files/projects/govdelivery_bulletins-8.x-1.5.zip",
+                "reference": "8.x-1.5",
+                "shasum": "e0e15ca1f1718c50b41bc30495d1eff9688ef4b5"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -5860,8 +5860,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1605564728",
+                    "version": "8.x-1.5",
+                    "datestamp": "1626385868",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -22572,5 +22572,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
## Description
For https://github.com/department-of-veterans-affairs/va.gov-cms/issues/5545.  

Upstream code for this release update is here > https://www.drupal.org/project/govdelivery_bulletins/issues/3223883

## Testing done
Tested this live on STAGING with opcache and memcache clearing, GovDelivery endpoint triggering works consistently now. 

This cannot be tested in a PR with our tests so I am not waiting for tests to pass before merge. 



