### PR TITLE
VACMS-7819: remove editorial workflow widget from non-clinical node view

### DIFF
--- a/config/sync/core.entity_view_display.node.vha_facility_nonclinical_service.default.yml
+++ b/config/sync/core.entity_view_display.node.vha_facility_nonclinical_service.default.yml
@@ -18,11 +18,6 @@ targetEntityType: node
 bundle: vha_facility_nonclinical_service
 mode: default
 content:
-  content_moderation_control:
-    weight: -20
-    settings: {  }
-    third_party_settings: {  }
-    region: content
   field_enforce_unique_combo_offic:
     weight: 1
     label: above


### PR DESCRIPTION
## Description

Closes #7819 

## Testing done

Visual Testing

## Screenshots

Before
<img width="1296" alt="Screen Shot 2022-02-03 at 1 16 55 PM" src="https://user-images.githubusercontent.com/21045418/152407745-53572808-798b-480f-801e-47b8f087a5de.png">

After
<img width="1286" alt="Screen Shot 2022-02-03 at 1 38 57 PM" src="https://user-images.githubusercontent.com/21045418/152407791-67253573-c2f3-4599-a789-e9aea3cb92c1.png">

## QA steps

As an admin user
- [ ] Visit /admin/content
- [ ] Filter results to show VAMC Facility Non-clinical service nodes
- [ ] Open one in node view (not edit mode) and verify the workflow widget is no longer visible
- [ ] 
### Select Team for PR review

- [ ] `Platform CMS team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`
