### PR TITLE
VAMCS-5167: Date should be required on event nodes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -355,10 +355,9 @@
                 "2893933 - claimItem in the database and memory queues does not use expire correctly": "https://www.drupal.org/files/issues/2021-01-14/2893933-40.patch",
                 "3198608 - Migrate does not set set track_lst_updated from config": "https://www.drupal.org/files/issues/2021-07-27/track-last-updated-tests-3198608-14.patch",
                 "3025164 - Make moderation_state available to field queries":"https://www.drupal.org/files/issues/2020-09-25/3025164-28.patch",
-                "3205691 - Disallow aria-required on fieldsets": "https://www.drupal.org/files/issues/2021-03-25/disallow-aria-required-fieldsets.patch",
                 "3229493 - TextareaWidget::errorElement() does not consult violation property path.": "https://www.drupal.org/files/issues/2021-08-23/test_module-3229493-2.patch",
                 "3027240 - Undefined index: #parents FormState.php": "https://www.drupal.org/files/issues/2019-01-21/form_system-undefined_index-3027240-2.patch",
-                "3213473 - Checkbox input can't have aria-required attribute": "https://www.drupal.org/files/issues/2021-11-07/3213473-39.patch",
+                "3096790 - Remove aria-required attribute": "https://www.drupal.org/files/issues/2021-09-28/drupal-remove-aria-require-3096790-7.patch",
                 "3219165 - Seven inactive vertical tabs do not meet contrast requirements": "https://www.drupal.org/files/issues/2021-06-16/3219165-3.patch"
             },
             "drupal/entity_browser": {

--- a/config/sync/field.field.node.event.field_datetime_range_timezone.yml
+++ b/config/sync/field.field.node.event.field_datetime_range_timezone.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: event
 label: 'Date and time'
 description: 'Set a start and end date.'
-required: false
+required: true
 translatable: false
 default_value:
   -

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -22,7 +22,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Event | Additional registration  information | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
 | Content type | Event | Address | field_address | Address |  | 1 | Address |  |
 | Content type | Event | Cost | field_event_cost | Text (plain) |  | 1 | Textfield with counter |  |
-| Content type | Event | Date and time | field_datetime_range_timezone | Smart date range |  | 1 | Date and time range with timezone |  |
+| Content type | Event | Date and time | field_datetime_range_timezone | Smart date range | Required | 1 | Date and time range with timezone |  |
 | Content type | Event | Where should the event be listed? | field_listing | Entity reference | Required | 1 | Select list |  |
 | Content type | Event | Facility location | field_facility_location | Entity reference |  | 1 | Select list |  |
 | Content type | Event | Full event description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |


### PR DESCRIPTION
## Description

closes #5167.

## Testing done

Visual, behat.

## Screenshots


## QA steps

As any VAMC or Outreach hub content creator, go to https://pr7028-dowvileyxc46dzwu4tpoeb1yvj4r8nnq.ci.cms.va.gov/node/add/event
- [x] validate Date field is required
  -  Note that end date is also requried, which may not be ideal (see discussion on #5167)

![image](https://user-images.githubusercontent.com/5752113/143051152-8dadb649-0729-43c9-8c47-de03ab49e702.png)

- [x] validate no  PHP errors 😬 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
