### PR TITLE
VACMS-5248: Add logic to prevent non admin archive from node form.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -191,6 +191,7 @@ module:
   va_gov_user: 0
   va_gov_vamc: 0
   va_gov_vet_center: 0
+  va_gov_workflow: 0
   va_gov_workflow_assignments: 0
   video_embed_field: 0
   video_embed_media: 0

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\va_gov_workflow\EventSubscriber;
+
+use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\core_event_dispatcher\Event\Form\FormBaseAlterEvent;
+use Drupal\node\NodeForm;
+use Drupal\va_gov_user\Service\UserPermsService;
+use Drupal\va_gov_workflow\Service\WorkflowContentControl;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * VA.gov Workflow Entity Event Subscriber.
+ */
+class EntityEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The User Perms Service.
+   *
+   * @var \Drupal\va_gov_user\Service\UserPermsService
+   */
+  protected $userPermsService;
+
+  /**
+   * The Workflow content control Service.
+   *
+   * @var \Drupal\va_gov_workflow\Service\WorkflowContentControl
+   */
+  protected $workflowContentControl;
+
+  /**
+   * Constructs the EventSubscriber object.
+   *
+   * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
+   *   The user perms service.
+   * @param \Drupal\va_gov_workflow\Service\WorkflowContentControl $workflow_content_control
+   *   The workflow content control service.
+   */
+  public function __construct(
+    UserPermsService $user_perms_service,
+    WorkflowContentControl $workflow_content_control
+  ) {
+    $this->userPermsService = $user_perms_service;
+    $this->workflowContentControl = $workflow_content_control;
+  }
+
+  /**
+   * Alters to be applied to all content types.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Form\FormBaseAlterEvent $event
+   *   The event.
+   */
+  public function alterNodeForm(FormBaseAlterEvent $event) {
+    $form_state = $event->getFormState();
+    if ($form_state->getFormObject() instanceof EntityFormInterface) {
+      $this->removeArchiveOption($event);
+    }
+  }
+
+  /**
+   * Removes archive option for non-admins on certain content types.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Form\FormBaseAlterEvent $event
+   *   The event.
+   */
+  private function removeArchiveOption(FormBaseAlterEvent $event) {
+    $form = &$event->getForm();
+    $form_state = $event->getFormState();
+    if ($form_state->getFormObject() instanceof NodeForm) {
+      /** @var \Drupal\node\NodeInterface $node **/
+      $node = $form_state->getFormObject()->getEntity();
+      $bundle = $node->bundle();
+      $is_admin = $this->userPermsService->hasAdminRole();
+      $is_archived = $node->get('moderation_state')->getString() === 'archived' ? TRUE : FALSE;
+      $is_archiveable = $this->workflowContentControl->isBundleArchiveableByNonAdmins($bundle);
+      if (!$is_admin && !$is_archiveable && !$is_archived) {
+        unset($form['moderation_state']['widget'][0]['state']['#options']['archived']);
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      'hook_event_dispatcher.form_base_node_form.alter' => 'alterNodeForm',
+    ];
+  }
+
+}

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -72,7 +72,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       $bundle = $node->bundle();
       $is_admin = $this->userPermsService->hasAdminRole();
       $is_archiveable = $this->workflowContentControl->isBundleArchiveableByNonAdmins($bundle);
-      if (!$is_admin && !$is_archiveable && !$is_archived) {
+      if (!$is_admin && !$is_archiveable) {
         unset($form['moderation_state']['widget'][0]['state']['#options']['archived']);
       }
     }

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -71,7 +71,6 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       $node = $form_state->getFormObject()->getEntity();
       $bundle = $node->bundle();
       $is_admin = $this->userPermsService->hasAdminRole();
