### PR TITLE
VACMS-6148: Prevent non admins from altering banner scope path fields.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -167,6 +167,7 @@ module:
   va_gov_dashboards: 0
   va_gov_db: 0
   va_gov_flags: 0
+  va_gov_banner: 0
   va_gov_govdelivery: 0
   va_gov_graphql: 0
   va_gov_help_center: 0

--- a/docroot/modules/custom/va_gov_banner/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_banner/src/EventSubscriber/EntityEventSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\va_gov_banner\EventSubscriber;
+
+use Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent;
+use Drupal\va_gov_user\Service\UserPermsService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * VA.gov VAMC Entity Event Subscriber.
+ */
+class EntityEventSubscriber implements EventSubscriberInterface {
+  /**
+   * The User Perms Service.
+   *
+   * @var \Drupal\va_gov_user\Service\UserPermsService
+   */
+  protected $userPermsService;
+
+  /**
+   * Constructs the EventSubscriber object.
+   *
+   * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
+   *   The user perms service.
+   */
+  public function __construct(
+    UserPermsService $user_perms_service
+  ) {
+    $this->userPermsService = $user_perms_service;
+  }
+
+  /**
+   * Disable fields on Banner node form.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent $event
+   *   The event.
+   */
+  public function alterBannerNodeForm(FormIdAlterEvent $event): void {
+    $form = &$event->getForm();
+    if (!$this->userPermsService->hasAdminRole()) {
+      $form['field_target_paths']['#disabled'] = TRUE;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      // React on banner forms.
+      'hook_event_dispatcher.form_node_banner_form.alter' => 'alterBannerNodeForm',
+      'hook_event_dispatcher.form_node_banner_edit_form.alter' => 'alterBannerNodeForm',
+    ];
+  }
+
+}

--- a/docroot/modules/custom/va_gov_banner/va_gov_banner.info.yml
+++ b/docroot/modules/custom/va_gov_banner/va_gov_banner.info.yml
@@ -1,0 +1,7 @@
+name: 'VA.gov banner'
+type: module
+description: 'Custom code used for banner node bundle.'
+core_version_requirement: ^8 || ^9
+dependencies:
+  - va_gov_user
+package: 'Custom'

--- a/docroot/modules/custom/va_gov_banner/va_gov_banner.module
+++ b/docroot/modules/custom/va_gov_banner/va_gov_banner.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains va_gov_banner.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function va_gov_banner_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the va_gov_banner module.
+    case 'help.page.va_gov_banner':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Custom code used for banner node bundle') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/docroot/modules/custom/va_gov_banner/va_gov_banner.services.yml
+++ b/docroot/modules/custom/va_gov_banner/va_gov_banner.services.yml
@@ -1,0 +1,6 @@
+services:
+  va_gov_banner.entity_event_subscriber:
+    class: Drupal\va_gov_banner\EventSubscriber\EntityEventSubscriber
+    arguments: ['@va_gov_user.user_perms']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
@@ -81,12 +81,12 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Add js script and disallowed nids to Banner node form.
+   * Add js script and disallowed nids to Full Width Banner node form.
    *
    * @param \Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent $event
    *   The event.
    */
