### PR TITLE
VACMS-7217: Fix duplicate help text below textarea fields.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,7 @@
         "drupal/taxonomy_entity_index": "^1.1",
         "drupal/taxonomy_menu": "3.x-dev#e89d1e8",
         "drupal/textfield_counter": "^2.0",
+        "drupal/themable_forms": "^1.0@beta",
         "drupal/toolbar_menu": "^2.1",
         "drupal/user_history": "^1.0@alpha",
         "drupal/video_embed_media": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef57d436f973df829eeb9e004246f710",
+    "content-hash": "a577f88bbefc1bea0d4f815922396745",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -10183,6 +10183,58 @@
             "homepage": "https://www.drupal.org/project/textfield_counter",
             "support": {
                 "source": "https://git.drupalcode.org/project/textfield_counter"
+            }
+        },
+        {
+            "name": "drupal/themable_forms",
+            "version": "1.0.0-beta2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/themable_forms.git",
+                "reference": "8.x-1.0-beta2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/themable_forms-8.x-1.0-beta2.zip",
+                "reference": "8.x-1.0-beta2",
+                "shasum": "5834a7615682f62a2bc9eb9c46dfbc55833aaac0"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "drupal/coder": "^8.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-beta2",
+                    "datestamp": "1612276954",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Ruuds",
+                    "homepage": "https://www.drupal.org/user/3074673"
+                },
+                {
+                    "name": "lauriii",
+                    "homepage": "https://www.drupal.org/user/1078742"
+                }
+            ],
+            "description": "This module adds some helpful theme suggestions for form elements.",
+            "homepage": "https://www.drupal.org/project/themable_forms",
+            "support": {
+                "source": "https://git.drupalcode.org/project/themable_forms"
             }
         },
         {
@@ -24742,6 +24794,7 @@
         "drupal/schemata": 10,
         "drupal/styleguide": 10,
         "drupal/taxonomy_menu": 20,
+        "drupal/themable_forms": 10,
         "drupal/user_history": 15,
         "drupal/views_data_export": 10,
         "drupal/workflow_assignments": 20,

--- a/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - workflows.workflow.editorial
   module:
     - allow_only_one
+    - allowed_formats
     - content_moderation
     - field_group
     - text
@@ -62,7 +63,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
   field_enforce_unique_combo:

--- a/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_facility_health_servi.inline_entity_form.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.vet_center_facility_health_servi.field_service_name_and_descripti
     - node.type.vet_center_facility_health_servi
   module:
+    - allowed_formats
     - field_group
     - text
 third_party_settings:
@@ -58,7 +59,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
   field_office:

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -165,6 +165,7 @@ module:
   telephone: 0
   text: 0
   textfield_counter: 0
+  themable_forms: 0
   token: 0
   toolbar: 0
   toolbar_menu: 0

--- a/docroot/themes/custom/vagovadmin/templates/form/form-element--type--textarea.html.twig
+++ b/docroot/themes/custom/vagovadmin/templates/form/form-element--type--textarea.html.twig
@@ -1,0 +1,85 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - errors: (optional) Any errors for this form element, may not be set.
+ * - prefix: (optional) The form element prefix, may not be set.
+ * - suffix: (optional) The form element suffix, may not be set.
+ * - required: The required marker, or empty if the associated form element is
+ *   not required.
+ * - type: The type of the element.
+ * - name: The name of the element.
+ * - label: A rendered label element.
+ * - label_display: Label display setting. It can have these values:
+ *   - before: The label is output before the element. This is the default.
+ *     The label includes the #title and the required marker, if #required.
+ *   - after: The label is output after the element. For example, this is used
+ *     for radio and checkbox #type elements. If the #title is empty but the
+ *     field is #required, the label will contain only the required marker.
+ *   - invisible: Labels are critical for screen readers to enable them to
+ *     properly navigate through forms but can be visually distracting. This
+ *     property hides the label for everyone except screen readers.
+ *   - attribute: Set the title attribute on the element to create a tooltip but
+ *     output no label element. This is supported only for checkboxes and radios
+ *     in \Drupal\Core\Render\Element\CompositeFormElementTrait::preRenderCompositeFormElement().
+ *     It is used where a visual label is not needed, such as a table of
+ *     checkboxes where the row and column provide the context. The tooltip will
+ *     include the title and required marker.
+ * - description: (optional) A list of description properties containing:
+ *    - content: A description of the form element, may not be set.
+ *    - attributes: (optional) A list of HTML attributes to apply to the
+ *      description content wrapper. Will only be set when description is set.
+ * - description_display: Description display setting. It can have these values:
+ *   - before: The description is output before the element.
+ *   - after: The description is output after the element. This is the default
+ *     value.
+ *   - invisible: The description is output after the element, hidden visually
+ *     but available to screen readers.
+ * - disabled: True if the element is disabled.
+ * - title_display: Title display setting.
+ *
+ * @see template_preprocess_form_element()
+ */
+#}
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+    'js-form-type-' ~ type|clean_class,
+    'form-type-' ~ type|clean_class,
+    'js-form-item-' ~ name|clean_class,
+    'form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'form-disabled',
+    errors ? 'form-item--error',
+  ]
+%}
+{%
+  set description_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+<div{{attributes.addClass(classes)}}>
+	{% if label_display in ['before', 'invisible'] %}
+		{{ label }}
+	{% endif %}
+	{% if prefix is not empty %}
+		<span class="field-prefix">{{ prefix }}</span>
+	{% endif %}
+	{{ children }}
+	{% if suffix is not empty %}
+		<span class="field-suffix">{{ suffix }}</span>
+	{% endif %}
+	{% if label_display == 'after' %}
+		{{ label }}
+	{% endif %}
+	{% if errors %}
+		<div class="form-item--error-message">
+			<strong>{{ errors }}</strong>
+		</div>
+	{% endif %}
+</div>


### PR DESCRIPTION
## Description
See #7217

## Testing done
Visual / behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/145248915-095657cb-529d-4571-ae92-f72fab77c49f.png)

## QA steps
 - [ ] As an administrator, go to `/node/3597/edit` and open up multiple existing services via the edit button.
 - [ ] Visually verify help text appears below title, and is not duplicated.