### PR TITLE
VACMS-7433: Update pathauto for events to use nid instead of title.

### DIFF
--- a/config/sync/pathauto.pattern.event.yml
+++ b/config/sync/pathauto.pattern.event.yml
@@ -7,16 +7,16 @@ dependencies:
 id: event
 label: Event
 type: 'canonical_entities:node'
-pattern: '[node:field_listing:entity:field_office:entity:url:path]/events/[node:title]'
+pattern: '[node:field_listing:entity:field_office:entity:url:path]/events/[node:nid]'
 selection_criteria:
-  66413759-adac-4742-8740-349da68f9d0a:
+  0446890a-8059-400e-aae8-89a42dc90a6f:
     id: node_type
     bundles:
       event: event
     negate: false
     context_mapping:
       node: node
-    uuid: 66413759-adac-4742-8740-349da68f9d0a
+    uuid: 0446890a-8059-400e-aae8-89a42dc90a6f
 selection_logic: and
 weight: -5
 relationships: {  }


### PR DESCRIPTION
## Description

Relates to #7433 .

## Testing done
Created a test event locally and saw that the url was updated to the new format.

## Screenshots
See the path config updated to use nid here:
![image](https://user-images.githubusercontent.com/8375335/147943711-d1e7e111-598d-494c-a530-18d62e4d7049.png)

See the correct path in the cms here:
![image](https://user-images.githubusercontent.com/8375335/147943926-79ba4bf9-1813-43b6-aed8-6e9b9fa1cc3b.png)


## QA steps

As cms editor I can
1. Create a new event and verify that the url is using the node id in the url and not the name
2. View an old event (/tampa-health-care/events/virtual-move-16-week-weight-management-program) and verify that the url is still using the name and not the node id
3. Run a bulk update on the URLs for events and see that the frontend builds and has no errors on [VAMC ](https://web-vvrcki00pnxyz1i6xolwjrozmcpko2be.ci.cms.va.gov/tampa-health-care/events/42305/) or [Hub ](https://web-vvrcki00pnxyz1i6xolwjrozmcpko2be.ci.cms.va.gov/outreach-and-events/events/27258/) events. 
3. Then validate Acceptance Criteria from issue
- [x] New events get the URL pattern /[event listing calendar URL]/[node ID]
- [x] Existing URL aliases are not changed, only new events will get this pattern.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
