### PR TITLE
VACMS-7905: Fix broken textarea desriptions.

### DIFF
--- a/docroot/themes/custom/vagovadmin/templates/form/form-element--textarea.html.twig
+++ b/docroot/themes/custom/vagovadmin/templates/form/form-element--textarea.html.twig
@@ -60,6 +60,7 @@
 {%
   set description_classes = [
     'description',
+    'form-item__description',
     description_display == 'invisible' ? 'visually-hidden',
   ]
 %}
@@ -69,6 +70,11 @@
 	{% endif %}
 	{% if prefix is not empty %}
 		<span class="field-prefix">{{ prefix }}</span>
+	{% endif %}
+	{% if description_display == 'before' and description.content %}
+		<div{{description.attributes.addClass(description_classes)}}>
+			{{ description.content }}
+		</div>
 	{% endif %}
 	{{ children }}
 	{% if suffix is not empty %}
@@ -82,4 +88,10 @@
 			<strong>{{ errors }}</strong>
 		</div>
 	{% endif %}
+	{% if description_display in ['after', 'invisible'] and description.content %}
+		<div{{description.attributes.addClass(description_classes)}}>
+			{{ description.content }}
+		</div>
+	{% endif %}
 </div>
+


### PR DESCRIPTION
## Description
closes #7905

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/152650060-d0cc5951-a8ec-4d06-8953-aa04c5a89bdb.png)

![image](https://user-images.githubusercontent.com/2404547/152650066-148ce5dd-c817-4f54-9420-b5aa098eaf46.png)


## QA steps
 - [x] As an admin, go to `/admin/config/content/va_gov_menu_access` and visually verify help text appears below textarea labels
 - [x] As an admin, go to `/admin/config/content/node_link_report` and visually verify help text appears below textarea labels