### PR TITLE
VACMS-6113: Automatically fix broken links to email addresses.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -329,6 +329,7 @@
                 "2911932 - Correct vertical tab does not focus on form validation": "https://www.drupal.org/files/issues/2020-12-12/vertical-tabs--focus-on-onvalid-7b.patch",
                 "2893933 - claimItem in the database and memory queues does not use expire correctly": "https://www.drupal.org/files/issues/2021-01-14/2893933-40.patch",
                 "3198608 - Migrate does not set set track_lst_updated from config": "https://www.drupal.org/files/issues/2021-07-27/track-last-updated-tests-3198608-14.patch",
+                "3025164 - Make moderation_state available to field queries":"https://www.drupal.org/files/issues/2020-09-25/3025164-28.patch",
                 "3205691 - Disallow aria-required on fieldsets": "https://www.drupal.org/files/issues/2021-03-25/disallow-aria-required-fieldsets.patch"
             },
             "drupal/entity_browser": {

--- a/config/sync/filter.format.rich_text.yml
+++ b/config/sync/filter.format.rich_text.yml
@@ -20,31 +20,31 @@ filters:
     id: filter_align
     provider: filter
     status: false
-    weight: -42
+    weight: -41
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: false
-    weight: -41
+    weight: -40
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: -49
+    weight: -48
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: true
-    weight: -48
+    weight: -47
     settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: true
-    weight: -43
+    weight: -42
     settings: {  }
   filter_html:
     id: filter_html
@@ -59,39 +59,39 @@ filters:
     id: filter_autop
     provider: filter
     status: false
-    weight: -39
+    weight: -38
     settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -40
+    weight: -39
     settings: {  }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -38
+    weight: -37
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: true
-    weight: -47
+    weight: -46
     settings:
       filter_url_length: 72
   linkit:
     id: linkit
     provider: linkit
     status: true
-    weight: -44
+    weight: -43
     settings:
       title: true
   filter_pathologic:
     id: filter_pathologic
     provider: pathologic
     status: true
-    weight: -46
+    weight: -45
     settings:
       settings_source: local
       local_settings:
@@ -101,7 +101,7 @@ filters:
     id: media_embed
     provider: media
     status: false
-    weight: -36
+    weight: -35
     settings:
       default_view_mode: default
       allowed_media_types: {  }
@@ -110,7 +110,7 @@ filters:
     id: blazy_filter
     provider: blazy
     status: false
-    weight: -37
+    weight: -36
     settings:
       filter_tags:
         img: img
@@ -121,6 +121,13 @@ filters:
     id: va_gov_backend_node_link_enforcement
     provider: va_gov_backend
     status: true
-    weight: -45
+    weight: -44
+    settings:
+      title: '1'
+  va_gov_backend_email_link_repair:
+    id: va_gov_backend_email_link_repair
+    provider: va_gov_backend
+    status: true
+    weight: -49
     settings:
       title: '1'

--- a/config/sync/filter.format.rich_text_limited.yml
+++ b/config/sync/filter.format.rich_text_limited.yml
@@ -20,31 +20,31 @@ filters:
     id: filter_align
     provider: filter
     status: false
-    weight: -41
+    weight: -40
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: false
-    weight: -40
+    weight: -39
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: -49
+    weight: -48
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: false
-    weight: -43
+    weight: -42
     settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: false
-    weight: -42
+    weight: -41
     settings: {  }
   filter_html:
     id: filter_html
@@ -59,39 +59,39 @@ filters:
     id: filter_autop
     provider: filter
     status: true
-    weight: -44
+    weight: -43
     settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -39
+    weight: -38
     settings: {  }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -38
+    weight: -37
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: true
-    weight: -48
+    weight: -47
     settings:
       filter_url_length: 72
   linkit:
     id: linkit
     provider: linkit
     status: true
-    weight: -45
+    weight: -44
     settings:
       title: true
   filter_pathologic:
     id: filter_pathologic
     provider: pathologic
     status: true
-    weight: -47
+    weight: -46
     settings:
       settings_source: local
       local_settings:
@@ -101,7 +101,7 @@ filters:
     id: media_embed
     provider: media
     status: false
-    weight: -36
+    weight: -35
     settings:
       default_view_mode: default
       allowed_media_types: {  }
@@ -110,7 +110,7 @@ filters:
     id: blazy_filter
     provider: blazy
     status: false
-    weight: -37
+    weight: -36
     settings:
       filter_tags:
         img: img
@@ -121,6 +121,13 @@ filters:
     id: va_gov_backend_node_link_enforcement
     provider: va_gov_backend
     status: true
-    weight: -46
+    weight: -45
+    settings:
+      title: '1'
+  va_gov_backend_email_link_repair:
+    id: va_gov_backend_email_link_repair
+    provider: va_gov_backend
+    status: true
+    weight: -49
     settings:
       title: '1'

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
@@ -35,7 +35,7 @@ class EmailLinkRepairFilter extends FilterBase {
       $url = $element->getAttribute('href');
       $email = filter_var($url, FILTER_VALIDATE_EMAIL);
       if ($email !== FALSE) {
-        $element->setAttribute('href', "mailto:$email");
+        $element->setAttribute('href', 'mailto:' . $email);
       }
     }
     $result->setProcessedText(Html::serialize($dom));

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
@@ -2,12 +2,9 @@
 
 namespace Drupal\va_gov_backend\Plugin\Filter;
 
-use Drupal\Core\Path\PathValidatorInterface;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\filter\FilterProcessResult;
 use Drupal\filter\Plugin\FilterBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Repairs formatting of email address links.
@@ -22,43 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE
  * )
  */
