### PR TITLE
VACMS-4830: Add tests for BuildFrontend.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -188,16 +188,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.188.1",
+            "version": "3.190.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "7c84f39290067c6e86b3bc4518f211be0f499dc8"
+                "reference": "4e641e25cc8f4d04002404afe050e25035fad0f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7c84f39290067c6e86b3bc4518f211be0f499dc8",
-                "reference": "7c84f39290067c6e86b3bc4518f211be0f499dc8",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4e641e25cc8f4d04002404afe050e25035fad0f3",
+                "reference": "4e641e25cc8f4d04002404afe050e25035fad0f3",
                 "shasum": ""
             },
             "require": {
@@ -272,9 +272,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.188.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.190.3"
             },
-            "time": "2021-08-09T18:29:02+00:00"
+            "time": "2021-08-16T18:13:42+00:00"
         },
         {
             "name": "behat/behat",

--- a/tests/phpunit/FrontendBuild/BuildFrontendTest.php
+++ b/tests/phpunit/FrontendBuild/BuildFrontendTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace tests\phpunit\FrontendBuild;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\va_gov_build_trigger\Service\BuildFrontend;
+use Drupal\va_gov_build_trigger\Environment\EnvironmentDiscovery;
+use Drupal\va_gov_build_trigger\WebBuildStatusInterface;
+use Prophecy\Argument;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Functional test of the BuildFrontend class.
+ *
+ * @coversDefaultClass \Drupal\va_gov_build_trigger\Service\BuildFrontend
+ */
+class BuildFrontendTest extends ExistingSiteBase {
+
+  /**
+   * Test triggerFrontendBuild()
+   *
+   * @param string $env
+   *   Environment name, like 'lando', 'prod', etc.
+   * @param bool $permitted
+   *   Indicates whether the specified environment name is considered valid.
+   *
+   * @dataProvider triggerFrontendBuildDataProvider
+   */
+  public function testTriggerFrontendBuild(string $env, bool $permitted) {
+    $realPermitted = $this->container->get('plugin.manager.va_gov.environment')->hasDefinition($env);
+    $this->assertEquals($permitted, $realPermitted);
+
+    $environmentDiscoveryProphecy = $this->prophesize(EnvironmentDiscovery::class);
+
+    $loggerProphecy = $this->prophesize(LoggerChannelInterface::class);
+    $messengerProphecy = $this->prophesize(MessengerInterface::class);
+    $webBuildStatusProphecy = $this->prophesize(WebBuildStatusInterface::class);
+    $webBuildStatusProphecy->enableWebBuildStatus()->shouldNotBeCalled();
+    if ($permitted) {
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::any(), Argument::any())->shouldBeCalled();
+      $loggerProphecy->warning(Argument::any())->shouldNotBeCalled();
+      $messengerProphecy->addWarning(Argument::any())->shouldNotBeCalled();
+      $webBuildStatusProphecy->disableWebBuildStatus()->shouldNotBeCalled();
+    }
+    else {
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::any(), Argument::any())->willThrow(PluginException::class);
+      $loggerProphecy->warning(Argument::type(TranslatableMarkup::class))->shouldBeCalled();
+      $messengerProphecy->addWarning(Argument::type(TranslatableMarkup::class))->shouldBeCalled();
+      $webBuildStatusProphecy->disableWebBuildStatus()->shouldBeCalled();
+    }
+
+    $messenger = $messengerProphecy->reveal();
+    $logger = $loggerProphecy->reveal();
+    $loggerFactoryProphecy = $this->prophesize(LoggerChannelFactoryInterface::class);
+    $loggerFactoryProphecy->get(Argument::type('string'))->willReturn($logger);
+    $loggerFactory = $loggerFactoryProphecy->reveal();
+    $webBuildStatus = $webBuildStatusProphecy->reveal();
+
+    $environmentDiscovery = $environmentDiscoveryProphecy->reveal();
+    $buildFrontend = new BuildFrontend($messenger, $loggerFactory, $webBuildStatus, $environmentDiscovery);
+
+    $buildFrontend->triggerFrontendBuild('no', FALSE);
+  }
+
+  /**
+   * Data provider for ::testTriggerFrontendBuild().
+   */
+  public function triggerFrontendBuildDataProvider() {
+    return [
+      [
+        'lando',
+        TRUE,
+      ],
+      [
+        'tugboat',
+        TRUE,
+      ],
+      [
+        'brd',
+        TRUE,
+      ],
+      [
+        'test',
+        FALSE,
+      ],
+    ];
+  }
+
+}

--- a/tests/phpunit/FrontendBuild/BuildFrontendTest.php
+++ b/tests/phpunit/FrontendBuild/BuildFrontendTest.php
@@ -7,6 +7,8 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\Traits\Core\GeneratePermutationsTrait;
 use Drupal\va_gov_build_trigger\Service\BuildFrontend;
 use Drupal\va_gov_build_trigger\Environment\EnvironmentDiscovery;
 use Drupal\va_gov_build_trigger\WebBuildStatusInterface;
