### PR TITLE
VACMS-6874: prepopulate entity reference fields on nonclinical service form when context is known

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "drupal/entity_reference_validators": "^1.0@alpha",
         "drupal/entityqueue": "^1.0@beta",
         "drupal/environment_indicator": "^4.0",
+        "drupal/epp": "^1.1",
         "drupal/fast_404": "2.x-dev#5382a99335ee466f8261dc1774a3d56f1699da81",
         "drupal/feature_toggle": "1.0",
         "drupal/field_group": "^3.1",
@@ -462,7 +463,7 @@
                 "Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch"
             },
             "drupal/viewfield": {
-              "Add option to display default view on node edit when always use default value selected": "https://www.drupal.org/files/issues/2021-12-09/viewfield-option-display-default-view-on-node-edit-3252356-2.patch"
+              "Add option to display default view on node edit when always use default value selected": "https://www.drupal.org/files/issues/2021-12-15/viewfield-option-display-default-view-on-node-edit-3252356-4.patch"
             },
             "drupal/workbench_access": {
                 "3118596 - Cache isn't invalidated after user is removed from section/added to section.": "https://www.drupal.org/files/issues/2020-06-30/3118596_workbench_access-user-cache-18.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48534d500b3011482411b9118f054785",
+    "content-hash": "4e05911adea5f71f0853c0491a511b45",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -911,7 +911,7 @@
             "version": "v4.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fengyuanchen/cropper.git",
+                "url": "git@github.com:fengyuanchen/cropper.git",
                 "reference": "617d9bdb8688cc4edb3b03bc49a04b83c7facbe7"
             },
             "dist": {
@@ -5629,6 +5629,58 @@
             }
         },
         {
+            "name": "drupal/epp",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/epp.git",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/epp-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "d52e973eb61182b56929aa62a9dc673e0acfd9e4"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1622317397",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "anruether",
+                    "homepage": "https://www.drupal.org/user/894458"
+                },
+                {
+                    "name": "geek-merlin",
+                    "homepage": "https://www.drupal.org/user/229048"
+                },
+                {
+                    "name": "heliogabal",
+                    "homepage": "https://www.drupal.org/user/998658"
+                }
+            ],
+            "description": "Prepopulate entity values via tokens.",
+            "homepage": "https://www.drupal.org/project/epp",
+            "support": {
+                "source": "https://git.drupalcode.org/project/epp"
+            }
+        },
+        {
             "name": "drupal/externalauth",
             "version": "1.3.0",
             "source": {
@@ -6684,6 +6736,10 @@
                     "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
+                    "name": "ram4nd",
+                    "homepage": "https://www.drupal.org/user/601534"
+                },
+                {
                     "name": "rszrama",
                     "homepage": "https://www.drupal.org/user/49344"
                 },
@@ -6958,7 +7014,7 @@
             "extra": {
                 "drupal": {
                     "version": "6.0.0-beta3",
-                    "datestamp": "1632933683",
+                    "datestamp": "1632946984",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -7639,6 +7695,10 @@
                     "name": "Lucas Hedding",
                     "homepage": "https://www.drupal.org/u/heddn",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "mikeryan",
+                    "homepage": "https://www.drupal.org/user/4420"
                 }
             ],
             "description": "Enhancements to core migration support.",
@@ -7766,7 +7826,7 @@
                 "reference": "7ae3747d1e30790d11c2eefcc56e0796bea25c76"
             },
             "require": {
-                "drupal/core": "^8.8 | ^9",
+                "drupal/core": "^9.1",
                 "drupal/migrate_plus": "^5",
                 "php": ">=7.1"
             },
@@ -7783,8 +7843,8 @@
                     "dev-5.x": "5.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-5.0+13-dev",
