### PR TITLE
VACMS-7377: Ensures compatibility with Composer >2.2.0.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -13,7 +13,6 @@ mysql_version: ""
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
-composer_version: "2.1.8"
 disable_settings_management: true
 web_environment:
   - PHP_IDE_CONFIG='serverName=appserver'

--- a/.lando.yml
+++ b/.lando.yml
@@ -6,7 +6,6 @@ config:
   # Match with terraform-aws-vsp-cms/rds.tf (another repo)
   # Match with .tugboat/config.yml (this repo)
   database: mariadb:10.5
-  composer_version: '2.1.8'
 
 events:
   post-db-import:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -94,7 +94,7 @@ services:
         - docker-php-ext-enable memcache
 
         # Ensure that we're using version 2 of composer.
-        - composer self-update 2.1.8
+        - composer self-update --2
 
         # Install the Task task runner/build tool.
         - ./scripts/install_task_runner.sh

--- a/composer.json
+++ b/composer.json
@@ -277,6 +277,16 @@
             "drupal/core": "source",
             "va-gov/content-build": "source",
             "*": "dist"
+        },
+        "allow-plugins": {
+            "simplesamlphp/composer-module-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "zaporylie/composer-drupal-optimizations": true,
+            "drupal/console-extend-plugin": true,
+            "mouf/nodejs-installer": true,
+            "oomphinc/composer-installers-extender": true
         }
     },
     "extra": {


### PR DESCRIPTION
## Description

Closes #7377.  This PR:
- adds the `config.allow-plugins` object that will be required by future versions of Composer (and in the meantime emits annoying and worrisome messsages)
- reverts Lando pinning Composer version to 2.1.8.
- reverts DDEV pinning Composer version to 2.1.8.
- reverts Tugboat pinning Composer version to 2.1.8.

BRD Composer version pinning is undone in [this Devops PR](department-of-veterans-affairs/devops#10479).

I've tested Lando and DDEV and not seen any issues.  Tugboat shouldn't cause any issues but it's substantially more difficult to test.  That said, given that I'm just reverting Eric's change, it should be safe.  Assuming tests pass this should be good.

## Testing done
Build, deploy, and post-deploy tests on BRD passed (see [here](http://jenkins.vfs.va.gov/job/testing/job/cms-test-post-deploy-tests-staging/68/console)).

## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
