### PR TITLE
Update PHP workflow to use fork

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,20 @@
+name: phpstan
+on: [pull_request]
+jobs:
+  phpstan:
+    name: runner / phpstan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+      - uses: lindluni/composer@master
+      - uses: php-actions/phpstan@v3
+        with:
+          version: 8.4.0
+          php_version: 7.3
+          php_extensions: dom curl libxml mbstring zip pdo mysql pdo_mysql gd
+          configuration: 'phpstan.neon'
+          path: 'docroot/modules/custom docroot/themes/custom tests'


### PR DESCRIPTION
Testing PHP builds with a forked copy of the `php-actions/composer` where I plugged in a forked copy of `php-actions/php-build` to push to GHCR.io rather than the legacy docker.pkg.github.com 