-  public function alterBannerNodeForm(FormIdAlterEvent $event): void {
+  public function alterFullWidthBannerNodeForm(FormIdAlterEvent $event): void {
     $form = &$event->getForm();
     $vamc_field_options = $form['field_banner_alert_vamcs']['widget']['#options'];
     foreach ($vamc_field_options as $nid => $node_option_string) {
@@ -106,10 +106,10 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       // React on Op status forms.
       'hook_event_dispatcher.form_node_vamc_operating_status_and_alerts_form.alter' => 'alterOpStatusNodeForm',
       'hook_event_dispatcher.form_node_vamc_operating_status_and_alerts_edit_form.alter' => 'alterOpStatusNodeForm',
-      // React on banner forms.
-      'hook_event_dispatcher.form_node_full_width_banner_alert_form.alter' => 'alterBannerNodeForm',
-      'hook_event_dispatcher.form_node_full_width_banner_alert_edit_form.alter' => 'alterBannerNodeForm',
       HookEventDispatcherInterface::ENTITY_PRE_SAVE => 'entityPresave',
+      // React on full width banner forms.
+      'hook_event_dispatcher.form_node_full_width_banner_alert_form.alter' => 'alterFullWidthBannerNodeForm',
+      'hook_event_dispatcher.form_node_full_width_banner_alert_edit_form.alter' => 'alterFullWidthBannerNodeForm',
     ];
   }
 

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/EventSubscriber/EntityEventSubscriber.php
@@ -58,6 +58,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public function alterAlertBlocksForm(FormIdAlterEvent $event): void {
     $form = &$event->getForm();
+    $form['#attached']['library'][] = 'va_gov_workflow_assignments/alert_block_treatment';
     if (!$this->userPermsService->hasAdminRole()) {
       $form['field_node_reference']['#disabled'] = TRUE;
     }

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/EventSubscriber/EntityEventSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\va_gov_workflow_assignments\EventSubscriber;
 
-use Drupal\Core\Session\AccountInterface;
 use Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent;
 use Drupal\va_gov_user\Service\UserPermsService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -11,13 +10,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * VA.gov Workflow Assignments Entity Event Subscriber.
  */
 class EntityEventSubscriber implements EventSubscriberInterface {
-  /**
-   * The active user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   *  The user object.
-   */
-  private $currentUser;
 
   /**
    * The User Perms Service.
@@ -29,16 +21,12 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   /**
    * Constructs the EventSubscriber object.
    *
-   * @param \Drupal\Core\Session\AccountInterface $currentUser
-   *   The current user.
    * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
    *   The user perms service.
    */
   public function __construct(
-    AccountInterface $currentUser,
     UserPermsService $user_perms_service
   ) {
-    $this->currentUser = $currentUser;
     $this->userPermsService = $user_perms_service;
   }
 
@@ -46,6 +34,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    * Alter alert block form governance settings.
    *
    * Set alert block edit form status default to draft.
+   *
+   * Disable the scope field for non-admins.
    *
    * @param \Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent $event
    *   The event.
@@ -56,21 +46,20 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $form['moderation_state']['widget'][0]['state']['#default_value'] = 'draft';
     if (!$this->userPermsService->hasAdminRole()) {
       $form['field_is_this_a_header_alert_']['widget']['#attributes']['disabled'] = TRUE;
-      $form['field_node_reference']['#access'] = FALSE;
+      $form['field_node_reference']['#disabled'] = TRUE;
     }
   }
 
   /**
-   * Alter alert block form governance settings.
+   * Disable the scope field for non-admins.
    *
    * @param \Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent $event
    *   The event.
    */
   public function alterAlertBlocksForm(FormIdAlterEvent $event): void {
     $form = &$event->getForm();
-    $form['#attached']['library'][] = 'va_gov_workflow_assignments/alert_block_treatment';
     if (!$this->userPermsService->hasAdminRole()) {
-      $form['field_node_reference']['#access'] = FALSE;
+      $form['field_node_reference']['#disabled'] = TRUE;
     }
   }
 
@@ -79,10 +68,10 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents(): array {
     return [
-      // React on alert block edit forms.
+      // React on alert block forms.
       'hook_event_dispatcher.form_block_content_alert_edit_form.alter' => 'alterAlertBlocksEditForm',
-      // React on alert block add forms.
       'hook_event_dispatcher.form_block_content_alert_form.alter' => 'alterAlertBlocksForm',
+
     ];
   }
 

--- a/docroot/modules/custom/va_gov_workflow_assignments/va_gov_workflow_assignments.services.yml
+++ b/docroot/modules/custom/va_gov_workflow_assignments/va_gov_workflow_assignments.services.yml
@@ -4,6 +4,6 @@ services:
     arguments: ['@database']
   va_gov_workflow_assignments.entity_event_subscriber:
     class: Drupal\va_gov_workflow_assignments\EventSubscriber\EntityEventSubscriber
-    arguments: ['@current_user', '@va_gov_user.user_perms']
+    arguments: ['@va_gov_user.user_perms']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
## Description

Closes to #6148

## Testing done
Visual / behat

## QA steps

**Scenario 1**
- [x] As an administrator, go to `node/33317/edit` and visually verify that `Paths` are editable - make a change, confirm save preserves change.

**Scenario 2**
- [x] As an administrator, go to `node/add/banner` and visually verify that `Paths` are editable - complete the form, confirm save preserves additions to paths field.

**Scenario 3**
- [x] As an administrator, go to `block/add/alert` and visually verify that `Scope` is editable - complete the form, confirm save preserves addition to scope field.

**Scenario 4**
- [x] As an administrator, go to `block/101` and visually verify that `Scope` is editable - complete the form, confirm save preserves addition to scope field.

**Scenario 5**
- [x] As a non content_admin/administrator, go to `node/33317/edit` and visually verify that `Paths` is not editable - make a change to the node, confirm save does not lose `Paths` data.

**Scenario 6**
- [ ] As a non content_admin/administrator, go to `node/add/banner` and visually verify that `Paths` is not editable - complete the form, confirm save works.
**Not allowed as non content-admins are not allowed to create banners.**

**Scenario 7**
- [ ] As a non content_admin/administrator, go to `block/add/alert` and visually verify that `Scope` is not editable - complete the form, confirm save works.
**Not allowed as non-content admins are not allowed to create block alerts.** 

**Scenario 8**
- [x] As a non content_admin/administrator, go to `block/101` and visually verify that `Scope` is not editable - complete the form, confirm save does not lose scope field data.


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
