### PR TITLE
VACMS-839: Add Entity Diff UI module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "drupal/entity_browser": "^2.4",
         "drupal/entity_browser_table": "^1.2",
         "drupal/entity_clone": "^1.0@beta",
+        "drupal/entity_diff_ui": "^1.0",
         "drupal/entity_embed": "^1.0",
         "drupal/entity_field_fetch": "^1.0@beta",
         "drupal/entity_reference_revisions": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "688aac9c15fbde91b095f337cda252ba",
+    "content-hash": "accd8888c682bc99993f9e37f3f6780d",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -5245,6 +5245,51 @@
             "homepage": "https://www.drupal.org/project/entity_clone",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_clone"
+            }
+        },
+        {
+            "name": "drupal/entity_diff_ui",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_diff_ui.git",
+                "reference": "1.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_diff_ui-1.0.1.zip",
+                "reference": "1.0.1",
+                "shasum": "a204401ccc3e9136087cb038f743134b3a03f664"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9",
+                "drupal/diff": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.1",
+                    "datestamp": "1617756156",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mingsong",
+                    "homepage": "https://www.drupal.org/user/2986445"
+                }
+            ],
+            "description": "Provide UI plugins of diff for entities.",
+            "homepage": "https://www.drupal.org/project/entity_diff_ui",
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_diff_ui"
             }
         },
         {
@@ -24922,5 +24967,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -15,6 +15,7 @@ module:
   block: 0
   block_content: 0
   block_content_permissions: 0
+  block_diff_ui: 0
   breakpoint: 0
   cer: 0
   ckeditor: 0
@@ -50,6 +51,7 @@ module:
   entity_browser_entity_form: 0
   entity_browser_table: 0
   entity_clone: 0
+  entity_diff_ui: 0
   entity_embed: 0
   entity_field_fetch: 0
   entity_reference_revisions: 0
@@ -98,6 +100,7 @@ module:
   linkit: 0
   markup: 0
   media: 0
+  media_diff_ui: 0
   media_entity_generic: 0
   media_library: 0
   memcache: 0


### PR DESCRIPTION
## Description
This PR replaces #7766 and covers blocks and media revisioning. There's still some work to be done for taxonomies that may require some custom code. 

Relates to #832. Closes #5102 and #5672 

## Testing done
Verified the Entity Diff UI module was enabled. Edited a custom block and saw the revision tab appeared. Clicked a revision and saw the content of revision. Clicked revert and verified reverting worked. Did the same for media.


## Screenshots
Blocks
![image](https://user-images.githubusercontent.com/8375335/151422955-ea145f3a-d5c3-4e8a-8da5-26f356fb15ce.png)

![image](https://user-images.githubusercontent.com/8375335/151423084-4af20073-7702-42d3-9ff5-482d274d596e.png)


Media
![image](https://user-images.githubusercontent.com/8375335/151422849-8aef0c82-196d-4090-979f-748d37d5b740.png)

## QA steps

As a CMS editor

1. I can edit a block (/block/146)
2. I can click the revision tab (/block/146/revisions) and view existing revisions
3. I can click the 'revert' button to revert to a previous state
4. I can edit media (/media/11393) and add a new revision
5. I can click the revision tab (/media/11393/revisions) and view existing revisions
6. I can click the 'revert' button to revert to a previous state
7. Then validate Acceptance Criteria from issue
8. Then validate Acceptance Criteria from issue
- [x] Revisions tab exists

Additional AC's from @kevwalsh 

- [x] i want to be able to see the history of all content (not just nodes) in the CMS, so that i can see what changed, and who changed it
- [x] i want a revision log message if there is one
- [x] i want to be able to compare diffs
- [x] i want to be able to revert to a revision

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [x] `Sitewide CMS Team`
  - [x] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
