### PR TITLE
Revert "VACMS-6918: Limit number of links added to Common Links on VAMC system content type"

### DIFF
--- a/config/sync/field.storage.node.field_related_links.yml
+++ b/config/sync/field.storage.node.field_related_links.yml
@@ -14,7 +14,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: 8
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_benefits_hubs_content_type_fields.feature
@@ -19,7 +19,7 @@ Feature: Content model: Benefits hubs Content Type fields
 | Content type | Benefits Detail Page | Page introduction | field_intro_text_limited_html | Text (formatted, long) | Required | 1 | Text area (multiple rows) |  |
 | Content type | Benefits Detail Page | Page last built | field_page_last_built | Date |  | 1 | -- Disabled -- |  |
 | Content type | Benefits Detail Page | Plain Language Certification Date | field_plainlanguage_date | Date |  | 1 | -- Disabled -- |  |
-| Content type | Benefits Detail Page | Related Links | field_related_links | Entity reference revisions |  | 8 | Paragraphs EXPERIMENTAL |  |
+| Content type | Benefits Detail Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL |  |
 | Content type | Benefits Hub Landing Page | Alert | field_alert | Entity reference |  | 1 | Entity browser | Translatable |
 | Content type | Benefits Hub Landing Page | Hub Icon | field_title_icon | List (text) |  | 1 | Select list |  |
 | Content type | Benefits Hub Landing Page | Hub label | field_home_page_hub_label | Text (plain) |  | 1 | Textfield |  |
@@ -33,7 +33,7 @@ Feature: Content model: Benefits hubs Content Type fields
 | Content type | Benefits Hub Landing Page | Page last built | field_page_last_built | Date |  | 1 | Date and time | Translatable |
 | Content type | Benefits Hub Landing Page | Plain language Certified Date | field_plainlanguage_date | Date |  | 1 | -- Disabled -- | Translatable |
 | Content type | Benefits Hub Landing Page | Promo | field_promo | Entity reference |  | 1 | Select list |  |
-| Content type | Benefits Hub Landing Page | Related Links | field_related_links | Entity reference revisions |  | 8 | Paragraphs Classic | Translatable |
+| Content type | Benefits Hub Landing Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs Classic | Translatable |
 | Content type | Benefits Hub Landing Page | Spokes | field_spokes | Entity reference revisions | Required | 4 | Paragraphs EXPERIMENTAL |  |
 | Content type | Benefits Hub Landing Page | Support Services | field_support_services | Entity reference |  | Unlimited | Inline entity form - Complex |  |
 | Content type | Benefits Hub Landing Page | Related office | field_related_office | Entity reference |  | 1 | -- Disabled -- |  |

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -16,7 +16,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Detail Page | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | VAMC Detail Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Detail Page | Page introduction | field_intro_text | Text (plain, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | VAMC Detail Page | Related Links | field_related_links | Entity reference revisions |  | 8 | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | VAMC Detail Page | Related Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | VAMC Detail Page | Related office or health care system | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Event | Building, floor, or room | field_location_humanreadable | Text (plain) |  | 1 | Textfield |  |
 | Content type | Event | Additional registration  information | field_additional_information_abo | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
@@ -146,7 +146,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility Health Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget |  |
 | Content type | VAMC System | Appointments can be scheduled and viewed online | field_appointments_online | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC System | Banner image | field_media | Entity reference | Required | 1 | Media library | Translatable |
-| Content type | VAMC System | Common Links | field_related_links | Entity reference revisions |  | 8 | Paragraphs EXPERIMENTAL | Translatable |
+| Content type | VAMC System | Common Links | field_related_links | Entity reference revisions |  | 1 | Paragraphs EXPERIMENTAL | Translatable |
 | Content type | VAMC System | Facebook | field_facebook | Link |  | 1 | Linkit | Translatable |
 | Content type | VAMC System | Flickr | field_flickr | Link |  | 1 | Linkit | Translatable |
 | Content type | VAMC System | GovDelivery ID for Emergency updates email | field_govdelivery_id_emerg | Text (plain) | Required | 1 | Textfield |  |


### PR DESCRIPTION
Reverts department-of-veterans-affairs/va.gov-cms#7036

The original is causing a change in structure to the graphQL results.  