### PR TITLE
VACMS-7340 Make toptask deduper fire on node publish.

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
@@ -14,6 +14,31 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * VA.gov VAMC Entity Event Subscriber.
  */
 class EntityEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      // React on Op status forms.
+      'hook_event_dispatcher.form_node_vamc_operating_status_and_alerts_form.alter' => 'alterOpStatusNodeForm',
+      'hook_event_dispatcher.form_node_vamc_operating_status_and_alerts_edit_form.alter' => 'alterOpStatusNodeForm',
+      HookEventDispatcherInterface::ENTITY_PRE_SAVE => 'entityPresave',
+      'hook_event_dispatcher.form_node_full_width_banner_alert_form.alter' => 'alterFullWidthBannerNodeForm',
+      'hook_event_dispatcher.form_node_full_width_banner_alert_edit_form.alter' => 'alterFullWidthBannerNodeForm',
+      'hook_event_dispatcher.form_node_regional_health_care_service_des_form.alter' => 'alterRegionalHealthCareServiceDesNodeForm',
+      'hook_event_dispatcher.form_node_regional_health_care_service_des_edit_form.alter' => 'alterRegionalHealthCareServiceDesNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_register_for_care_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_register_for_care_edit_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_medical_records_offi_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_medical_records_offi_edit_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_billing_insurance_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_billing_insurance_edit_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_policies_page_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_vamc_system_policies_page_edit_form.alter' => 'alterTopTaskNodeForm',
+    ];
+  }
+
   /**
    * The content hardening deduper.
    *
@@ -126,30 +151,6 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       }
     }
     $form['#attached']['library'][] = 'va_gov_vamc/limit_vamcs_to_workbench';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getSubscribedEvents(): array {
-    return [
-      // React on Op status forms.
-      'hook_event_dispatcher.form_node_vamc_operating_status_and_alerts_form.alter' => 'alterOpStatusNodeForm',
-      'hook_event_dispatcher.form_node_vamc_operating_status_and_alerts_edit_form.alter' => 'alterOpStatusNodeForm',
-      HookEventDispatcherInterface::ENTITY_PRE_SAVE => 'entityPresave',
-      'hook_event_dispatcher.form_node_full_width_banner_alert_form.alter' => 'alterFullWidthBannerNodeForm',
-      'hook_event_dispatcher.form_node_full_width_banner_alert_edit_form.alter' => 'alterFullWidthBannerNodeForm',
-      'hook_event_dispatcher.form_node_regional_health_care_service_des_form.alter' => 'alterRegionalHealthCareServiceDesNodeForm',
-      'hook_event_dispatcher.form_node_regional_health_care_service_des_edit_form.alter' => 'alterRegionalHealthCareServiceDesNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_register_for_care_form.alter' => 'alterTopTaskNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_register_for_care_edit_form.alter' => 'alterTopTaskNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_medical_records_offi_form.alter' => 'alterTopTaskNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_medical_records_offi_edit_form.alter' => 'alterTopTaskNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_billing_insurance_form.alter' => 'alterTopTaskNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_billing_insurance_edit_form.alter' => 'alterTopTaskNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_policies_page_form.alter' => 'alterTopTaskNodeForm',
-      'hook_event_dispatcher.form_node_vamc_system_policies_page_edit_form.alter' => 'alterTopTaskNodeForm',
-    ];
   }
 
 }

--- a/docroot/modules/custom/va_gov_vamc/src/Service/ContentHardeningDeduper.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Service/ContentHardeningDeduper.php
@@ -47,21 +47,19 @@ class ContentHardeningDeduper {
   protected $contentTypeReplacements = [
     // Key: content_type => [related data].
     // This deduper needs to act on these content types as soon as they have a
-    // Front End presence. Commented out ones need to be un-commented as they
-    // come online.
-    // 'vamc_system_billing_insurance' => [
-    // 'title' => 'Billing and insurance',
-    // ],
-    // 'vamc_system_medical_records_offi' => [
-    // 'title' => 'Medical records office',
-    // ],
-    // Uncomment these as the content types have a Front End presence.
+    // Front End presence.
+    'vamc_system_billing_insurance' => [
+      'title' => 'Billing and insurance',
+    ],
+    'vamc_system_medical_records_offi' => [
+      'title' => 'Medical records office',
+    ],
     'vamc_system_policies_page' => [
       'title' => 'Policies',
     ],
-    // 'vamc_system_register_for_care' => [
-    // 'title' => 'Register for care',
-    // ],
+    'vamc_system_register_for_care' => [
+      'title' => 'Register for care',
+    ],
   ];
 
   /**
@@ -97,7 +95,7 @@ class ContentHardeningDeduper {
    *   The entity being created.
    */
   public function removeDuplicate(EntityInterface $entity): void {
-    if ($this->isHardendType($entity)) {
+    if ($this->isHardendType($entity) && $this->isBeingPublished($entity)) {
       /** @var \Drupal\node\NodeInterface $entity */
       $existing_moderation_state = '';
       $duplicate_alias = '';
@@ -161,6 +159,28 @@ class ContentHardeningDeduper {
     if ($entity instanceof NodeInterface) {
       $bundle = $entity->bundle();
       if (!empty($this->contentTypeReplacements[$bundle])) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Checks to see if this is node is transitioning to published state.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity being checked.
+   *
+   * @return bool
+   *   TRUE if this entity is being published. FALSE otherwise.
+   */
+  protected function isBeingPublished(EntityInterface $entity): bool {
+    if ($entity instanceof NodeInterface) {
+      /** @var \Drupal\node\NodeInterface $entity */
+      $ispublished = $entity->isPublished();
+      $waspublished = !empty($entity->original) ? $entity->original->isPublished() : FALSE;
+      if (!$waspublished && $ispublished) {
+        // This is either a new publish, or a publish following an archive.
         return TRUE;
       }
     }

--- a/docroot/modules/custom/va_gov_vamc/src/Service/ContentHardeningDeduper.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Service/ContentHardeningDeduper.php
@@ -97,7 +97,6 @@ class ContentHardeningDeduper {
   public function removeDuplicate(EntityInterface $entity): void {
     if ($this->isHardendType($entity) && $this->isBeingPublished($entity)) {
       /** @var \Drupal\node\NodeInterface $entity */
-      $existing_moderation_state = '';
       $duplicate_alias = '';
       $title = $this->contentTypeReplacements[$entity->bundle()]['title'];
       // @phpstan-ignore-next-line
@@ -108,16 +107,10 @@ class ContentHardeningDeduper {
         /** @var \Drupal\node\NodeInterface $duplicate_entity */
         // @phpstan-ignore-next-line
         $duplicate_alias = $duplicate_entity->path->alias;
-        // Risk: only the last duplicate determines the moderation state.
-        // Risk is small since there should only be one. If there more than one,
-        // there is no reliable way to determine which is proper.
-        // @phpstan-ignore-next-line
-        $existing_moderation_state = $duplicate_entity->moderation_state->value;
         $this->retireDuplicateEntity($duplicate_entity, $entity, $title);
         $this->logAndMessage($duplicate_entity, $title);
       }
 
-      $this->updateNewModerationState($entity, $existing_moderation_state);
       $this->updateNewAlias($entity, $duplicate_alias);
     }
   }
@@ -178,6 +171,7 @@ class ContentHardeningDeduper {
     if ($entity instanceof NodeInterface) {
       /** @var \Drupal\node\NodeInterface $entity */
       $ispublished = $entity->isPublished();
+      // @phpstan-ignore-next-line
       $waspublished = !empty($entity->original) ? $entity->original->isPublished() : FALSE;
       if (!$waspublished && $ispublished) {
         // This is either a new publish, or a publish following an archive.
@@ -241,24 +235,6 @@ class ContentHardeningDeduper {
       // This entity is not new and likely has a bad alias, so set it right.
       // @phpstan-ignore-next-line
       $entity->path->alias = $duplicate_alias;
-    }
-  }
-
-  /**
-   * Updates the moderation state of the new hardened node.
-   *
-   * @param \Drupal\node\NodeInterface $entity
-   *   The node being saved.
-   * @param string $existing_moderation_state
-   *   The moderation state of the unhardened node being replaced.
-   */
-  protected function updateNewModerationState(NodeInterface $entity, $existing_moderation_state) : void {
-    // If we have a moderation_state on the existing, only carry it forward if
-    // it has not already been archived.
-    // If the current state is already set to published, do not override.
-    // @phpstan-ignore-next-line
-    if ($existing_moderation_state !== 'archived' && $entity->moderation_state->value !== 'published') {
-      $entity->set('moderation_state', $existing_moderation_state);
     }
   }
 


### PR DESCRIPTION
## Description

Closes #7340.

## Testing done


## Screenshots


## QA steps

As a vamc editor (Ryan.Stubblebine@va.gov)
### Billing and Insurance & Direct Publish
1. Go to https://pr7356-nbt55fbdgc1ptojqbdfeb8dakuxmx763.ci.cms.va.gov/node/add/vamc_system_billing_insurance
2. Fill out all required fields.
3. Save the node as "published"
   - [x] validate that a message appears showing the old node was archived.
![image](https://user-images.githubusercontent.com/5752113/146930808-523f9565-d63c-4c09-bb4a-57af18246566.png)
   - [x] validate the path of the new node is /SYSTEM_health_care/billing-and-insurance  {no -0}
4.  Go to the node that was listed as archived 
   
![image](https://user-images.githubusercontent.com/5752113/146931595-35e65047-b2c2-4de7-bfd0-af7e84802d91.png)

   - [x] Validate that the title is "Billing and insurance - REPLACED"
   - [x] Validate the alias ends in "-replaced"
   - [x] validate that node is archived

### Medical records & Delayed publish
1. Go to https://pr7356-nbt55fbdgc1ptojqbdfeb8dakuxmx763.ci.cms.va.gov/node/add/vamc_system_medical_records_offi
2. Fill out all required fields.
3. Save the node as "draft"
   - [x] validate that **NO** message appears showing the old node was archived.
4. Edit and save the node as "draft"
   - [x] validate that **NO** message appears showing the old node was archived.
5. Save the node as "published"
   - [x] validate that a message appears showing the old node was archived.
   - [x] validate the path of the new node is /SYSTEM_health_care/medical-records-office  {no -0}
6.  Go to the node that was listed as archived 
   - [x] Validate that the title is "Medical records office - REPLACED"
   - [x] Validate the alias ends in "-replaced"
   - [x] validate that node is archived

### Register for care & Drafts after publish
1. Go to https://pr7356-nbt55fbdgc1ptojqbdfeb8dakuxmx763.ci.cms.va.gov/node/add/vamc_system_register_for_care
2. Fill out all required fields.
3. Save the node as "published"
   - [x] validate that a message appears showing the old node was archived.
   - [x] validate the path of the new node is /SYSTEM_health_care/register-for-care {no -0}
6.  Go to the node that was listed as archived 
   - [x] Validate that the title is "Register for care - REPLACED"
   - [x] Validate the alias ends in "-replaced"
   - [x] validate that node is archived
7. Edit the new Register for care node and save as draft
  - [x]  validate that no message about archiving old appears.
8. Edit the new Register for care node and save as draft
  - [x]  validate that no message about archiving old appears.
9. Edit the new Register for care node and save as published
  - [x]  validate that no message about archiving old appears.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`


### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
