### PR TITLE
Vacms 3573 trim node titles on save

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\va_gov_backend\EventSubscriber;
+
+use Drupal\node\Entity\Node;
+use Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * VA.gov Backend Entity Event Subscriber.
+ */
+class EntityEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Entity create Event call.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent $event
+   *   The event.
+   */
+  public function entityPresave(EntityPresaveEvent $event): void {
+    $entity = $event->getEntity();
+    if ($entity->getEntityTypeId() === 'node') {
+      $this->trimNodeTitleWhitespace($entity);
+    }
+  }
+
+  /**
+   * Trim any preceding and trailing whitespace on node titles.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The node to be modified.
+   */
+  private function trimNodeTitleWhitespace(Node $node) {
+    $title = $node->getTitle();
+    // Trim leading and then trailing separately to avoid a convoluted regex.
+    $title = preg_replace('/^\s+/', '', $title);
+    $title = preg_replace('/\s+$/', '', $title);
+    $node->setTitle($title);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      HookEventDispatcherInterface::ENTITY_PRE_SAVE => 'entityPresave',
+    ];
+  }
+
+}

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.install
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.install
@@ -428,7 +428,7 @@ function va_gov_backend_update_8010() {
 /**
  * Re-save all nodes to correct leading and trailing whitespace issues.
  */
-function va_gov_backend_update_8013(&$sandbox) {
+function va_gov_backend_update_8011(&$sandbox) {
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
 
   // Get the node count.

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.install
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.install
@@ -424,3 +424,92 @@ function va_gov_backend_update_8010() {
   }
   return "content_moderation_state_field_data and content_moderation_state_field_revision updated to workflow editor.";
 }
+
+/**
+ * Re-save all nodes to correct leading and trailing whitespace issues.
+ */
+function va_gov_backend_update_8013(&$sandbox) {
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  // Get the node count.
+  // This runs only once.
+  if (!isset($sandbox['total'])) {
+    $query = $node_storage->getQuery();
+    $nids_to_update = $query->execute();
+    $result_count = count($nids_to_update);
+    $sandbox['total'] = $result_count;
+    $sandbox['current'] = 0;
+    $sandbox['nids_to_update'] = array_combine(
+            array_map('_va_gov_backend_stringifynid', array_values($nids_to_update)),
+            array_values($nids_to_update));
+  }
+
+  // Do not continue if no nodes are found.
+  if (empty($sandbox['total'])) {
+    $sandbox['#finished'] = 1;
+    return t('No nodes were found to be processed.');
+  }
+
+  $limit = 25;
+
+  // Load entities.
+  $node_ids = array_slice($sandbox['nids_to_update'], 0, $limit, TRUE);
+  $nodes = $node_storage->loadMultiple($node_ids);
+
+  foreach ($nodes as $node) {
+    // Save some time by only saving nodes that need adjustments.
+    if (
+        preg_match('/\s+$/', $node->getTitle())
+        ||
+        preg_match('/^\s+/', $node->getTitle())
+        ) {
+      // Make this change a new revision.
+      $node->setNewRevision(TRUE);
+
+      // Set revision author to uid 1317 (CMS Migrator user).
+      $node->setRevisionUserId(1317);
+      $node->setChangedTime(time());
+      $node->setRevisionCreationTime(time());
+
+      // Set revision log message.
+      $node->setRevisionLogMessage('Resaved node to update title.');
+      $node->save();
+    }
+
+    unset($sandbox['nids_to_update']["node_{$node->id()}"]);
+    $nids[] = $node->id();
+    $sandbox['current'] = $sandbox['total'] - count($sandbox['nids_to_update']);
+  }
+
+  // Log the processed nodes.
+  Drupal::logger('va_gov_backend')
+    ->log(LogLevel::INFO, '%current nodes saved to update the title & alias. Nodes processed: %nids', [
+      '%current' => $sandbox['current'],
+      '%nids' => implode(', ', $nids),
+    ]);
+
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+  // Log the all-finished notice.
+  if ($sandbox['#finished'] == 1) {
+    Drupal::logger('va_gov_backend')->log(LogLevel::INFO, 'RE-saving all %count nodes to correct title issues.', [
+      '%count' => $sandbox['total'],
+    ]);
+    return "Node re-saving complete. {$sandbox['current']} / {$sandbox['total']}";
+  }
+
+  return "Processing node titles...{$sandbox['current']} / {$sandbox['total']}";
+}
+
+/**
+ * Callback function to concat node ids with string.
+ *
+ * @param int $nid
+ *   The node id.
+ *
+ * @return string
+ *   The node id concatenated to the end o node_
+ */
+function _va_gov_backend_stringifynid($nid) {
+  return "node_$nid";
+}

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.services.yml
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.services.yml
@@ -9,3 +9,7 @@ services:
   va_gov_backend.va_gov_url:
     class: Drupal\va_gov_backend\Service\VaGovUrl
     arguments: ['@http_client', '@settings', '@va_gov.build_trigger.environment_discovery']
+  va_gov_backend.entity_event_subscriber:
+    class: Drupal\va_gov_backend\EventSubscriber\EntityEventSubscriber
+    tags:
+      - {name: event_subscriber }

--- a/tests/phpunit/Content/TrimNodeTitleWhitespaceTest.php
+++ b/tests/phpunit/Content/TrimNodeTitleWhitespaceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace tests\phpunit\Content;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * A test to confirm the proper functioning of TrimNodeTitleWhitespace.
+ *
+ * @group functional
+ * @group all
+ *
+ * @coversDefaultClass \Drupal\va_gov_backend\EventSubscriber\EntityEventSubscriber
+ */
+class TrimNodeTitleWhitespaceTest extends ExistingSiteBase {
+
+  /**
+   * Confirm that the trimmed title is as expected.
+   *
+   * @param string $titleInput
+   *   The node title to test.
+   * @param string $expectedTitleOutput
+   *   The expected node title.
+   *
+   * @dataProvider confirmExpectedOutputDataProvider
+   */
+  public function testConfirmExpectedOutput($titleInput, $expectedTitleOutput) {
+    // Creates a user. Will be automatically cleaned up at the end of the test.
+    $author = $this->createUser();
+
+    // Create a node with the input title.
+    $entity = $this->createNode([
+      'title' => $titleInput,
+      'type' => 'health_care_region_page',
+      'uid' => $author->id(),
+    ]);
+
+    $this->assertEquals($expectedTitleOutput, $entity->getTitle());
+  }
+
+  /**
+   * Confirm that 'title' trimming is limited to nodes.
+   *
+   * @param string $entityTypeId
+   *   The type of entity to create.
+   * @param string $titleInput
+   *   The entity title to input.
+   * @param string $expectedTitleOutput
+   *   The expected entity title.
+   *
+   * @dataProvider titleTrimRestrictedToNodesDataProvider
+   */
+  public function testTitleTrimRestrictedToNodes($entityTypeId, $titleInput, $expectedTitleOutput) {
+    // Creates a user. Will be automatically cleaned up at the end of the test.
+    $author = $this->createUser();
+    // Create a vocabulary for testing terms.
+    $vocabulary = $this->createVocabulary();
+
+    switch ($entityTypeId) {
+      case 'node':
+        // Create a node with the input title.
+        $entity = $this->createNode([
+          'title' => $titleInput,
+          'type' => 'health_care_region_page',
+          'uid' => $author->id(),
+        ]);
+        $actualOutput = $entity->getTitle();
+        break;
+
+      case 'term':
+        $term = $this->createTerm($vocabulary, ['name' => $titleInput]);
+        $actualOutput = $term->getName();
+        break;
+
+      case 'user':
+        $user = $this->createUser([], $titleInput);
+        $actualOutput = $user->getAccountName();
+        break;
+
+      default:
+        $actualOutput = 'bad entity type';
+    }
+
+    $this->assertEquals($expectedTitleOutput, $actualOutput);
+  }
+
+  /**
+   * Data provider for testConfirmExpectedOutput.
+   */
+  public function confirmExpectedOutputDataProvider() {
+    return [
+      [
+        'This has no spaces',
+        'This has no spaces',
+      ],
+      [
+        'This had trailing spaces    ',
+        'This had trailing spaces',
+      ],
+      [
+        '    This had leading spaces',
+        'This had leading spaces',
+      ],
+      [
+        '     This was all spaced out       ',
+        'This was all spaced out',
+      ],
+      [
+        '     Interior     spaces     are not     touched       ',
+        'Interior     spaces     are not     touched',
+      ],
+    ];
+  }
+
+  /**
+   * Data provider for testTitleTrimRestrictedToNodes.
+   */
+  public function titleTrimRestrictedToNodesDataProvider() {
+    return [
+      [
+        'node',
+        '   Spacey Stacey   ',
+        'Spacey Stacey',
+      ],
+      [
+        'term',
+        '   Spacey Stacey   ',
+        '   Spacey Stacey   ',
+      ],
+      [
+        'user',
+        '   Spacey Stacey   ',
+        '   Spacey Stacey   ',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Description

Relates to #_3573_. 

## Testing done


## QA steps

As a user with node edit permissions.
1. Create any node, giving it a title that has leading and/or trailing spaces in it, e.g. "   About Us  ", and save it.
1. Edit the node you just created, and examine the title.
- [ ] There should be no leading spaces
- [ ] There should be no trailing spaces
- [ ] The title is otherwise unaltered. 

1. Create a taxonomy term, giving it a name that has leading and/or trailing spaces in it, e.g. "   Orange  ", and save it.
1. Edit the term you just created, and examine the name.
- [ ] The title is unaltered, including the original spaces.

### Definition of Done

- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Core Application Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
