### PR TITLE
VACMS-6130: Some improvements to the user-login-single thing test.

### DIFF
--- a/tests/behavioral/cypress/integration/common/i_should_be_at_url.js
+++ b/tests/behavioral/cypress/integration/common/i_should_be_at_url.js
@@ -1,0 +1,3 @@
+import { Then } from "cypress-cucumber-preprocessor/steps";
+
+Then(`I should be at {string}`, (url) => cy.url().should('include', url));

--- a/tests/behavioral/cypress/integration/user_login.feature
+++ b/tests/behavioral/cypress/integration/user_login.feature
@@ -9,4 +9,4 @@ Feature: User Login
     And my workbench access sections are set to "204"
     And I log out
     And I log back in
-    Then I should see "VA Bedford health care"
+    Then I should be at "/section/veterans-health-administration/vamc-facilities/va-bedford-health-care"

--- a/tests/behavioral/cypress/support/index.js
+++ b/tests/behavioral/cypress/support/index.js
@@ -17,6 +17,9 @@ import './commands';
 
 /**
  * Allows Cypress to collect the results of multiple operations.
+ *
+ * Remove when/if https://github.com/cypress-io/cypress/issues/8719 is implemented.
+ *
  */
 const chainStart = Symbol();
 cy.all = (...commands) => {


### PR DESCRIPTION
## Description

Relates to #6130.  Addresses some requested changes by @acrollet 

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
