### PR TITLE
VACMS-7746 prelaunch fixes

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/js/limit_vamcs_to_workbench.es6.js
+++ b/docroot/modules/custom/va_gov_vamc/js/limit_vamcs_to_workbench.es6.js
@@ -6,9 +6,6 @@
   // Grab our fields.
   const adminField = document.getElementById("edit-field-administration");
 
-  // const checkBoxDivs = document.querySelectorAll(
-  //   "#edit-field-banner-alert-vamcs-wrapper div.form-type-checkbox"
-  // );
   const checkBoxDivs = document.querySelectorAll(
     "#edit-field-banner-alert-vamcs div.js-form-type-checkbox"
   );

--- a/docroot/modules/custom/va_gov_vamc/js/limit_vamcs_to_workbench.es6.js
+++ b/docroot/modules/custom/va_gov_vamc/js/limit_vamcs_to_workbench.es6.js
@@ -6,8 +6,11 @@
   // Grab our fields.
   const adminField = document.getElementById("edit-field-administration");
 
+  // const checkBoxDivs = document.querySelectorAll(
+  //   "#edit-field-banner-alert-vamcs-wrapper div.form-type-checkbox"
+  // );
   const checkBoxDivs = document.querySelectorAll(
-    "#edit-field-banner-alert-vamcs-wrapper div.form-type-checkbox"
+    "#edit-field-banner-alert-vamcs div.js-form-type-checkbox"
   );
 
   const selectListSystems = document.querySelectorAll(

--- a/docroot/modules/custom/va_gov_vamc/js/limit_vamcs_to_workbench.js
+++ b/docroot/modules/custom/va_gov_vamc/js/limit_vamcs_to_workbench.js
@@ -8,7 +8,7 @@
 (function (Drupal) {
   var adminField = document.getElementById("edit-field-administration");
 
-  var checkBoxDivs = document.querySelectorAll("#edit-field-banner-alert-vamcs-wrapper div.form-type-checkbox");
+  var checkBoxDivs = document.querySelectorAll("#edit-field-banner-alert-vamcs div.js-form-type-checkbox");
 
   var selectListSystems = document.querySelectorAll("#edit-field-region-page option");
 

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_alerts.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_alerts.scss
@@ -47,7 +47,7 @@
 
 .messages-list {
   margin-bottom: var(--space-m);
-  margin-top: var(--space-m);
+  margin-top: 0;
 }
 
 // node link report tweaks

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_buttons.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_buttons.scss
@@ -59,6 +59,10 @@
   }
 }
 
+.node-preview-button {
+  margin-top: 0;
+}
+
 // no fuzzy buttons in tables
 table .button,
 table .button:not(:focus) {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_centralized_content.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_centralized_content.scss
@@ -86,6 +86,11 @@
         padding: 0;
       }
 
+      .field--name-field-questions thead th {
+        display: flex;
+        justify-content: space-between;
+      }
+
       .cc-paragraph-header {
         background: var(--va-gray-med);
         color: var(--color-white);
@@ -107,6 +112,7 @@
 
         .cc-paragraph-header {
           display: block;
+          height: auto;
           padding: 15px 0 0 15px;
           width: 100%;
 

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
@@ -68,3 +68,15 @@
     max-width: 54rem;
   }
 }
+
+.page-content {
+  margin-top: 0;
+}
+
+.node-columns {
+  margin-top: var(--space-l);
+}
+
+.region-sidebar-first h2 {
+  margin-top: 0;
+}

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_paragraphs.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_paragraphs.scss
@@ -34,6 +34,10 @@
   margin-top: 0;
 }
 
+.js .field--widget-paragraphs th .paragraphs-actions {
+  margin-right: 0;
+}
+
 .paragraphs-browser-paragraph-type {
   margin-bottom: 3rem;
 }

--- a/docroot/themes/custom/vagovclaro/assets/scss/pages/_node-view.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/pages/_node-view.scss
@@ -73,6 +73,5 @@ tr:only-child {
 // adjust spacing on unpublished nodes
 .node--unpublished {
   background-color: var(--va-red-lightest);
-  margin: -1rem;
-  padding: 1rem;
+  padding: var(--spacing-m);
 }

--- a/docroot/themes/custom/vagovclaro/assets/scss/pages/_proofing.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/pages/_proofing.scss
@@ -58,6 +58,10 @@
     }
   }
 
