### PR TITLE
VACMS-0000: Removes unused(?) function from va_gov_backend.module

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -2037,41 +2037,6 @@ function _va_gov_backend_feature_bump(EntityInterface $entity) {
 }
 
 /**
- * Sets field_listing value or throws an exception for an empty value.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   Entity.
- * @param array $entity_listing_mapping
- *   Mapping that specifies how content type maps to corresponding
- *   "listing" content type.
- * @param int|null $id
- *   NID of the node of type "listing".
- *
- * @throws \Exception
- */
-function _va_gov_backend_set_field_listing_value(EntityInterface &$entity, array $entity_listing_mapping, int $id = NULL) {
-  if (!is_int($id) || $id == 0) {
-    // @codingStandardsIgnoreStart
-    // Listing corresponding to field_office, was not found. Fail silently.
-    // Give a warning message to the user and log in dblog.
-    Drupal::messenger()->addWarning("{$entity->type->entity->label()} Listing page for the office or system you've selected does not exist. Please create {$entity->type->entity->label()} Listing page and come back to re-save this {$entity->type->entity->label()}.");
-    Drupal::logger('va_gov_backend')->warning(
-      '%bundle Listing page for the office or system you\'ve selected does not exist. Please create %bundle Listing page and come back to re-save %bundle with NID %nid.',
-      ['%bundle' => $entity->type->entity->label(), '%nid' => $entity->id()]);
-    return;
-    // @codingStandardsIgnoreEnd
-  }
-
-  // We have a listing node id.
-  if ($entity->hasField('field_listing')) {
-    // Clear previous value.
-    $entity->set('field_listing', NULL);
-    // Assuming there's only one Event Listing per Office/VAMC System.
-    $entity->field_listing[] = ['target_id' => $id];
-  }
-}
-
-/**
  * Implements hook_raven_options_alter().
  */
 function va_gov_backend_raven_options_alter(array &$options) {


### PR DESCRIPTION
## Description

Closes diddly.  Looks like this added by Oksana in a481d5ecdbaa5247817909fff20b695e680960a7 and was only ever called from `_va_gov_backend_sync_office_listing_fields()`, which was removed in cd3dd92753c4c7157914bc3667411618e0a63832 by the Teaguester.  

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
