### PR TITLE
VACMS-7788 update char count on operating status

### DIFF
--- a/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
@@ -23,6 +23,7 @@ dependencies:
     - media_library
     - office_hours
     - telephone
+    - textfield_counter
 third_party_settings:
   field_group:
     group_editorial_workflow:
@@ -194,8 +195,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+      maxlength: 300
+      counter_position: after
+      js_prevent_submit: true
+      count_html_characters: true
+      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
-    type: string_textarea
+    type: string_textarea_with_counter
     region: content
   field_phone_number:
     weight: 23

--- a/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
@@ -199,7 +199,7 @@ content:
       counter_position: after
       js_prevent_submit: true
       count_html_characters: true
-      textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
     third_party_settings: {  }
     type: string_textarea_with_counter
     region: content

--- a/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
@@ -62,6 +62,6 @@ Feature: Content model: Vet Center Content Type fields
 | Content type | Vet Center - Outstation | Location address | field_address | Address |  | 1 | Address | Translatable |
 | Content type | Vet Center - Outstation | Main Vet Center location | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Outstation | Operating status | field_operating_status_facility | List (text) |  | 1 | Select list | Translatable |
-| Content type | Vet Center - Outstation | Operating status more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | Vet Center - Outstation | Operating status more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | Vet Center - Outstation | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Outstation | Table of contents | field_table_of_contents | Markup |  | 1 | Markup | Translatable |


### PR DESCRIPTION
## Description

Closes #7788 .

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/8375335/152224711-9b188686-90b8-4b81-bb6e-f76429131e2e.png)

![image](https://user-images.githubusercontent.com/8375335/152224846-0348f21c-d510-4d99-aa0e-677fdd307c1f.png)


## QA steps

As CMS editor, 
1. I can only put up to 300 characters in the operating status more info field.
2. Then validate Acceptance Criteria from issue
- [ ] vet_center_outstation need field_operating_status_more_info limited with the same settings as are used on VAMC facility.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
