### PR TITLE
VACMS-7016: remove status endpoints for the week of December 1 2021

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -18,27 +18,12 @@ source:
   data_parser_plugin: csv
   item_selector: ''
   urls:
-    - 'https://www.amarillo.va.gov/locations/facilities.asp'
-    - 'https://www.beckley.va.gov/locations/facilities.asp'
-    - 'https://www.boston.va.gov/locations/facilities.asp'
-    - 'https://www.centralwesternmass.va.gov/locations/facilities.asp'
-    - 'https://www.columbiamo.va.gov/locations/facilities.asp'
-    - 'https://www.columbus.va.gov/locations/facilities.asp'
-    - 'https://www.elpaso.va.gov/locations/facilities.asp'
-    - 'https://www.indianapolis.va.gov/locations/facilities.asp'
     - 'https://www.leavenworth.va.gov/locations/facilities.asp'
     - 'https://www.losangeles.va.gov/locations/facilities.asp'
-    - 'https://www.louisville.va.gov/locations/facilities.asp'
     - 'https://www.lovell.fhcc.va.gov/locations/facilities.asp'
-    - 'https://www.marion.va.gov/locations/facilities.asp'
-    - 'https://www.mountainhome.va.gov/locations/facilities.asp'
-    - 'https://www.northtexas.va.gov/locations/facilities.asp'
-    - 'https://www.phoenix.va.gov/locations/facilities.asp'
     - 'https://www.prescott.va.gov/locations/facilities.asp'
     - 'https://www.stlouis.va.gov/locations/facilities.asp'
-    - 'https://www.texasvalley.va.gov/locations/facilities.asp'
     - 'https://www.topeka.va.gov/locations/facilities.asp'
-    - 'https://www.wallawalla.va.gov/locations/facilities.asp'
   request_options:
     allow_redirects: false
   delimiter: "\t"

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -19,27 +19,12 @@ source:
   # Selector should not be needed for CSV but the DataParser requires it.
   item_selector: ''
   urls:
-    - https://www.amarillo.va.gov/locations/facilities.asp
-    - https://www.beckley.va.gov/locations/facilities.asp
-    - https://www.boston.va.gov/locations/facilities.asp
-    - https://www.centralwesternmass.va.gov/locations/facilities.asp
-    - https://www.columbiamo.va.gov/locations/facilities.asp
-    - https://www.columbus.va.gov/locations/facilities.asp
-    - https://www.elpaso.va.gov/locations/facilities.asp
-    - https://www.indianapolis.va.gov/locations/facilities.asp
     - https://www.leavenworth.va.gov/locations/facilities.asp
     - https://www.losangeles.va.gov/locations/facilities.asp
-    - https://www.louisville.va.gov/locations/facilities.asp
     - https://www.lovell.fhcc.va.gov/locations/facilities.asp
-    - https://www.marion.va.gov/locations/facilities.asp
-    - https://www.mountainhome.va.gov/locations/facilities.asp
-    - https://www.northtexas.va.gov/locations/facilities.asp
-    - https://www.phoenix.va.gov/locations/facilities.asp
     - https://www.prescott.va.gov/locations/facilities.asp
     - https://www.stlouis.va.gov/locations/facilities.asp
-    - https://www.texasvalley.va.gov/locations/facilities.asp
     - https://www.topeka.va.gov/locations/facilities.asp
-    - https://www.wallawalla.va.gov/locations/facilities.asp
   request_options:
     allow_redirects: false
   delimiter: "\t"


### PR DESCRIPTION
## Description

closes #7016  

## QA steps

As a github user

- [ ] Validate 15 items are removed from both the migration ymls
- [ ] Validate the items removed match the list in the issue
- [ ] Validate the yml structure near changes is ok

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`