@@ -19,6 +21,8 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @coversDefaultClass \Drupal\va_gov_build_trigger\Service\BuildFrontend
  */
 class BuildFrontendTest extends ExistingSiteBase {
+
+  use GeneratePermutationsTrait;
 
   /**
    * Test triggerFrontendBuild()
@@ -88,6 +92,187 @@ class BuildFrontendTest extends ExistingSiteBase {
         FALSE,
       ],
     ];
+  }
+
+  /**
+   * Test setPendingState()
+   *
+   * @dataProvider setPendingStateDataProvider
+   */
+  public function testSetPendingState(bool $status) {
+    $environmentDiscoveryProphecy = $this->prophesize(EnvironmentDiscovery::class);
+
+    $loggerProphecy = $this->prophesize(LoggerChannelInterface::class);
+    $messengerProphecy = $this->prophesize(MessengerInterface::class);
+    $webBuildStatusProphecy = $this->prophesize(WebBuildStatusInterface::class);
+    if ($status) {
+      $webBuildStatusProphecy->enableWebBuildStatus()->shouldBeCalled();
+      $webBuildStatusProphecy->disableWebBuildStatus()->shouldNotBeCalled();
+    }
+    else {
+      $webBuildStatusProphecy->enableWebBuildStatus()->shouldNotBeCalled();
+      $webBuildStatusProphecy->disableWebBuildStatus()->shouldBeCalled();
+    }
+
+    $messenger = $messengerProphecy->reveal();
+    $logger = $loggerProphecy->reveal();
+
+    $loggerFactoryProphecy = $this->prophesize(LoggerChannelFactoryInterface::class);
+    $loggerFactoryProphecy->get(Argument::type('string'))->willReturn($logger);
+    $loggerFactory = $loggerFactoryProphecy->reveal();
+    $webBuildStatus = $webBuildStatusProphecy->reveal();
+    $environmentDiscovery = $environmentDiscoveryProphecy->reveal();
+
+    $buildFrontend = new BuildFrontend($messenger, $loggerFactory, $webBuildStatus, $environmentDiscovery);
+
+    $buildFrontend->setPendingState($status);
+  }
+
+  /**
+   * Data provider for ::testSetPendingState().
+   */
+  public function setPendingStateDataProvider() {
+    return [
+      [
+        TRUE,
+      ],
+      [
+        FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * Test triggerFrontendBuildFromContentSave()'s environment-based blocking.
+   */
+  public function testTriggerFrontendBuildFromContentSave1() {
+    $environmentDiscoveryProphecy = $this->prophesize(EnvironmentDiscovery::class);
+    $loggerProphecy = $this->prophesize(LoggerChannelInterface::class);
+    $messengerProphecy = $this->prophesize(MessengerInterface::class);
+    $webBuildStatusProphecy = $this->prophesize(WebBuildStatusInterface::class);
+    $nodeProphecy = $this->prophesize(NodeInterface::class);
+
+    $environmentDiscoveryProphecy->shouldTriggerFrontendBuild()->willReturn(FALSE);
+    $environmentDiscoveryProphecy->triggerFrontendBuild()->shouldNotBeCalled();
+
+    $nodeProphecy->isPublished()->willReturn(FALSE)->shouldNotBeCalled();
+    $nodeProphecy->getType()->willReturn('fail')->shouldNotBeCalled();
+    $node = $nodeProphecy->reveal();
+
+    $messenger = $messengerProphecy->reveal();
+    $logger = $loggerProphecy->reveal();
+    $loggerFactoryProphecy = $this->prophesize(LoggerChannelFactoryInterface::class);
+    $loggerFactoryProphecy->get(Argument::type('string'))->willReturn($logger);
+    $loggerFactory = $loggerFactoryProphecy->reveal();
+    $webBuildStatus = $webBuildStatusProphecy->reveal();
+    $environmentDiscovery = $environmentDiscoveryProphecy->reveal();
+
+    $buildFrontend = new BuildFrontend($messenger, $loggerFactory, $webBuildStatus, $environmentDiscovery);
+
+    $buildFrontend->triggerFrontendBuildFromContentSave($node);
+  }
+
+  /**
+   * Test triggerFrontendBuildFromContentSave()
+   *
+   * @param bool $isPublished
+   *   Value for mock NodeInterface::isPublished().
+   * @param string $contentType
+   *   Value for mock NodeInterface::getType().
+   * @param bool $hasOriginal
+   *   Whether this node has a previous revision.
+   * @param string $moderationState
+   *   Value for mock NodeInterface::get('moderation_state')->value.
+   * @param string $originalModerationState
+   *   Pretend we had an original node with a different moderation state.
+   * @param bool $expected
+   *   Whether the frontend build should be triggered or not.
+   *
+   * @dataProvider triggerFrontendBuildFromContentSaveDataProvider
+   */
+  public function testTriggerFrontendBuildFromContentSave(bool $isPublished, string $contentType, bool $hasOriginal, string $moderationState, string $originalModerationState, bool $expected) {
+    $environmentDiscoveryProphecy = $this->prophesize(EnvironmentDiscovery::class);
+    $loggerProphecy = $this->prophesize(LoggerChannelInterface::class);
+    $messengerProphecy = $this->prophesize(MessengerInterface::class);
+    $webBuildStatusProphecy = $this->prophesize(WebBuildStatusInterface::class);
+    $nodeProphecy = $this->prophesize(NodeInterface::class);
+
+    $environmentDiscoveryProphecy->shouldTriggerFrontendBuild()->willReturn(TRUE);
+    if ($expected) {
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::exact(NULL), Argument::exact(FALSE))->shouldBeCalled();
+    }
+    else {
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::exact(NULL), Argument::exact(FALSE))->shouldNotBeCalled();
+    }
+
+    $nodeProphecy->isPublished()->willReturn($isPublished)->shouldBeCalled();
+    $nodeProphecy->getType()->willReturn($contentType)->shouldBeCalled();
+    $nodeProphecy->hasField(Argument::type('string'))->willReturn(FALSE);
+    $nodeProphecy->get('moderation_state')->willReturn((object) ['value' => $moderationState])->shouldBeCalled();
+
+    $node = $nodeProphecy->reveal();
+    if ($hasOriginal) {
+      $node2Prophecy = $this->prophesize(NodeInterface::class);
+      $node2Prophecy->hasField(Argument::type('string'))->willReturn(FALSE);
+      $node2Prophecy->get('moderation_state')->willReturn((object) ['value' => $originalModerationState])->shouldBeCalled();
+      $node->original = $node2Prophecy->reveal();
+    }
+
+    $messenger = $messengerProphecy->reveal();
+    $logger = $loggerProphecy->reveal();
+    $loggerFactoryProphecy = $this->prophesize(LoggerChannelFactoryInterface::class);
+    $loggerFactoryProphecy->get(Argument::type('string'))->willReturn($logger);
+    $loggerFactory = $loggerFactoryProphecy->reveal();
+    $webBuildStatus = $webBuildStatusProphecy->reveal();
+    $environmentDiscovery = $environmentDiscoveryProphecy->reveal();
+
+    $buildFrontend = new BuildFrontend($messenger, $loggerFactory, $webBuildStatus, $environmentDiscovery);
+
+    $buildFrontend->triggerFrontendBuildFromContentSave($node);
+  }
+
+  /**
+   * Data provider for ::testTriggerFrontendBuildFromContentSave().
+   */
+  public function triggerFrontendBuildFromContentSaveDataProvider() {
+    $combinations = [
+      'content_type' => [
+        'page',
+        'full_width_banner_alert',
+        'health_care_local_facility',
+      ],
+      'has_original' => [
+        TRUE,
+        FALSE,
+      ],
+      'moderation_state' => [
+        'published',
+        'archived',
+      ],
+      'original_moderation_state' => [
+        'published',
+        'archived',
+      ],
+    ];
+    $permutations = $this->generatePermutations($combinations);
+    $result = [];
+    foreach ($permutations as $permutation) {
+      $isFacility = $permutation['content_type'] === 'health_care_local_facility';
+      $permutation['expected'] = TRUE;
+      $permutation['expected'] &= $permutation['content_type'] !== 'page';
+      $permutation['expected'] &= $permutation['moderation_state'] === 'published';
+      $permutation['expected'] &= !$isFacility || !$permutation['has_original'] || $permutation['original_moderation_state'] !== 'published';
+      $arguments = [
+        $permutation['moderation_state'] === 'published',
+        $permutation['content_type'],
+        $permutation['has_original'],
+        $permutation['moderation_state'],
+        $permutation['original_moderation_state'],
+        (bool) $permutation['expected'],
+      ];
+      $result[] = $arguments;
+    }
+    return $result;
   }
 
 }


### PR DESCRIPTION
## Description

Relates to #4830.  Had worked on this when @mchelen-gov brought it up, decided to finish the job.  Private methods and NodeInterface made this not terribly fun, but my heart will go on.

## Testing done
literally nothing but tests.  a landscape of tests and test data extending boundlessly in all directions.  אור אין סוף

## Screenshots
<img width="839" alt="Screen Shot 2021-08-18 at 10 43 49 AM" src="https://user-images.githubusercontent.com/1318579/129919534-db4de620-6b12-4877-8dff-c6e6d242e38d.png">

## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