-      $is_archived = $node->get('moderation_state')->getString() === 'archived' ? TRUE : FALSE;
       $is_archiveable = $this->workflowContentControl->isBundleArchiveableByNonAdmins($bundle);
       if (!$is_admin && !$is_archiveable && !$is_archived) {
         unset($form['moderation_state']['widget'][0]['state']['#options']['archived']);

--- a/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
+++ b/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\va_gov_workflow\Service;
+
+use Drupal\va_gov_user\Service\UserPermsService;
+
+/**
+ * Service used for controlling entity workflow transitions.
+ */
+class WorkflowContentControl {
+
+  /**
+   * The User Perms Service.
+   *
+   * @var \Drupal\va_gov_user\Service\UserPermsService
+   */
+  protected $userPermsService;
+
+  /**
+   * Constructs the EventSubscriber object.
+   *
+   * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
+   *   The user perms service.
+   */
+  public function __construct(
+    UserPermsService $user_perms_service
+  ) {
+    $this->userPermsService = $user_perms_service;
+  }
+
+  /**
+   * An array of node bundles that only Admins can archive.
+   *
+   * @return array
+   *   The content type array.
+   */
+  public function getBundlesArchiveableByAdmins() {
+    return [
+      'basic_landing_page',
+      'centralized_content',
+      'documentation_page',
+      'event_listing',
+      'full_width_banner_alert',
+      'health_care_local_facility',
+      'health_care_region_page',
+      'health_services_listing',
+      'landing_page',
+      'leadership_listing',
+      'locations_listing',
+      'nca_facility',
+      'office',
+      'page',
+      'press_releases_listing',
+      'publication_listing',
+      'story_listing',
+      'support_service',
+      'va_form',
+      'vamc_operating_status_and_alerts',
+      'vamc_system_policies_page',
+      'vamc_system_register_for_care',
+      'vamc_system_medical_records_offi',
+      'vamc_system_billing_insurance',
+      'vba_facility',
+      'vet_center',
+      'vet_center_locations_list',
+    ];
+  }
+
+  /**
+   * Check if subject node bundle is allowed to be archived by non-admin user.
+   *
+   * @param string $bundle
+   *   The entity bundle type.
+   *
+   * @return bool
+   *   Returns true if non-admin can archive, false if non-admin can not.
+   */
+  public function isBundleArchiveableByNonAdmins($bundle) {
+    return in_array($bundle, $this->getBundlesArchiveableByAdmins()) ? FALSE : TRUE;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
+++ b/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
@@ -40,7 +40,6 @@ class WorkflowContentControl {
       'centralized_content',
       'documentation_page',
       'event_listing',
-      'full_width_banner_alert',
       'health_care_local_facility',
       'health_care_region_page',
       'health_services_listing',

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.info.yml
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.info.yml
@@ -1,0 +1,5 @@
+name: 'VA.gov Workflow'
+type: module
+description: 'Provides customizations for publishing workflow.'
+package: 'Custom'
+core_version_requirement: ^8 || ^9

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains va_gov_workflow.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function va_gov_workflow_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the va_gov_workflow module.
+    case 'help.page.va_gov_workflow':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Provides customizations for publishing workflow.') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.services.yml
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.services.yml
@@ -1,0 +1,9 @@
+services:
+  va_gov_workflow.entity_event_subscriber:
+    class: Drupal\va_gov_workflow\EventSubscriber\EntityEventSubscriber
+    arguments: [ '@va_gov_user.user_perms', '@va_gov_workflow.workflow_content_control']
+    tags:
+      - { name: event_subscriber }
+  va_gov_workflow.workflow_content_control:
+    class: Drupal\va_gov_workflow\Service\WorkflowContentControl
+    arguments: ['@va_gov_user.user_perms']


### PR DESCRIPTION
## Description
Closes #5248

## Testing done
Visual

## QA steps

### Non restricted archiving - events
-  as RS 
   - [x] validate that archive IS an option on  event https://pr6483-tte0mdzzbrbuksawoqn7wbmgdge6pq0n.ci.cms.va.gov/node/35024/edit 
 - as  LT
   - [x] validate that archive IS an option on https://pr6483-tte0mdzzbrbuksawoqn7wbmgdge6pq0n.ci.cms.va.gov/node/35024/edit

###  Restricted archiving - event list
-  as RS 
   - [x] validate that archive IS NOT an option on  event list  https://pr6483-tte0mdzzbrbuksawoqn7wbmgdge6pq0n.ci.cms.va.gov/node/2807/edit
 - as  LT
   - [x] validate that archive IS an option on event list https://pr6483-tte0mdzzbrbuksawoqn7wbmgdge6pq0n.ci.cms.va.gov/node/2807/edit

###  Restricted archiving - facility
-  as RS 
   - [x] validate that archive IS NOT an option on  facility https://pr6483-tte0mdzzbrbuksawoqn7wbmgdge6pq0n.ci.cms.va.gov/node/86/edit
 - as  LT
   - [x] validate that archive IS an option on https://pr6483-tte0mdzzbrbuksawoqn7wbmgdge6pq0n.ci.cms.va.gov/node/86/edit

 - [x] As Ryan.Stubblebine@va.gov, go to  system `/node/318/edit` and visually verify the `Archived` option is not available in the Editorial workflow Save as select field.
 - [x] As an administrator, go to `/node/318/edit` and visually verify the `Archived` option is available in the Editorial workflow Save as select field.
 - [x] As an administrator, save as Archived, and visually verify that there aren't any notices or errors.
 - [x]  As admin go to https://pr6483-tte0mdzzbrbuksawoqn7wbmgdge6pq0n.ci.cms.va.gov/admin/reports/dblog and validate there are no related warnings or errors.