### PR TITLE
VACMS-6187: Remove email help links from node view.

### DIFF
--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -97,7 +97,7 @@ third_party_settings:
         show_empty_fields: false
         id: locations-and-contact-information
         classes: ''
-        description: 'To request a correction or update to this centrally-managed data, <a class="admin-help-email-tpl" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''change street address from 123 Fake Street to 456 Real Street.'']">email an administrator</a>.'
+        description: ''
       label: 'Locations and contact information'
     group_facility_data_from_vast:
       children:

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
@@ -98,7 +98,7 @@ third_party_settings:
       format_settings:
         show_label: '0'
         tooltip_description: "Why can’t I edit this?\r\nThis content is automatically populated from centralized databases, and helps maintain consistent information across all of VA.gov."
-        description: 'To request a correction or update to this centrally-managed data, <a class="admin-help-email-tpl" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''''change street address from 123 Fake Street to 456 Real Street.'''']">email an administrator</a>.'
+        description: ''
         id: ''
         classes: not-editable
         show_empty_fields: 0

--- a/config/sync/core.entity_view_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.default.yml
@@ -65,7 +65,7 @@ third_party_settings:
       format_type: fieldset
       region: content
       format_settings:
-        description: 'To request a correction or update to this centrally-managed data, <a class="admin-help-email-tpl" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''change street address from 123 Fake Street to 456 Real Street.'']">email an administrator</a>.'
+        description: ''
         id: top-of-page-information
         classes: ''
         show_empty_fields: false
@@ -83,7 +83,7 @@ third_party_settings:
         show_empty_fields: false
         id: locations-and-contact-information
         classes: ''
-        description: 'To request a correction or update to this centrally-managed data, <a class="admin-help-email-tpl" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''change street address from 123 Fake Street to 456 Real Street.'']">email an administrator</a>.'
+        description: ''
       label: 'Locations and contact information'
     group_vet_center_data:
       children:
@@ -98,7 +98,7 @@ third_party_settings:
       format_settings:
         show_label: '0'
         tooltip_description: "Why can’t I edit this?\r\nThis content is automatically populated from centralized databases, and helps maintain consistent information across all of VA.gov."
-        description: 'To request a correction or update to this centrally-managed data, <a class="admin-help-email-tpl" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''''change street address from 123 Fake Street to 456 Real Street.'''']">email an administrator</a>.'
+        description: ''
         id: external-content
         classes: 'not-editable '
         show_empty_fields: 0

--- a/config/sync/core.entity_view_display.node.vet_center.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.external_content.yml
@@ -42,7 +42,7 @@ third_party_settings:
       format_settings:
         show_label: '0'
         tooltip_description: "Why can’t I edit this?\r\nThis content is automatically populated from centralized databases, and helps maintain consistent information across all of VA.gov."
-        description: 'To request a correction or update to this centrally-managed data, <a class="admin-help-email-tpl" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''''change street address from 123 Fake Street to 456 Real Street.'''']">email an administrator</a>.'
+        description: ''
         id: ''
         classes: 'not-editable '
         show_empty_fields: 0

--- a/config/sync/core.entity_view_display.node.vet_center_outstation.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_outstation.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
       format_type: fieldset
       region: content
       format_settings:
-        description: 'To request a correction or update to this centrally-managed data, <a class="admin-help-email-tpl" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''change street address from 123 Fake Street to 456 Real Street.'']">email an administrator</a>.'
+        description: ''
         id: locations-and-contact-information
         classes: ''
         show_empty_fields: false


### PR DESCRIPTION
## Description
Relates to #6187

## Testing done
Visual / behat

## QA steps
 - [ ] As an administrator, go to `/antelope-valley-vet-center` and `/pittsburgh-health-care/locations/beaver-county-va-clinic` and visually verify email help links no longer appear

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
