### PR TITLE
VACMS-7333: Update help text on vet center facility service body field

### DIFF
--- a/config/sync/field.field.node.vet_center_facility_health_servi.field_body.yml
+++ b/config/sync/field.field.node.vet_center_facility_health_servi.field_body.yml
@@ -7,18 +7,22 @@ dependencies:
     - node.type.vet_center_facility_health_servi
   module:
     - allowed_formats
+    - epp
     - text
 third_party_settings:
   allowed_formats:
     rich_text_limited: rich_text_limited
     rich_text: '0'
     plain_text: '0'
+  epp:
+    value: ''
+    on_update: 1
 id: node.vet_center_facility_health_servi.field_body
 field_name: field_body
 entity_type: node
 bundle: vet_center_facility_health_servi
 label: 'Vet Center service description'
-description: 'Add another short paragraph and up to six bullet points detailing how your Vet Center provides this service.'
+description: 'Use this short paragraph and up to six bullet points to detail how your Vet Center provides this service.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
- Updated the "Vet Center - Facility Service" content type "body" field description text.

## Description

closes #7333 

## Testing done

Passes all tests.

## Screenshots
![vet-center-facility-service-body-field-description-updated](https://user-images.githubusercontent.com/846871/147508761-e0bdc0af-faf7-4111-b95e-5221e08a0635.png)


## QA steps

As user administrator
1. [x] Go to a "Vet Center - Facility Service" node (e.g.: /node/39885/edit) and verify and confirm that the "**Vet Center service description**" reads: _Use this short paragraph and up to six bullet points to detail how your Vet Center provides this service._


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
