### PR TITLE
VACMS-7246 Remove Los Angeles status endpoint.

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/config/sync/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -19,7 +19,6 @@ source:
   item_selector: ''
   urls:
     - 'https://www.leavenworth.va.gov/locations/facilities.asp'
-    - 'https://www.losangeles.va.gov/locations/facilities.asp'
     - 'https://www.lovell.fhcc.va.gov/locations/facilities.asp'
     - 'https://www.prescott.va.gov/locations/facilities.asp'
     - 'https://www.stlouis.va.gov/locations/facilities.asp'

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility_status.yml
@@ -20,7 +20,6 @@ source:
   item_selector: ''
   urls:
     - https://www.leavenworth.va.gov/locations/facilities.asp
-    - https://www.losangeles.va.gov/locations/facilities.asp
     - https://www.lovell.fhcc.va.gov/locations/facilities.asp
     - https://www.prescott.va.gov/locations/facilities.asp
     - https://www.stlouis.va.gov/locations/facilities.asp


### PR DESCRIPTION
## Description

Relates to #7246


## QA Steps
- [ ]  Validate the removal of Los Angeles from the two ymls
- [ ] Validate CMS build ran without config import error (tests pass) 
 

