### PR TITLE
VACMS-5884 Allow vamc facility menu roots to show.

### DIFF
--- a/config/sync/va_gov_menu_access.settings.yml
+++ b/config/sync/va_gov_menu_access.settings.yml
@@ -1,3 +1,3 @@
 va_gov_menu_access:
-  paths: "%-health-care~\r\n%-health-care/work-with-us~\r\n%-health-care/work-with-us/internships-and-fellowships\r\n%-health-care/work-with-us/doing-business-with-us\r\n%-health-care/work-with-us/jobs-and-careers\r\n%-health-care/work-with-us/volunteer-or-donate\r\n%-health-care/programs\r\n%-health-care/research\r\n\r\n\r\n\r\n"
+  paths: "%^/[a-zA-Z-_]+-health-care~\r\n%-health-care/work-with-us~\r\n%-health-care/work-with-us/internships-and-fellowships\r\n%-health-care/work-with-us/doing-business-with-us\r\n%-health-care/work-with-us/jobs-and-careers\r\n%-health-care/work-with-us/volunteer-or-donate\r\n%-health-care/programs\r\n%-health-care/research\r\n"
   locked_paths: '%-health-care*'

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -411,12 +411,10 @@ class MenuReductionService {
       if (strpos($parent_rule, '~') !== FALSE) {
         // The ~ tells us we just have a disabled parent.
         $parent_rule = $this->removeWildCard('~', $parent_rule);
-        if (strpos($alias, $parent_rule) !== FALSE) {
-          // Check to see if this is the parent item.
-          $parent_sanitized = str_replace('/', '\/', $parent_rule);
-          if (preg_match("/{$parent_sanitized}$/", $alias)) {
-            return self::DISABLED;
-          }
+        // Check to see if this is the parent item.
+        $parent_sanitized = str_replace('/', '\/', $parent_rule);
+        if (preg_match("/{$parent_sanitized}$/", $alias)) {
+          return self::DISABLED;
         }
       }
     }


### PR DESCRIPTION
## Description

closes #5884 

## Testing done


## Screenshots


## QA steps

As user assigned to multiple systems (james.hoehn2@va.gov)  
1.Navigate to https://pr5898-eesb1ll60jncmefcfkfwdpsua5layknl.ci.cms.va.gov/node/add/health_care_region_detail_page
  - [x] validate that you can see the menu roots and determine which sub menu items are in which system. 
![image](https://user-images.githubusercontent.com/5752113/126208702-291a9e0c-0cca-489b-a526-b6f834d8cf51.png)
  - [x] Validate that the available options are correct and match the allowed segments.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
