### PR TITLE
VACMS-6430: Remove option to dismiss banner for single session

### DIFF
--- a/config/sync/field.storage.node.field_dismissible_option.yml
+++ b/config/sync/field.storage.node.field_dismissible_option.yml
@@ -15,9 +15,6 @@ settings:
       value: perm
       label: 'Don''t allow site visitors to dismiss banner'
     -
-      value: dismiss-session
-      label: 'Allow site visitors to dismiss banner for a single session'
-    -
       value: dismiss
       label: 'Allow site visitors to dismiss banner permanently'
   allowed_values_function: ''


### PR DESCRIPTION
## Description

Closes issue #6430  

## Testing done

Visual testing

## Screenshots

<img width="1467" alt="Screen Shot 2021-10-08 at 3 05 14 PM" src="https://user-images.githubusercontent.com/21045418/136612555-b536ff6d-4945-4862-94a8-4b26eaea965c.png">

<img width="1454" alt="Screen Shot 2021-10-08 at 3 05 37 PM" src="https://user-images.githubusercontent.com/21045418/136612581-70033f6c-848f-4e06-a9a7-4f5956bda662.png">

## QA steps

As a user with the admin role:

- [ ] Visit admin/structure/types/manage/banner/fields/node.banner.field_dismissible_option/storage
- [ ] Verify that there are now only two options: **perm & dismiss**
- [ ] Visit admin/content?title=&type=banner&moderation_state=All&owner=All
- [ ] Edit one of the banner nodes available
- [ ] Verify that there are now only two options for the **Persistence** field
