### PR TITLE
VACMS-6201: Add Additional Downtime User-Agent for Datadog

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Deploy/Plugin/HealthCheck.php
+++ b/docroot/modules/custom/va_gov_backend/src/Deploy/Plugin/HealthCheck.php
@@ -15,7 +15,8 @@ class HealthCheck implements DeployPluginInterface {
    *
    * Two different downtime user agents are required since we want uptime graphs
    * to work correctly in both Grafana and Datadog. The addition of a Datadog
-   * deploy user-agent is to quell alerts during deploys. Prometheus no longer alerts.
+   * deploy user-agent is to quell alerts during deploys. 
+   * Prometheus no longer alerts.
    */
   public const VAGOV_DOWNTIME_DETECT_USER_AGENT_PROMETHEUS = 'curl-prometheus-check';
   public const VAGOV_DOWNTIME_DETECT_USER_AGENT_DATADOG = 'Datadog/Synthetics';

--- a/docroot/modules/custom/va_gov_backend/src/Deploy/Plugin/HealthCheck.php
+++ b/docroot/modules/custom/va_gov_backend/src/Deploy/Plugin/HealthCheck.php
@@ -15,7 +15,7 @@ class HealthCheck implements DeployPluginInterface {
    *
    * Two different downtime user agents are required since we want uptime graphs
    * to work correctly in both Grafana and Datadog. The addition of a Datadog
-   * deploy user-agent is to quell alerts during deploys. 
+   * deploy user-agent is to quell alerts during deploys.
    * Prometheus no longer alerts.
    */
   public const VAGOV_DOWNTIME_DETECT_USER_AGENT_PROMETHEUS = 'curl-prometheus-check';

--- a/docroot/modules/custom/va_gov_backend/src/Deploy/Plugin/HealthCheck.php
+++ b/docroot/modules/custom/va_gov_backend/src/Deploy/Plugin/HealthCheck.php
@@ -10,7 +10,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class HealthCheck implements DeployPluginInterface {
 
-  public const VAGOV_DOWNTIME_DETECT_USER_AGENT = 'curl-prometheus-check';
+  /**
+   * Add additional downtime user-agent.
+   *
+   * Two different downtime user agents are required since we want uptime graphs
+   * to work correctly in both Grafana and Datadog. The addition of a Datadog
+   * deploy user-agent is to quell alerts during deploys. Prometheus no longer alerts.
+   */
+  public const VAGOV_DOWNTIME_DETECT_USER_AGENT_PROMETHEUS = 'curl-prometheus-check';
+  public const VAGOV_DOWNTIME_DETECT_USER_AGENT_DATADOG = 'Datadog/Synthetics';
 
   /**
    * {@inheritDoc}
@@ -24,7 +32,7 @@ class HealthCheck implements DeployPluginInterface {
     // The system which detects and measures downtime shouldn't
     // register a downtime during deploys.
     $user_agent = $request->headers->get('User-Agent');
-    if ($user_agent === static::VAGOV_DOWNTIME_DETECT_USER_AGENT) {
+    if ($user_agent === static::VAGOV_DOWNTIME_DETECT_USER_AGENT_PROMETHEUS || $user_agent === static::VAGOV_DOWNTIME_DETECT_USER_AGENT_DATADOG) {
       return TRUE;
     }
 


### PR DESCRIPTION
## Description

Relates to #6201 

## Testing done
- Activated "Deploy Mode" on Tugboat environment with `cp docroot/sites/default/settings/settings.deploy.inactive.php docroot/sites/default/settings/settings.deploy.active.php`
- Curl command without user-agent sent to Preview URL received HTTP 503 response.
- Curl command with `curl-prometheus-check` user-agent sent to Preview URL, received HTTP 200 response.
- Curl command with `Datadog/Synthetics` user-agent sent to Preview URL, received HTTP 200 response.

## Screenshots
![image](https://user-images.githubusercontent.com/31904439/138185478-03e5cce0-4a0c-47a5-8129-b3c14f68cc6f.png)


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
