### PR TITLE
VACMS-7373: Remove save and continue from edit form for temp fix.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -474,6 +474,14 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
       unset($form['actions']['preview']);
     }
 
+    /*
+     * @todo Remove this after root issue causing
+     * https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7373
+     * is resolved.
+     */
+    if ($node_type === 'vet_center') {
+      unset($form['actions']['save_continue']);
+    }
   }
 
   // Add after_build callback for Press Release node forms.


### PR DESCRIPTION
## Description
Relates to #7373

## Testing done
Visual / behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/147132091-33f134d1-7d74-429c-bd9b-b89d9ca073df.png)

## QA steps
 - [ ] As wesley.landry@va.gov, go to `http://va-gov-cms.lndo.site/node/3855/edit` and visually verify `Save content and continue editing` button does not appear at bottom of node edit form.