### PR TITLE
VACMS-6098: Allow any user to a workbench access section, regardless of their role.

### DIFF
--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -35,4 +35,5 @@ permissions:
   - 'override news_story authored on option'
   - 'override outreach_asset authored on option'
   - 'override press_release authored on option'
+  - 'use workbench access'
   - 'view media'

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -82,6 +82,7 @@ class RolesPermissionsTest extends ExistingSiteBase {
           'override news_story authored on option',
           'override outreach_asset authored on option',
           'override press_release authored on option',
+          'use workbench access',
           'view media',
         ],
       ],


### PR DESCRIPTION
## Description
Relates to #6098

## Testing done
Phpunit

## QA steps
 - [ ] As an administrator, go to `/user/2659/workbench_access` and assign multiple sections to account.
 - [ ] Verify successful save and assignment

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
