### PR TITLE
VACMS-6216: Fix "Operation not permitted" in CI base image builds

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -22,7 +22,8 @@ services:
     commands:
       # Commands that set up the basic preview infrastructure
       init:
-        - apt-get update
+        # Added upgrade because of error here
+        - apt-get update && apt-get upgrade
 
         # TODO: Add "Why" comment for Python, was this for the FE dependencies `yarn install`, if so which dependencies
         # so we can remove if they are removed in the future.

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -22,15 +22,14 @@ services:
     commands:
       # Commands that set up the basic preview infrastructure
       init:
-        # Added upgrade because of error here
-        - apt-get update && apt-get upgrade
+        - apt-get update
 
         # TODO: Add "Why" comment for Python, was this for the FE dependencies `yarn install`, if so which dependencies
         # so we can remove if they are removed in the future.
         - apt-get install python
 
         # cypress-axe dependencies - https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
-        - apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+        - apt-get install --fix-broken libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
         # Install php ZIP extension (drush 10 requires it).
         - apt-get install libzip-dev zip

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -2,6 +2,8 @@ services:
   # What to call the service hosting the site.
   php:
     # Use PHP 7.x with Apache; this syntax pulls in the latest version of PHP 7
+    # Pinning to 7.3.28 until we update from Docker 19 to Docker 20
+    # See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/6216
     image: tugboatqa/php:7.3.28-apache
 
     aliases:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -28,7 +28,9 @@ services:
         # so we can remove if they are removed in the future.
         - apt-get install python
 
-        - apt-get install gconf2-common
+        # Ignore errors just for gconf2 right now because need to get builds working again.
+        # https://github.com/department-of-veterans-affairs/va.gov-cms/issues/6216
+        - apt-get install gconf2-common || true
 
         # cypress-axe dependencies - https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
         - apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -23,6 +23,8 @@ services:
       # Commands that set up the basic preview infrastructure
       init:
         - apt-get update
+        - whoami
+        - pwd
 
         # TODO: Add "Why" comment for Python, was this for the FE dependencies `yarn install`, if so which dependencies
         # so we can remove if they are removed in the future.
@@ -37,6 +39,7 @@ services:
 
         # Install php ZIP extension (drush 10 requires it).
         - apt-get install libzip-dev zip
+        - pwd
         - docker-php-ext-install zip
 
         # Install opcache, and Apache modules

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -28,8 +28,10 @@ services:
         # so we can remove if they are removed in the future.
         - apt-get install python
 
+        - apt-get install gconf2-common
+
         # cypress-axe dependencies - https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
-        - apt-get install --fix-broken libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+        - apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
         # Install php ZIP extension (drush 10 requires it).
         - apt-get install libzip-dev zip

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -2,7 +2,7 @@ services:
   # What to call the service hosting the site.
   php:
     # Use PHP 7.x with Apache; this syntax pulls in the latest version of PHP 7
-    image: tugboatqa/php:7.3-apache
+    image: tugboatqa/php:7.3.28-apache
 
     aliases:
       - cms
@@ -23,23 +23,16 @@ services:
       # Commands that set up the basic preview infrastructure
       init:
         - apt-get update
-        - whoami
-        - pwd
 
         # TODO: Add "Why" comment for Python, was this for the FE dependencies `yarn install`, if so which dependencies
         # so we can remove if they are removed in the future.
         - apt-get install python
-
-        # Ignore errors just for gconf2 right now because need to get builds working again.
-        # https://github.com/department-of-veterans-affairs/va.gov-cms/issues/6216
-        - apt-get install gconf2-common || true
 
         # cypress-axe dependencies - https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
         - apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
         # Install php ZIP extension (drush 10 requires it).
         - apt-get install libzip-dev zip
-        - pwd
         - docker-php-ext-install zip
 
         # Install opcache, and Apache modules


### PR DESCRIPTION
## Description

Relates to #6216 . 

## Testing done
Tested base image build on Tugboat, works now. 

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
