### PR TITLE
VACMS-7702: implement UX enhancements for non-clinical services

### DIFF
--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -75,7 +75,15 @@ display:
       style:
         type: default
         options:
-          grouping: {  }
+          grouping:
+            -
+              field: edit_node
+              rendered: true
+              rendered_strip: false
+            -
+              field: title_1
+              rendered: true
+              rendered_strip: false
           row_class: ''
           default_row_class: true
       row:
@@ -1112,7 +1120,7 @@ display:
           empty: true
           tokenize: false
           content:
-            value: 'You have not added a facility service yet. '
+            value: 'You have not added a register for care location yet. '
             format: rich_text
           plugin_id: text
       relationships:
@@ -1228,7 +1236,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1025&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add location (opens in a new window)</a></p>'
+            value: 'Add or edit locations where Veterans can register for care. Each location is associated with a VAMC Facility.'
             format: rich_text
           plugin_id: text
       defaults:
@@ -1238,6 +1246,8 @@ display:
         fields: false
         style: false
         row: false
+        footer: false
+        empty: false
       title: 'Register for care locations'
       arguments:
         nid:
@@ -1454,7 +1464,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '{{ field_clinic_name }}'
+            text: '<strong>{{ field_clinic_name }}</strong>'
             make_link: false
             path: ''
             absolute: false
@@ -1757,63 +1767,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        views_conditional_field_2:
-          id: views_conditional_field_2
-          table: views_conditional
-          field: views_conditional_field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Conditional Location'
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          if: field_clinic_name
-          condition: nem
-          equalto: ''
-          then: "<h3>{{ field_clinic_name }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n<div>{{ title_1 }}</div>"
-          then_translate: 1
-          or: "<h3>{{ title_1 }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>"
-          or_translate: 1
-          strip_tags: 0
-          plugin_id: views_conditional_field
         views_conditional_field_1:
           id: views_conditional_field_1
           table: views_conditional
@@ -1865,9 +1818,9 @@ display:
           if: field_use_facility_address
           condition: eq
           equalto: 'On'
-          then: "{{ views_conditional_field_2 }}\r\n{{ field_address }}"
+          then: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address }}"
           then_translate: 1
-          or: "<h3>{{ field_clinic_name }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address_1 }}"
+          or: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address_1 }}"
           or_translate: 1
           strip_tags: 0
           plugin_id: views_conditional_field
@@ -2330,7 +2283,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -2370,7 +2323,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          text: 'Edit location (opens in a new window)'
+          text: 'Edit locations at this facility (opens in a new window)'
           output_url_as_text: false
           absolute: false
           entity_type: node
@@ -2378,7 +2331,15 @@ display:
       style:
         type: default
         options:
-          grouping: {  }
+          grouping:
+            -
+              field: edit_node
+              rendered: true
+              rendered_strip: false
+            -
+              field: title_1
+              rendered: true
+              rendered_strip: false
           row_class: ''
           default_row_class: true
       row:
@@ -2388,6 +2349,34 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      footer:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: true
+          content:
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1025&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add facility (opens in a new window)</a></p>'
+            format: rich_text
+          plugin_id: text
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          content:
+            value: "<p>You have not added a register for care location yet.</p>\r\n<p><a href=\"/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1025&field_administration={{ arguments.field_administration_target_id }}\" target=\"_blank\">Add location (opens in a new window)</a></p>"
+            format: rich_text
+          plugin_id: text
     cache_metadata:
       max-age: -1
       contexts:
@@ -2425,7 +2414,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1027&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add location (opens in a new window)</a></p>'
+            value: 'Add or edit locations where Veterans can pay their bills. Each location is associated with a VAMC Facility.'
             format: rich_text
           plugin_id: text
       defaults:
@@ -2437,6 +2426,8 @@ display:
         fields: false
         style: false
         row: false
+        footer: false
+        empty: false
       filters:
         type:
           id: type
@@ -2716,7 +2707,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '<h3>{{ field_clinic_name }}</h3>'
+            text: '<strong>{{ field_clinic_name }}</strong>'
             make_link: false
             path: ''
             absolute: false
@@ -3019,63 +3010,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        views_conditional_field_2:
-          id: views_conditional_field_2
-          table: views_conditional
-          field: views_conditional_field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Conditional Location'
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          if: field_clinic_name
-          condition: nem
-          equalto: ''
-          then: "<h3>{{ field_clinic_name }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n<div>{{ title_1 }}</div>"
-          then_translate: 1
-          or: "<h3>{{ title_1 }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>"
-          or_translate: 1
-          strip_tags: 0
-          plugin_id: views_conditional_field
         views_conditional_field_1:
           id: views_conditional_field_1
           table: views_conditional
@@ -3127,9 +3061,9 @@ display:
           if: field_use_facility_address
           condition: eq
           equalto: 'On'
-          then: "{{ views_conditional_field_2 }}\r\n{{ field_address }}"
+          then: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address }}"
           then_translate: 1
-          or: "<h3>{{ field_clinic_name }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address_1 }}"
+          or: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address_1 }}"
           or_translate: 1
           strip_tags: 0
           plugin_id: views_conditional_field
