### PR TITLE
VACMS-0000: Ignores complaints about module and core updates on status-error check.

### DIFF
--- a/tests.yml
+++ b/tests.yml
@@ -200,7 +200,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --severity=2 2>&1 | tee \$output)
+          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
           line_count=\$(grep -c "\S" <<< \$lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$line_count" -eq 0 ]; then


### PR DESCRIPTION
## Description

The status-error check can fail because of components that are outdated on `main`.  This doesn't really help anything and instead just delays code approval and deployment, results in more resource use on Tugboat, etc.

This PR ignores certain classes of status error explicitly -- outdated core, outdated modules, and security updates -- on the assumption that these are already present on `main` and being handled in other PRs.

The punctuation in the change is intentional -- Drush reads the option as CSV, then transforms it into an array.  Apparently it's maddeningly particular about quotation marks.

```
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore=35 --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='35' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='"35"' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='"35","Module and theme update status"' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='"update status"' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='"update_core","update_contrib"' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='"update_core","update_contrib","update status"' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='"update_core","update_contrib","update status",35' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='"update_core","update_contrib","update status","Module and theme update status",35' --format=list --severity=2
35
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='update status' --format=list --severity=2
34
root@php:/var/lib/tugboat# drush $DRUSH_ALIAS core-requirements --ignore='update_core,update_contrib,"update status"' --format=list --severity=2

root@php:/var/lib/tugboat# 
```

## Testing done
Typing variations of the same infernal command repeatedly until one of them did the thing, and then putting my head down on my desk for a little bit.

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Core Application Team`
- [ ] `Product Support Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change? 
- [ ] Yes, and it's written in issue ____ and queued for publication. 
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written 
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change. 
  - [ ] Merge & carry on unburdened by announcements 
