### PR TITLE
VACMS-7163: Remove "VA Lovell Federal health care" menu in CMS

### DIFF
--- a/config/sync/node.type.event.yml
+++ b/config/sync/node.type.event.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.event_listing.yml
+++ b/config/sync/node.type.event_listing.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.health_care_local_facility.yml
+++ b/config/sync/node.type.health_care_local_facility.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.health_care_region_detail_page.yml
+++ b/config/sync/node.type.health_care_region_detail_page.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.health_care_region_page.yml
+++ b/config/sync/node.type.health_care_region_page.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.health_services_listing.yml
+++ b/config/sync/node.type.health_services_listing.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.leadership_listing.yml
+++ b/config/sync/node.type.leadership_listing.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.locations_listing.yml
+++ b/config/sync/node.type.locations_listing.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.news_story.yml
+++ b/config/sync/node.type.news_story.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.person_profile.yml
+++ b/config/sync/node.type.person_profile.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.press_release.yml
+++ b/config/sync/node.type.press_release.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.press_releases_listing.yml
+++ b/config/sync/node.type.press_releases_listing.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.publication_listing.yml
+++ b/config/sync/node.type.publication_listing.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.story_listing.yml
+++ b/config/sync/node.type.story_listing.yml
@@ -81,7 +81,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.vamc_operating_status_and_alerts.yml
+++ b/config/sync/node.type.vamc_operating_status_and_alerts.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.vamc_system_billing_insurance.yml
+++ b/config/sync/node.type.vamc_system_billing_insurance.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.vamc_system_medical_records_offi.yml
+++ b/config/sync/node.type.vamc_system_medical_records_offi.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.vamc_system_policies_page.yml
+++ b/config/sync/node.type.vamc_system_policies_page.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care

--- a/config/sync/node.type.vamc_system_register_for_care.yml
+++ b/config/sync/node.type.vamc_system_register_for_care.yml
@@ -80,7 +80,6 @@ third_party_settings:
       - va-loma-linda-health-care
       - va-long-beach-health-care
       - va-louisville-health-care
-      - va-lovell-federal-health-care
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care


### PR DESCRIPTION
- Disabled "VA Lovell Federal health care" menu in all content types.
- Cleared "VA Lovell Federal health care" menu data.
- Deleted "VA Lovell Federal health care" menu.

## Description

closes #7163 

## Testing done

Passes all tests.

## Screenshots


## QA steps

As user administrator
1. [ ] Go to `/admin/content-models/content` and verify and confirm that the "VA Lovell Federal health care" menu doesn't exist
1. [ ] Go to `/admin/structure/menu/manage/lovell-federal-health-care` and verify that this menu and its menu items are accessible and there are no errors
1. [ ] Go to the `/lovell-federal-health-care` node, edit it, change its page title to "Lovell Federal health care" and verify that there is no "VA Lovell Federal health care" menu available and the "Lovell Federal health care" menu is assigned to it


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
