### PR TITLE
VACMS-7721: display published status on non-clinical service cards

### DIFF
--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -81,6 +81,10 @@ display:
               rendered: true
               rendered_strip: false
             -
+              field: status
+              rendered: true
+              rendered_strip: false
+            -
               field: title_1
               rendered: true
               rendered_strip: false
@@ -2328,12 +2332,83 @@ display:
           absolute: false
           entity_type: node
           plugin_id: entity_link_edit
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: node--published
+            format_custom_false: node--unpublished
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: status
+          plugin_id: field
       style:
         type: default
         options:
           grouping:
             -
               field: edit_node
+              rendered: true
+              rendered_strip: false
+            -
+              field: status
               rendered: true
               rendered_strip: false
             -
@@ -3571,12 +3646,83 @@ display:
           absolute: false
           entity_type: node
           plugin_id: entity_link_edit
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: node--published
+            format_custom_false: node--unpublished
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: status
+          plugin_id: field
       style:
         type: default
         options:
           grouping:
             -
               field: edit_node
+              rendered: true
+              rendered_strip: false
+            -
+              field: status
               rendered: true
               rendered_strip: false
             -
@@ -4812,6 +4958,73 @@ display:
           absolute: false
           entity_type: node
           plugin_id: entity_link_edit
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: node--published
+            format_custom_false: node--unpublished
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: status
+          plugin_id: field
       footer:
         area:
           id: area

--- a/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
+++ b/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
@@ -111,6 +111,10 @@
 }
 
 /* Non-clinical services view - block displays */
+.field--name-field-non-clinical-services {
+  background-color: #fff;
+}
+
 .view-non-clinical-services {
   .view-empty {
     border: 1px solid #bfbfbf;
@@ -124,6 +128,12 @@
     border-radius: 2px;
     margin: 1em 0;
     padding: 1em 1.5em;
+
+    .view-grouping-content {
+      border: 0;
+      margin: 0;
+      padding: 0;
+    }
 
     .views-row {
       margin: 2em 0;

--- a/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
+++ b/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
@@ -17,6 +17,10 @@
   }
 }
 
+.node--unpublished {
+  background-color: #fff4f4;
+}
+
 /* Node view from page--node.html.twig */
 
 .node-columns {

--- a/docroot/themes/custom/vagovadmin/templates/views/views-view-grouping--non-clinical-services.html.twig
+++ b/docroot/themes/custom/vagovadmin/templates/views/views-view-grouping--non-clinical-services.html.twig
@@ -14,9 +14,16 @@
  * @see template_preprocess_views_view_grouping()
  */
 #}
+{% if grouping_level == 0 %}
+<div class="view-grouping {{ content|first['#title']|render|striptags|trim|lower }}">
+{% else %}
 <div class="view-grouping">
+{% endif %}
+
   <div class="view-grouping-content">
     {{ content }}
+    {% if grouping_level != 1 %}
     <div class="view-grouping-header">{{ title }}</div>
+    {% endif %}
   </div>
 </div>

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
@@ -3,6 +3,15 @@
 }
 
 /* Non-clinical services view - block displays */
+.field--name-field-non-clinical-services {
+  background-color: #fff;
+}
+
+.view-grouping.node--unpublished {
+  margin: 0;
+  padding: 0;
+}
+
 .view-non-clinical-services {
   .view-empty {
     border: 1px solid var(--va-gray-cool-med);
@@ -16,6 +25,12 @@
     border-radius: 2px;
     margin: 1em 0;
     padding: 1em 1.5em;
+
+    .view-grouping-content {
+      border: 0;
+      margin: 0;
+      padding: 0;
+    }
 
     .views-row {
       margin: 2em 0;

--- a/docroot/themes/custom/vagovclaro/templates/views/views-view-grouping--non-clinical-services.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/views/views-view-grouping--non-clinical-services.html.twig
@@ -14,9 +14,16 @@
  * @see template_preprocess_views_view_grouping()
  */
 #}
+{% if grouping_level == 0 %}
+<div class="view-grouping {{ content|first['#title']|render|striptags|trim|lower }}">
+{% else %}
 <div class="view-grouping">
+{% endif %}
+
   <div class="view-grouping-content">
     {{ content }}
+    {% if grouping_level != 1 %}
     <div class="view-grouping-header">{{ title }}</div>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Description

Closes #7721

## Testing done

Visual Testing

## Screenshots

VA.gov Claro Theme
<img width="814" alt="Screen Shot 2022-02-08 at 10 07 00 AM" src="https://user-images.githubusercontent.com/21045418/153020810-0078ff7f-3203-413a-8c2c-3abfc8a28000.png">

VA.gov Admin Theme
![Screen Shot 2022-02-08 at 10 43 01 AM](https://user-images.githubusercontent.com/21045418/153022364-bc3ce294-77f0-40e1-ab0f-7195fe48cba9.png)

## QA steps

As an admin user:
- [ ] Visit /admin/appearance and set the default and admin themes to VA.gov Claro
- [ ] Visit /admin/content and filter the content for section: VA Eastern Colorado health care
- [ ] Further filter the content for content type: VAMC System Billing and Insurance (Edit the existing node)
- [ ] Verify that the background color for the listed non-clinical service nodes match the actual published state (pink background for unpublished)
- [ ] On /admin/content change the content type to VAMC System Medical Records Office (Edit the existing node)
- [ ] Verify that the background color for the listed non-clinical service nodes match the actual published state (pink background for unpublished)
- [ ] On /admin/content change the content type to VAMC System Register for Care (Edit the existing node)
- [ ] Verify that the background color for the listed non-clinical service nodes match the actual published state (pink background for unpublished)

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`
