### PR TITLE
VACMS-6923 Exempt admin paths from node link report scan.

### DIFF
--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -29,6 +29,7 @@ domains_to_skip: |-
 enable_reporting_skipped_links: 1
 user_agent: 'VA.gov CMS link checker'
 path_patterns_to_skip: |-
+  /admin/*
   /block/*
   /node/*/edit
   /section/*


### PR DESCRIPTION
## Description

Closes #6923

This change has already been made on prod.  This is just getting it into config

## Testing done


## Screenshots


## QA steps

- [x] validate No longer showing broken link for admin path 
https://pr6924-825b31zszo9ak8gqdhsd2hnns6dsh2gf.ci.cms.va.gov/centralized-content/vamc-system-medical-records-page-content
![image](https://user-images.githubusercontent.com/5752113/140581765-753937cf-7161-4678-aa11-2a66bf108cfc.png)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
