### PR TITLE
VAMCS-5167: Date field should be required.

### DIFF
--- a/config/sync/field.field.node.event.field_datetime_range_timezone.yml
+++ b/config/sync/field.field.node.event.field_datetime_range_timezone.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: event
 label: 'Date and time'
 description: 'Set a start and end date.'
-required: false
+required: true
 translatable: false
 default_value:
   -

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -22,7 +22,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Event | Additional registration  information | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | Event | Address | field_address | Address |  | 1 | Address |  |
 | Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  |
-| Content type | Event | Date and time | field_datetime_range_timezone | Smart date range |  | 1 | Date and time range with timezone |  |
+| Content type | Event | Date and time | field_datetime_range_timezone | Smart date range | Required | 1 | Date and time range with timezone |  |
 | Content type | Event | Where should the event be listed? | field_listing | Entity reference | Required | 1 | Select list |  |
 | Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  |
 | Content type | Event | Full event description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |


### PR DESCRIPTION
## Description

closes #5167.

## Testing done

Visual, behat.

## Screenshots

<details><summary>Screenshot</summary>

<img width="1164" alt="Create_Event___VA_gov_CMS" src="https://user-images.githubusercontent.com/643678/142798290-5f72c2b2-ec7b-4368-ac09-1dbf1204d740.png">


</details>

<details><summary>Php error </summary>