@@ -3592,7 +3526,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -3632,7 +3566,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          text: 'Edit location (opens in a new window)'
+          text: 'Edit locations at this facility (opens in a new window)'
           output_url_as_text: false
           absolute: false
           entity_type: node
@@ -3640,7 +3574,15 @@ display:
       style:
         type: default
         options:
-          grouping: {  }
+          grouping:
+            -
+              field: edit_node
+              rendered: true
+              rendered_strip: false
+            -
+              field: title_1
+              rendered: true
+              rendered_strip: false
           row_class: ''
           default_row_class: true
       row:
@@ -3650,6 +3592,34 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      footer:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: true
+          content:
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1027&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add facility (opens in a new window)</a></p>'
+            format: rich_text
+          plugin_id: text
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          content:
+            value: "<p>You have not added a billing and insurance location yet.</p>\r\n<p><a href=\"/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1027&field_administration={{ arguments.field_administration_target_id }}\" target=\"_blank\">Add facility (opens in a new window)</a></p>"
+            format: rich_text
+          plugin_id: text
     cache_metadata:
       max-age: -1
       contexts:
@@ -3687,7 +3657,7 @@ display:
           empty: true
           tokenize: true
           content:
-            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1026&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add location (opens in a new window)</a> </p>'
+            value: 'Add or edit locations where Veterans can request medical records in person. Each location is associated with a VAMC Facility.'
             format: rich_text
           plugin_id: text
       defaults:
@@ -3697,6 +3667,8 @@ display:
         arguments: false
         fields: false
         title: false
+        footer: false
+        empty: false
       filters:
         type:
           id: type
@@ -3976,7 +3948,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '<h3>{{ field_clinic_name }}</h3>'
+            text: '<strong>{{ field_clinic_name }}</strong>'
             make_link: false
             path: ''
             absolute: false
@@ -4279,63 +4251,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        views_conditional_field_2:
-          id: views_conditional_field_2
-          table: views_conditional
-          field: views_conditional_field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Conditional Location'
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          if: field_clinic_name
-          condition: nem
-          equalto: ''
-          then: "<h3>{{ field_clinic_name }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n<div>{{ title_1 }}</div>"
-          then_translate: 1
-          or: "<h3>{{ title_1 }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>"
-          or_translate: 1
-          strip_tags: 0
-          plugin_id: views_conditional_field
         views_conditional_field_1:
           id: views_conditional_field_1
           table: views_conditional
@@ -4387,9 +4302,9 @@ display:
           if: field_use_facility_address
           condition: eq
           equalto: 'On'
-          then: "{{ views_conditional_field_2 }}\r\n{{ field_address }}"
+          then: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address }}"
           then_translate: 1
-          or: "<h3>{{ field_clinic_name }}</h3>\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address_1 }}"
+          or: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address_1 }}"
           or_translate: 1
           strip_tags: 0
           plugin_id: views_conditional_field
@@ -4852,7 +4767,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -4892,11 +4807,39 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          text: 'Edit location (opens in a new window)'
+          text: 'Edit locations at this facility (opens in a new window)'
           output_url_as_text: false
           absolute: false
           entity_type: node
           plugin_id: entity_link_edit
+      footer:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: true
+          content:
+            value: '<p><a href="/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1026&field_administration={{ arguments.field_administration_target_id }}" target="_blank">Add facility (opens in a new window)</a> </p>'
+            format: rich_text
+          plugin_id: text
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          content:
+            value: "<p>You have not added a medical records office location yet.</p>\r\n<p><a href=\"/node/add/vha_facility_nonclinical_service?field_service_name_and_descripti=1026&field_administration={{ arguments.field_administration_target_id }}\" target=\"_blank\">Add location (opens in a new window)</a></p>"
+            format: rich_text
+          plugin_id: text
     cache_metadata:
       max-age: -1
       contexts:

