### PR TITLE
VACMS-7163: Fix Lovell Federal health care breadcrumb

### DIFF
--- a/config/sync/menu_breadcrumb.settings.yml
+++ b/config/sync/menu_breadcrumb.settings.yml
@@ -154,7 +154,7 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-lovell-fhcc-health-care:
+  va-lovell-federal-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -339,9 +339,9 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-wallawalla-health-care:
-    enabled: 1
+  va-walla-walla-health-care:
     weight: 0
+    enabled: 0
     taxattach: 0
     langhandle: 0
   pension-benefits-hub:


### PR DESCRIPTION
- Enabled the "VA Lovell Federal health care" menu in menu-breadcrumb.

## Description

closes #7163 

## Testing done


## Screenshots
![enabled-lovell-federal-health-care-menu-in-menu-breadcrumb](https://user-images.githubusercontent.com/846871/145085087-5fba5469-35fd-4695-af68-c5a296bbe6de.png)
![lovell-federal-health-care-page](https://user-images.githubusercontent.com/846871/145085114-da90de3e-7a1a-43eb-8621-f2f117205822.png)

## QA steps

As user administrator
1. [x] Go to `/admin/config/user-interface/menu-breadcrumb` and verify and confirm that the **VA Lovell Federal health care** menu is enabled.
1. [x] Then as an anonymous user go to `/lovell-federal-health-care` and verify and confirm that the breadcrumb, page title and left column menu item title all matches and read **Lovell Federal health care**.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
