### PR TITLE
VACMS-6696: Prevent previews and url links on no bio staff pages.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -980,6 +980,10 @@ function va_gov_backend_preprocess_page(&$variables) {
       'vet_center_mobile_vet_center',
       'vet_center_outstation',
     ];
+    // Exclude staff pages without bios.
+    if ($node->bundle === 'person_profile' && $node->field_complete_biography_create->value === '0') {
+      $exclusion_types[] = 'person_profile';
+    }
     // Make sure we aren't on the node form or an excluded type.
     $route_name = \Drupal::routeMatch()->getRouteName();
     if (($route_name !== 'entity.node.edit_form') &&

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -981,7 +981,7 @@ function va_gov_backend_preprocess_page(&$variables) {
       'vet_center_outstation',
     ];
     // Exclude staff pages without bios.
-    if ($node->bundle === 'person_profile' && $node->field_complete_biography_create->value === '0') {
+    if ($node->bundle() === 'person_profile' && $node->field_complete_biography_create->value === '0') {
       $exclusion_types[] = 'person_profile';
     }
     // Make sure we aren't on the node form or an excluded type.

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -140,7 +140,6 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     else {
       $block_items['Owner'] = $this->getSectionHierarchyBreadcrumbLinks($node);
     }
-
     if ($this->vaGovUrlShouldBeDisplayed($node)) {
       $va_gov_url = $this->vaGovUrl->getVaGovFrontEndUrlForEntity($node);
 
@@ -281,6 +280,11 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
    *   Boolean value.
    */
   private function vaGovUrlShouldBeDisplayed(NodeInterface $node) : bool {
+    // Make sure this isn't a staff page without bio.
+    if (!empty($node->field_complete_biography_create) && $node->field_complete_biography_create->value === '0') {
+      return FALSE;
+    }
+
     if ($this->exclusionTypes->typeIsExcluded($node->bundle())) {
       return FALSE;
     }


### PR DESCRIPTION
## Description
closes #6696

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/153074008-c717442d-ad48-4435-bb56-7a29056e6ecb.png)

![image](https://user-images.githubusercontent.com/2404547/153074033-037da3dd-30a6-4983-a29b-00e3cfc01eca.png)


## QA steps
 - [ ] as an administrator, go to `kansas-city-health-care/staff-profiles/patty-callahan` and visually verify `CREATE PROFILE PAGE WITH BIOGRAPHY` is set to `Off` and preview button and preview url are not visible
 - [ ]  - [ ] as an administrator, go to `pittsburgh-health-care/staff-profiles/lovetta-ford` and visually verify `CREATE PROFILE PAGE WITH BIOGRAPHY` is set to `On` and preview button and preview url are not visible (preview url will show as pending b/c this is a dev environment with a link to the static build of the cms).