--- a/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
+++ b/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
@@ -112,29 +112,36 @@
 
 /* Non-clinical services view - block displays */
 .view-non-clinical-services {
-  .views-row {
+  .view-empty {
     border: 1px solid #bfbfbf;
+    border-radius: 2px;
+    margin: 1em 0;
+    padding: 1em 1.5em;
+  }
+
+  .view-grouping-content {
+    border: 1px solid #bfbfbf;
+    border-radius: 2px;
     margin: 1em 0;
     padding: 1em 1.5em;
 
-    .location-details span:not(:first-child)::before {
-      content: ', ';
-    }
-
-    .address {
-      margin-top: 0;
-
-      br,
-      span {
-        &:last-child {
-          display: none;
+    .views-row {
+      margin: 2em 0;
+  
+      .location-details span:not(:first-child)::before {
+        content: ', ';
+      }
+  
+      .address {
+        margin-top: 0;
+  
+        br,
+        span {
+          &:last-child {
+            display: none;
+          }
         }
       }
-    }
-
-    .views-field-edit-node {
-      margin-top: 1em;
-      text-align: right;
     }
   }
 }

--- a/docroot/themes/custom/vagovadmin/templates/views/views-view-grouping--non-clinical-services.html.twig
+++ b/docroot/themes/custom/vagovadmin/templates/views/views-view-grouping--non-clinical-services.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Theme override to display a single views grouping.
+ *
+ * Available variables:
+ * - view: The view object.
+ * - grouping: The grouping instruction.
+ * - grouping_level: A number indicating the hierarchical level of the grouping.
+ * - title: The group heading.
+ * - content: The content to be grouped.
+ * - rows: The rows returned from the view.
+ *
+ * @see template_preprocess_views_view_grouping()
+ */
+#}
+<div class="view-grouping">
+  <div class="view-grouping-content">
+    {{ content }}
+    <div class="view-grouping-header">{{ title }}</div>
+  </div>
+</div>

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
@@ -4,29 +4,36 @@
 
 /* Non-clinical services view - block displays */
 .view-non-clinical-services {
-  .views-row {
+  .view-empty {
     border: 1px solid #bfbfbf;
+    border-radius: 2px;
+    margin: 1em 0;
+    padding: 1em 1.5em;
+  }
+
+  .view-grouping-content {
+    border: 1px solid #bfbfbf;
+    border-radius: 2px;
     margin: 1em 0;
     padding: 1em 1.5em;
 
-    .location-details span:not(:first-child)::before {
-      content: ', ';
-    }
-
-    .address {
-      margin-top: 0;
-
-      br,
-      span {
-        &:last-child {
-          display: none;
+    .views-row {
+      margin: 2em 0;
+  
+      .location-details span:not(:first-child)::before {
+        content: ', ';
+      }
+  
+      .address {
+        margin-top: 0;
+  
+        br,
+        span {
+          &:last-child {
+            display: none;
+          }
         }
       }
-    }
-
-    .views-field-edit-node {
-      margin-top: 1em;
-      text-align: right;
     }
   }
 }

--- a/docroot/themes/custom/vagovclaro/templates/views/views-view-grouping--non-clinical-services.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/views/views-view-grouping--non-clinical-services.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Theme override to display a single views grouping.
+ *
+ * Available variables:
+ * - view: The view object.
+ * - grouping: The grouping instruction.
+ * - grouping_level: A number indicating the hierarchical level of the grouping.
+ * - title: The group heading.
+ * - content: The content to be grouped.
+ * - rows: The rows returned from the view.
+ *
+ * @see template_preprocess_views_view_grouping()
+ */
+#}
+<div class="view-grouping">
+  <div class="view-grouping-content">
+    {{ content }}
+    <div class="view-grouping-header">{{ title }}</div>
+  </div>
+</div>


### PR DESCRIPTION
## Description

Closes #7702 

## Testing done

Visual testing

## Screenshots

Register for care (multiple locations)
<img width="1111" alt="Screen Shot 2022-01-25 at 9 19 29 AM" src="https://user-images.githubusercontent.com/21045418/150996884-7b2bce4f-10d0-42a1-b8ec-c7d8318e9017.png">

Register for care (no locations)
<img width="1107" alt="Screen Shot 2022-01-25 at 9 20 37 AM" src="https://user-images.githubusercontent.com/21045418/150996992-434493b8-2534-4dcf-b78f-9a1613354b7e.png">

Billing and insurance
<img width="1113" alt="Screen Shot 2022-01-25 at 9 21 04 AM" src="https://user-images.githubusercontent.com/21045418/150997084-6123fe6e-2d38-4183-ab5c-8681587ccfee.png">

Billing and insurance (no locations)
<img width="1116" alt="Screen Shot 2022-01-25 at 9 21 13 AM" src="https://user-images.githubusercontent.com/21045418/150997123-a480459d-2226-4ad5-83ec-d8c9f6447af9.png">

Medical records offices
<img width="1121" alt="Screen Shot 2022-01-25 at 9 21 37 AM" src="https://user-images.githubusercontent.com/21045418/150997179-cdc15e62-a28d-471b-b212-74cdeb76a6f7.png">

Medical records offices (no locations)
<img width="1106" alt="Screen Shot 2022-01-25 at 9 21 44 AM" src="https://user-images.githubusercontent.com/21045418/150997236-ee9bf240-db47-4c0b-8fab-2ec8ca61814f.png">

## QA steps

As an admin user

- [x] Visit /admin/content
- [x] Filter the content to locate a **VAMC System Register for Care** node within the **VA Eastern Colorado health care** section
- [x] Verify the styles for the non-clinical services match the specification from #7595
- [x] Filter the content to locate a **VAMC System Billing and Insurance** node within the **VA Eastern Colorado health care** section
- [x] Verify the styles for the non-clinical services match the specification from #7595
[ ] Filter the content to locate a **VAMC System Medical Records** node within the **VA Eastern Colorado health care** section
- [x] Verify the styles for the non-clinical services match the specification from #7595
- [x] In each of the above examples, delete the related non-clinical service nodes and revisit the top task page. Verify that the displayed (no results) text matches the specification from #7595 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`