-                    "datestamp": "1618603463",
+                    "version": "8.x-5.0+20-dev",
+                    "datestamp": "1637259316",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -8541,6 +8601,10 @@
                     "homepage": "https://www.drupal.org/user/1557710"
                 },
                 {
+                    "name": "paulocs",
+                    "homepage": "https://www.drupal.org/user/3640109"
+                },
+                {
                     "name": "shrop",
                     "homepage": "https://www.drupal.org/user/14767"
                 }
@@ -8969,7 +9033,7 @@
             "extra": {
                 "drupal": {
                     "version": "3.2.9",
-                    "datestamp": "1637015812",
+                    "datestamp": "1637015893",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -23131,6 +23195,7 @@
                 "issues": "https://github.com/webmozart/path-util/issues",
                 "source": "https://github.com/webmozart/path-util/tree/2.3.0"
             },
+            "abandoned": "symfony/filesystem",
             "time": "2015-12-17T08:42:14+00:00"
         },
         {
@@ -24808,5 +24873,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
@@ -112,8 +112,8 @@ content:
     label: hidden
     settings:
       view_title: above
-      empty_view_title: hidden
-      always_build_output: false
+      always_build_output: true
+      empty_view_title: above
     third_party_settings: {  }
     type: viewfield_default
     region: content

--- a/config/sync/core.entity_view_display.node.vamc_system_medical_records_offi.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_medical_records_offi.default.yml
@@ -134,8 +134,8 @@ content:
     label: hidden
     settings:
       view_title: above
-      empty_view_title: hidden
-      always_build_output: false
+      always_build_output: true
+      empty_view_title: above
     third_party_settings: {  }
     type: viewfield_default
     region: content

--- a/config/sync/core.entity_view_display.node.vamc_system_register_for_care.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_register_for_care.default.yml
@@ -69,22 +69,14 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_non_clinical_services:
-    weight: 3
+    weight: 2
     label: hidden
     settings:
       view_title: above
-      empty_view_title: hidden
-      always_build_output: false
+      always_build_output: true
+      empty_view_title: above
     third_party_settings: {  }
     type: viewfield_default
-    region: content
-  field_service_name_and_descripti:
-    weight: 2
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
     region: content
   links:
     weight: 0
@@ -97,4 +89,5 @@ hidden:
   field_enforce_unique_combo: true
   field_enforce_unique_combo_offic: true
   field_office: true
+  field_service_name_and_descripti: true
   search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -58,6 +58,7 @@ module:
   entityqueue: 0
   environment_indicator: 0
   environment_indicator_ui: 0
+  epp: 0
   externalauth: 0
   feature_toggle: 0
   field: 0

--- a/config/sync/field.field.node.vamc_system_billing_insurance.field_non_clinical_services.yml
+++ b/config/sync/field.field.node.vamc_system_billing_insurance.field_non_clinical_services.yml
@@ -7,7 +7,12 @@ dependencies:
     - node.type.vamc_system_billing_insurance
     - views.view.non_clinical_services
   module:
+    - epp
     - viewfield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
 id: node.vamc_system_billing_insurance.field_non_clinical_services
 field_name: field_non_clinical_services
 entity_type: node
@@ -20,7 +25,7 @@ default_value:
   -
     token_help: ''
     display_id: billing_and_insurance
-    arguments: '[node:field_office:target_id]'
+    arguments: '[node:field_office:target_id]/[node:field_administration:target_id]'
     items_to_display: ''
     target_uuid: a9e07b4c-6178-43d4-a7e3-57d67e85dbd6
 default_value_callback: ''

--- a/config/sync/field.field.node.vamc_system_medical_records_offi.field_non_clinical_services.yml
+++ b/config/sync/field.field.node.vamc_system_medical_records_offi.field_non_clinical_services.yml
@@ -7,7 +7,12 @@ dependencies:
     - node.type.vamc_system_medical_records_offi
     - views.view.non_clinical_services
   module:
+    - epp
     - viewfield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
 id: node.vamc_system_medical_records_offi.field_non_clinical_services
 field_name: field_non_clinical_services
 entity_type: node
@@ -20,7 +25,7 @@ default_value:
   -
     token_help: ''
     display_id: medical_records_offices
-    arguments: '[node:field_office:target_id]'
+    arguments: '[node:field_office:target_id]/[node:field_administration:target_id]'
     items_to_display: ''
     target_uuid: a9e07b4c-6178-43d4-a7e3-57d67e85dbd6
 default_value_callback: ''

--- a/config/sync/field.field.node.vamc_system_register_for_care.field_non_clinical_services.yml
+++ b/config/sync/field.field.node.vamc_system_register_for_care.field_non_clinical_services.yml
@@ -7,7 +7,12 @@ dependencies:
     - node.type.vamc_system_register_for_care
     - views.view.non_clinical_services
   module:
+    - epp
     - viewfield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
 id: node.vamc_system_register_for_care.field_non_clinical_services
 field_name: field_non_clinical_services
 entity_type: node
@@ -20,7 +25,7 @@ default_value:
   -
     token_help: ''
     display_id: admissions_offices
-    arguments: '[node:field_office:target_id]'
+    arguments: '[node:field_office:target_id]/[node:field_administration:target_id]'
     items_to_display: ''
     target_uuid: a9e07b4c-6178-43d4-a7e3-57d67e85dbd6
 default_value_callback: ''

--- a/config/sync/field.field.node.vha_facility_nonclinical_service.field_administration.yml
+++ b/config/sync/field.field.node.vha_facility_nonclinical_service.field_administration.yml
@@ -8,11 +8,15 @@ dependencies:
     - taxonomy.vocabulary.administration
   module:
     - entity_reference_validators
+    - epp
 third_party_settings:
   entity_reference_validators:
     circular_reference: false
     circular_reference_deep: false
     duplicate_reference: false
+  epp:
+    value: '[current-page:query:field_administration]'
+    on_update: 0
 id: node.vha_facility_nonclinical_service.field_administration
 field_name: field_administration
 entity_type: node

--- a/config/sync/field.field.node.vha_facility_nonclinical_service.field_service_name_and_descripti.yml
+++ b/config/sync/field.field.node.vha_facility_nonclinical_service.field_service_name_and_descripti.yml
@@ -7,18 +7,22 @@ dependencies:
     - node.type.vha_facility_nonclinical_service
   module:
     - entity_reference_validators
+    - epp
 third_party_settings:
   entity_reference_validators:
     circular_reference: false
     circular_reference_deep: false
     duplicate_reference: false
+  epp:
+    value: '[current-page:query:field_service_name_and_descripti]'
+    on_update: 0
 id: node.vha_facility_nonclinical_service.field_service_name_and_descripti
 field_name: field_service_name_and_descripti
 entity_type: node
 bundle: vha_facility_nonclinical_service
 label: Service
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -37,6 +37,7 @@ user_agent: 'VA.gov CMS link checker'
 path_patterns_to_skip: |-
   /admin/*
   /block/*
+  /node/add/*
   /node/*/edit
   /section/*
   /user/*

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -70,12 +70,35 @@ display:
           description: ''
           columns:
             title: title
-            changed: changed
-            edit_node: edit_node
+            title_1: title_1
             moderation_state: moderation_state
+            edit_node: edit_node
+            changed: changed
+            field_administration: field_administration
           info:
             title:
               sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title_1:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            moderation_state:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            edit_node:
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
@@ -88,15 +111,8 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-            edit_node:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            moderation_state:
-              sortable: true
+            field_administration:
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -455,7 +455,7 @@ display:
           empty: true
           tokenize: false
           content:
-            value: 'You have not yet added a facility service yet. '
+            value: 'You have not added a facility service yet. '
             format: rich_text
           plugin_id: text
       relationships:

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_administration
     - node.type.vha_facility_nonclinical_service
     - taxonomy.vocabulary.health_care_service_taxonomy
   content:
@@ -546,7 +545,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1025&field_administration={{ field_administration }}" target="_blank">Add an admissions office</a> (opens in a new window).</p>'
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1025&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add an admissions office</a> (opens in a new window).</p>'
             format: rich_text
           plugin_id: text
       defaults:
@@ -593,6 +592,41 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: node_nid
+        field_administration_target_id:
+          id: field_administration_target_id
+          table: node__field_administration
+          field: field_administration_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
       fields:
         title:
           id: title
@@ -905,68 +939,6 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
-        field_administration:
-          id: field_administration
-          table: node__field_administration
-          field: field_administration
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Section
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_entity_id
-          settings: {  }
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
     cache_metadata:
       max-age: -1
       contexts:
@@ -976,8 +948,7 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-      tags:
-        - 'config:field.storage.node.field_administration'
+      tags: {  }
   billing_and_insurance:
     display_plugin: block
     id: billing_and_insurance
@@ -997,7 +968,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1027&field_administration={{ field_administration }}" target="_blank">Add a billing and insurance office</a> (opens in a new window).</p>'
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1027&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add a billing and insurance office</a> (opens in a new window).</p>'
             format: rich_text
           plugin_id: text
       defaults:
@@ -1109,6 +1080,41 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: node_nid
+        field_administration_target_id:
+          id: field_administration_target_id
+          table: node__field_administration
+          field: field_administration_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
       fields:
         title:
           id: title
@@ -1421,68 +1427,6 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
-        field_administration:
-          id: field_administration
-          table: node__field_administration
-          field: field_administration
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Section
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_entity_id
-          settings: {  }
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
     cache_metadata:
       max-age: -1
       contexts:
@@ -1492,8 +1436,7 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-      tags:
-        - 'config:field.storage.node.field_administration'
+      tags: {  }
   medical_records_offices:
     display_plugin: block
     id: medical_records_offices
@@ -1513,7 +1456,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1026&field_administration={{ field_administration }}" target="_blank">Add a medical records office</a> (opens in a new window).</p>'
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1026&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add a medical records office</a> (opens in a new window).</p>'
             format: rich_text
           plugin_id: text
       defaults:
@@ -1624,6 +1567,41 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: node_nid
+        field_administration_target_id:
+          id: field_administration_target_id
+          table: node__field_administration
+          field: field_administration_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
       fields:
         title:
           id: title
@@ -1936,68 +1914,6 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
-        field_administration:
-          id: field_administration
-          table: node__field_administration
-          field: field_administration
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Section
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_entity_id
-          settings: {  }
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
       title: 'Medical records offices'
     cache_metadata:
       max-age: -1
@@ -2008,5 +1924,4 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-      tags:
-        - 'config:field.storage.node.field_administration'
+      tags: {  }

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -514,7 +514,7 @@ display:
   admissions_offices:
     display_plugin: block
     id: admissions_offices
-    display_title: 'Admissions Offices'
+    display_title: 'Admissions offices'
     position: 2
     display_options:
       display_extenders: {  }
@@ -538,7 +538,7 @@ display:
         title: false
         arguments: false
         fields: false
-      title: 'Admissions Offices'
+      title: 'Admissions offices'
       arguments:
         nid:
           id: nid
@@ -965,7 +965,7 @@ display:
   billing_and_insurance:
     display_plugin: block
     id: billing_and_insurance
-    display_title: 'Billing and Insurance Offices'
+    display_title: 'Billing and insurance offices'
     position: 3
     display_options:
       display_extenders: {  }
@@ -1054,7 +1054,7 @@ display:
         operator: AND
         groups:
           1: AND
-      title: 'Billing and Insurance Offices'
+      title: 'Billing and insurance offices'
       arguments:
         nid:
           id: nid
@@ -1481,7 +1481,7 @@ display:
   medical_records_offices:
     display_plugin: block
     id: medical_records_offices
-    display_title: 'Medical Records Offices'
+    display_title: 'Medical records offices'
     position: 1
     display_options:
       display_extenders: {  }
@@ -1982,7 +1982,7 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-      title: 'Medical Records Offices'
+      title: 'Medical records offices'
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -547,7 +547,7 @@ display:
           relationship: field_region_page
           group_type: group
           admin_label: ''
-          default_action: default
+          default_action: empty
           exception:
             value: all
             title_enable: false
@@ -1063,7 +1063,7 @@ display:
           relationship: field_region_page
           group_type: group
           admin_label: ''
-          default_action: default
+          default_action: empty
           exception:
             value: all
             title_enable: false
@@ -1578,7 +1578,7 @@ display:
           relationship: field_region_page
           group_type: group
           admin_label: ''
-          default_action: default
+          default_action: empty
           exception:
             value: all
             title_enable: false

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_administration
     - node.type.vha_facility_nonclinical_service
     - taxonomy.vocabulary.health_care_service_taxonomy
   content:
@@ -513,7 +514,7 @@ display:
   admissions_offices:
     display_plugin: block
     id: admissions_offices
-    display_title: 'Admissions offices'
+    display_title: 'Admissions Offices'
     position: 2
     display_options:
       display_extenders: {  }
@@ -527,9 +528,9 @@ display:
           group_type: group
           admin_label: ''
           empty: true
-          tokenize: false
+          tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?edit[field_office][widget][0][target_id]=123&edit[field_service_name_and_descripti][widget][0][target_id]=1025">Add an admissions office</a> (opens in a new window).</p>'
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1025&field_administration={{ field_administration }}" target="_blank">Add an admissions office</a> (opens in a new window).</p>'
             format: rich_text
           plugin_id: text
       defaults:
@@ -537,7 +538,7 @@ display:
         title: false
         arguments: false
         fields: false
-      title: 'Admissions offices'
+      title: 'Admissions Offices'
       arguments:
         nid:
           id: nid
@@ -888,6 +889,68 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
+        field_administration:
+          id: field_administration
+          table: node__field_administration
+          field: field_administration
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Section
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
     cache_metadata:
       max-age: -1
       contexts:
@@ -897,11 +960,12 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_administration'
   billing_and_insurance:
     display_plugin: block
     id: billing_and_insurance
-    display_title: 'Billing and insurance offices'
+    display_title: 'Billing and Insurance Offices'
     position: 3
     display_options:
       display_extenders: {  }
@@ -915,9 +979,9 @@ display:
           group_type: group
           admin_label: ''
           empty: true
-          tokenize: false
+          tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?edit[field_office][widget][0][target_id]=123&edit[field_service_name_and_descripti][widget][0][target_id]=1027" target="_blank">Add a billing and insurance office</a> (opens in a new window).</p>'
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1027&field_administration={{ field_administration }}" target="_blank">Add a billing and insurance office</a> (opens in a new window).</p>'
             format: rich_text
           plugin_id: text
       defaults:
@@ -990,7 +1054,7 @@ display:
         operator: AND
         groups:
           1: AND
-      title: 'Billing and insurance offices'
+      title: 'Billing and Insurance Offices'
       arguments:
         nid:
           id: nid
@@ -1341,6 +1405,68 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
+        field_administration:
+          id: field_administration
+          table: node__field_administration
+          field: field_administration
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Section
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
     cache_metadata:
       max-age: -1
       contexts:
@@ -1350,11 +1476,12 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_administration'
   medical_records_offices:
     display_plugin: block
     id: medical_records_offices
-    display_title: 'Medical records offices'
+    display_title: 'Medical Records Offices'
     position: 1
     display_options:
       display_extenders: {  }
@@ -1368,9 +1495,9 @@ display:
           group_type: group
           admin_label: ''
           empty: true
-          tokenize: false
+          tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?edit[field_office][widget][0][target_id]=123&edit[field_service_name_and_descripti][widget][0][target_id]=1026">Add a medical records office</a> (opens in a new window).</p>'
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1026&field_administration={{ field_administration }}" target="_blank">Add a medical records office</a> (opens in a new window).</p>'
             format: rich_text
           plugin_id: text
       defaults:
@@ -1379,6 +1506,7 @@ display:
         filter_groups: false
         arguments: false
         fields: false
+        title: false
       filters:
         type:
           id: type
@@ -1792,6 +1920,69 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
+        field_administration:
+          id: field_administration
+          table: node__field_administration
+          field: field_administration
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Section
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      title: 'Medical Records Offices'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1801,4 +1992,5 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_administration'


### PR DESCRIPTION
## Description

Closes #6874 

## Testing done

Visual Testing

## Screenshots
In the following examples all content is part of the VA Alaska health care section:

From the edit view of a given VAMC System Billing and Insurance node:
<img width="1017" alt="Screen Shot 2021-12-15 at 9 37 33 AM" src="https://user-images.githubusercontent.com/21045418/146207147-dd719071-5ad3-4915-a972-b8abbb187e1f.png">

After clicking the **Add a billing and insurance office** link in the image above:
<img width="1774" alt="Screen Shot 2021-12-15 at 9 38 28 AM" src="https://user-images.githubusercontent.com/21045418/146207361-fb1e63fa-1161-4b4b-b858-8c96320c12fa.png">

From the edit view of a given VAMC System Medical Records Office node:
<img width="1027" alt="Screen Shot 2021-12-15 at 9 38 37 AM" src="https://user-images.githubusercontent.com/21045418/146207910-0592e52d-561e-45a0-928b-cdabf7742fb6.png">

After clicking the **Add a medical records office** link in the image above:
<img width="1772" alt="Screen Shot 2021-12-15 at 9 38 56 AM" src="https://user-images.githubusercontent.com/21045418/146207945-3c280a74-c8db-4262-8eb8-a715c0c9ed76.png">

From the edit view of a given VAMC System Register for Care node:
<img width="1024" alt="Screen Shot 2021-12-15 at 9 39 08 AM" src="https://user-images.githubusercontent.com/21045418/146207998-656b5d20-574e-420d-b91b-821acd9533b2.png">

After clicking the **Add an admissions office** link in the image above:
<img width="1775" alt="Screen Shot 2021-12-15 at 9 39 27 AM" src="https://user-images.githubusercontent.com/21045418/146208028-0d780d15-86c5-441e-ac2d-69abbac7f83d.png">

## QA steps

As an admin user
Billing and Insurance
- [x] Create a VAMC System Billing and Insurance node https://pr7292-e6gssk9rqwby2ud2suwiqdqqfcfppzow.ci.cms.va.gov/node/add/vamc_system_billing_insurance - save the new node
- [x] Edit the node above, scroll to the bottom of the edit page - you should see a link to **Add a billing and insurance office** Click this link and a new tab should open up. Switch to this new tab.
- [x] In this new tab the service field should say Billing and Insurance and the section should match the section for the VAMC System Billing and Insurance node above

Medical Records Office
- [x] Create a VAMC System Medical Records Office node - save the new node
- [x] Edit the node above, scroll to the bottom of the edit page - you should see a link to **Add a medical records office** Click this link and a new tab should open up. Switch to this new tab.
- [x] In this new tab the service field should say Medical Records and the section should match the section for the VAMC System Medical Records Office node above

Register for Care
- [x] Create a VAMC System Register for Care node - save the new node
- [x] Edit the node above, scroll to the bottom of the edit page - you should see a link to **Add an admissions office** Click this link and a new tab should open up. Switch to this new tab.
- [x] A new tab should open up. In this new tab the service field should say Register for Care and the section should match the section for the VAMC System Register for Care node above

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`