### PR TITLE
VACMS-6135: Make product field multivalue in KB articles. 

### DIFF
--- a/config/sync/core.entity_form_display.node.documentation_page.default.yml
+++ b/config/sync/core.entity_form_display.node.documentation_page.default.yml
@@ -37,7 +37,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: 4
+      weight: -5
       format_type: details_sidebar
       format_settings:
         description: ''
@@ -60,7 +60,7 @@ content:
     type: options_select
     region: content
   field_content_block:
-    weight: 2
+    weight: 3
     settings:
       title: 'Content block'
       title_plural: 'Content blocks'
@@ -92,7 +92,7 @@ content:
     weight: 1
     settings: {  }
     third_party_settings: {  }
-    type: options_select
+    type: options_buttons
     region: content
   field_related_user_guides:
     weight: 4
@@ -112,7 +112,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.documentation_page.default.yml
+++ b/config/sync/core.entity_form_display.node.documentation_page.default.yml
@@ -22,6 +22,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 6
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.documentation_page.default.yml
+++ b/config/sync/core.entity_form_display.node.documentation_page.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.node.documentation_page.field_administration
     - field.field.node.documentation_page.field_content_block
     - field.field.node.documentation_page.field_intro_text
-    - field.field.node.documentation_page.field_product
+    - field.field.node.documentation_page.field_products
     - field.field.node.documentation_page.field_related_user_guides
     - field.field.node.documentation_page.field_table_of_contents_boolean
     - field.field.node.documentation_page.layout_builder__layout
@@ -22,9 +22,8 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         id: ''
@@ -37,7 +36,7 @@ third_party_settings:
       children:
         - field_administration
       parent_name: ''
-      weight: -5
+      weight: 0
       format_type: details_sidebar
       format_settings:
         description: ''
@@ -60,7 +59,7 @@ content:
     type: options_select
     region: content
   field_content_block:
-    weight: 3
+    weight: 4
     settings:
       title: 'Content block'
       title_plural: 'Content blocks'
@@ -81,21 +80,21 @@ content:
     type: paragraphs_browser
     region: content
   field_intro_text:
-    weight: 2
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
     region: content
-  field_product:
-    weight: 1
+  field_products:
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_related_user_guides:
-    weight: 4
+    weight: 5
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -118,7 +117,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 0
+    weight: 1
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_form_display.taxonomy_term.products.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.products.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.products.field_kb_landing_page
     - taxonomy.vocabulary.products
   module:
     - path
@@ -14,11 +15,21 @@ mode: default
 content:
   description:
     type: text_textarea
-    weight: 1
+    weight: 2
     region: content
     settings:
       placeholder: ''
       rows: 5
+    third_party_settings: {  }
+  field_kb_landing_page:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   name:
     type: string_textfield
@@ -30,7 +41,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.documentation_page.default.yml
+++ b/config/sync/core.entity_view_display.node.documentation_page.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.node.documentation_page.field_administration
     - field.field.node.documentation_page.field_content_block
     - field.field.node.documentation_page.field_intro_text
-    - field.field.node.documentation_page.field_product
+    - field.field.node.documentation_page.field_products
     - field.field.node.documentation_page.field_related_user_guides
     - field.field.node.documentation_page.field_table_of_contents_boolean
     - field.field.node.documentation_page.layout_builder__layout
@@ -96,7 +96,7 @@ content:
     third_party_settings: {  }
     type: basic_string
     region: content
-  field_product:
+  field_products:
     weight: 3
     label: above
     settings:

--- a/config/sync/core.entity_view_display.node.documentation_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.documentation_page.teaser.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.node.documentation_page.field_administration
     - field.field.node.documentation_page.field_content_block
     - field.field.node.documentation_page.field_intro_text
-    - field.field.node.documentation_page.field_product
+    - field.field.node.documentation_page.field_products
     - field.field.node.documentation_page.field_related_user_guides
     - field.field.node.documentation_page.field_table_of_contents_boolean
     - field.field.node.documentation_page.layout_builder__layout
