### PR TITLE
VACMS-6725 Bump entity_field_fetch to 1.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5322,17 +5322,17 @@
         },
         {
             "name": "drupal/entity_field_fetch",
-            "version": "1.0.0-beta11",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_field_fetch.git",
-                "reference": "1.0.0-beta11"
+                "reference": "1.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_field_fetch-1.0.0-beta11.zip",
-                "reference": "1.0.0-beta11",
-                "shasum": "7cf9a8628d1aa1a00c09e5949215c245290910ab"
+                "url": "https://ftp.drupal.org/files/projects/entity_field_fetch-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "2a63ad9bf3657a327a1c5acad50a5c1cf16ea117"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -5340,11 +5340,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.0-beta11",
-                    "datestamp": "1632157936",
+                    "version": "1.0.0",
+                    "datestamp": "1635563481",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },


### PR DESCRIPTION
## Description

closes #6725

## Testing done


## Screenshots


## QA steps
Automated testing to cover yjod and nothing to test until the FE team alters their query.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`


### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
