### PR TITLE
VACMS-7353: Make name fields required on staff profiles.

### DIFF
--- a/config/sync/field.field.node.person_profile.field_last_name.yml
+++ b/config/sync/field.field.node.person_profile.field_last_name.yml
@@ -5,13 +5,19 @@ dependencies:
   config:
     - field.storage.node.field_last_name
     - node.type.person_profile
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
 id: node.person_profile.field_last_name
 field_name: field_last_name
 entity_type: node
 bundle: person_profile
 label: 'Last name'
 description: 'This should include suffixes that are part of the name, like "Jr" or "IV"'
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.person_profile.field_name_first.yml
+++ b/config/sync/field.field.node.person_profile.field_name_first.yml
@@ -5,13 +5,19 @@ dependencies:
   config:
     - field.storage.node.field_name_first
     - node.type.person_profile
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
 id: node.person_profile.field_name_first
 field_name: field_name_first
 entity_type: node
 bundle: person_profile
 label: 'First name'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -83,10 +83,10 @@ Feature: Content model: VAMC Content Type fields
 | Content type | Staff Profile | Complete Biography | field_complete_biography | File |  | 1 | File |  |
 | Content type | Staff Profile | Create profile page with biography | field_complete_biography_create | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | Staff Profile | Email address | field_email_address | Email |  | 1 | Email |  |
-| Content type | Staff Profile | First name | field_name_first | Text (plain) |  | 1 | Textfield |  |
+| Content type | Staff Profile | First name | field_name_first | Text (plain) | Required | 1 | Textfield |  |
 | Content type | Staff Profile | High-resolution photo should be available for download by site visitors | field_photo_allow_hires_download | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | Staff Profile | First sentence | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Staff Profile | Last name | field_last_name | Text (plain) |  | 1 | Textfield |  |
+| Content type | Staff Profile | Last name | field_last_name | Text (plain) | Required | 1 | Textfield |  |
 | Content type | Staff Profile | Job title | field_description | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Staff Profile | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Staff Profile | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |


### PR DESCRIPTION
## Description

Closes #7353.

## Testing done
Created a new staff profile, saw fields were required. 

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/152379696-d1ed3cfb-4436-4602-ae9f-cd8eaa4e61df.png)


## QA steps

As cms editor I can
1. create a new staff profile (`/node/add/person_profile`) and see the fields for first and last name are now required.
2. Then that
3. Then validate Acceptance Criteria from issue
- [x] make field_name_first required
- [x] make field_last_name required
- [x] Update spectool and related tests to reflect these fields are required.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
