### PR TITLE
VACMS-7274 do not allow empty media refs

### DIFF
--- a/config/sync/field.field.paragraph.link_teaser_with_image.field_media.yml
+++ b/config/sync/field.field.paragraph.link_teaser_with_image.field_media.yml
@@ -18,7 +18,7 @@ entity_type: paragraph
 bundle: link_teaser_with_image
 label: Image
 description: 'Your image will be displayed with a 3:2 aspect ratio, so select an image that will work in with that aspect ratio. If your image does not already match that size, you may want to specify the 3:2 crop when prompted, or the system will crop it for you.'
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.paragraph.media.field_media.yml
+++ b/config/sync/field.field.paragraph.media.field_media.yml
@@ -12,7 +12,7 @@ entity_type: paragraph
 bundle: media
 label: 'Select an image'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -51,12 +51,12 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Service location | Email contacts | field_email_contacts | Entity reference revisions |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
 | Paragraph type | Embedded image | Allow clicks on this image to open it in new tab | field_allow_clicks_on_this_image | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Embedded image | Markup | field_markup | Markup |  | 1 | Markup |  |
-| Paragraph type | Embedded image | Select an image | field_media | Entity reference |  | 1 | Media library |  |
+| Paragraph type | Embedded image | Select an image | field_media | Entity reference | Required | 1 | Media library |  |
 | Paragraph type | Expandable Text | Full Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Expandable Text | Text Expander | field_text_expander | Text (plain) | Required | 1 | Textfield with counter |  |
 | Paragraph type | Link teaser | Link | field_link | Link | Required | 1 | Linkit |  |
 | Paragraph type | Link teaser | Link summary | field_link_summary | Text (plain) |  | 1 | Textfield with counter |  |
-| Paragraph type | Link teaser with image | Image | field_media | Entity reference |  | 1 | Media library | Translatable |
+| Paragraph type | Link teaser with image | Image | field_media | Entity reference | Required | 1 | Media library | Translatable |
 | Paragraph type | Link teaser with image | Link teaser | field_link_teaser | Entity reference revisions |  | 1 | Paragraphs Classic |  |
 | Paragraph type | Link to file or video | Link text | field_title | Text (plain) | Required | 1 | Textfield | Translatable |
 | Paragraph type | Link to file or video | Link to a file or video | field_media | Entity reference | Required | 1 | Media library | Translatable |


### PR DESCRIPTION
## Description

closes #7274.

## Testing done
Added a benefit detail page and saw that media fields were required.

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/148967920-68ff04bc-a969-4529-b3cb-cdaa35b53381.png)

![image](https://user-images.githubusercontent.com/8375335/148969024-1a8a3019-bccf-423c-a676-a06dc8dba7cf.png)

## QA steps

As a CMS editor, I can
1. Create a benefits detail page (`node/add/page`) 
2. Add a content block paragraph of 'embedded image' 
3. Create a CLP (`/node/add/campaign_landing_page`)
4. Enable the 'stories' panel and add a story and
- [x] Verify media field is required on  both content blocks

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`
  - [x] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
