### PR TITLE
VACMS-6136: Update staff selection widget to use view.

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.staff_profile.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.staff_profile.default.yml
@@ -12,9 +12,13 @@ mode: default
 content:
   field_staff_profile:
     weight: 0
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: entity_reference_autocomplete
     region: content
 hidden:
   created: true

--- a/config/sync/field.field.node.leadership_listing.field_leadership.yml
+++ b/config/sync/field.field.node.leadership_listing.field_leadership.yml
@@ -5,14 +5,13 @@ dependencies:
   config:
     - field.storage.node.field_leadership
     - node.type.leadership_listing
-    - node.type.person_profile
   module:
     - entity_reference_validators
 third_party_settings:
   entity_reference_validators:
     circular_reference: false
     circular_reference_deep: false
-    duplicate_reference: false
+    duplicate_reference: true
 id: node.leadership_listing.field_leadership
 field_name: field_leadership
 entity_type: node
@@ -24,13 +23,10 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: unpublished
+  handler: views
   handler_settings:
-    target_bundles:
-      person_profile: person_profile
-    sort:
-      field: title
-      direction: ASC
-    auto_create: 0
-    auto_create_bundle: ''
+    view:
+      view_name: content_entity_reference_source
+      display_name: entity_reference_5
+      arguments: {  }
 field_type: entity_reference

--- a/config/sync/field.field.paragraph.staff_profile.field_staff_profile.yml
+++ b/config/sync/field.field.paragraph.staff_profile.field_staff_profile.yml
@@ -4,8 +4,14 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_staff_profile
-    - node.type.person_profile
     - paragraphs.paragraphs_type.staff_profile
+  module:
+    - entity_reference_validators
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: true
 id: paragraph.staff_profile.field_staff_profile
 field_name: field_staff_profile
 entity_type: paragraph
@@ -17,13 +23,11 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: unpublished
+  handler: views
   handler_settings:
-    target_bundles:
-      person_profile: person_profile
-    sort:
-      field: title
-      direction: ASC
-    auto_create: 0
-    auto_create_bundle: ''
+    view:
+      view_name: content_entity_reference_source
+      display_name: entity_reference_5
+      arguments:
+        - '@1'
 field_type: entity_reference

--- a/config/sync/views.view.content_entity_reference_source.yml
+++ b/config/sync/views.view.content_entity_reference_source.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - node.type.event_listing
+    - node.type.person_profile
     - node.type.press_releases_listing
     - node.type.publication_listing
     - node.type.story_listing
@@ -569,6 +570,254 @@ display:
           separator: ': '
           hide_empty: false
       display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  entity_reference_5:
+    display_plugin: entity_reference
+    id: entity_reference_5
+    display_title: 'Entity Reference: Staff profiles'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            person_profile: person_profile
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            argument: null
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      defaults:
+        filters: false
+        filter_groups: false
+        fields: false
+        arguments: false
+        relationships: false
+        sorts: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+            title_1: '0'
+      pager:
+        type: some
+        options:
+          items_per_page: 0
+          offset: 0
+      row:
+        type: entity_reference
+        options:
+          default_field_elements: true
+          inline:
+            title: title
+            title_1: title_1
+          separator: ' -  '
+          hide_empty: true
+      display_description: ''
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: true
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        title_1:
+          id: title_1
+          table: node_field_data
+          field: title
+          relationship: field_office
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: true
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+      arguments: {  }
+      relationships:
+        field_office:
+          id: field_office
+          table: node__field_office
+          field: field_office
+          relationship: none
+          group_type: group
+          admin_label: 'field_office: Content'
+          required: true
+          plugin_id: standard
+      sorts:
+        title_1:
+          id: title_1
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
     cache_metadata:
       max-age: -1
       contexts:

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -115,7 +115,7 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Situation update | Date and time | field_datetime_range_timezone | Smart date range | Required | 1 | Date and time range with timezone |  |
 | Paragraph type | Situation update | Send email to subscribers via GovDelivery? | field_send_email_to_subscribers | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Situation update | Update | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
-| Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Select list |  |
+| Paragraph type | Staff profile | Staff profile | field_staff_profile | Entity reference | Required | 1 | Autocomplete |  |
 | Paragraph type | Step | Alert | field_alert | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Paragraph type | Step | Select an image | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Paragraph type | Step | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -107,6 +107,7 @@ Feature: Views
 | Content Entity Reference Source | Entity Reference: Publication Listing | entity_reference_2 | Entity Reference |
 | Content Entity Reference Source | Entity Reference: Story Listing | entity_reference_3 | Entity Reference |
 | Content Entity Reference Source | Entity Reference: News Release Listing | entity_reference_4 | Entity Reference |
+| Content Entity Reference Source | Entity Reference: Staff profiles | entity_reference_5 | Entity Reference |
 | Content release logs | Master | default | Default |
 | Content release logs | Page | page_1 | Page |
 | Content served from Drupal | Page | page_1 | Page |


### PR DESCRIPTION
## Description
Closes #6136

## Testing done
Visual / behat

## QA steps
- As an administrator go to `node/23354/edit` -> Main content, and add a staff profile block.
- Visually verify that the field is now autocomplete, and choices are displayed in [Name] - [System] format
- As an administrator go to `node/33491/edit` -> Leadership and add another item
- Visually verify that the field is now autocomplete, and choices are displayed in [Name] - [System] format

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
