### PR TITLE
VACMS-6453: Add Official Name field to Vet Center migration

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_facility_vet_centers.yml
+++ b/config/sync/migrate_plus.migration.va_node_facility_vet_centers.yml
@@ -95,11 +95,16 @@ process:
       - mvc
       - os
       - cap
-  title:
+  field_official_name:
     plugin: skip_on_empty
     method: row
     source: name
     message: 'Skipped: Source title/name is empty, can not have a node without title.'
+  title:
+    plugin: skip_on_empty
+    method: row
+    source:
+      - '@field_official_name'
   field_facility_locator_api_id:
     plugin: skip_on_empty
     method: row
@@ -225,6 +230,7 @@ destination:
     - field_address/postal_code
     - field_administration
     - field_office_hours
+    - field_official_name
     - field_phone_number
     - new_revision
     - revision_default

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers.yml
@@ -105,11 +105,16 @@ process:
       - mvc
       - os
       - cap
-  title:
+  field_official_name:
     plugin: skip_on_empty
     method: row
     source: name
     message: 'Skipped: Source title/name is empty, can not have a node without title.'
+  title:
+    plugin: skip_on_empty
+    method: row
+    source:
+      - '@field_official_name'
   field_facility_locator_api_id:
     plugin: skip_on_empty
     method: row
@@ -241,6 +246,7 @@ destination:
     - 'field_address/postal_code'
     - field_administration
     - field_office_hours
+    - field_official_name
     - field_phone_number
     - new_revision
     - revision_default


### PR DESCRIPTION
## Description

Closes #6453 

## Testing done

Visual

## Screenshots

![Screen Shot 2021-10-04 at 4 20 01 PM](https://user-images.githubusercontent.com/21045418/135919068-d3d54b49-9933-4ed4-ae22-4efab07c1ad7.png)

## QA steps

-  ~Checkout this branch locally~ Go to https://pr6612-ce4wsxcbijctfw0ls3hecx7ixkywk2qh.ci.cms.va.gov and login as admin 
-  ~Clear the site cache with `lando drush cr`~  Tugboat does this as part of its build.
- [ ] Run the updated migration with `lando drush migrate:import va_node_facility_vet_centers --update`
OR 
- [x] https://pr6612-ce4wsxcbijctfw0ls3hecx7ixkywk2qh.ci.cms.va.gov/admin/structure/migrate/manage/facility/migrations/va_node_facility_vet_centers/execute check the "Update" bux and execute the migration
-  ~As an administrator,~ visit `/admin/structure/types/manage/vet_center/form-display`
- Enable the Official Name field and click Save
-  Visit `admin/content`, filter the list by Content type = Vet Center and click Edit for ~one~ several of the listed items
- [x] Validate the Official Name field contains the same text as the node title
