### PR TITLE
VACMS-6639: autogenerate required service nodes for all vet centers

### DIFF
--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -114,8 +114,12 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public function entityInsert(EntityInsertEvent $event): void {
     $entity = $event->getEntity();
-    // Add all required services for this newly created facility.
-    $this->requiredServices->addServicesByFacility($entity);
+    if ($entity->getEntityTypeId() == 'node') {
+      $this->requiredServices->addRequiredServicesByFacility($entity);
+    }
+    if ($entity->getEntityTypeId() === 'taxonomy_term') {
+      $this->requiredServices->addRequiredServicesByTerm($entity);
+    }
   }
 
   /**
@@ -126,8 +130,9 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public function entityUpdate(EntityUpdateEvent $event): void {
     $entity = $event->getEntity();
-    // Add any missing services for this newly required term.
-    $this->requiredServices->addServicesByTerm($entity);
+    if ($entity->getEntityTypeId() === 'taxonomy_term') {
+      $this->requiredServices->addRequiredServicesByTerm($entity);
+    }
   }
 
   /**

--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -115,7 +115,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $entity = $event->getEntity();
     if ($entity->getEntityTypeId() == 'node'
       && $entity->bundle() == 'vet_center'
-      && $entity->isNew()) {
+      && is_null($entity->original)) {
       // Add all required services for this newly created facility.
       $this->requiredServices->addServicesByFacility($entity);
     }

--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -31,6 +31,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
 
   /**
    * Vet center required service service.
+   * The required services service.
    *
    * @var \Drupal\va_gov_vet_center\Service\RequiredServices
    *  The required services service.
@@ -113,12 +114,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public function entityInsert(EntityInsertEvent $event): void {
     $entity = $event->getEntity();
-    if ($entity->getEntityTypeId() == 'node'
-      && $entity->bundle() == 'vet_center'
-      && is_null($entity->original)) {
-      // Add all required services for this newly created facility.
-      $this->requiredServices->addServicesByFacility($entity);
-    }
+    // Add all required services for this newly created facility.
+    $this->requiredServices->addServicesByFacility($entity);
   }
 
   /**
@@ -129,16 +126,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public function entityUpdate(EntityUpdateEvent $event): void {
     $entity = $event->getEntity();
-    if ($entity->getEntityTypeId() == 'taxonomy_term'
-      && $entity->bundle() == 'health_care_service_taxonomy'
-      && $entity->hasField('field_vet_center_required_servic')
-      && !$entity->isNew()) {
-      if (!$entity->original->get('field_vet_center_required_servic')->value
-        && $entity->get('field_vet_center_required_servic')->value) {
-        // Add any missing services for this newly required term.
-        $this->requiredServices->addServicesByTerm($entity);
-      }
-    }
+    // Add any missing services for this newly required term.
+    $this->requiredServices->addServicesByTerm($entity);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -3,14 +3,17 @@
 namespace Drupal\va_gov_vet_center\EventSubscriber;
 
 use Drupal\Component\Render\FormattableMarkup;
-use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
+use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
 use Drupal\core_event_dispatcher\Event\Form\FormAlterEvent;
 use Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent;
+use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\va_gov_user\Service\UserPermsService;
+use Drupal\va_gov_vet_center\Service\RequiredServices;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -27,16 +30,31 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   protected $userPermsService;
 
   /**
+   * Vet center required service service.
+   *
+   * @var \Drupal\va_gov_vet_center\Service\RequiredServices
+   *  The required services service.
+   */
+  protected $requiredServices;
+
+  /**
    * Constructs a EntityEventSubscriber object.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The string translation service.
    * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
    *   The string translation service.
+   * @param \Drupal\va_gov_vet_center\Service\RequiredServices $required_services
+   *   The required services service.
    */
