### PR TITLE
VACMS-5522: Prevent outputting empty clp panels on node view.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -180,6 +180,7 @@ module:
   va_gov_banner: 0
   va_gov_build_trigger: 0
   va_gov_bulk: 0
+  va_gov_clp: 0
   va_gov_consumers: 0
   va_gov_dashboards: 0
   va_gov_db: 0

--- a/docroot/modules/custom/va_gov_clp/va_gov_clp.info.yml
+++ b/docroot/modules/custom/va_gov_clp/va_gov_clp.info.yml
@@ -1,0 +1,5 @@
+name: 'VA.gov clp'
+type: module
+description: 'VA.gov CLP'
+core_version_requirement: ^8 || ^9
+package: 'Custom'

--- a/docroot/modules/custom/va_gov_clp/va_gov_clp.module
+++ b/docroot/modules/custom/va_gov_clp/va_gov_clp.module
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Contains va_gov_clp.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function va_gov_clp_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the va_gov_clp module.
+    case 'help.page.va_gov_clp':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('VA.gov CLP') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Prevent outputting empty fieldgroups on clp.
+ *
+ * @param array $variables
+ *   The entity renderable items array.
+ */
+function va_gov_clp_field_group_build_pre_render_alter(array &$variables) {
+  if (empty($variables['field_clip_spotlight_panel'])) {
+    $variables['group_spotlight']['#access'] = FALSE;
+  }
+  if (empty($variables['field_clip_events_panel'])) {
+    $variables['group_events']['#access'] = FALSE;
+  }
+  if (empty($variables['field_clip_faq_panel'])) {
+    $variables['group_faq']['#access'] = FALSE;
+  }
+  if (empty($variables['field_clip_stories_panel'])) {
+    $variables['group_stories']['#access'] = FALSE;
+  }
+  if (empty($variables['field_clip_video_panel'])) {
+    $variables['group_video']['#access'] = FALSE;
+  }
+  if (empty($variables['field_clip_resources_panel'])) {
+    $variables['group_resources']['#access'] = FALSE;
+  }
+}


### PR DESCRIPTION
## Description
closes #5522

## Testing done
Visual

## QA steps
 - [ ] As an administrator, go to `/initiatives/veteran-trust-in-va` and visually verify that panel items on `/node/18299/edit` that do not have the `Enable this page segment` checkbox set to TRUE do not appear