### PR TITLE
VACMS-7171: Disallow non admins vast data editing ability.

### DIFF
--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -174,6 +174,8 @@ function _vagov_consumers_modify_vet_center_fields(array &$form, $form_id, FormS
   $external_content_form_ids = [
     'node_health_care_local_facility_form',
     'node_health_care_local_facility_edit_form',
+    'node_vet_center_form',
+    'node_vet_center_edit_form',
     'node_vet_center_mobile_vet_center_form',
     'node_vet_center_mobile_vet_center_edit_form',
     'node_vet_center_outstation_form',


### PR DESCRIPTION
## Description
Relates to #7171

## Testing done
Visual

## Screenshots
As witt.cook:
![image](https://user-images.githubusercontent.com/2404547/144879343-93c95b32-8d4f-49a8-9708-6b95b79899c4.png)

As admin:
![image](https://user-images.githubusercontent.com/2404547/144879369-c3f39d99-4983-4efe-a922-a9dfaf54bc75.png)


## QA steps
 - [x] As witt.cook@va.gov Edit your vet center
 - [x] You'll see you can not edit the VAST data
 - [x] As admin go to `node/3877/edit` and visually verify you can edit VAST data