### PR TITLE
VACMS-6844: Change Production manual content release to use Github Actions

### DIFF
--- a/docroot/sites/default/settings/settings.prod.php
+++ b/docroot/sites/default/settings/settings.prod.php
@@ -41,5 +41,6 @@ $settings['trusted_host_patterns'] = [
     '.*\.us-gov-west-1\.elb\.amazonaws\.com',
 ];
 
-$settings['va_gov_frontend_build_type'] = 'brd';
 $settings['va_gov_frontend_url'] = 'https://www.va.gov';
+$settings['va_gov_frontend_build_type'] = 'brdgha';
+$settings['github_actions_deploy_env'] = 'prod';


### PR DESCRIPTION
## Description

Relates to #6844.

Turn on Github Actions for Prod.  