-  public function __construct(TranslationInterface $string_translation, UserPermsService $user_perms_service) {
+  public function __construct(
+    TranslationInterface $string_translation,
+    UserPermsService $user_perms_service,
+    RequiredServices $required_services
+    ) {
     $this->stringTranslation = $string_translation;
     $this->userPermsService = $user_perms_service;
+    $this->requiredServices = $required_services;
   }
 
   /**
@@ -84,6 +102,42 @@ class EntityEventSubscriber implements EventSubscriberInterface {
         '#description' => $this->t('@markup', ['@markup' => $formatted_markup]),
         '#open' => TRUE,
       ];
+    }
+  }
+
+  /**
+   * Entity insert.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent $event
+   *   The event.
+   */
+  public function entityInsert(EntityInsertEvent $event): void {
+    $entity = $event->getEntity();
+    if ($entity->getEntityTypeId() == 'node'
+      && $entity->bundle() == 'vet_center'
+      && $entity->isNew()) {
+      // Add all required services for this newly created facility.
+      $this->requiredServices->addServicesByFacility($entity);
+    }
+  }
+
+  /**
+   * Entity update.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent $event
+   *   The event.
+   */
+  public function entityUpdate(EntityUpdateEvent $event): void {
+    $entity = $event->getEntity();
+    if ($entity->getEntityTypeId() == 'taxonomy_term'
+      && $entity->bundle() == 'health_care_service_taxonomy'
+      && $entity->hasField('field_vet_center_required_servic')
+      && !$entity->isNew()) {
+      if (!$entity->original->get('field_vet_center_required_servic')->value
+        && $entity->get('field_vet_center_required_servic')->value) {
+        // Add any missing services for this newly required term.
+        $this->requiredServices->addServicesByTerm($entity);
+      }
     }
   }
 
@@ -251,6 +305,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents(): array {
     return [
+      HookEventDispatcherInterface::ENTITY_INSERT => 'entityInsert',
+      HookEventDispatcherInterface::ENTITY_UPDATE => 'entityUpdate',
       HookEventDispatcherInterface::FORM_ALTER => 'formAlter',
       'hook_event_dispatcher.form_node_vet_center_locations_list_edit_form.alter' => 'alterVetCenterLocationsListNodeEditForm',
       'hook_event_dispatcher.form_node_vet_center_edit_form.alter' => 'vetcenterFormAlter',

--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -31,7 +31,6 @@ class EntityEventSubscriber implements EventSubscriberInterface {
 
   /**
    * Vet center required service service.
-   * The required services service.
    *
    * @var \Drupal\va_gov_vet_center\Service\RequiredServices
    *  The required services service.

--- a/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/CronRequiredService.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/CronRequiredService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\va_gov_vet_center\Plugin\QueueWorker;
+
+/**
+ * A queue worker that creates required services on CRON run.
+ *
+ * @QueueWorker(
+ *   id = "cron_required_service",
+ *   title = @Translation("Cron Required Service"),
+ *   cron = {"time" = 180}
+ * )
+ */
+class CronRequiredService extends RequiredServiceBase {}

--- a/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/RequiredServiceBase.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/RequiredServiceBase.php
@@ -55,12 +55,13 @@ abstract class RequiredServiceBase extends QueueWorkerBase implements ContainerF
     // Use the "cms migrator" user account (1317).
     $author_uid = 1317;
     $vet_center = $this->nodeStorage->load($data->facility_id);
+    /** @var \Drupal\node\NodeInterface $vet_center */
     $published = $vet_center->isPublished();
     $section_id = $vet_center->field_administration->target_id;
-    $moderation_state = ($published ? 'published' : 'draft');
+    $moderation_state = $vet_center->get('moderation_state')->value;
 
     // Create the new node.
-    $node = Node::create([
+    $vet_center_facility_health_service_node = Node::create([
       'type' => 'vet_center_facility_health_servi',
       'status' => $published,
       'moderation_state' => $moderation_state,
@@ -76,7 +77,7 @@ abstract class RequiredServiceBase extends QueueWorkerBase implements ContainerF
       ],
     ]);
 
-    $node->save();
+    $vet_center_facility_health_service_node->save();
 
   }
 

--- a/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/RequiredServiceBase.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/RequiredServiceBase.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\va_gov_vet_center\Plugin\QueueWorker;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\node\Entity\Node;
+
+/**
+ * Provides base functionality for the Subscription Builder Queue Workers.
+ */
+abstract class RequiredServiceBase extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * The term storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $termStorage;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    EntityStorageInterface $node_storage,
+    EntityStorageInterface $term_storage
+  ) {
+    $this->nodeStorage = $node_storage;
+    $this->termStorage = $term_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $container->get('entity_type.manager')->getStorage('node'),
+      $container->get('entity_type.manager')->getStorage('taxonomy_term')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    // Use the "cms migrator" user account (1317).
+    $author_uid = 1317;
+    $vet_center = $this->nodeStorage->load($data->facility_id);
+    $published = $vet_center->isPublished();
+    $section_id = $vet_center->field_administration->target_id;
+    $moderation_state = ($published ? 'published' : 'draft');
+
+    // Create the new node.
+    $node = Node::create([
+      'type' => 'vet_center_facility_health_servi',
+      'status' => $published,
+      'moderation_state' => $moderation_state,
+      'uid' => $author_uid,
+      'field_administration' => [
+        ['target_id' => $section_id],
+      ],
+      'field_office' => [
+        ['target_id' => $data->facility_id],
+      ],
+      'field_service_name_and_descripti' => [
+        ['target_id' => $data->term_id],
+      ],
+    ]);
+
+    $node->save();
+
+  }
+
+}

--- a/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/RequiredServiceBase.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Plugin/QueueWorker/RequiredServiceBase.php
@@ -54,20 +54,16 @@ abstract class RequiredServiceBase extends QueueWorkerBase implements ContainerF
   public function processItem($data) {
     // Use the "cms migrator" user account (1317).
     $author_uid = 1317;
-    $vet_center = $this->nodeStorage->load($data->facility_id);
-    /** @var \Drupal\node\NodeInterface $vet_center */
-    $published = $vet_center->isPublished();
-    $section_id = $vet_center->field_administration->target_id;
-    $moderation_state = $vet_center->get('moderation_state')->value;
 
     // Create the new node.
     $vet_center_facility_health_service_node = Node::create([
       'type' => 'vet_center_facility_health_servi',
-      'status' => $published,
-      'moderation_state' => $moderation_state,
+      'status' => $data->published,
+      'moderation_state' => $data->moderation_state,
+      'revision_log' => $data->log_message,
       'uid' => $author_uid,
       'field_administration' => [
-        ['target_id' => $section_id],
+        ['target_id' => $data->section_id],
       ],
       'field_office' => [
         ['target_id' => $data->facility_id],

--- a/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Drupal\va_gov_vet_center\Service;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Class RequiredServices enforces required services for Vet Centers.
+ */
+class RequiredServices {
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The query factory used to construct all queries in the test.
+   *
+   * @var \Drupal\Core\Config\Entity\Query\QueryFactory
+   */
+  protected $queryFactory;
+
+  /**
+   * Constructs a new RequiredServices object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Add a new queue item for this term/facility combination.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $service_term
+   *   The taxonomy term for the new service item.
+   * @param \Drupal\Core\Entity\EntityInterface $facility_node
+   *   The vet center (facility) node for the new service item.
+   */
+  public function addService(EntityInterface $service_term, EntityInterface $facility_node) {
+    // Add a queue item to be processed on next cron run.
+    $queue_factory = \Drupal::service('queue');
+    $queue = $queue_factory->get('cron_required_service');
+
+    $item = new \stdClass();
+    $item->facility_id = $facility_node->id();
+    $item->term_id = $service_term->id();
+    $queue->createItem($item);
+  }
+
+  /**
+   * Add all required services for a provided facility (vet center).
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $facility_node
+   *   The vet center (facility) node for the new service items.
+   */
+  public function addServicesByFacility(EntityInterface $facility_node) {
+    // Be sure a given facility has all required services.
+    $required_services = $this->getRequiredServices();
+
+    foreach ($required_services as $required_service) {
+      $this->addService($required_service, $facility_node);
+    }
+  }
+
+  /**
+   * Add all required services for a provided service term.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $service_term
+   *   The taxonomy term for the new service items.
+   */
+  public function addServicesByTerm(EntityInterface $service_term) {
+    $term_id = $service_term->id();
+
+    // Get all the vet center node ids.
+    $vet_center_nids = \Drupal::entityQuery('node')
+      ->condition('type', 'vet_center')
+      ->execute();
+
+    // Get all the facility health service node ids using this term.
+    $facility_service_nids = \Drupal::entityQuery('node')
+      ->condition('type', 'vet_center_facility_health_servi')
+      ->condition('field_service_name_and_descripti.target_id', $term_id)
+      ->execute();
+
+    // Load all the facility health service nodes.
+    $storage_handler = $this->entityTypeManager->getStorage('node');
+    $facility_services = $storage_handler->loadMultiple($facility_service_nids);
+    $serviced_nids = [];
+
+    // Get the id for the vet center referenced in each facility service.
+    foreach ($facility_services as $facility_service) {
+      if ($facility_service->hasField('field_office')) {
+        $serviced_nids[] = $facility_service->get('field_office')->entity->id();
+      }
+    }
+
+    // Remove the vet centers where this service is already present.
+    $missing_nids = array_diff($vet_center_nids, $serviced_nids);
+
+    // Add each item to the queue for creation.
+    foreach ($missing_nids as $missing_nid) {
+      $vet_center = $storage_handler->load($missing_nid);
+      $this->addService($service_term, $vet_center);
+    }
+  }
+
+  /**
+   * Retrieve an array of required health care service taxonomy term entities.
+   *
+   * @return array
+   *   An array of required taxonomy term (service) entities.
+   */
+  public function getRequiredServices() {
+    // Return a list of required services.
+    $term_ids = \Drupal::entityQuery('taxonomy_term')
+      ->condition('vid', 'health_care_service_taxonomy')
+      ->execute();
+    $storage_handler = $this->entityTypeManager->getStorage('taxonomy_term');
+    $service_terms = $storage_handler->loadMultiple($term_ids);
+    $required_services = [];
+
+    // Unset any items in the array that aren't required.
+    foreach ($service_terms as $service_term) {
+      if ($this->isRequiredService($service_term)) {
+        $required_services[] = $service_term;
+      }
+    }
+
+    return $required_services;
+  }
+
+  /**
+   * Determine whether a provided service term is required or not.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $service_term
+   *   The taxonomy term to be evaluated.
+   *
+   * @return bool
+   *   Is this term is required or not.
+   */
+  public function isRequiredService(EntityInterface $service_term) {
+    // Check a service to see if it is required.
+    $required = $service_term->get('field_vet_center_required_servic')->value;
+
+    return $required;
+  }
+
+  /**
+   * Determine whether a provided service exists for a provided facility.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $service_term
+   *   The taxonomy term to be evaluated.
+   * @param \Drupal\Core\Entity\EntityInterface $facility_node
+   *   The vet center (facility) node to be evaluated.
+   *
+   * @return bool
+   *   Does the provided service exist for the provided facility.
+   */
+  protected function hasService(EntityInterface $service_term, EntityInterface $facility_node) {
+    // Check to see if a given facility has a given service.
+    $term_id = $service_term->id();
+    $facility_id = $facility_node->id();
+    $facility_service_nids = \Drupal::entityQuery('node')
+      ->condition('type', 'vet_center_facility_health_servi')
+      ->condition('field_office.target_id', $facility_id)
+      ->condition('field_service_name_and_descripti.target_id', $term_id)
+      ->execute();
+
+    $has_service = (count($facility_service_nids) > 0 ? TRUE : FALSE);
+
+    return $has_service;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
@@ -167,7 +167,7 @@ class RequiredServices {
       $this->requiredServices = $required_services;
     }
 
-    return $required_services;
+    return $this->requiredServices;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
@@ -25,6 +25,13 @@ class RequiredServices {
   protected $queueFactory;
 
   /**
+   * An array of required service taxonomy term objects.
+   *
+   * @var array
+   */
+  protected $requiredServices;
+
+  /**
    * Constructs a new RequiredServices object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -139,21 +146,25 @@ class RequiredServices {
    *   An array of required taxonomy term (service) entities.
    */
   public function getRequiredServices() {
-    $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
-    $term_query = $term_storage->getQuery();
+    if (empty($this->requiredServices)) {
+      $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+      $term_query = $term_storage->getQuery();
 
-    // Return a list of required services.
-    $term_ids = $term_query
-      ->condition('vid', 'health_care_service_taxonomy')
-      ->execute();
-    $service_terms = $term_storage->loadMultiple($term_ids);
-    $required_services = [];
+      // Return a list of required services.
+      $term_ids = $term_query
+        ->condition('vid', 'health_care_service_taxonomy')
+        ->execute();
+      $service_terms = $term_storage->loadMultiple($term_ids);
+      $required_services = [];
 
-    // Unset any items in the array that aren't required.
-    foreach ($service_terms as $service_term) {
-      if ($this->isRequiredService($service_term)) {
-        $required_services[] = $service_term;
+      // Unset any items in the array that aren't required.
+      foreach ($service_terms as $service_term) {
+        if ($this->isRequiredService($service_term)) {
+          $required_services[] = $service_term;
+        }
       }
+
+      $this->requiredServices = $required_services;
     }
 
     return $required_services;

--- a/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
@@ -114,6 +114,7 @@ class RequiredServices {
 
         // Get the id for the vet center referenced in each facility service.
         foreach ($facility_services as $facility_service) {
+          /** @var \Drupal\node\NodeInterface $facility_service */
           if ($facility_service->hasField('field_office')) {
             $serviced_nids[] = $facility_service->get('field_office')->entity->id();
           }

--- a/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
@@ -8,7 +8,9 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
+use Drupal\Core\Queue\SuspendQueueException;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Class RequiredServices enforces required services for Vet Centers.

--- a/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
@@ -224,14 +224,13 @@ class RequiredServices {
   /**
    * Determine whether a provided service term is required or not.
    *
-   * @param \Drupal\Core\Entity\EntityInterface $service_term
+   * @param \Drupal\taxonomy\TermInterface $service_term
    *   The taxonomy term to be evaluated.
    *
    * @return bool
    *   TRUE if required. FALSE otherwise.
    */
-  public function isRequiredService(EntityInterface $service_term) {
-    /** @var \Drupal\taxonomy\TermInterface $service_term */
+  public function isRequiredService(TermInterface $service_term) {
     // Check a service to see if it is required.
     $required = $service_term->get('field_vet_center_required_servic')->value;
 

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
@@ -193,6 +193,6 @@ function va_gov_vet_center_form_node_form_alter(array &$form, FormStateInterface
  */
 function va_gov_vet_center_page_attachments(array &$attachments) {
   $attachments['#attached']['library'][] = 'va_gov_vet_center/alert_form';
-  // PRevent duplicate services in select.
+  // Prevent duplicate services in select.
   $attachments['#attached']['library'][] = 'va_gov_vet_center/prevent_select_duplicates';
 }

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.services.yml
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.services.yml
@@ -6,5 +6,4 @@ services:
       - { name: event_subscriber }
   va_gov_vet_center.required_services:
     class: Drupal\va_gov_vet_center\Service\RequiredServices
-    arguments: ['@entity_type.manager']
-    #arguments: ['@entity_type.manager', '@entity.query']
+    arguments: ['@entity_type.manager', '@queue']

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.services.yml
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.services.yml
@@ -1,6 +1,10 @@
 services:
   va_gov_vet_center.entity_event_subscriber:
     class: Drupal\va_gov_vet_center\EventSubscriber\EntityEventSubscriber
-    arguments: ['@string_translation', '@va_gov_user.user_perms']
+    arguments: ['@string_translation', '@va_gov_user.user_perms', '@va_gov_vet_center.required_services']
     tags:
       - { name: event_subscriber }
+  va_gov_vet_center.required_services:
+    class: Drupal\va_gov_vet_center\Service\RequiredServices
+    arguments: ['@entity_type.manager']
+    #arguments: ['@entity_type.manager', '@entity.query']

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.services.yml
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.services.yml
@@ -6,4 +6,4 @@ services:
       - { name: event_subscriber }
   va_gov_vet_center.required_services:
     class: Drupal\va_gov_vet_center\Service\RequiredServices
-    arguments: ['@entity_type.manager', '@queue']
+    arguments: ['@entity_type.manager', '@logger.factory', '@messenger', '@queue']


### PR DESCRIPTION
## Description

Closes #6639 

## Testing done

Manual/visual testing

## Screenshots

Changing the required status for a given facility health service
<img width="1372" alt="Screen Shot 2021-11-17 at 3 10 48 PM" src="https://user-images.githubusercontent.com/21045418/142275409-1217f27c-bb1e-4e12-9623-35eb76357332.png">

Filtering existing content to only show Vet Center - Facility Services (note the count)
<img width="1382" alt="Screen Shot 2021-11-17 at 3 15 27 PM" src="https://user-images.githubusercontent.com/21045418/142275579-54712396-96e4-4dc5-987d-2ea6acfa013f.png">

How many missing Vet Center - Facility Services are we creating
![Screen Shot 2021-11-17 at 3 16 22 PM](https://user-images.githubusercontent.com/21045418/142275746-b6d290e1-d897-40e9-b79c-e1d4d0e14729.png)

Grab a list of Vet Centers to spot check before we run cron (3890, 3891, 3892, etc...)
![Screen Shot 2021-11-17 at 3 17 38 PM](https://user-images.githubusercontent.com/21045418/142275871-f9df2723-1932-4704-88a9-864657fd81a9.png)

## QA steps

As an admin user:
- [x] Visit https://pr6985-jvxycwmqn1bd1j6xuddccdxgpbwna4b9.ci.cms.va.gov/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview for a list of VHA Health Service taxonomy terms
- [x] Edit a term that is currently required (example: `Addiction and substance abuse care` - https://pr6985-jvxycwmqn1bd1j6xuddccdxgpbwna4b9.ci.cms.va.gov/taxonomy/term/47/edit)
- [x] Uncheck the `This is a required Vet Center service` checkbox and save the term
- [x] Edit the item again, check the `This is a required Vet Center service` checkbox and save the term
- [x] In your terminal run ~`lando drush sql:query "Select count(*) from queue WHERE name = 'cron_required_service'"`~ 'lando drush queue:list and note the number of items listed
![image](https://user-images.githubusercontent.com/5752113/144549743-19ed1a9b-dd00-4ad0-9216-91ccfdc5b7e5.png)

- [x] Visit https://pr6985-jvxycwmqn1bd1j6xuddccdxgpbwna4b9.ci.cms.va.gov/admin/content and filter the content to only list `Vet Center - Facility Service nodes` and note the count
- [x] In your terminal run `lando drush sql:query "Select * from queue WHERE name = 'cron_required_service'"` and grab a handful of node ids to check
- [x] Open up a handful of Vet Center to spot check by visiting https://pr6985-jvxycwmqn1bd1j6xuddccdxgpbwna4b9.ci.cms.va.gov/node/nodeid/edit (replacing <nodeid> with the ids from the query above) None of these Vet Centers should currently have the service we just reset the required checkbox for.
- [ ] Run cron manually by visiting https://pr6985-jvxycwmqn1bd1j6xuddccdxgpbwna4b9.ci.cms.va.gov/admin/config/system/cron
- [ ] Refresh the https://pr6985-jvxycwmqn1bd1j6xuddccdxgpbwna4b9.ci.cms.va.gov/admin/content view filtered to only list `Vet Center - Facility Service nodes` and note the new count. It should be the original count plus the number of new items our sql:query showed.
- [x] Refresh the nodes you were spot checking. Each should now have the newly required service present. Each new Vet Center - Facility Service node should also share the published state of the Vet Center it belongs to.
- [ ] Create a brand new Vet Center
- [ ] In your terminal run `lando drush sql:query "Select count(*) from queue WHERE name = 'cron_required_service'"` and note the number of items listed (It should be one item for each required service)
- [ ] Run cron manually by visiting https://pr6985-jvxycwmqn1bd1j6xuddccdxgpbwna4b9.ci.cms.va.gov/admin/config/system/cron
- [ ] Refresh the newly created vet center. It should now have all required services present.