+  .field--name-field-table .field__label {
+    display: none;
+  }
+
   .field--name-field-intro-text .field__item {
     @include intro-text;
 

--- a/docroot/themes/custom/vagovclaro/assets/scss/styles.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/styles.scss
@@ -12,6 +12,7 @@
 @import 'components/layout';
 @import 'components/buttons';
 @import 'components/media';
+@import 'components/menu';
 @import 'components/paragraphs';
 @import 'components/fields';
 @import 'components/views';

--- a/docroot/themes/custom/vagovclaro/templates/block/node-link-report-block.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/block/node-link-report-block.html.twig
@@ -21,8 +21,15 @@
  *   ['http://www.someurl.com' => 'Link Title']
  */
 #}
-
+{% if (bad_links is not empty) or
+  (((inaccessible_links is not empty)) and (display_inaccessible_links == 1)) or
+  (unpublished_links is not empty) or
+  (redirected_links is not empty) or
+  (((skipped_links is not empty)) and (display_skipped_links == 1)) or
+  ((good_links is not empty) and (display_good_links == 1))
+%}
 <div class="messages-list node-link-report-list">
+{% endif %}
   {% if bad_links is not empty %}
     <div class="bad_links va-alert messages messages--error">
       <details class="js-form-wrapper">
@@ -211,4 +218,12 @@
       </details>
     </div>
   {% endif %}
+{% if (bad_links is not empty) or
+  (((inaccessible_links is not empty)) and (display_inaccessible_links == 1)) or
+  (unpublished_links is not empty) or
+  (redirected_links is not empty) or
+  (((skipped_links is not empty)) and (display_skipped_links == 1)) or
+  ((good_links is not empty) and (display_good_links == 1))
+%}
 </div>
+{% endif %}

--- a/docroot/themes/custom/vagovclaro/vagovclaro.theme
+++ b/docroot/themes/custom/vagovclaro/vagovclaro.theme
@@ -10,6 +10,7 @@ use Drupal\Core\Url;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_preprocess_html().
@@ -29,6 +30,10 @@ function vagovclaro_preprocess_html(&$variables) {
  */
 function vagovclaro_theme_suggestions_page_alter(&$suggestions, $variables) {
   if ($node = \Drupal::routeMatch()->getParameter('node')) {
+    // Revisions pages load $node as a nid string instead of a node entity.
+    if (!is_object($node)) {
+      $node = Node::load($node);
+    }
     $content_type = $node->bundle();
     $suggestions[] = 'page__' . $content_type;
   }


### PR DESCRIPTION
## Description

Relates to #7746.

- Updates display of centralized content for editors (help text was getting cut off in the headers)
- Updates system banner alerts to correctly winnow available options for editors in vagovclaro
- Fixes white screen of death when changing revisions in vagovclaro
- Adjusts spacing on the node view tab for consistency

## Testing done
- verified the above in vagovclaro
- made sure the winnowing still works as expected in vagovadmin as well
- made sure revisions could be changed, reverted, compared, without breaking the site.

## Screenshots
<img width="1068" alt="Screen Shot 2022-02-10 at 11 57 48 AM" src="https://user-images.githubusercontent.com/11279744/153491876-d120fad6-0926-425b-ac46-34f6efcbcfd0.png">
<img width="916" alt="Screen Shot 2022-02-10 at 12 31 19 PM" src="https://user-images.githubusercontent.com/11279744/153491881-76318378-ab63-472b-8c40-0ad87701e3b2.png">
<img width="641" alt="Screen Shot 2022-02-10 at 12 31 50 PM" src="https://user-images.githubusercontent.com/11279744/153491885-2e3db74a-e61d-4a48-a305-65ae3accd6d7.png">
<img width="1403" alt="Screen Shot 2022-02-10 at 12 32 04 PM" src="https://user-images.githubusercontent.com/11279744/153491886-d00d22e1-25b2-4062-bc9a-cebabda245d2.png">



## QA steps
- enable vagovclaro as the admin & default theme if it is not already
- log in as `randi.hecht@va.gov`
- visit `node/16142/edit` and see centralized content help text not cut off.
- log out
- log in as `ryan.stubblebine@va.gov`
- visit `/node/add/full_width_banner_alert` and see the options are restricted 
- visit `/node/1017/edit` and click the revisions tab.
- Update revisions, compare revisions, revert to an older one. .. all actions should behave as expected, no site errors.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [x] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
