### PR TITLE
VACMS-6504: Turn off caching in the people view.

### DIFF
--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -33,7 +33,8 @@ display:
         options:
           perm: 'administer users'
       cache:
-        type: tag
+        type: none
+        options: {  }
       query:
         type: views_query
         options:


### PR DESCRIPTION
## Description
Relates to #6504

## Testing done
Visual / behat

## QA steps
 - [ ] While logged in as an administrator, open another browser and login as any other user.
 - [ ] With admin acct, visit `admin/people` and visually verify other user login shows immediately.