### PR TITLE
VACMS-5921: Update op status node aliases. [DO NOT MERGE BEFORE 5940 IS DEPLOYED]

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.install
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.install
@@ -392,3 +392,32 @@ function va_gov_backend_update_8009() {
     }
   }
 }
+
+/**
+ * Resave op status nodes to regenerate path alias.
+ */
+function va_gov_backend_update_8010() {
+
+  $storage = \Drupal::entityTypeManager()->getStorage('node');
+  $updated = 0;
+  $failed = 0;
+  $failed_nids = [];
+  $entities = $storage->loadByProperties(['type' => 'vamc_operating_status_and_alerts']);
+
+  foreach ($entities as $entity) {
+    // Save in order to update path alias without creating a new revision.
+    $saved = $entity->save();
+    $updated = (is_int($saved) && $saved > 0) ? $updated + 1 : $updated;
+    $failed = (is_int($saved) && $saved <= 0) ? $failed + 1 : $failed;
+    $failed_nids = (is_int($saved) && $saved <= 0) ? $failed_nids[$entity->id()] : $failed_nids;
+  }
+
+  Drupal::logger('va_gov_backend')
+    ->log(LogLevel::INFO, 'Path Alias for %bundle: Successfully updated path alias for %updated out of %count entities. %failed %failed_nids', [
+      '%bundle' => 'vamc_operating_status_and_alerts',
+      '%count' => count($entities),
+      '%updated' => $updated,
+      '%failed' => $failed ? 'Failed to update ' . $failed . ' out of %count.' : NULL,
+      '%failed_nids' => count($failed_nids) ? 'Failed nids: ' . implode(', ', $failed_nids) . '.' : NULL,
+    ]);
+}


### PR DESCRIPTION
## Description

Closes #5921 (Part 2 of 2)

## Testing done
N/A

## QA steps
N/A

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
