### PR TITLE
VACMS-7166: service_location - make address field required if not usi…

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/service_location_address.es6.js
+++ b/docroot/modules/custom/va_gov_backend/js/service_location_address.es6.js
@@ -2,58 +2,53 @@
  * @file
  */
 
-(($, Drupal) => {
+((Drupal) => {
   Drupal.behaviors.vaGovServiceLocationAddress = {
     attach(context) {
       // Add or remove the classes and attributes needed to make the address required.
       function addressRequired(address, action) {
-        address
-          .find(".form-item label")
-          .not(".visually-hidden")
-          .each(function cycleAddress() {
+        const labels = address.querySelectorAll(".form-item label");
+        labels.forEach((label) => {
+          if (!label.classList.contains("visually-hidden")) {
             if (action === "yes") {
-              $(this).addClass("js-form-required form-required");
-              $(this)
-                .next("input, select")
-                .addClass("required")
-                .attr("required", "required");
+              label.classList.add("js-form-required", "form-required");
+              label.nextElementSibling.classList.add("required");
+              label.nextElementSibling.setAttribute("required", "required");
             } else {
-              $(this).removeClass("js-form-required form-required");
-              $(this)
-                .next("input, select")
-                .removeClass("required")
-                .removeAttr("required");
+              label.classList.remove("js-form-required", "form-required");
+              label.nextElementSibling.classList.remove("required");
+              label.nextElementSibling.removeAttribute("required");
             }
-          });
+          }
+        });
       }
 
-      $(".paragraph-type--service-location-address .form-checkbox").each(
-        function cycleCheckbox() {
-          // Grab our closest address.
-          const $address = $(this)
-            .parent()
-            .parent()
-            .next(".field--type-address");
-          // Set initial visibility for the address based on the checkbox value.
-          if ($(this).prop("checked")) {
-            $address.css("display", "none");
-            addressRequired($address, "no");
-          } else {
-            $address.css("display", "block");
-            addressRequired($address, "yes");
-          }
-          // Determine whether or not to display after checkbox interaction.
-          $(this).on("change", function onChange() {
-            if ($(this).prop("checked")) {
-              $address.css("display", "none");
-              addressRequired($address, "no");
-            } else {
-              $address.css("display", "block");
-              addressRequired($address, "yes");
-            }
-          });
-        }
+      // Grab our address toggles.
+      const checkboxes = document.querySelectorAll(
+        ".paragraph-type--service-location-address .form-checkbox"
       );
+      checkboxes.forEach((check) => {
+        // Grab our closest address.
+        const address = check.parentElement.parentElement.nextElementSibling;
+        // Set initial visibility for the address based on the checkbox value.
+        if (check.checked) {
+          address.style.display = "none";
+          addressRequired(address, "no");
+        } else {
+          address.style.display = "block";
+          addressRequired(address, "yes");
+        }
+        check.addEventListener("click", () => {
+          // Detemine whether or not to display after checkbox interaction.
+          if (check.checked) {
+            address.style.display = "none";
+            addressRequired(address, "no");
+          } else {
+            address.style.display = "block";
+            addressRequired(address, "yes");
+          }
+        });
+      });
 
       const serviceLocations = context.querySelectorAll(
         ".paragraph-type--service-location"
@@ -69,4 +64,4 @@
       }
     },
   };
-})(jQuery, Drupal);
+})(Drupal);

--- a/docroot/modules/custom/va_gov_backend/js/service_location_address.es6.js
+++ b/docroot/modules/custom/va_gov_backend/js/service_location_address.es6.js
@@ -2,31 +2,58 @@
  * @file
  */
 
-((Drupal) => {
+(($, Drupal) => {
   Drupal.behaviors.vaGovServiceLocationAddress = {
     attach(context) {
-      // Grab our address toggles.
-      const checkboxes = document.querySelectorAll(
-        ".paragraph-type--service-location-address .form-checkbox"
-      );
-      checkboxes.forEach((check) => {
-        // Grab our closest address.
-        const address = check.parentElement.parentElement.nextElementSibling;
-        // Set initial visibility for the address based on the checkbox value.
-        if (check.checked) {
-          address.style.display = "none";
-        } else {
-          address.style.display = "block";
-        }
-        check.addEventListener("click", () => {
-          // Detemine whether or not to display after checkbox interaction.
-          if (check.checked) {
-            address.style.display = "none";
+      // Add or remove the classes and attributes needed to make the address required.
+      function addressRequired(address, action) {
+        address
+          .find(".form-item label")
+          .not(".visually-hidden")
+          .each(function cycleAddress() {
+            if (action === "yes") {
+              $(this).addClass("js-form-required form-required");
+              $(this)
+                .next("input, select")
+                .addClass("required")
+                .attr("required", "required");
+            } else {
+              $(this).removeClass("js-form-required form-required");
+              $(this)
+                .next("input, select")
+                .removeClass("required")
+                .removeAttr("required");
+            }
+          });
+      }
+
+      $(".paragraph-type--service-location-address .form-checkbox").each(
+        function cycleCheckbox() {
+          // Grab our closest address.
+          const $address = $(this)
+            .parent()
+            .parent()
+            .next(".field--type-address");
+          // Set initial visibility for the address based on the checkbox value.
+          if ($(this).prop("checked")) {
+            $address.css("display", "none");
+            addressRequired($address, "no");
           } else {
-            address.style.display = "block";
+            $address.css("display", "block");
+            addressRequired($address, "yes");
           }
-        });
-      });
+          // Determine whether or not to display after checkbox interaction.
+          $(this).on("change", function onChange() {
+            if ($(this).prop("checked")) {
+              $address.css("display", "none");
+              addressRequired($address, "no");
+            } else {
+              $address.css("display", "block");
+              addressRequired($address, "yes");
+            }
+          });
+        }
+      );
 
       const serviceLocations = context.querySelectorAll(
         ".paragraph-type--service-location"
@@ -42,4 +69,4 @@
       }
     },
   };
-})(Drupal);
+})(jQuery, Drupal);

--- a/docroot/modules/custom/va_gov_backend/js/service_location_address.js
+++ b/docroot/modules/custom/va_gov_backend/js/service_location_address.js
@@ -5,23 +5,39 @@
 * @preserve
 **/
 
-(function (Drupal) {
+(function ($, Drupal) {
   Drupal.behaviors.vaGovServiceLocationAddress = {
     attach: function attach(context) {
-      var checkboxes = document.querySelectorAll(".paragraph-type--service-location-address .form-checkbox");
-      checkboxes.forEach(function (check) {
-        var address = check.parentElement.parentElement.nextElementSibling;
-
-        if (check.checked) {
-          address.style.display = "none";
-        } else {
-          address.style.display = "block";
-        }
-        check.addEventListener("click", function () {
-          if (check.checked) {
-            address.style.display = "none";
+      function addressRequired(address, action) {
+        address.find(".form-item label").not(".visually-hidden").each(function cycleAddress() {
+          if (action === "yes") {
+            $(this).addClass("js-form-required form-required");
+            $(this).next("input, select").addClass("required").attr("required", "required");
           } else {
-            address.style.display = "block";
+            $(this).removeClass("js-form-required form-required");
+            $(this).next("input, select").removeClass("required").removeAttr("required");
+          }
+        });
+      }
+
+      $(".paragraph-type--service-location-address .form-checkbox").each(function cycleCheckbox() {
+        var $address = $(this).parent().parent().next(".field--type-address");
+
+        if ($(this).prop("checked")) {
+          $address.css("display", "none");
+          addressRequired($address, "no");
+        } else {
+          $address.css("display", "block");
+          addressRequired($address, "yes");
+        }
+
+        $(this).on("change", function onChange() {
+          if ($(this).prop("checked")) {
+            $address.css("display", "none");
+            addressRequired($address, "no");
+          } else {
+            $address.css("display", "block");
+            addressRequired($address, "yes");
           }
         });
       });
@@ -36,4 +52,4 @@
       }
     }
   };
-})(Drupal);
+})(jQuery, Drupal);

--- a/docroot/modules/custom/va_gov_backend/js/service_location_address.js
+++ b/docroot/modules/custom/va_gov_backend/js/service_location_address.js
@@ -5,39 +5,44 @@
 * @preserve
 **/
 
-(function ($, Drupal) {
+(function (Drupal) {
   Drupal.behaviors.vaGovServiceLocationAddress = {
     attach: function attach(context) {
       function addressRequired(address, action) {
-        address.find(".form-item label").not(".visually-hidden").each(function cycleAddress() {
-          if (action === "yes") {
-            $(this).addClass("js-form-required form-required");
-            $(this).next("input, select").addClass("required").attr("required", "required");
-          } else {
-            $(this).removeClass("js-form-required form-required");
-            $(this).next("input, select").removeClass("required").removeAttr("required");
+        var labels = address.querySelectorAll(".form-item label");
+        labels.forEach(function (label) {
+          if (!label.classList.contains("visually-hidden")) {
+            if (action === "yes") {
+              label.classList.add("js-form-required", "form-required");
+              label.nextElementSibling.classList.add("required");
+              label.nextElementSibling.setAttribute("required", "required");
+            } else {
+              label.classList.remove("js-form-required", "form-required");
+              label.nextElementSibling.classList.remove("required");
+              label.nextElementSibling.removeAttribute("required");
+            }
           }
         });
       }
 
-      $(".paragraph-type--service-location-address .form-checkbox").each(function cycleCheckbox() {
-        var $address = $(this).parent().parent().next(".field--type-address");
+      var checkboxes = document.querySelectorAll(".paragraph-type--service-location-address .form-checkbox");
+      checkboxes.forEach(function (check) {
+        var address = check.parentElement.parentElement.nextElementSibling;
 
-        if ($(this).prop("checked")) {
-          $address.css("display", "none");
-          addressRequired($address, "no");
+        if (check.checked) {
+          address.style.display = "none";
+          addressRequired(address, "no");
         } else {
-          $address.css("display", "block");
-          addressRequired($address, "yes");
+          address.style.display = "block";
+          addressRequired(address, "yes");
         }
-
-        $(this).on("change", function onChange() {
-          if ($(this).prop("checked")) {
-            $address.css("display", "none");
-            addressRequired($address, "no");
+        check.addEventListener("click", function () {
+          if (check.checked) {
+            address.style.display = "none";
+            addressRequired(address, "no");
           } else {
-            $address.css("display", "block");
-            addressRequired($address, "yes");
+            address.style.display = "block";
+            addressRequired(address, "yes");
           }
         });
       });
@@ -52,4 +57,4 @@
       }
     }
   };
-})(jQuery, Drupal);
+})(Drupal);


### PR DESCRIPTION
…ng facility address

## Description

Closes #7166 

## Testing done

Visual Testing

## Screenshots

When use facility address is unchecked the fields are now marked as required:
![Screen Shot 2022-01-20 at 1 13 20 PM](https://user-images.githubusercontent.com/21045418/150397622-4af1ed12-078f-4567-b516-0753c64ab325.png)

If not supplied, each field is highlighted as required on form submission:
![Screen Shot 2022-01-20 at 1 13 47 PM](https://user-images.githubusercontent.com/21045418/150397792-834d3696-e9eb-4577-9860-ace578570551.png)

![Screen Shot 2022-01-20 at 1 13 58 PM](https://user-images.githubusercontent.com/21045418/150397820-ec27d2d8-06e1-4f31-a9b9-ca3349ec7a08.png)

![Screen Shot 2022-01-20 at 1 14 27 PM](https://user-images.githubusercontent.com/21045418/150397860-4836023b-75e8-4677-9563-0658c79bebd2.png)

![Screen Shot 2022-01-20 at 1 14 51 PM](https://user-images.githubusercontent.com/21045418/150397884-1c85cb43-26ad-413c-915a-8ce8f07d63f7.png)

## QA steps

As an administrator
- [ ] Visit /node/42010/edit
- [ ] Verify that the Country, Street Address1, City, State and Zip code fields are all marked as required if **Use the facility's street address?** is unchecked.
- [ ] Attempt to submit the form with the fields marked as required but not filled out. Form submission should fail and focus should fall on the first of the missing fields prompting you to supply a value (ensure this is the case for all required fields)
- [ ] View the page source for each required field and toggle the **Use the facility's street address?** checkbox, verify that the required classes and attributes are removed from each one and the form can then be submitted even if no values were supplied.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`