@@ -29,7 +29,7 @@ hidden:
   field_administration: true
   field_content_block: true
   field_intro_text: true
-  field_product: true
+  field_products: true
   field_related_user_guides: true
   field_table_of_contents_boolean: true
   layout_builder__layout: true

--- a/config/sync/field.field.node.documentation_page.field_products.yml
+++ b/config/sync/field.field.node.documentation_page.field_products.yml
@@ -1,9 +1,9 @@
-uuid: c8368e18-0403-4930-bde1-a5a9293c005b
+uuid: c14f388b-d7fb-4a77-ade1-e0d6add631fe
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_product
+    - field.storage.node.field_products
     - node.type.documentation_page
     - taxonomy.vocabulary.products
   module:
@@ -13,14 +13,14 @@ third_party_settings:
     circular_reference: false
     circular_reference_deep: false
     duplicate_reference: false
-id: node.documentation_page.field_product
-field_name: field_product
+id: node.documentation_page.field_products
+field_name: field_products
 entity_type: node
 bundle: documentation_page
-label: Product
+label: Products
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.taxonomy_term.products.field_kb_landing_page.yml
+++ b/config/sync/field.field.taxonomy_term.products.field_kb_landing_page.yml
@@ -1,0 +1,36 @@
+uuid: 261c8fb6-a0f3-477e-8361-eba966236368
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_kb_landing_page
+    - node.type.documentation_page
+    - taxonomy.vocabulary.products
+  module:
+    - entity_reference_validators
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: false
+id: taxonomy_term.products.field_kb_landing_page
+field_name: field_kb_landing_page
+entity_type: taxonomy_term
+bundle: products
+label: 'Knowledge base landing page'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      documentation_page: documentation_page
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_product.yml
+++ b/config/sync/field.storage.node.field_product.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.node.field_products.yml
+++ b/config/sync/field.storage.node.field_products.yml
@@ -1,19 +1,19 @@
-uuid: 2db4674d-a528-4553-ba1e-47715689c987
+uuid: a91fe791-e132-4e54-a59e-81d85276d31c
 langcode: en
 status: true
 dependencies:
   module:
     - node
     - taxonomy
-id: node.field_product
-field_name: field_product
+id: node.field_products
+field_name: field_products
 entity_type: node
 type: entity_reference
 settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.taxonomy_term.field_kb_landing_page.yml
+++ b/config/sync/field.storage.taxonomy_term.field_kb_landing_page.yml
@@ -1,0 +1,20 @@
+uuid: 81480546-f400-4d0e-8eaa-eba38b0e6e3d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: taxonomy_term.field_kb_landing_page
+field_name: field_kb_landing_page
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.knowledge_base_article_administration.yml
+++ b/config/sync/views.view.knowledge_base_article_administration.yml
@@ -4,7 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_administration
-    - field.storage.node.field_product
+    - field.storage.node.field_products
     - node.type.documentation_page
     - system.menu.admin
     - taxonomy.vocabulary.products
@@ -407,6 +407,69 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
+        field_products:
+          id: field_products
+          table: node__field_products
+          field: field_products
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Products
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         revision_uid:
           id: revision_uid
           table: node_revision
@@ -471,69 +534,6 @@ display:
           field_api_classes: false
           entity_type: node
           entity_field: revision_uid
-          plugin_id: field
-        field_product:
-          id: field_product
-          table: node__field_product
-          field: field_product
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Product
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
-          settings:
-            link: true
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
           plugin_id: field
         field_administration:
           id: field_administration
@@ -837,10 +837,10 @@ display:
             group_items: {  }
           entity_type: node
           plugin_id: moderation_state_filter
