### PR TITLE
VACMS-7540: Remove UI help text that says create a new alert in VAMC detail page

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
@@ -42,6 +42,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       parent_name: ''
       weight: 13
       format_type: fieldset

--- a/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_detail_page.default.yml
@@ -42,7 +42,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       parent_name: ''
       weight: 13
       format_type: fieldset
@@ -74,9 +73,10 @@ third_party_settings:
       weight: 3
       format_type: fieldset
       format_settings:
-        description: 'Alerts draw attention to information that may be critical to a veteran, family member, or caregiver. You can <a href="/block/add/alert?destination=/admin/content/alerts">create a new alert</a>, or reuse an existing one.'
+        description: 'Alerts draw attention to information that may be critical to a veteran, family member, or caregiver.'
         id: ''
         classes: ''
+        show_empty_fields: false
         required_fields: false
       label: 'Include alert'
       region: content
@@ -96,7 +96,6 @@ third_party_settings:
       region: content
     group_meta_tags:
       children:
-        - field_meta_title
         - field_description
       parent_name: ''
       weight: 1


### PR DESCRIPTION
- Removed text that contained the "create a new alert" link from the "Include alert" fieldset in the VAMC Detail Page content type.

## Description

closes #7540

## Testing done

Passes all tests

## Screenshots
![VACMS-7540_removed_create_alert_link](https://user-images.githubusercontent.com/846871/152407952-ab72a555-895d-4945-b920-558fcd66ce97.png)


## QA steps

As user administrator or editor
1. Go to `/node/add/health_care_region_detail_page` to verify and confirm that the "_You can <a href="/block/add/alert?destination=/admin/content/alerts">create a new alert</a>, or reuse an existing one._" text is not displayed


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
