### PR TITLE
Add post-merge hook to display a message after a git pull

### DIFF
--- a/hooks/git/post-merge
+++ b/hooks/git/post-merge
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 echo -e "
-*******************ATTN*******************
-* master branch will be renamed to main! *
-* This will happen 11/3/2021             *
-* You will have to update your local env *
-* instructions will be provided          *   
-*******************ATTN*******************
+******************************ATTN*******************************
+* IMPORTANT: The default master branch will be renamed to main! *
+* This will happen 11/3/2021                                    *
+* You will have to update your local env                        *
+* instructions will be provided by `@cms-devops-engineers`      *
+* in `\#cms-team` Slack                                         *
+******************************ATTN*******************************
 "


### PR DESCRIPTION
## Description
Add a hook to display after a `git pull` of an impending default branch name change.

Relates to #6289 .

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
