### PR TITLE
VACMS-7113: Forbids PHPUnit to reuse connections.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -465,6 +465,9 @@
             },
             "traviscarden/behat-table-comparison": {
                 "Throw meaningful message for duplicate entry. See https://github.com/TravisCarden/behat-table-comparison/pull/7": "patches/duplicate-row-message.patch"
+            },
+            "weitzman/drupal-test-traits": {
+                "Forbid connection reuse in PHPUnit tests": "patches/weitzman-drupal-test-traits-forbid-connection-reuse.patch"
             }
         }
     },

--- a/patches/weitzman-drupal-test-traits-forbid-connection-reuse.patch
+++ b/patches/weitzman-drupal-test-traits-forbid-connection-reuse.patch
@@ -1,0 +1,19 @@
+diff --git a/src/GoutteTrait.php b/src/GoutteTrait.php
+index be28dd9..64c9e14 100644
+--- a/src/GoutteTrait.php
++++ b/src/GoutteTrait.php
+@@ -70,7 +70,13 @@ trait GoutteTrait
+             // Turn off curl timeout. Having a timeout is not a problem in a normal
+             // test running, but it is a problem when debugging. Also, disable SSL
+             // peer verification so that testing under HTTPS always works.
+-            $client = new Client(['timeout' => null, 'verify' => false]);
++            $client = new Client([
++              'timeout' => null,
++              'verify' => false,
++              'headers' => ['Connection' => 'close'],
++              CURLOPT_FORBID_REUSE => true,
++              CURLOPT_FRESH_CONNECT => true,
++            ]);
+             $handler_stack = $client->getConfig('handler');
+             $handler_stack->push($this->getResponseLogHandler());
+             $driver->getClient()->setClient($client);


### PR DESCRIPTION
## Description

Relates to #7023.  Closes #7113.  This patches the `weitzman/drupal-test-traits` package to forbid it from reusing connections, in the hopes that this might keep it from basically sorta SlowLoris'ing our own machines during PHPUnit tests.

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
