### PR TITLE
VACMS-7030: Fixes appearances of the preview button.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -894,6 +894,10 @@ function va_gov_backend_preprocess_page(&$variables) {
       'regional_health_care_service_des',
       'support_service',
       'story_listing',
+      'vet_center_cap',
+      'vet_center_facility_health_servi',
+      'vet_center_mobile_vet_center',
+      'vet_center_outstation',
     ];
     // Make sure we aren't on the node form or an excluded type.
     $route_name = \Drupal::routeMatch()->getRouteName();

--- a/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
+++ b/docroot/modules/custom/va_gov_vet_center/va_gov_vet_center.module
@@ -9,8 +9,6 @@ use Drupal\views\Views;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\node\NodeInterface;
-use Drupal\va_gov_build_trigger\Form\PreviewForm;
 
 /**
  * Implements hook_help().
@@ -197,37 +195,4 @@ function va_gov_vet_center_page_attachments(array &$attachments) {
   $attachments['#attached']['library'][] = 'va_gov_vet_center/alert_form';
   // PRevent duplicate services in select.
   $attachments['#attached']['library'][] = 'va_gov_vet_center/prevent_select_duplicates';
-}
-
-/**
- * Add preview button to node view.
- */
-function va_gov_vet_center_preprocess_page(&$variables) {
-
-  $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node instanceof NodeInterface) {
-    // It's a node.
-    $exclusion_types = [
-      'vet_center_cap',
-      'vet_center_facility_health_servi',
-      'vet_center_mobile_vet_center',
-      'vet_center_outstation',
-    ];
-    // Make sure we aren't on the node form or an excluded type.
-    $route_name = \Drupal::routeMatch()->getRouteName();
-    if (($route_name !== 'entity.node.edit_form') &&
-      (!in_array($node->bundle(), $exclusion_types))) {
-      // Make sure we aren't on /training-guide.
-      $current_uri = \Drupal::request()->getRequestUri();
-      if ($current_uri !== '/training-guide') {
-        $node = \Drupal::routeMatch()->getParameter('node');
-        $nid = $node->id();
-        $host = \Drupal::request()->getHost();
-        $preview_form = new PreviewForm();
-        $url = $preview_form->getEnvironment($host, $nid);
-        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" target="_blank" href="' . $url . '">Preview</a>';
-        $variables['page']['sidebar_second']['#markup'] = $button;
-      }
-    }
-  }
 }


### PR DESCRIPTION
## Description

Closes #7030.  The logic was split out into two separate functions.  Unfortunately, this meant that the preview button would be added to a lot of different types.

I would like to figure out a good way of preserving the original intent of the change.  Also, I would like to add tests so we catch this next time 😃 

## Testing done


## Screenshots


## QA steps
| Link | Type | Behavior |
| ---- | ----- | --------- |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/banner/covid-19-vaccines-at-va) | Banner | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services) | Benefits Detail Page | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/health-care) | Benefits Hub Landing Page | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/help/promo-banners) | Knowledge Base | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/initiatives/have-questions-before-you-get-your-covid-19-vaccine) | Campaign Landing Page | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/centralized-content/vamc-system-medical-records-page-content) | Centralized Content | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/centralized-content/vamc-system-medical-records-page-content) | Centralized Content | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/resources/test-copy-checklist-for-scheduling-a-burial-at-a-national-cemetery) | Checklist | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/saginaw-health-care/events/morning-meditation-with-mallory) | Event | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/roseburg-health-care/events) | Events List | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/resources/how-your-reason-for-withdrawing-from-a-class-affects-your-va-debt) | FAQ - Multiple Q and As | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/central-iowa-health-care/health-services) | Health Services List | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/resources) | Landing Page | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/jackson-health-care/about-us/leadership) | Leadership List | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/resources/test-copy-emblems-of-belief-for-headstones-and-markers) | Media List - Images | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/resources/testing-video-article-in-vba-rs-section) | Media List - Videos | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/nca-facilities/locations/fort-richardson-national-cemetery) | NCA Facility | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/st-cloud-health-care/news-releases/st-cloud-va-offering-expanded-eligibility-for-covid-19-vaccine-booster-doses) | News Release | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/roseburg-health-care/news-releases) | News Releases List | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/nca) | Office | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/outreach-and-events/benefits-for-people-whove-served) | Publication | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/outreach-and-events/outreach-materials) | Publication Listing Page | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/resources/will-i-have-to-pay-back-the-gi-bill-benefits-i-used-if-i-fail-a-class) | Q&A | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/martinsburg-health-care/staff-profiles/rachel-link) | Staff Profile | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/resources/how-to-file-a-travel-pay-claim-online) | Step-by-Step | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/atlanta-health-care/stories) | Stories List | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/connecticut-health-care/stories/virtual-veterans-town-hall) | Story | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/va-central-office/support-for-wwi-wwii-and-korean-war-era-programs) | Support Service | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/find-forms/about-form-21p-534ez) | VA Form | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/boston-health-care/work-with-us/internships-and-fellowships/trainee-programs) | VAMC Detail Page | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/chicago-health-care/locations/jesse-brown-department-of-veterans-affairs-medical-center) | VAMC Facility | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/hampton-health-care/locations/hampton-va-medical-center/urgent-care) | VAMC Facility Health Service | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/jackson-health-care) | VAMC System | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/va-dayton-health-care/vamc-banner-alert/2021-11-26/thanksgiving-holiday-vaccine-clinic-schedule) | VAMC System Banner Alert with Situation Updates | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/tennessee-valley-health-care/health-services/blind-and-low-vision-rehabilitation-at-va-tennessee-valley-health-care) | VAMC System Health Service | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/pittsburgh-health-care/operating-status) | VAMC System Operating Status | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/salem-health-care/policies) | VAMC System Policies Page | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/vba-facilities/locations/national-capital-region-benefits-office) | VBA Facility | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/cape-cod-vet-center) | Vet Center | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/brockton-vet-center/community-access-point/brockton-vet-center-holliston-community-access-point) | Vet Center - Community Access Point | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/cape-cod-vet-center/service/cape-cod-vet-center-veteran-connections) | Vet Center - Facility Service | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/binghamton-vet-center/locations) | Vet Center - Locations List | Should show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/south-orange-county-vet-center/south-orange-county-mobile-vet-center) | Vet Center - Mobile Vet Center | Should NOT show a banner |
| [Link](https://cms-e2yu31m89ruy2isogbs6bxi4jzh0v8mn.ci.cms.va.gov/elkton-vet-center/salisbury-outstation) | Vet Center - Outstation | Should NOT show a banner |


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
