### PR TITLE
VACMS-5952: patch graphql to make the explorer work when layout_builder is enabled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -355,6 +355,9 @@
                 "2787179 Visibility of invalid fields": "https://www.drupal.org/files/issues/2021-01-05/2787179-highlight-html5-validation-59.patch",
                 "1482958-47 Allow field_group with empty fields to be displayed via setting": "https://www.drupal.org/files/issues/2020-06-24/field_group-empty-config-1482958-47.patch"
             },
+            "drupal/graphql": {
+                "Fix Explorer with Layout Builder enabled - https://github.com/drupal-graphql/graphql/pull/1144": "patches/graphql_8x3x_layout_builder_incompat.patch"
+            },
             "drupal/health_check_url": {
                 "3147740 - Make d9 compatible": "https://www.drupal.org/files/issues/2020-06-06/health_check_url.2.x-dev.rector.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8252589de598ad114e11bbfc3a9ee34b",
+    "content-hash": "f78c05afe9b88b7607e3ff1fb04d56b5",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -15013,6 +15013,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -22621,5 +22622,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/patches/graphql_8x3x_layout_builder_incompat.patch
+++ b/patches/graphql_8x3x_layout_builder_incompat.patch
@@ -1,0 +1,32 @@
+diff --git a/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php b/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
+index dc60dd9..1c2bd89 100644
+--- a/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
++++ b/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
+@@ -439,7 +439,15 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
+    * {@inheritdoc}
+    */
+   public function processFields(array $fields) {
+-    return array_map([$this, 'buildField'], $fields);
++    $processFields = array_map([$this, 'buildField'], $fields);
++
++    foreach($processFields as $key => $processField) {
++      if ($processField === false) {
++        unset($processFields[$key]);
++      }
++    }
++
++    return $processFields;
+   }
+ 
+   /**
+@@ -506,6 +514,10 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
+    *   The field definition.
+    */
+   protected function buildField($field) {
++    if ($field['definition']['type'][0] === 'layout_section') {
++      return false;
++    }
++
+     if (!isset($this->fields[$field['id']])) {
+       $creator = [$field['class'], 'createInstance'];
+       $this->fields[$field['id']] = $creator($this, $this->fieldManager, $field['definition'], $field['id']);


### PR DESCRIPTION
## Description

See #5952 

## Testing done

Manual testing of /graphql/explorer

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