```
Message	Notice: Undefined index: #type in Drupal\Core\Render\Element\RenderElement::setAttributes() (line 145 of /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Element/RenderElement.php)
#0 /var/lib/tugboat/docroot/core/includes/bootstrap.inc(312): _drupal_error_handler_real(8, 'Undefined index...', '/var/lib/tugboa...', 145)
#1 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Element/RenderElement.php(145): _drupal_error_handler(8, 'Undefined index...', '/var/lib/tugboa...', 145, Array)
#2 /var/lib/tugboat/docroot/core/includes/form.inc(195): Drupal\Core\Render\Element\RenderElement::setAttributes(Array)
#3 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Theme/ThemeManager.php(287): template_preprocess_fieldset(Array, 'fieldset', Array)
#4 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(492): Drupal\Core\Theme\ThemeManager->render('fieldset', Array)
#5 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(201): Drupal\Core\Render\Renderer->doRender(Array, false)
#6 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Template/TwigExtension.php(450): Drupal\Core\Render\Renderer->render(Array)
#7 /var/lib/tugboat/docroot/sites/default/files/php/twig/619b1210cd61c_field-multiple-value-form_DGpoKjf63GmJZPMe74DshrsZi/VPcetoyHTk9UZrNseFhUUqmW6AlxQBmoLhsQE5mvarg.php(83): Drupal\Core\Template\TwigExtension->escapeFilter(Object(Drupal\Core\Template\TwigEnvironment), Array, 'html', NULL, true)
#8 /var/lib/tugboat/docroot/vendor/twig/twig/src/Template.php(405): __TwigTemplate_75d6f6854999dc1afbfbeaa18a6e27c4a58c3452166c87a35f965c5f65c12446->doDisplay(Array, Array)
#9 /var/lib/tugboat/docroot/vendor/twig/twig/src/Template.php(378): Twig\Template->displayWithErrorHandling(Array, Array)
#10 /var/lib/tugboat/docroot/vendor/twig/twig/src/Template.php(390): Twig\Template->display(Array)
#11 /var/lib/tugboat/docroot/core/themes/engines/twig/twig.engine(65): Twig\Template->render(Array)
#12 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Theme/ThemeManager.php(384): twig_render_template('core/modules/sy...', Array)
#13 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(436): Drupal\Core\Theme\ThemeManager->render('field_multiple_...', Array)
#14 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(449): Drupal\Core\Render\Renderer->doRender(Array)
#15 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(449): Drupal\Core\Render\Renderer->doRender(Array)
#16 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(201): Drupal\Core\Render\Renderer->doRender(Array, false)
#17 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Template/TwigExtension.php(450): Drupal\Core\Render\Renderer->render(Array)
#18 /var/lib/tugboat/docroot/sites/default/files/php/twig/619b1210cd61c_node-edit-form.html.twig_ilV6g-3FQtuyg8hS3PxZn8X64/F3NS0fzgXbNJw74s6x8hvSME6qdN93i9KBiQrQTXl88.php(43): Drupal\Core\Template\TwigExtension->escapeFilter(Object(Drupal\Core\Template\TwigEnvironment), Array, 'html', NULL, true)
#19 /var/lib/tugboat/docroot/vendor/twig/twig/src/Template.php(405): __TwigTemplate_59c10c950b0915cff31cf058acb2414b4d200c27ca7976640f884adaa2666b08->doDisplay(Array, Array)
#20 /var/lib/tugboat/docroot/vendor/twig/twig/src/Template.php(378): Twig\Template->displayWithErrorHandling(Array, Array)
#21 /var/lib/tugboat/docroot/vendor/twig/twig/src/Template.php(390): Twig\Template->display(Array)
#22 /var/lib/tugboat/docroot/core/themes/engines/twig/twig.engine(65): Twig\Template->render(Array)
#23 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Theme/ThemeManager.php(384): twig_render_template('core/themes/sev...', Array)
#24 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(436): Drupal\Core\Theme\ThemeManager->render('node_edit_form', Array)
#25 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(201): Drupal\Core\Render\Renderer->doRender(Array, false)
#26 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/MainContent/HtmlRenderer.php(241): Drupal\Core\Render\Renderer->render(Array, false)
#27 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/Renderer.php(578): Drupal\Core\Render\MainContent\HtmlRenderer->Drupal\Core\Render\MainContent\{closure}()
#28 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/MainContent/HtmlRenderer.php(242): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#29 /var/lib/tugboat/docroot/core/lib/Drupal/Core/Render/MainContent/HtmlRenderer.php(132): Drupal\Core\Render\MainContent\HtmlRenderer->prepare(Array, Object(Symfony\Component\HttpFoundation\Request), Object(Drupal\Core\Routing\CurrentRouteMatch))
#30 /var/lib/tugboat/docroot/core/lib/Drupal/Core/EventSubscriber/MainContentViewSubscriber.php(90): Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object(Symfony\Component\HttpFoundation\Request), Object(Drupal\Core\Routing\CurrentRouteMatch))
#31 [internal function]: Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object(Symfony\Component\HttpKernel\Event\ViewEvent), 'kernel.view', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#32 /var/lib/tugboat/docroot/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php(142): call_user_func(Array, Object(Symfony\Component\HttpKernel\Event\ViewEvent), 'kernel.view', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#33 /var/lib/tugboat/docroot/vendor/symfony/http-kernel/HttpKernel.php(163): Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\ViewEvent), 'kernel.view')
#34 /var/lib/tugboat/docroot/vendor/symfony/http-kernel/HttpKernel.php(80): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#35 /var/lib/tugboat/docroot/core/lib/Drupal/Core/StackMiddleware/Session.php(57): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#36 /var/lib/tugboat/docroot/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(47): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#37 /var/lib/tugboat/docroot/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#38 /var/lib/tugboat/docroot/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#39 /var/lib/tugboat/docroot/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(47): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#40 /var/lib/tugboat/docroot/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(52): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#41 /var/lib/tugboat/docroot/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#42 /var/lib/tugboat/docroot/core/lib/Drupal/Core/DrupalKernel.php(717): Stack\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#43 /var/lib/tugboat/docroot/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#44 {main}
```

</details>

## QA steps

As any VAMC or Outreach hub content creator, go to /node/add/eevent
- [ ] Date field should be required
- [ ] Note that end date is also requried, which may not be ideal (see discussion on #5167)
- [ ] Note PHP errors 😬 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
