### PR TITLE
VACMS-7459: Increases Tugboat Memcached max item size to 4MB.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -174,6 +174,7 @@ services:
     commands:
       init:
         - sed -e 's/256/1024/' -i /etc/service/memcached/run
+        - sed '$s/$/ -I 4m/' -i /etc/service/memcached/run
         - sv restart memcached
 
   # What to call the service hosting MySQL. This name also acts as the


### PR DESCRIPTION
## Description

Relates to #7459.

This'll add a CLI parameter to Memcached on Tugboat to increase the maximum item size from the default of 1MB to 4MB, which should hopefully eliminate the occurrence of 502 errors in CI.

## Testing done


## Screenshots


## QA steps

As user _uid_ with _user_role_
1. Do this
1. Then that
1. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
