### PR TITLE
VACMS-7784: add help text to non-clinical service forms

### DIFF
--- a/config/sync/node.type.vha_facility_nonclinical_service.yml
+++ b/config/sync/node.type.vha_facility_nonclinical_service.yml
@@ -18,7 +18,7 @@ third_party_settings:
 name: 'VAMC Facility Non-clinical Service'
 type: vha_facility_nonclinical_service
 description: 'Address and contact info for offices and other non-clinical service locations. This content is always embedded within a VAMC system non-clinical service page.'
-help: ''
+help: 'Add or edit the street address, operating hours, and contact info for an office or other non-clinical service at a VAMC facility.'
 new_revision: true
 preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
## Description

Closes #7784 

## Testing done

Visual testing

## Screenshots

![Screen Shot 2022-02-02 at 5 33 57 PM](https://user-images.githubusercontent.com/21045418/152249170-f7662ac8-3879-4d01-8d12-849064e32429.png)

## QA steps

As an admin
- [x] Visit /admin/content and filter the results by VAMC Facility Non-clinical service
- [x] Edit one of the items and verify the help text described in the issue is present at the top of the node form
- [x] Add a new VAMC Facility Non-clinical service and verify the help text is present at the top of the node form

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`