### PR TITLE
VACMS 6172: Adds validator and constraint to fail Drupal URLs.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinks.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinks.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that the text does not contain any absolute links to the CMS.
+ *
+ * @Constraint(
+ *   id = "PreventAbsoluteCmsLinks",
+ *   label = @Translation("Prevent Absolute CMS Links", context = "Validation"),
+ *   type = "string"
+ * )
+ */
+class PreventAbsoluteCmsLinks extends Constraint {
+
+  /**
+   * The error message for plain text fields.
+   *
+   * @var string
+   * @see \Drupal\va_gov_backend\Plugin\Validation\ConstraintPreventAbsoluteCmsLinksValidator
+   */
+  public $plainTextMessage = 'The text contains an absolute CMS URL ( :url ).';
+
+  /**
+   * The error message for rich text fields.
+   *
+   * @var string
+   * @see \Drupal\va_gov_backend\Plugin\Validation\ConstraintPreventAbsoluteCmsLinksValidator
+   */
+  public $richTextMessage = 'The link ":link" contains an absolute CMS URL ( :url ).';
+
+}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use Drupal\Component\Utility\Html;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the PreventAbsoluteCmsLinks constraint.
+ */
+class PreventAbsoluteCmsLinksValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($items, Constraint $constraint) {
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint */
+    foreach ($items as $item) {
+      $type = $item->getFieldDefinition()->getType();
+      $fieldValue = $item->getValue();
+      if ($type === 'text_long' && $fieldValue['format'] === 'rich_text') {
+        $this->validateHtml($fieldValue['value'], $constraint);
+      }
+      else {
+        $this->validateText($fieldValue['value'], $constraint);
+      }
+    }
+  }
+
+  /**
+   * Validates plain text.
+   *
+   * @param string $text
+   *   A plain text string to validate.
+   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint
+   *   The constraint we're validating.
+   */
+  public function validateText(string $text, PreventAbsoluteCmsLinks $constraint) {
+    if (strpos($text, 'cms.va.gov') === FALSE) {
+      return;
+    }
+    // We don't need no stinkin' XPath bc plain text.
+    if (preg_match_all('#(https?://.*?cms\.va\.gov[^\s]*)#', $text, $matches) && !empty($matches[1])) {
+      foreach ($matches[1] as $match) {
+        $this->context->addViolation($constraint->plainTextMessage, [
+          ':url' => $match,
+        ]);
+      }
+    }
+  }
+
+  /**
+   * Validates HTML.
+   *
+   * @param string $html
+   *   An HTML string to validate.
+   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint
+   *   The constraint we're validating.
+   */
+  public function validateHtml(string $html, PreventAbsoluteCmsLinks $constraint) {
+    if (strpos($html, 'cms.va.gov') === FALSE) {
+      return;
+    }
+    $dom = Html::load($html);
+    $xpath = new \DOMXPath($dom);
+    // DOMXPath doesn't support matches(), so we need to use contains().
+    foreach ($xpath->query('//a[contains(@href, "cms.va.gov/")]') as $element) {
+      $url = $element->getAttribute('href');
+      // XPath contains() is fast but could lead to false positives.
+      // The following is slower but will not.
+      if (preg_match('#.*?cms\.va.gov$#', parse_url($url, PHP_URL_HOST))) {
+        $firstChild = $element->hasChildNodes() ? $element->childNodes[0] : NULL;
+        $link = $element->ownerDocument->saveHTML($firstChild ?? $element);
+        $this->context->addViolation($constraint->richTextMessage, [
+          ':link' => $link,
+          ':url' => $url,
+        ]);
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
@@ -15,10 +15,10 @@ class PreventAbsoluteCmsLinksValidator extends ConstraintValidator {
    * {@inheritdoc}
    */
   public function validate($items, Constraint $constraint) {
-    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint */
     foreach ($items as $item) {
       $type = $item->getFieldDefinition()->getType();
       $fieldValue = $item->getValue();
+      /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint */
       if ($type === 'text_long' && $fieldValue['format'] === 'rich_text') {
         $this->validateHtml($fieldValue['value'], $constraint);
       }

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
@@ -41,7 +41,7 @@ class PreventAbsoluteCmsLinksValidator extends ConstraintValidator {
       return;
     }
     // We don't need no stinkin' XPath bc plain text.
-    if (preg_match_all('#(https?://.*?cms\.va\.gov[^\s]*)#', $text, $matches) && !empty($matches[1])) {
+    if (preg_match_all('#((https?:)?//.*?cms\.va\.gov[^\s]*)#', $text, $matches) && !empty($matches[1])) {
       foreach ($matches[1] as $match) {
         $this->context->addViolation($constraint->plainTextMessage, [
           ':url' => $match,

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1544,6 +1544,16 @@ function va_gov_backend_entity_bundle_field_info_alter(&$fields, EntityTypeInter
   if ($entity_type->id() === 'node' && $bundle === 'campaign_landing_page' && isset($fields['field_benefit_categories'])) {
     $fields['field_benefit_categories']->addConstraint('BenefitsSelectionLimit');
   }
+  // Prevent absolute CMS links in any text or rich text field.
+  $validate_types = [
+    'string_long',
+    'text_long',
+  ];
+  foreach ($fields as $field_name => $field) {
+    if (in_array($field->getType(), $validate_types)) {
+      $fields[$field_name]->addConstraint('PreventAbsoluteCmsLinks');
+    }
+  }
   // Add paragraph checks on clp panels.
   if ($entity_type->id() === 'node' && $bundle === 'campaign_landing_page') {
     // Add range check on faq panel.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "stylelint": "npx stylelint",
     "test:accessibility": "cd tests/accessibility && cypress run",
     "test:behavioral": "cd tests/behavioral && cypress run -e \"TAGS=not @ignore\"",
-    "test:interactive": "cd tests/behavioral && cypress open -e \"VAGOV_INTERACTIVE=true\""
+    "test:interactive": "cd tests/behavioral && cypress open -e \"TAGS=not @ignore,VAGOV_INTERACTIVE=true\""
   },
   "repository": {
     "type": "git",

--- a/tests/behavioral/cypress/integration/common/i_click_the_button.js
+++ b/tests/behavioral/cypress/integration/common/i_click_the_button.js
@@ -1,0 +1,5 @@
+import { Given } from "cypress-cucumber-preprocessor/steps";
+
+Given(`I click the {string} button`, (text) => {
+  cy.contains(text).click({ force: true });
+});

--- a/tests/behavioral/cypress/integration/common/i_create_a_node.js
+++ b/tests/behavioral/cypress/integration/common/i_create_a_node.js
@@ -11,6 +11,17 @@ const creators = {
     cy.findAllByLabelText('Parent link').select('-- CMS Knowledge Base (disabled)', { force: true });
     return cy.get('form.node-form').find('input#edit-submit').click();
   },
+  health_care_region_detail_page: () => {
+    cy.visit('/node/add/health_care_region_detail_page');
+    cy.scrollTo('top');
+    cy.findAllByLabelText('Page title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
+    cy.findAllByLabelText('Page introduction').type(faker.lorem.sentence(), { force: true });
+    cy.findAllByLabelText('Section').select('Veterans Affairs', { force: true });
+    cy.findAllByLabelText('Related office or health care system').select('VA Alaska health care', { force: true });
+    cy.findAllByLabelText('Parent link').select('-------- Anchorage VA Medical Center', { force: true });
+    cy.findAllByLabelText('Meta description').type(faker.lorem.sentence(), { force: true });
+    return cy.get('form.node-form').find('input#edit-submit').click();
+  },
   office: () => {
     cy.visit('/node/add/office');
     cy.scrollTo('top');

--- a/tests/behavioral/cypress/integration/common/i_fill_in_ckeditor_field_with_value.js
+++ b/tests/behavioral/cypress/integration/common/i_fill_in_ckeditor_field_with_value.js
@@ -1,0 +1,7 @@
+import { Then } from "cypress-cucumber-preprocessor/steps";
+
+Then(`I fill in ckeditor {string} with {string}`, (label, value) => {
+  cy.type_ckeditor(label, value);
+});
+
+

--- a/tests/behavioral/cypress/integration/common/i_scroll_to_element.js
+++ b/tests/behavioral/cypress/integration/common/i_scroll_to_element.js
@@ -1,0 +1,5 @@
+import { Then } from "cypress-cucumber-preprocessor/steps";
+
+Then(`I scroll to element {string}`, (element) => {
+  cy.scrollToSelector(element);
+});

--- a/tests/behavioral/cypress/integration/common/i_scroll_to_position.js
+++ b/tests/behavioral/cypress/integration/common/i_scroll_to_position.js
@@ -1,5 +1,5 @@
 import { Then } from "cypress-cucumber-preprocessor/steps";
 
-Then(`I scroll to {string}`, (position) => {
+Then(`I scroll to position {string}`, (position) => {
   cy.scrollTo(position);
 });

--- a/tests/behavioral/cypress/integration/text_validation.feature
+++ b/tests/behavioral/cypress/integration/text_validation.feature
@@ -1,0 +1,25 @@
+@text_validation
+Feature: Text fields are validated
+  In order to ensure a consistent experience for users
+  As an editor
+  I need my text fields validated
+
+  Scenario: Long rich text fields are checked for any absolute links to the CMS.
+    Given I am logged in as a user with the "content_admin" role
+    And I create a "health_care_region_detail_page" node
+    And I click the edit tab
+    And I click the "Add Content block" button
+    And I scroll to element 'div.cke_inner'
+    And I fill in ckeditor "field-content-block-0" with '<a href="https://staging.cms.va.gov/">test</a>'
+    And I save the node
+    Then I should see "1 error has been found: Text"
+    And I should see 'The link "test" contains an absolute CMS URL ( https://staging.cms.va.gov/ ).'
+
+  Scenario: Long plain text fields are checked for any absolute links to the CMS.
+    Given I am logged in as a user with the "content_admin" role
+    And I create a "health_care_region_detail_page" node
+    And I click the edit tab
+    And I fill in 'Page introduction' with "https://prod.cms.va.gov/"
+    And I save the node
+    Then I should see "1 error has been found: Page introduction"
+    And I should see "The text contains an absolute CMS URL ( https://prod.cms.va.gov/ )."

--- a/tests/behavioral/cypress/support/commands.js
+++ b/tests/behavioral/cypress/support/commands.js
@@ -94,6 +94,13 @@ Cypress.Commands.add('iframe', { prevSubject: 'element' }, ($iframe, callback = 
 
 Cypress.Commands.add("type_ckeditor", (element, content) => {
   cy.window().then((win) => {
+    const elements = Object.keys(win.CKEDITOR.instances);
+    if (elements.indexOf(element) === -1) {
+      const matches = elements.filter((el) => el.includes(element));
+      if (matches.length) {
+        element = matches[0];
+      }
+    }
     win.CKEDITOR.instances[element].setData(content);
   });
 });


### PR DESCRIPTION
## Description

Relates to #6172.  Wrote two tests: one for rich text fields and one for plain text fields.  I don't think we need tests to prove it doesn't trigger falsely -- the normal functional tests should prove that.  Assuming I didn't mess something up.

## Testing done
Added two Behat tests.  Was gonna add PHPUnit tests to test mechanically, and still might depending on my mood and dictatorial disposition of my reviewer.

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
