### PR TITLE
VACMS-4904: Drupal sends number of active users.

### DIFF
--- a/config/sync/prometheus_exporter.settings.yml
+++ b/config/sync/prometheus_exporter.settings.yml
@@ -3,10 +3,11 @@ collectors:
     id: node_count
     provider: prometheus_exporter
     enabled: true
-    weight: 0
+    weight: -50
     settings:
       status: 1
       bundles:
+        banner: 0
         basic_landing_page: 0
         campaign_landing_page: 0
         centralized_content: 0
@@ -42,7 +43,10 @@ collectors:
         support_resources_detail_page: 0
         support_service: 0
         vamc_operating_status_and_alerts: 0
+        vamc_system_billing_insurance: 0
+        vamc_system_medical_records_offi: 0
         vamc_system_policies_page: 0
+        vamc_system_register_for_care: 0
         va_form: 0
         vba_facility: 0
         vet_center: 0
@@ -55,28 +59,35 @@ collectors:
     id: user_count
     provider: prometheus_exporter
     enabled: true
-    weight: 0
+    weight: -49
+    settings: {  }
+  va_gov_active_user_count:
+    id: va_gov_active_user_count
+    provider: va_gov_backend
+    enabled: true
+    weight: -48
     settings: {  }
   phpinfo:
     id: phpinfo
     provider: prometheus_exporter
     enabled: false
-    weight: 0
+    weight: -47
     settings: {  }
   queue_size:
     id: queue_size
     provider: prometheus_exporter
     enabled: false
-    weight: 0
+    weight: -46
     settings: {  }
   revision_count:
     id: revision_count
     provider: prometheus_exporter
     enabled: false
-    weight: 0
+    weight: -45
     settings:
       status: 0
       bundles:
+        banner: 0
         basic_landing_page: 0
         campaign_landing_page: 0
         centralized_content: 0
@@ -112,7 +123,10 @@ collectors:
         support_resources_detail_page: 0
         support_service: 0
         vamc_operating_status_and_alerts: 0
+        vamc_system_billing_insurance: 0
+        vamc_system_medical_records_offi: 0
         vamc_system_policies_page: 0
+        vamc_system_register_for_care: 0
         va_form: 0
         vba_facility: 0
         vet_center: 0

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
@@ -33,11 +33,11 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
   protected $userStorage;
 
   /**
-   * The user type storage.
+   * The settings service.
    *
    * @var \Drupal\Core\Site\Settings
    */
-  protected $settings;
+  protected $settingsService;
 
   /**
    * UserCount constructor.
@@ -56,7 +56,7 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityStorageInterface $user_storage, Settings $settings) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->userStorage = $user_storage;
-    $this->settings = $settings;
+    $this->settingsService = $settings;
   }
 
   /**
@@ -80,7 +80,7 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
    */
   protected function getCount() {
     $query = $this->userStorage->getQuery();
-    $sessionWriteInterval = $this->settings->get('session_write_interval', 180);
+    $sessionWriteInterval = $this->settingsService->get('session_write_interval', 180);
     $sinceTime = time() - $sessionWriteInterval;
     $query
       ->accessCheck(TRUE)

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\MetricsCollector;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\prometheus_exporter\Plugin\BaseMetricsCollector;
+use PNX\Prometheus\Gauge;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Collects metrics for the total node count.
+ *
+ * The granularity of the active user count is limited to the session write
+ * interval.
+ *
+ * @see \Drupal\user\EventSubscriber\UserRequestSubscriber
+ *
+ * @MetricsCollector(
+ *   id = "va_gov_active_user_count",
+ *   title = @Translation("Active user count"),
+ *   description = @Translation("Active user count.")
+ * )
+ */
+class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPluginInterface {
+
+  /**
+   * The user type storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $userStorage;
+
+  /**
+   * The user type storage.
+   *
+   * @var \Drupal\Core\Site\Settings
+   */
+  protected $settings;
+
+  /**
+   * UserCount constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $user_storage
+   *   The user type storage.
+   * @param \Drupal\Core\Site\Settings $settings
+   *   The site settings.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityStorageInterface $user_storage, Settings $settings) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->userStorage = $user_storage;
+    $this->settings = $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')->getStorage('user'),
+      $container->get('settings')
+    );
+  }
+
+  /**
+   * Gets a count for this metric.
+   *
+   * @return int
+   *   The count of active users in the most recent session write interval.
+   */
+  protected function getCount() {
+    $query = $this->userStorage->getQuery();
+    $sessionWriteInterval = $this->settings->get('session_write_interval', 180);
+    $sinceTime = time() - $sessionWriteInterval;
+    $query
+      ->accessCheck(TRUE)
+      ->condition('access', $sinceTime, '>=');
+    $count = $query->count()->execute();
+    return $count;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collectMetrics() {
+    $gauge = new Gauge($this->getNamespace(), 'total', $this->getDescription());
+    $gauge->set($this->getCount());
+    $metrics[] = $gauge;
+    return $metrics;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
@@ -10,7 +10,7 @@ use PNX\Prometheus\Gauge;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Collects metrics for the total node count.
+ * Collects metrics for the active user count.
  *
  * The granularity of the active user count is limited to the session write
  * interval.


### PR DESCRIPTION
## Description

Relates to #4904. 

The issue says 60 seconds, I'm leery of the performance impact of 60 seconds, think it should be 180 seconds.

**EDIT** Per discussion at standup, we'll leave this at 180 seconds unless we see an issue with the granularity.

## Testing done
Refreshed `/metrics` and saw my endpoint.  This shouldn't be approved/merged though until the current criteria are discussed.

## Screenshots
<img width="552" alt="Screen Shot 2021-09-14 at 8 33 32 AM" src="https://user-images.githubusercontent.com/1318579/133258708-0cf2c5f1-5ad5-435a-b804-40c43e0337cd.png">

## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue #4904 
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change. 
  - [x] Merge & carry on unburdened by announcements 