-class EmailLinkRepairFilter extends FilterBase implements ContainerFactoryPluginInterface {
-
-  /**
-   * The path validator.
-   *
-   * @var \Drupal\Core\Path\PathValidatorInterface
-   */
-  protected $pathValidator;
-
-  /**
-   * Constructs a Email Link Repair Filter object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
-   *   The path validator.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, PathValidatorInterface $path_validator) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->pathValidator = $path_validator;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('path.validator')
-    );
-  }
+class EmailLinkRepairFilter extends FilterBase {
 
   /**
    * {@inheritdoc}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Filter;
+
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Repairs formatting of email address links.
+ *
+ * @Filter(
+ *   id = "va_gov_backend_email_link_repair",
+ *   title = @Translation("Email Link Repair"),
+ *   description = @Translation("Repairs formatting of email address links."),
+ *   settings = {
+ *     "title" = TRUE,
+ *   },
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE
+ * )
+ */
+class EmailLinkRepairFilter extends FilterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The path validator.
+   *
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  protected $pathValidator;
+
+  /**
+   * Constructs a Email Link Repair Filter object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+   *   The path validator.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PathValidatorInterface $path_validator) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->pathValidator = $path_validator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('path.validator')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode) {
+    $result = new FilterProcessResult($text);
+    if (strpos($text, '<a href="') === FALSE || strpos($text, '@') === FALSE) {
+      return $result;
+    }
+    $dom = Html::load($text);
+    $xpath = new \DOMXPath($dom);
+    foreach ($xpath->query('//a[contains(@href, "@")]') as $element) {
+      $url = $element->getAttribute('href');
+      $email = filter_var($url, FILTER_VALIDATE_EMAIL);
+      if ($email !== FALSE) {
+        $element->setAttribute('href', "mailto:$email");
+      }
+    }
+    $result->setProcessedText(Html::serialize($dom));
+    return $result;
+  }
+
+}

--- a/tests/phpunit/Content/EmailLinkRepairFilterTest.php
+++ b/tests/phpunit/Content/EmailLinkRepairFilterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace tests\phpunit\Content;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * A test to confirm the proper functioning of the EmailLinkRepair filter.
+ *
+ * @group functional
+ * @group all
+ * @group filter
+ *
+ * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Filter\EmailLinkRepairFilter
+ */
+class EmailLinkRepairFilterTest extends ExistingSiteBase {
+
+  /**
+   * Tests the filter's processing.
+   *
+   * @param string $input
+   *   The input string (HTML).
+   * @param string $expected
+   *   The expected output, if different from the input.
+   *
+   * @covers EmailLinkRepairFilter::process
+   * @dataProvider processDataProvider
+   */
+  public function testProcess(string $input, string $expected = NULL) {
+    $filter = $this->container->get('plugin.manager.filter')->createInstance('va_gov_backend_email_link_repair');
+    $langcode = 'en';
+    $expected = $expected ?? $input;
+    $this->assertEquals($expected, $filter->process($input, $langcode)->getProcessedText());
+  }
+
+  /**
+   * Data Provider for ::testProcess().
+   *
+   * The first value of each pair is the input, the second the expected output.
+   *
+   * If the second value is not provided, it is expected that no changes will be
+   * made to the input.
+   */
+  public function processDataProvider() {
+    return [
+      [
+        'Some innocuous text with some <b>bold</b> text.',
+      ],
+      [
+        'test@example.org',
+      ],
+      [
+        '<a id="test">test</a>',
+      ],
+      [
+        '<a href="test@example.org">test</a>',
+        '<a href="mailto:test@example.org">test</a>',
+      ],
+      [
+        '<a href="test%40example.org">test</a>',
+      ],
+      [
+        '<a href="/test@example.org">test</a>',
+        '<a href="mailto:/test@example.org">test</a>',
+      ],
+      [
+        '<a href="/test%40example.org">test</a>',
+      ],
+      [
+        '<a href="/node/5313">test</a>',
+      ],
+      [
+        '<a href="https://www.google.com/">test</a>',
+      ],
+      [
+        '<a href="https://www.google.com/test@example.org">test</a>',
+      ],
+      [
+        '<a href="https://www.google.com/test%40example.org">test</a>',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Description

Relates to #6113. 

Super simple approach based around `filter_var($string, FILTER_VALIDATE_EMAIL)` and a pretty selective XPath query.

TL;DR: If it looks like a bare email address, stick a `mailto:` in front of it.

```php
$urls = [
    'test@example.org',
    'test%40example.org',
    '/test@example.org',
    '/test%40example.org',
    'mailto:test@example.org',
    'mailto://test@example.org',
    'https://absolute.url/test@example.org',
    'https://absolute.url/test%40example.org',
];

foreach ($urls as $in) {
    $out = filter_var($in, FILTER_VALIDATE_EMAIL);
    $out = $out === FALSE ? 'Not Matched' : $out;
    echo "$in: $out\n"; 
}
```

```
test@example.org: test@example.org
test%40example.org: Not Matched
/test@example.org: /test@example.org
/test%40example.org: Not Matched
mailto:test@example.org: Not Matched
mailto://test@example.org: Not Matched
https://absolute.url/test@example.org: Not Matched
https://absolute.url/test%40example.org: Not Matched
```

I went back in time to check a node from a few days ago that caused issues along these lines, and the emails had been entered correctly (just minus the `mailto:`), so I don't see any need for the `%40` or other extra case capturing at this time.  These are handled fine provided the filter is early enough in the order.  I contemplated using a fancier approach but it doesn't seem necessary (or necessarily a good idea) at this time.

See https://cms-bcfwwvxxcsfvivtlqavq6hnj0ebf9esa.ci.cms.va.gov/node/32957/latest for a test node with some example links.

Note that this _does_ check strings that begin with forward slashes.  That's valid per the RFC.  Does anyone actually have an email address like that?  I hope not, but a standard's a standard.

## Testing done
Fiddled around with a test node.

## Screenshots

## QA steps

As an admin user:
1. Check out https://cms-bcfwwvxxcsfvivtlqavq6hnj0ebf9esa.ci.cms.va.gov/node/32957/latest
2. Verify that these links (or any others you might think of) are processed correctly:
  - [ ] valid email addresses (and only valid email addresses) are transformed into `mailto:` links
  - [ ] valid email addresses already preceded by a `mailto:` aren't altered
  - [ ] non-email paths and absolute URLs aren't altered 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
