### PR TITLE
VACMS-6317: Enable style guide for auth and anon users.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,6 +124,7 @@
         "drupal/smart_date": "3.4.2",
         "drupal/social_media_links": "^2.6",
         "drupal/string_field_formatter": "^2.0",
+        "drupal/styleguide": "^2.0@beta",
         "drupal/tablefield": "^2.1",
         "drupal/taxonomy_entity_index": "^1.1",
         "drupal/taxonomy_menu": "3.x-dev#e89d1e8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f81f81e2053917951cf0abcb5817dfa1",
+    "content-hash": "41c2b5e604ab53f0531ef75079b3f28e",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -6774,6 +6774,10 @@
                     "homepage": "https://stjerneman.com",
                     "email": "emil@stjerneman.com",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "johnwebdev",
+                    "homepage": "https://www.drupal.org/user/3331569"
                 }
             ],
             "description": "Linkit - Enriched linking experience",
@@ -15958,6 +15962,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -23962,6 +23967,7 @@
         "drupal/path_redirect_import": 10,
         "drupal/pathologic": 15,
         "drupal/prometheus_exporter": 10,
+        "drupal/styleguide": 10,
         "drupal/taxonomy_menu": 20,
         "drupal/user_history": 15,
         "drupal/views_data_export": 10,
@@ -23975,5 +23981,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9295,6 +9295,90 @@
             }
         },
         {
+            "name": "drupal/styleguide",
+            "version": "2.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/styleguide.git",
+                "reference": "2.0.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/styleguide-2.0.0-beta1.zip",
+                "reference": "2.0.0-beta1",
+                "shasum": "accf943a36e0162c2539162739e8f4d5035935d8"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-beta1",
+                    "datestamp": "1603816575",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Bevan",
+                    "homepage": "https://www.drupal.org/user/49989"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Greg Boggs",
+                    "homepage": "https://www.drupal.org/user/153069"
+                },
+                {
+                    "name": "Oleksiy",
+                    "homepage": "https://www.drupal.org/user/2744301"
+                },
+                {
+                    "name": "agentrickard",
+                    "homepage": "https://www.drupal.org/user/20975"
+                },
+                {
+                    "name": "dead_arm",
+                    "homepage": "https://www.drupal.org/user/597730"
+                },
+                {
+                    "name": "geerlingguy",
+                    "homepage": "https://www.drupal.org/user/389011"
+                },
+                {
+                    "name": "irakli",
+                    "homepage": "https://www.drupal.org/user/96826"
+                },
+                {
+                    "name": "markabur",
+                    "homepage": "https://www.drupal.org/user/217822"
+                },
+                {
+                    "name": "mfer",
+                    "homepage": "https://www.drupal.org/user/25701"
+                },
+                {
+                    "name": "psynaptic",
+                    "homepage": "https://www.drupal.org/user/93429"
+                }
+            ],
+            "description": "Generates a theme style guide for proofing common elements.",
+            "homepage": "https://www.drupal.org/project/styleguide",
+            "support": {
+                "source": "https://git.drupalcode.org/project/styleguide"
+            }
+        },
+        {
             "name": "drupal/tablefield",
             "version": "2.2.0",
             "source": {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -146,6 +146,7 @@ module:
   social_media_links: 0
   social_media_links_field: 0
   string_field_formatter: 0
+  styleguide: 0
   system: 0
   tablefield: 0
   taxonomy: 0

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -13,3 +13,4 @@ permissions:
   - 'access prometheus metrics'
   - 'access site-wide contact form'
   - 'view media'
+  - 'view style guides'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -37,3 +37,4 @@ permissions:
   - 'override press_release authored on option'
   - 'use workbench access'
   - 'view media'
+  - 'view style guides'

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -51,6 +51,7 @@ class RolesPermissionsTest extends ExistingSiteBase {
           'access prometheus metrics',
           'access site-wide contact form',
           'view media',
+          'view style guides',
         ],
       ],
       [
@@ -84,6 +85,7 @@ class RolesPermissionsTest extends ExistingSiteBase {
           'override press_release authored on option',
           'use workbench access',
           'view media',
+          'view style guides',
         ],
       ],
       [


### PR DESCRIPTION
## Description

Resolves #6317. 

## Testing done

phpunit, manual.

## Screenshots

![VA_gov_Admin_Theme___Veterans_Affairs](https://user-images.githubusercontent.com/643678/131743525-18c06a53-c496-40a1-8d71-8b672a97ff3d.png)

## QA steps

As anon verify that you can go to admin/appearance/styleguide/vagovadmin


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`
- [x] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
