### PR TITLE
VACMS-0000: Pin Composer version to 2.1.8 to fix breaking change

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -13,7 +13,7 @@ mysql_version: ""
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
-composer_version: ""
+composer_version: "2.1.8"
 disable_settings_management: true
 web_environment:
   - PHP_IDE_CONFIG='serverName=appserver'

--- a/.lando.yml
+++ b/.lando.yml
@@ -6,7 +6,7 @@ config:
   # Match with terraform-aws-vsp-cms/rds.tf (another repo)
   # Match with .tugboat/config.yml (this repo)
   database: mariadb:10.5
-  composer_version: '2.0.11'
+  composer_version: '2.1.8'
 
 events:
   post-db-import:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -94,7 +94,7 @@ services:
         - docker-php-ext-enable memcache
 
         # Ensure that we're using version 2 of composer.
-        - composer self-update --2
+        - composer self-update 2.1.8
 
         # Install the Task task runner/build tool.
         - ./scripts/install_task_runner.sh


### PR DESCRIPTION
## Description

Relates to #7376 .

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