-        field_product_target_id:
-          id: field_product_target_id
-          table: node__field_product
-          field: field_product_target_id
+        field_products_target_id:
+          id: field_products_target_id
+          table: node__field_products
+          field: field_products_target_id
           relationship: none
           group_type: group
           admin_label: ''
@@ -849,14 +849,14 @@ display:
           group: 1
           exposed: true
           expose:
-            operator_id: field_product_target_id_op
-            label: Product
+            operator_id: field_products_target_id_op
+            label: Products
             description: ''
             use_operator: false
-            operator: field_product_target_id_op
+            operator: field_products_target_id_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_product_target_id
+            identifier: products
             required: false
             remember: false
             multiple: false
@@ -930,7 +930,7 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.node.field_administration'
-        - 'config:field.storage.node.field_product'
+        - 'config:field.storage.node.field_products'
         - 'config:workflow_list'
   knowledge_base_admin:
     display_plugin: page
@@ -961,5 +961,5 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.node.field_administration'
-        - 'config:field.storage.node.field_product'
+        - 'config:field.storage.node.field_products'
         - 'config:workflow_list'

--- a/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
@@ -14,4 +14,4 @@ Feature: Content model: User guides Content Type fields
 | Content type | CMS Knowledge Base Article | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | -- Disabled -- | Translatable |
 | Content type | CMS Knowledge Base Article | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
 | Content type | CMS Knowledge Base Article | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | CMS Knowledge Base Article | Products | field_products | Entity reference |  | Unlimited | Check boxes/radio buttons | Translatable |
+| Content type | CMS Knowledge Base Article | Products | field_products | Entity reference |  | Unlimited | Check boxes/radio buttons | Translatable | |

--- a/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
@@ -14,4 +14,4 @@ Feature: Content model: User guides Content Type fields
 | Content type | CMS Knowledge Base Article | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | -- Disabled -- | Translatable |
 | Content type | CMS Knowledge Base Article | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
 | Content type | CMS Knowledge Base Article | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | CMS Knowledge Base Article | Product | field_product | Entity reference |  | 1 | Select list | Translatable |
+| Content type | CMS Knowledge Base Article | Products | field_products | Entity reference |  | Unlimited | Check boxes/radio buttons | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_user_guides_content_type_fields.feature
@@ -14,4 +14,4 @@ Feature: Content model: User guides Content Type fields
 | Content type | CMS Knowledge Base Article | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | -- Disabled -- | Translatable |
 | Content type | CMS Knowledge Base Article | Main content | field_content_block | Entity reference revisions |  | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
 | Content type | CMS Knowledge Base Article | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | CMS Knowledge Base Article | Products | field_products | Entity reference |  | Unlimited | Check boxes/radio buttons | Translatable | |
+| Content type | CMS Knowledge Base Article | Products | field_products | Entity reference |  | Unlimited | Check boxes/radio buttons | |

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -10,6 +10,7 @@ Feature: Content model: Vocabulary fields
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Vocabulary | Audience - Beneficiaries | Promoted to Resources and Support Homepage | field_audience_rs_homepage | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | Audience - Non-beneficiaries | Promoted to Resources and Support Homepage | field_audience_rs_homepage | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Vocabulary | Products | Knowledge base landing page | field_kb_landing_page | Entity reference |  | 1 | Autocomplete |  |
 | Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | Sections | Link text | field_email_updates_link_text | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | Sections | Link | field_link | Link |  | 1 | Linkit |  |


### PR DESCRIPTION
## Description

Relates to #6135 and #6103  

## Testing done

Behat, visual.

## Screenshots

6135




6103 

## QA steps

As a content admin 

- [x] Edit a KB article. you should be able to tag each KB article by multiple products.
- [x] Edit a Basic Landing Page. Product field should still be single value (we now have one multivalue, one single value product reference field). 
- [x] Edit a product taxonomy term (eg /taxonomy/term/291/edit). You should be able to reference a KB landing page using an autocomplete field. 


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
