### PR TITLE
VACMS-6860: Update media view to include alt text.

### DIFF
--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.media.media_library
     - field.storage.media.field_media_in_library
     - field.storage.media.field_owner
+    - field.storage.media.image
     - image.style.medium
     - image.style.thumbnail
     - media.type.document
@@ -32,12 +33,122 @@ base_table: media_field_data
 base_field: mid
 display:
   default:
+    display_plugin: default
     id: default
     display_title: Master
-    display_plugin: default
     position: 0
     display_options:
-      title: Media
+      access:
+        type: perm
+        options:
+          perm: 'access media overview'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            name: name
+            bundle: bundle
+            changed: changed
+            uid: uid
+            status: status
+            thumbnail__target_id: thumbnail__target_id
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            bundle:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            thumbnail__target_id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: changed
+          empty_table: true
+      row:
+        type: fields
       fields:
         thumbnail__target_id:
           id: thumbnail__target_id
@@ -46,9 +157,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
           label: Thumbnail
           exclude: false
           alter:
@@ -93,8 +201,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_link: ''
             image_style: thumbnail
+            image_link: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -105,6 +213,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
         mid:
           id: mid
           table: media_field_data
@@ -112,9 +223,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: mid
-          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -171,27 +279,34 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: mid
+          plugin_id: field
         name:
           id: name
           table: media_field_data
           field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
           entity_type: media
           entity_field: media
-          plugin_id: field
-          label: 'Media name'
-          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
+            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
-            trim: false
             html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Media name'
+          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -201,13 +316,9 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: false
-          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
-          settings:
-            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -218,6 +329,70 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        image:
+          id: image
+          table: media__image
+          field: image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Alt Text'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ image__alt }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         edit_media:
           id: edit_media
           table: media
@@ -225,8 +400,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          plugin_id: entity_link_edit
           label: ''
           exclude: false
           alter:
@@ -271,6 +444,8 @@ display:
           text: edit
           output_url_as_text: false
           absolute: false
+          entity_type: media
+          plugin_id: entity_link_edit
         bundle:
           id: bundle
           table: media_field_data
@@ -278,9 +453,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: field
           label: Type
           exclude: false
           alter:
@@ -336,6 +508,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: bundle
+          plugin_id: field
         uid:
           id: uid
           table: media_field_data
@@ -343,9 +518,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: uid
-          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -401,6 +573,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
         status:
           id: status
           table: media_field_data
@@ -408,9 +583,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: status
-          plugin_id: field
           label: Status
           exclude: true
           alter:
@@ -456,8 +628,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_false: Unpublished
             format_custom_true: Published
+            format_custom_false: Unpublished
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -468,6 +640,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: status
+          plugin_id: field
         changed:
           id: changed
           table: media_field_data
@@ -475,9 +650,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: changed
-          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -535,6 +707,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
         field_owner:
           id: field_owner
           table: media__field_owner
@@ -542,7 +717,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: field
           label: Section
           exclude: false
           alter:
@@ -598,6 +772,7 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          plugin_id: field
         field_media_in_library:
           id: field_media_in_library
           table: media__field_media_in_library
@@ -605,7 +780,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: field
           label: Reusable
           exclude: false
           alter:
@@ -651,8 +825,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_false: ''
             format_custom_true: ✓
+            format_custom_false: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -663,74 +837,7 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-      pager:
-        type: full
-        options:
-          offset: 0
-          items_per_page: 50
-          total_pages: null
-          id: 0
-          tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      access:
-        type: perm
-        options:
-          perm: 'access media overview'
-      cache:
-        type: tag
-        options: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: 'No media available.'
-          tokenize: false
-      sorts:
-        created:
-          id: created
-          table: media_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: created
-          plugin_id: date
-          order: DESC
-          expose:
-            label: ''
-            field_identifier: created
-          exposed: false
-          granularity: second
-      arguments: {  }
+          plugin_id: field
       filters:
         name:
           id: name
@@ -739,9 +846,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: name
-          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -752,8 +856,6 @@ display:
             description: ''
             use_operator: false
             operator: name_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: name
             required: false
             remember: false
@@ -762,6 +864,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -774,6 +878,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -781,9 +888,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -794,8 +898,6 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -805,6 +907,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -817,6 +921,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
         field_owner_target_id:
           id: field_owner_target_id
           table: media__field_owner
@@ -824,7 +931,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -835,8 +941,6 @@ display:
             description: ''
             use_operator: false
             operator: field_owner_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: field_owner_target_id
             required: false
             remember: false
@@ -853,6 +957,8 @@ display:
               redirect_administrator: '0'
               documentation_editor: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -866,14 +972,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          vid: administration
           type: select
-          hierarchy: true
           limit: true
+          vid: administration
+          hierarchy: true
           error_message: true
           parent: 0
           level_labels: ''
           force_deepest: false
+          plugin_id: taxonomy_index_tid
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -881,7 +988,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: boolean
           operator: '='
           value: ''
           group: 1
@@ -892,14 +998,14 @@ display:
             description: null
             use_operator: false
             operator: field_media_in_library_value_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: field_media_in_library_value
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Reusable?'
@@ -920,86 +1026,107 @@ display:
                 title: 'Not reusable'
                 operator: '='
                 value: '0'
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          columns:
-            name: name
-            bundle: bundle
-            changed: changed
-            uid: uid
-            status: status
-            thumbnail__target_id: thumbnail__target_id
-          default: changed
-          info:
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            bundle:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            thumbnail__target_id:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          override: true
-          sticky: false
-          summary: ''
-          empty_table: true
-          caption: ''
-          description: ''
-      row:
-        type: fields
-      query:
-        type: views_query
-        options:
-          query_comment: ''
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_tags: {  }
+          plugin_id: boolean
+        image_alt:
+          id: image_alt
+          table: media__image
+          field: image_alt
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: image_alt_op
+            label: 'Alt text'
+            description: ''
+            use_operator: true
+            operator: image_alt_op
+            operator_limit_selection: true
+            operator_list:
+              empty: empty
+              'not empty': 'not empty'
+            identifier: image_alt
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: 'Alt text'
+            description: ''
+            identifier: image_alt
+            optional: true
+            widget: radios
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Missing
+                operator: empty
+                value: ''
+              2:
+                title: Present
+                operator: 'not empty'
+                value: ''
+          plugin_id: string
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          order: DESC
+          entity_type: media
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: Media
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No media available.'
+          plugin_id: text_custom
       relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
       use_more: true
       use_more_always: false
       use_more_text: more
-      header: {  }
-      footer: {  }
-      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1012,12 +1139,38 @@ display:
       tags:
         - 'config:field.storage.media.field_media_in_library'
         - 'config:field.storage.media.field_owner'
+        - 'config:field.storage.media.image'
   entity_browser_1:
+    display_plugin: entity_browser
     id: entity_browser_1
     display_title: Browser
-    display_plugin: entity_browser
     position: 2
     display_options:
+      display_extenders: {  }
+      style:
+        type: grid
+        options:
+          grouping: {  }
+          columns: 4
+          automatic_width: true
+          alignment: horizontal
+          col_class_default: true
+          col_class_custom: ''
+          row_class_default: true
+          row_class_custom: ''
+      defaults:
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        empty: false
+        pager: false
+        css_class: false
+        arguments: false
+      row:
+        type: fields
+        options: {  }
       fields:
         thumbnail__target_id:
           id: thumbnail__target_id
@@ -1026,9 +1179,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1073,8 +1223,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_link: ''
             image_style: medium
+            image_link: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -1085,6 +1235,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
         entity_browser_select:
           id: entity_browser_select
           table: media
@@ -1092,8 +1245,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          plugin_id: entity_browser_select
           label: ''
           exclude: false
           alter:
@@ -1135,6 +1286,8 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          entity_type: media
+          plugin_id: entity_browser_select
         rendered_entity:
           id: rendered_entity
           table: media
@@ -1142,8 +1295,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -1186,87 +1337,8 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: media_library
-      pager:
-        type: full
-        options:
-          offset: 0
-          items_per_page: 50
-          total_pages: null
-          id: 0
-          tags:
-            next: ››
-            previous: ‹‹
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: 'There are no media items to display.'
-          tokenize: false
-      arguments:
-        bundle:
-          id: bundle
-          table: media_field_data
-          field: bundle
-          relationship: none
-          group_type: group
-          admin_label: ''
           entity_type: media
-          entity_field: bundle
-          plugin_id: string
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: entity_browser_widget_context
-          default_argument_options:
-            context_key: target_bundles
-            fallback: all
-            multiple: or
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:media_type'
-            fail: ignore
-          validate_options:
-            bundles: {  }
-            access: false
-            operation: view
-            multiple: 1
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: true
+          plugin_id: rendered_entity
       filters:
         status:
           id: status
@@ -1275,9 +1347,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: status
-          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1288,14 +1357,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Publishing status'
@@ -1316,6 +1385,9 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
+          plugin_id: boolean
+          entity_type: media
+          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -1323,9 +1395,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: name
-          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -1336,8 +1405,6 @@ display:
             description: ''
             use_operator: false
             operator: name_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: keywords
             required: false
             remember: false
@@ -1353,6 +1420,8 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1365,6 +1434,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -1372,9 +1444,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -1385,8 +1454,6 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -1404,6 +1471,8 @@ display:
               media_manager: '0'
             reduce: false
             argument: bundle
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1416,6 +1485,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -1423,7 +1495,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1434,14 +1505,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1454,37 +1525,94 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      style:
-        type: grid
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'There are no media items to display.'
+          plugin_id: text_custom
+      pager:
+        type: full
         options:
-          grouping: {  }
-          columns: 4
-          automatic_width: true
-          alignment: horizontal
-          row_class_custom: ''
-          row_class_default: true
-          col_class_custom: ''
-          col_class_default: true
-      row:
-        type: fields
-        options: {  }
-      defaults:
-        empty: false
-        css_class: false
-        pager: false
-        style: false
-        row: false
-        fields: false
-        arguments: false
-        filters: false
-        filter_groups: false
-      css_class: eb-media
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       display_description: ''
-      display_extenders: {  }
+      css_class: eb-media
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: entity_browser_widget_context
+          default_argument_options:
+            context_key: target_bundles
+            fallback: all
+            multiple: or
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:media_type'
+            fail: ignore
+          validate_options:
+            operation: view
+            multiple: 1
+            access: false
+            bundles: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
     cache_metadata:
       max-age: -1
       contexts:
@@ -1494,28 +1622,53 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.media.document.default'
         - 'config:core.entity_view_display.media.document.download_link'
         - 'config:core.entity_view_display.media.document.embedded'
-        - 'config:core.entity_view_display.media.document.thumbnail'
-        - 'config:core.entity_view_display.media.image.download_link'
-        - 'config:core.entity_view_display.media.image.embedded'
-        - 'config:core.entity_view_display.media.image.thumbnail'
-        - 'config:core.entity_view_display.media.video.embedded'
-        - 'config:core.entity_view_display.media.video.thumbnail'
-        - 'config:core.entity_view_display.media.video.user_guides'
-        - 'config:core.entity_view_display.media.document.default'
         - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.document_external.default'
         - 'config:core.entity_view_display.media.document_external.media_library'
         - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.download_link'
+        - 'config:core.entity_view_display.media.image.embedded'
         - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.embedded'
+        - 'config:core.entity_view_display.media.video.thumbnail'
+        - 'config:core.entity_view_display.media.video.user_guides'
   entity_browser_2:
+    display_plugin: entity_browser
     id: entity_browser_2
     display_title: 'Image Browser'
-    display_plugin: entity_browser
     position: 3
     display_options:
+      display_extenders: {  }
+      style:
+        type: grid
+        options:
+          grouping: {  }
+          columns: 4
+          automatic_width: true
+          alignment: horizontal
+          col_class_default: true
+          col_class_custom: ''
+          row_class_default: true
+          row_class_custom: ''
+      defaults:
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        empty: false
+        pager: false
+        css_class: false
+        relationships: false
+      row:
+        type: fields
+        options: {  }
       fields:
         thumbnail__target_id:
           id: thumbnail__target_id
@@ -1524,9 +1677,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1571,8 +1721,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_link: ''
             image_style: medium
+            image_link: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -1583,6 +1733,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
         entity_browser_select:
           id: entity_browser_select
           table: file_managed
@@ -1590,8 +1743,6 @@ display:
           relationship: image_target_id
           group_type: group
           admin_label: ''
-          entity_type: file
-          plugin_id: entity_browser_select
           label: ''
           exclude: false
           alter:
@@ -1633,39 +1784,8 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-      pager:
-        type: full
-        options:
-          offset: 0
-          items_per_page: 50
-          total_pages: null
-          id: 0
-          tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: 'There are no images to display.'
-          tokenize: false
+          entity_type: file
+          plugin_id: entity_browser_select
       filters:
         status:
           id: status
@@ -1674,9 +1794,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: status
-          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1687,14 +1804,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Publishing status'
@@ -1715,6 +1832,9 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
+          plugin_id: boolean
+          entity_type: media
+          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -1722,9 +1842,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: name
-          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -1735,8 +1852,6 @@ display:
             description: ''
             use_operator: false
             operator: name_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: keywords
             required: false
             remember: false
@@ -1752,6 +1867,8 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1764,6 +1881,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -1771,9 +1891,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
           operator: in
           value:
             image: image
@@ -1785,8 +1902,6 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -1803,6 +1918,8 @@ display:
               media_creator: '0'
               media_manager: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1815,6 +1932,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -1822,7 +1942,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1833,14 +1952,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1853,34 +1972,46 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      style:
-        type: grid
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'There are no images to display.'
+          plugin_id: text_custom
+      pager:
+        type: full
         options:
-          grouping: {  }
-          columns: 4
-          automatic_width: true
-          alignment: horizontal
-          row_class_custom: ''
-          row_class_default: true
-          col_class_custom: ''
-          col_class_default: true
-      row:
-        type: fields
-        options: {  }
-      defaults:
-        empty: false
-        css_class: false
-        pager: false
-        style: false
-        row: false
-        relationships: false
-        fields: false
-        filters: false
-        filter_groups: false
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      display_description: ''
+      css_class: eb-media
       relationships:
         image_target_id:
           id: image_target_id
@@ -1889,11 +2020,8 @@ display:
           relationship: none
           group_type: group
           admin_label: Image
-          plugin_id: standard
           required: true
-      css_class: eb-media
-      display_description: ''
-      display_extenders: {  }
+          plugin_id: standard
     cache_metadata:
       max-age: -1
       contexts:
@@ -1904,11 +2032,36 @@ display:
         - user.permissions
       tags: {  }
   entity_browser_3:
+    display_plugin: entity_browser
     id: entity_browser_3
     display_title: 'Downloadable document browser'
-    display_plugin: entity_browser
     position: 2
     display_options:
+      display_extenders: {  }
+      style:
+        type: grid
+        options:
+          grouping: {  }
+          columns: 4
+          automatic_width: true
+          alignment: horizontal
+          col_class_default: true
+          col_class_custom: ''
+          row_class_default: true
+          row_class_custom: ''
+      defaults:
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        empty: false
+        pager: false
+        css_class: false
+        arguments: false
+      row:
+        type: fields
+        options: {  }
       fields:
         entity_browser_select:
           id: entity_browser_select
@@ -1917,8 +2070,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          plugin_id: entity_browser_select
           label: ''
           exclude: false
           alter:
@@ -1960,6 +2111,8 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          entity_type: media
+          plugin_id: entity_browser_select
         rendered_entity:
           id: rendered_entity
           table: media
@@ -1967,8 +2120,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -2011,87 +2162,8 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: media_library
-      pager:
-        type: full
-        options:
-          offset: 0
-          items_per_page: 50
-          total_pages: null
-          id: 0
-          tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: 'There are no media items to display.'
-          tokenize: false
-      arguments:
-        bundle:
-          id: bundle
-          table: media_field_data
-          field: bundle
-          relationship: none
-          group_type: group
-          admin_label: ''
           entity_type: media
-          entity_field: bundle
-          plugin_id: string
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: entity_browser_widget_context
-          default_argument_options:
-            context_key: target_bundles
-            fallback: all
-            multiple: or
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:media_type'
-            fail: ignore
-          validate_options:
-            bundles: {  }
-            access: false
-            operation: view
-            multiple: 1
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: true
+          plugin_id: rendered_entity
       filters:
         status:
           id: status
@@ -2100,9 +2172,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: status
-          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2113,14 +2182,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Publishing status'
@@ -2141,6 +2210,9 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
+          plugin_id: boolean
+          entity_type: media
+          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -2148,9 +2220,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: name
-          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -2161,8 +2230,6 @@ display:
             description: ''
             use_operator: false
             operator: name_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: keywords
             required: false
             remember: false
@@ -2178,6 +2245,8 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2190,6 +2259,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -2197,9 +2269,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
           operator: in
           value:
             document: document
@@ -2211,8 +2280,6 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -2230,6 +2297,8 @@ display:
               documentation_editor: '0'
             reduce: false
             argument: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2242,6 +2311,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -2249,7 +2321,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2260,14 +2331,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2280,37 +2351,94 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      style:
-        type: grid
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'There are no media items to display.'
+          plugin_id: text_custom
+      pager:
+        type: full
         options:
-          grouping: {  }
-          columns: 4
-          automatic_width: true
-          alignment: horizontal
-          row_class_custom: ''
-          row_class_default: true
-          col_class_custom: ''
-          col_class_default: true
-      row:
-        type: fields
-        options: {  }
-      defaults:
-        empty: false
-        css_class: false
-        pager: false
-        style: false
-        row: false
-        fields: false
-        arguments: false
-        filters: false
-        filter_groups: false
-      css_class: eb-media
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       display_description: ''
-      display_extenders: {  }
+      css_class: eb-media
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: entity_browser_widget_context
+          default_argument_options:
+            context_key: target_bundles
+            fallback: all
+            multiple: or
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:media_type'
+            fail: ignore
+          validate_options:
+            operation: view
+            multiple: 1
+            access: false
+            bundles: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
     cache_metadata:
       max-age: -1
       contexts:
@@ -2336,14 +2464,23 @@ display:
         - 'config:core.entity_view_display.media.video.thumbnail'
         - 'config:core.entity_view_display.media.video.user_guides'
   media_page_list:
+    display_plugin: page
     id: media_page_list
     display_title: Media
-    display_plugin: page
     position: 1
     display_options:
-      defaults:
-        header: false
+      display_extenders: {  }
+      path: admin/content/media
       display_description: ''
+      menu:
+        type: normal
+        title: 'Media library'
+        description: ''
+        expanded: false
+        parent: system.admin_content
+        weight: 3
+        context: '0'
+        menu_name: admin
       header:
         area_text_custom:
           id: area_text_custom
@@ -2352,21 +2489,12 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: text_custom
           empty: false
-          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
           tokenize: false
-      display_extenders: {  }
-      path: admin/content/media
-      menu:
-        type: normal
-        title: 'Media library'
-        description: ''
-        weight: 3
-        expanded: false
-        menu_name: admin
-        parent: system.admin_content
-        context: '0'
+          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
+          plugin_id: text_custom
+      defaults:
+        header: false
       tab_options:
         type: none
         title: 'Media library'
@@ -2384,12 +2512,46 @@ display:
       tags:
         - 'config:field.storage.media.field_media_in_library'
         - 'config:field.storage.media.field_owner'
+        - 'config:field.storage.media.image'
   page_1:
+    display_plugin: page
     id: page_1
     display_title: 'Media bulk edit'
-    display_plugin: page
     position: 1
     display_options:
+      display_extenders: {  }
+      path: admin/content/media/bulk-edit
+      display_description: ''
+      menu:
+        type: normal
+        title: 'Media bulk edit'
+        description: ''
+        expanded: false
+        parent: 'views_view:views.media.media_page_list'
+        weight: 7
+        context: '0'
+        menu_name: admin
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
+          plugin_id: text_custom
+      defaults:
+        header: false
+        access: false
+        fields: false
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
       fields:
         views_bulk_operations_bulk_form:
           id: views_bulk_operations_bulk_form
@@ -2398,7 +2560,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: views_bulk_operations_bulk_form
           label: ''
           exclude: false
           alter:
@@ -2444,6 +2605,7 @@ display:
           batch_size: 10
           form_step: true
           buttons: true
+          clear_on_exposed: true
           action_title: Action
           selected_actions:
             -
@@ -2455,7 +2617,7 @@ display:
               action_id: 'entity:delete_action:media'
               preconfiguration:
                 label_override: ''
-          clear_on_exposed: true
+          plugin_id: views_bulk_operations_bulk_form
         thumbnail__target_id:
           id: thumbnail__target_id
           table: media_field_data
@@ -2463,9 +2625,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
           label: Thumbnail
           exclude: false
           alter:
@@ -2510,8 +2669,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_link: ''
             image_style: thumbnail
+            image_link: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -2522,27 +2681,34 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
         name:
           id: name
           table: media_field_data
           field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
           entity_type: media
           entity_field: media
-          plugin_id: field
-          label: 'Media name'
-          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
+            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
-            trim: false
             html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Media name'
+          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -2552,13 +2718,9 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: false
-          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
-          settings:
-            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2576,8 +2738,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -2620,6 +2780,8 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
+          entity_type: media
+          plugin_id: entity_operations
         bundle:
           id: bundle
           table: media_field_data
@@ -2627,9 +2789,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: field
           label: Type
           exclude: false
           alter:
@@ -2685,6 +2844,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: bundle
+          plugin_id: field
         uid:
           id: uid
           table: media_field_data
@@ -2692,9 +2854,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: uid
-          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -2750,6 +2909,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
         status:
           id: status
           table: media_field_data
@@ -2757,9 +2919,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: status
-          plugin_id: field
           label: Status
           exclude: true
           alter:
@@ -2805,8 +2964,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_false: Unpublished
             format_custom_true: Published
+            format_custom_false: Unpublished
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2817,6 +2976,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: status
+          plugin_id: field
         changed:
           id: changed
           table: media_field_data
@@ -2824,9 +2986,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: changed
-          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -2884,6 +3043,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
         field_owner:
           id: field_owner
           table: media__field_owner
@@ -2891,7 +3053,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: field
           label: Section
           exclude: false
           alter:
@@ -2947,6 +3108,7 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          plugin_id: field
         field_media_in_library:
           id: field_media_in_library
           table: media__field_media_in_library
@@ -2954,7 +3116,6 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: field
           label: Reusable
           exclude: false
           alter:
@@ -3000,8 +3161,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_false: ''
             format_custom_true: ✓
+            format_custom_false: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -3012,39 +3173,7 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-      access:
-        type: role
-        options:
-          role:
-            administrator: administrator
-      defaults:
-        access: false
-        fields: false
-        header: false
-      display_description: ''
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: false
-          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
-          tokenize: false
-      display_extenders: {  }
-      path: admin/content/media/bulk-edit
-      menu:
-        type: normal
-        title: 'Media bulk edit'
-        description: ''
-        weight: 7
-        expanded: false
-        menu_name: admin
-        parent: 'views_view:views.media.media_page_list'
-        context: '0'
+          plugin_id: field
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -32,122 +32,12 @@ base_table: media_field_data
 base_field: mid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access media overview'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            name: name
-            bundle: bundle
-            changed: changed
-            uid: uid
-            status: status
-            thumbnail__target_id: thumbnail__target_id
-          info:
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            bundle:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            thumbnail__target_id:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: changed
-          empty_table: true
-      row:
-        type: fields
+      title: Media
       fields:
         thumbnail__target_id:
           id: thumbnail__target_id
@@ -156,6 +46,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
           label: Thumbnail
           exclude: false
           alter:
@@ -200,8 +93,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: thumbnail
             image_link: ''
+            image_style: thumbnail
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -212,9 +105,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
         mid:
           id: mid
           table: media_field_data
@@ -222,6 +112,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: mid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -278,34 +171,27 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: mid
-          plugin_id: field
         name:
           id: name
           table: media_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
           entity_field: media
+          plugin_id: field
+          label: 'Media name'
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Media name'
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -315,9 +201,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -335,6 +225,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_link_edit
           label: ''
           exclude: false
           alter:
@@ -379,8 +271,6 @@ display:
           text: edit
           output_url_as_text: false
           absolute: false
-          entity_type: media
-          plugin_id: entity_link_edit
         bundle:
           id: bundle
           table: media_field_data
@@ -388,6 +278,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: field
           label: Type
           exclude: false
           alter:
@@ -443,9 +336,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: bundle
-          plugin_id: field
         uid:
           id: uid
           table: media_field_data
@@ -453,6 +343,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -508,9 +401,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: uid
-          plugin_id: field
         status:
           id: status
           table: media_field_data
@@ -518,6 +408,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: true
           alter:
@@ -563,8 +456,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: Published
             format_custom_false: Unpublished
+            format_custom_true: Published
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -575,9 +468,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: status
-          plugin_id: field
         changed:
           id: changed
           table: media_field_data
@@ -585,6 +475,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -642,9 +535,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: changed
-          plugin_id: field
         field_owner:
           id: field_owner
           table: media__field_owner
@@ -652,6 +542,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Section
           exclude: false
           alter:
@@ -707,7 +598,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_media_in_library:
           id: field_media_in_library
           table: media__field_media_in_library
@@ -715,6 +605,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Reusable
           exclude: false
           alter:
@@ -760,8 +651,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: ✓
             format_custom_false: ''
+            format_custom_true: ✓
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -772,7 +663,74 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access media overview'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No media available.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         name:
           id: name
@@ -781,6 +739,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -791,6 +752,8 @@ display:
             description: ''
             use_operator: false
             operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: name
             required: false
             remember: false
@@ -799,8 +762,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -813,9 +774,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -823,6 +781,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -833,6 +794,8 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -842,8 +805,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -856,9 +817,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
         field_owner_target_id:
           id: field_owner_target_id
           table: media__field_owner
@@ -866,6 +824,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -876,6 +835,8 @@ display:
             description: ''
             use_operator: false
             operator: field_owner_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_owner_target_id
             required: false
             remember: false
@@ -892,8 +853,6 @@ display:
               redirect_administrator: '0'
               documentation_editor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -907,15 +866,14 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: administration
+          type: select
           hierarchy: true
+          limit: true
           error_message: true
           parent: 0
           level_labels: ''
           force_deepest: false
-          plugin_id: taxonomy_index_tid
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -923,6 +881,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: ''
           group: 1
@@ -933,14 +892,14 @@ display:
             description: null
             use_operator: false
             operator: field_media_in_library_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_media_in_library_value
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Reusable?'
@@ -961,48 +920,90 @@ display:
                 title: 'Not reusable'
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-      sorts:
-        created:
-          id: created
-          table: media_field_data
-          field: created
-          order: DESC
-          entity_type: media
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-      title: Media
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No media available.'
-          plugin_id: text_custom
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
-      use_more: true
-      use_more_always: false
-      use_more_text: more
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            name: name
+            bundle: bundle
+            changed: changed
+            uid: uid
+            status: status
+            thumbnail__target_id: thumbnail__target_id
+          default: changed
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            bundle:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            thumbnail__target_id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_more: true
+      use_more_always: false
+      use_more_text: more
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1016,36 +1017,11 @@ display:
         - 'config:field.storage.media.field_media_in_library'
         - 'config:field.storage.media.field_owner'
   entity_browser_1:
-    display_plugin: entity_browser
     id: entity_browser_1
     display_title: Browser
+    display_plugin: entity_browser
     position: 2
     display_options:
-      display_extenders: {  }
-      style:
-        type: grid
-        options:
-          grouping: {  }
-          columns: 4
-          automatic_width: true
-          alignment: horizontal
-          col_class_default: true
-          col_class_custom: ''
-          row_class_default: true
-          row_class_custom: ''
-      defaults:
-        style: false
-        row: false
-        fields: false
-        filters: false
-        filter_groups: false
-        empty: false
-        pager: false
-        css_class: false
-        arguments: false
-      row:
-        type: fields
-        options: {  }
       fields:
         thumbnail__target_id:
           id: thumbnail__target_id
@@ -1054,6 +1030,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1098,8 +1077,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: medium
             image_link: ''
+            image_style: medium
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -1110,9 +1089,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
         entity_browser_select:
           id: entity_browser_select
           table: media
@@ -1120,6 +1096,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_browser_select
           label: ''
           exclude: false
           alter:
@@ -1161,8 +1139,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: media
-          plugin_id: entity_browser_select
         rendered_entity:
           id: rendered_entity
           table: media
@@ -1170,6 +1146,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -1212,8 +1190,87 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: media_library
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There are no media items to display.'
+          tokenize: false
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
-          plugin_id: rendered_entity
+          entity_field: bundle
+          plugin_id: string
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: entity_browser_widget_context
+          default_argument_options:
+            context_key: target_bundles
+            fallback: all
+            multiple: or
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:media_type'
+            fail: ignore
+          validate_options:
+            bundles: {  }
+            access: false
+            operation: view
+            multiple: 1
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
       filters:
         status:
           id: status
@@ -1222,6 +1279,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1232,14 +1292,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Publishing status'
@@ -1260,9 +1320,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: media
-          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -1270,6 +1327,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -1280,6 +1340,8 @@ display:
             description: ''
             use_operator: false
             operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: keywords
             required: false
             remember: false
@@ -1295,8 +1357,6 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1309,9 +1369,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -1319,6 +1376,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -1329,6 +1389,8 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -1346,8 +1408,6 @@ display:
               media_manager: '0'
             reduce: false
             argument: bundle
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1360,9 +1420,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -1370,6 +1427,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1380,14 +1438,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1400,94 +1458,37 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'There are no media items to display.'
-          plugin_id: text_custom
-      pager:
-        type: full
+      style:
+        type: grid
         options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      display_description: ''
+          grouping: {  }
+          columns: 4
+          automatic_width: true
+          alignment: horizontal
+          row_class_custom: ''
+          row_class_default: true
+          col_class_custom: ''
+          col_class_default: true
+      row:
+        type: fields
+        options: {  }
+      defaults:
+        empty: false
+        css_class: false
+        pager: false
+        style: false
+        row: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
       css_class: eb-media
-      arguments:
-        bundle:
-          id: bundle
-          table: media_field_data
-          field: bundle
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: entity_browser_widget_context
-          default_argument_options:
-            context_key: target_bundles
-            fallback: all
-            multiple: or
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:media_type'
-            fail: ignore
-          validate_options:
-            operation: view
-            multiple: 1
-            access: false
-            bundles: {  }
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: true
-          entity_type: media
-          entity_field: bundle
-          plugin_id: string
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1514,36 +1515,11 @@ display:
         - 'config:core.entity_view_display.media.video.thumbnail'
         - 'config:core.entity_view_display.media.video.user_guides'
   entity_browser_2:
-    display_plugin: entity_browser
     id: entity_browser_2
     display_title: 'Image Browser'
+    display_plugin: entity_browser
     position: 3
     display_options:
-      display_extenders: {  }
-      style:
-        type: grid
-        options:
-          grouping: {  }
-          columns: 4
-          automatic_width: true
-          alignment: horizontal
-          col_class_default: true
-          col_class_custom: ''
-          row_class_default: true
-          row_class_custom: ''
-      defaults:
-        style: false
-        row: false
-        fields: false
-        filters: false
-        filter_groups: false
-        empty: false
-        pager: false
-        css_class: false
-        relationships: false
-      row:
-        type: fields
-        options: {  }
       fields:
         thumbnail__target_id:
           id: thumbnail__target_id
@@ -1552,6 +1528,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1596,8 +1575,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: medium
             image_link: ''
+            image_style: medium
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -1608,9 +1587,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
         entity_browser_select:
           id: entity_browser_select
           table: file_managed
@@ -1618,6 +1594,8 @@ display:
           relationship: image_target_id
           group_type: group
           admin_label: ''
+          entity_type: file
+          plugin_id: entity_browser_select
           label: ''
           exclude: false
           alter:
@@ -1659,8 +1637,39 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: file
-          plugin_id: entity_browser_select
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There are no images to display.'
+          tokenize: false
       filters:
         status:
           id: status
@@ -1669,6 +1678,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1679,14 +1691,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Publishing status'
@@ -1707,9 +1719,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: media
-          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -1717,6 +1726,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -1727,6 +1739,8 @@ display:
             description: ''
             use_operator: false
             operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: keywords
             required: false
             remember: false
@@ -1742,8 +1756,6 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1756,9 +1768,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -1766,6 +1775,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
           operator: in
           value:
             image: image
@@ -1777,6 +1789,8 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -1793,8 +1807,6 @@ display:
               media_creator: '0'
               media_manager: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1807,9 +1819,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -1817,6 +1826,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1827,14 +1837,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1847,46 +1857,34 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'There are no images to display.'
-          plugin_id: text_custom
-      pager:
-        type: full
+      style:
+        type: grid
         options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      display_description: ''
-      css_class: eb-media
+          grouping: {  }
+          columns: 4
+          automatic_width: true
+          alignment: horizontal
+          row_class_custom: ''
+          row_class_default: true
+          col_class_custom: ''
+          col_class_default: true
+      row:
+        type: fields
+        options: {  }
+      defaults:
+        empty: false
+        css_class: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        filters: false
+        filter_groups: false
       relationships:
         image_target_id:
           id: image_target_id
@@ -1895,8 +1893,11 @@ display:
           relationship: none
           group_type: group
           admin_label: Image
-          required: true
           plugin_id: standard
+          required: true
+      css_class: eb-media
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1907,36 +1908,11 @@ display:
         - user.permissions
       tags: {  }
   entity_browser_3:
-    display_plugin: entity_browser
     id: entity_browser_3
     display_title: 'Downloadable document browser'
+    display_plugin: entity_browser
     position: 2
     display_options:
-      display_extenders: {  }
-      style:
-        type: grid
-        options:
-          grouping: {  }
-          columns: 4
-          automatic_width: true
-          alignment: horizontal
-          col_class_default: true
-          col_class_custom: ''
-          row_class_default: true
-          row_class_custom: ''
-      defaults:
-        style: false
-        row: false
-        fields: false
-        filters: false
-        filter_groups: false
-        empty: false
-        pager: false
-        css_class: false
-        arguments: false
-      row:
-        type: fields
-        options: {  }
       fields:
         entity_browser_select:
           id: entity_browser_select
@@ -1945,6 +1921,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_browser_select
           label: ''
           exclude: false
           alter:
@@ -1986,8 +1964,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: media
-          plugin_id: entity_browser_select
         rendered_entity:
           id: rendered_entity
           table: media
@@ -1995,6 +1971,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -2037,8 +2015,87 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: media_library
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There are no media items to display.'
+          tokenize: false
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
-          plugin_id: rendered_entity
+          entity_field: bundle
+          plugin_id: string
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: entity_browser_widget_context
+          default_argument_options:
+            context_key: target_bundles
+            fallback: all
+            multiple: or
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:media_type'
+            fail: ignore
+          validate_options:
+            bundles: {  }
+            access: false
+            operation: view
+            multiple: 1
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
       filters:
         status:
           id: status
@@ -2047,6 +2104,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2057,14 +2117,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Publishing status'
@@ -2085,9 +2145,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: media
-          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -2095,6 +2152,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -2105,6 +2165,8 @@ display:
             description: ''
             use_operator: false
             operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: keywords
             required: false
             remember: false
@@ -2120,8 +2182,6 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2134,9 +2194,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -2144,6 +2201,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
           operator: in
           value:
             document: document
@@ -2155,6 +2215,8 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -2172,8 +2234,6 @@ display:
               documentation_editor: '0'
             reduce: false
             argument: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2186,9 +2246,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -2196,6 +2253,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2206,14 +2264,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2226,94 +2284,37 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'There are no media items to display.'
-          plugin_id: text_custom
-      pager:
-        type: full
+      style:
+        type: grid
         options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      display_description: ''
+          grouping: {  }
+          columns: 4
+          automatic_width: true
+          alignment: horizontal
+          row_class_custom: ''
+          row_class_default: true
+          col_class_custom: ''
+          col_class_default: true
+      row:
+        type: fields
+        options: {  }
+      defaults:
+        empty: false
+        css_class: false
+        pager: false
+        style: false
+        row: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
       css_class: eb-media
-      arguments:
-        bundle:
-          id: bundle
-          table: media_field_data
-          field: bundle
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: entity_browser_widget_context
-          default_argument_options:
-            context_key: target_bundles
-            fallback: all
-            multiple: or
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:media_type'
-            fail: ignore
-          validate_options:
-            operation: view
-            multiple: 1
-            access: false
-            bundles: {  }
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: true
-          entity_type: media
-          entity_field: bundle
-          plugin_id: string
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -2339,23 +2340,14 @@ display:
         - 'config:core.entity_view_display.media.video.thumbnail'
         - 'config:core.entity_view_display.media.video.user_guides'
   media_page_list:
-    display_plugin: page
     id: media_page_list
     display_title: Media
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: admin/content/media
+      defaults:
+        header: false
       display_description: ''
-      menu:
-        type: normal
-        title: 'Media library'
-        description: ''
-        expanded: false
-        parent: system.admin_content
-        weight: 3
-        context: '0'
-        menu_name: admin
       header:
         area_text_custom:
           id: area_text_custom
@@ -2364,12 +2356,21 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
-          tokenize: false
-          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
           plugin_id: text_custom
-      defaults:
-        header: false
+          empty: false
+          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
+          tokenize: false
+      display_extenders: {  }
+      path: admin/content/media
+      menu:
+        type: normal
+        title: 'Media library'
+        description: ''
+        weight: 3
+        expanded: false
+        menu_name: admin
+        parent: system.admin_content
+        context: '0'
       tab_options:
         type: none
         title: 'Media library'
@@ -2388,44 +2389,11 @@ display:
         - 'config:field.storage.media.field_media_in_library'
         - 'config:field.storage.media.field_owner'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: 'Media bulk edit'
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: admin/content/media/bulk-edit
-      display_description: ''
-      menu:
-        type: normal
-        title: 'Media bulk edit'
-        description: ''
-        expanded: false
-        parent: 'views_view:views.media.media_page_list'
-        weight: 7
-        context: '0'
-        menu_name: admin
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
-          plugin_id: text_custom
-      defaults:
-        header: false
-        access: false
-        fields: false
-      access:
-        type: role
-        options:
-          role:
-            administrator: administrator
       fields:
         views_bulk_operations_bulk_form:
           id: views_bulk_operations_bulk_form
@@ -2434,6 +2402,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: views_bulk_operations_bulk_form
           label: ''
           exclude: false
           alter:
@@ -2479,7 +2448,6 @@ display:
           batch_size: 10
           form_step: true
           buttons: true
-          clear_on_exposed: true
           action_title: Action
           selected_actions:
             -
@@ -2491,7 +2459,7 @@ display:
               action_id: 'entity:delete_action:media'
               preconfiguration:
                 label_override: ''
-          plugin_id: views_bulk_operations_bulk_form
+          clear_on_exposed: true
         thumbnail__target_id:
           id: thumbnail__target_id
           table: media_field_data
@@ -2499,6 +2467,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
           label: Thumbnail
           exclude: false
           alter:
@@ -2543,8 +2514,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: thumbnail
             image_link: ''
+            image_style: thumbnail
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -2555,34 +2526,27 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
         name:
           id: name
           table: media_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
           entity_field: media
+          plugin_id: field
+          label: 'Media name'
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Media name'
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -2592,9 +2556,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2612,6 +2580,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -2654,8 +2624,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          entity_type: media
-          plugin_id: entity_operations
         bundle:
           id: bundle
           table: media_field_data
@@ -2663,6 +2631,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: field
           label: Type
           exclude: false
           alter:
@@ -2718,9 +2689,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: bundle
-          plugin_id: field
         uid:
           id: uid
           table: media_field_data
@@ -2728,6 +2696,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -2783,9 +2754,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: uid
-          plugin_id: field
         status:
           id: status
           table: media_field_data
@@ -2793,6 +2761,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: true
           alter:
@@ -2838,8 +2809,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: Published
             format_custom_false: Unpublished
+            format_custom_true: Published
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2850,9 +2821,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: status
-          plugin_id: field
         changed:
           id: changed
           table: media_field_data
@@ -2860,6 +2828,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -2917,9 +2888,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: changed
-          plugin_id: field
         field_owner:
           id: field_owner
           table: media__field_owner
@@ -2927,6 +2895,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Section
           exclude: false
           alter:
@@ -2982,7 +2951,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_media_in_library:
           id: field_media_in_library
           table: media__field_media_in_library
@@ -2990,6 +2958,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Reusable
           exclude: false
           alter:
@@ -3035,8 +3004,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: ✓
             format_custom_false: ''
+            format_custom_true: ✓
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -3047,7 +3016,39 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      defaults:
+        access: false
+        fields: false
+        header: false
+      display_description: ''
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: false
+          content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
+          tokenize: false
+      display_extenders: {  }
+      path: admin/content/media/bulk-edit
+      menu:
+        type: normal
+        title: 'Media bulk edit'
+        description: ''
+        weight: 7
+        expanded: false
+        menu_name: admin
+        parent: 'views_view:views.media.media_page_list'
+        context: '0'
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -6,7 +6,6 @@ dependencies:
     - core.entity_view_mode.media.media_library
     - field.storage.media.field_media_in_library
     - field.storage.media.field_owner
-    - field.storage.media.image
     - image.style.medium
     - image.style.thumbnail
     - media.type.document
@@ -329,70 +328,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        image:
-          id: image
-          table: media__image
-          field: image
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Alt Text'
-          exclude: false
-          alter:
-            alter_text: true
-            text: '{{ image__alt }}'
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: true
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: image
-          settings:
-            image_style: ''
-            image_link: ''
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
         edit_media:
           id: edit_media
           table: media
@@ -1027,69 +962,6 @@ display:
                 operator: '='
                 value: '0'
           plugin_id: boolean
-        image_alt:
-          id: image_alt
-          table: media__image
-          field: image_alt
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: 'not empty'
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: image_alt_op
-            label: 'Alt text'
-            description: ''
-            use_operator: true
-            operator: image_alt_op
-            operator_limit_selection: true
-            operator_list:
-              empty: empty
-              'not empty': 'not empty'
-            identifier: image_alt
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              content_api_consumer: '0'
-              content_creator_benefits_hubs: '0'
-              content_creator_resources_and_support: '0'
-              office_content_creator: '0'
-              vamc_content_creator: '0'
-              content_creator_vet_center: '0'
-              content_editor: '0'
-              content_reviewer: '0'
-              content_publisher: '0'
-              content_admin: '0'
-              redirect_administrator: '0'
-              admnistrator_users: '0'
-              administrator: '0'
-            placeholder: ''
-          is_grouped: true
-          group_info:
-            label: 'Alt text'
-            description: ''
-            identifier: image_alt
-            optional: true
-            widget: radios
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: Missing
-                operator: empty
-                value: ''
-              2:
-                title: Present
-                operator: 'not empty'
-                value: ''
-          plugin_id: string
       sorts:
         created:
           id: created
@@ -1127,6 +999,10 @@ display:
       use_more: true
       use_more_always: false
       use_more_text: more
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:
@@ -1139,7 +1015,6 @@ display:
       tags:
         - 'config:field.storage.media.field_media_in_library'
         - 'config:field.storage.media.field_owner'
-        - 'config:field.storage.media.image'
   entity_browser_1:
     display_plugin: entity_browser
     id: entity_browser_1
@@ -2512,7 +2387,6 @@ display:
       tags:
         - 'config:field.storage.media.field_media_in_library'
         - 'config:field.storage.media.field_owner'
-        - 'config:field.storage.media.image'
   page_1:
     display_plugin: page
     id: page_1

--- a/config/sync/views.view.media_images.yml
+++ b/config/sync/views.view.media_images.yml
@@ -30,122 +30,12 @@ base_table: media_field_data
 base_field: mid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access media overview'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            name: name
-            bundle: bundle
-            changed: changed
-            uid: uid
-            status: status
-            thumbnail__target_id: thumbnail__target_id
-          info:
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            bundle:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            thumbnail__target_id:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: changed
-          empty_table: true
-      row:
-        type: fields
+      title: 'Media - images export'
       fields:
         thumbnail__target_id:
           id: thumbnail__target_id
@@ -154,6 +44,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
           label: Thumbnail
           exclude: false
           alter:
@@ -198,8 +91,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: thumbnail
             image_link: ''
+            image_style: thumbnail
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -210,9 +103,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
         mid:
           id: mid
           table: media_field_data
@@ -220,6 +110,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: mid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -276,34 +169,27 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: mid
-          plugin_id: field
         name:
           id: name
           table: media_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
           entity_field: media
+          plugin_id: field
+          label: 'Media name'
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Media name'
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -313,9 +199,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -333,6 +223,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: 'Alt Text'
           exclude: false
           alter:
@@ -377,8 +268,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: ''
             image_link: ''
+            image_style: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -389,7 +280,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         edit_media:
           id: edit_media
           table: media
@@ -397,6 +287,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_link_edit
           label: ''
           exclude: false
           alter:
@@ -441,8 +333,6 @@ display:
           text: edit
           output_url_as_text: false
           absolute: false
-          entity_type: media
-          plugin_id: entity_link_edit
         uid:
           id: uid
           table: media_field_data
@@ -450,6 +340,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -505,9 +398,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: uid
-          plugin_id: field
         status:
           id: status
           table: media_field_data
@@ -515,6 +405,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: true
           alter:
@@ -560,8 +453,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: Published
             format_custom_false: Unpublished
+            format_custom_true: Published
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -572,9 +465,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: status
-          plugin_id: field
         changed:
           id: changed
           table: media_field_data
@@ -582,6 +472,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -639,9 +532,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: changed
-          plugin_id: field
         field_owner:
           id: field_owner
           table: media__field_owner
@@ -649,6 +539,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Section
           exclude: false
           alter:
@@ -704,7 +595,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_media_in_library:
           id: field_media_in_library
           table: media__field_media_in_library
@@ -712,6 +602,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Reusable
           exclude: false
           alter:
@@ -757,8 +648,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: ✓
             format_custom_false: ''
+            format_custom_true: ✓
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -769,7 +660,74 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access media overview'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No media available.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         name:
           id: name
@@ -778,6 +736,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -788,6 +749,8 @@ display:
             description: ''
             use_operator: false
             operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: name
             required: false
             remember: false
@@ -796,8 +759,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -810,9 +771,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -820,6 +778,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
           operator: in
           value:
             image: image
@@ -866,9 +827,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
         field_owner_target_id:
           id: field_owner_target_id
           table: media__field_owner
@@ -876,6 +834,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -886,6 +845,8 @@ display:
             description: ''
             use_operator: false
             operator: field_owner_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_owner_target_id
             required: false
             remember: false
@@ -902,8 +863,6 @@ display:
               redirect_administrator: '0'
               documentation_editor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -917,15 +876,14 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: administration
+          type: select
           hierarchy: true
+          limit: true
           error_message: true
           parent: 0
           level_labels: ''
           force_deepest: false
-          plugin_id: taxonomy_index_tid
         field_media_in_library_value:
           id: field_media_in_library_value
           table: media__field_media_in_library
@@ -933,6 +891,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: ''
           group: 1
@@ -943,14 +902,14 @@ display:
             description: null
             use_operator: false
             operator: field_media_in_library_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_media_in_library_value
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Reusable?'
@@ -971,7 +930,6 @@ display:
                 title: 'Not reusable'
                 operator: '='
                 value: '0'
-          plugin_id: boolean
         image_alt:
           id: image_alt
           table: media__image
@@ -979,6 +937,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: 'not empty'
           value: ''
           group: 1
@@ -1034,44 +993,86 @@ display:
                 title: Present
                 operator: 'not empty'
                 value: ''
-          plugin_id: string
-      sorts:
-        created:
-          id: created
-          table: media_field_data
-          field: created
-          order: DESC
-          entity_type: media
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-      title: 'Media - images export'
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No media available.'
-          plugin_id: text_custom
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            name: name
+            bundle: bundle
+            changed: changed
+            uid: uid
+            status: status
+            thumbnail__target_id: thumbnail__target_id
+          default: changed
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            bundle:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            thumbnail__target_id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
       use_more: true
       use_more_always: false
       use_more_text: more
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1086,19 +1087,11 @@ display:
         - 'config:field.storage.media.field_owner'
         - 'config:field.storage.media.image'
   images_export:
-    display_plugin: data_export
     id: images_export
     display_title: 'Data export'
+    display_plugin: data_export
     position: 2
     display_options:
-      display_extenders: {  }
-      path: admin/content/media/images-export.csv
-      filename: images-export.csv
-      automatic_download: false
-      store_in_public_file_directory: null
-      redirect_to_display: none
-      custom_redirect_path: false
-      include_query_params: false
       style:
         type: data_export
         options:
@@ -1113,8 +1106,16 @@ display:
             encoding: utf8
             utf8_bom: '0'
             use_serializer_encode_only: false
+      display_extenders: {  }
+      path: admin/content/media/images-export.csv
+      filename: images-export.csv
+      automatic_download: false
       export_method: batch
       export_batch_size: 1000
+      store_in_public_file_directory: null
+      custom_redirect_path: false
+      redirect_to_display: none
+      include_query_params: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -1129,33 +1130,33 @@ display:
         - 'config:field.storage.media.field_owner'
         - 'config:field.storage.media.image'
   media_images:
-    display_plugin: page
     id: media_images
     display_title: Media
+    display_plugin: page
     position: 1
     display_options:
+      title: 'Media - images'
+      defaults:
+        title: false
+        header: false
+      display_description: ''
+      header: {  }
       display_extenders: {  }
       path: admin/content/media/images
-      display_description: ''
       menu:
         type: normal
         title: 'Media library'
         description: ''
-        expanded: false
-        parent: system.admin_content
         weight: 3
-        context: '0'
+        expanded: false
         menu_name: admin
-      header: {  }
-      defaults:
-        header: false
-        title: false
+        parent: system.admin_content
+        context: '0'
       tab_options:
         type: none
         title: 'Media library'
         description: ''
         weight: 0
-      title: 'Media - images'
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.media_images.yml
+++ b/config/sync/views.view.media_images.yml
@@ -930,6 +930,59 @@ display:
                 title: 'Not reusable'
                 operator: '='
                 value: '0'
+        image_alt_1:
+          id: image_alt_1
+          table: media__image
+          field: image_alt
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: image_alt_1_op
+            label: 'Alt contains'
+            description: ''
+            use_operator: false
+            operator: image_alt_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: image_alt_1
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         image_alt:
           id: image_alt
           table: media__image
@@ -993,6 +1046,10 @@ display:
                 title: Present
                 operator: 'not empty'
                 value: ''
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:

--- a/config/sync/views.view.media_images.yml
+++ b/config/sync/views.view.media_images.yml
@@ -1,0 +1,1171 @@
+uuid: fa1cfd7a-4338-40c6-adf0-0d4ec664bc46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_in_library
+    - field.storage.media.field_owner
+    - field.storage.media.image
+    - image.style.thumbnail
+    - media.type.image
+    - system.menu.admin
+    - taxonomy.vocabulary.administration
+  module:
+    - csv_serialization
+    - image
+    - media
+    - rest
+    - serialization
+    - taxonomy
+    - user
+    - views_data_export
+_core:
+  default_config_hash: rRzAWaXpJGYA2gPG6BmGxy8gfFd4srCc-LQY3JB6tR8
+id: media_images
+label: 'Media Images'
+module: views
+description: ''
+tag: ''
+base_table: media_field_data
+base_field: mid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access media overview'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            name: name
+            bundle: bundle
+            changed: changed
+            uid: uid
+            status: status
+            thumbnail__target_id: thumbnail__target_id
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            bundle:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            thumbnail__target_id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: changed
+          empty_table: true
+      row:
+        type: fields
+      fields:
+        thumbnail__target_id:
+          id: thumbnail__target_id
+          table: media_field_data
+          field: thumbnail__target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Thumbnail
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: thumbnail
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
+        mid:
+          id: mid
+          table: media_field_data
+          field: mid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: mid
+          plugin_id: field
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          entity_type: media
+          entity_field: media
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Media name'
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        image:
+          id: image
+          table: media__image
+          field: image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Alt Text'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ image__alt }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        edit_media:
+          id: edit_media
+          table: media
+          field: edit_media
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="/media/{{ mid }}/edit" class="button">Edit</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: edit
+          output_url_as_text: false
+          absolute: false
+          entity_type: media
+          plugin_id: entity_link_edit
+        uid:
+          id: uid
+          table: media_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Status
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: Published
+            format_custom_false: Unpublished
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: status
+          plugin_id: field
+        changed:
+          id: changed
+          table: media_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
+        field_owner:
+          id: field_owner
+          table: media__field_owner
+          field: field_owner
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Section
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_media_in_library:
+          id: field_media_in_library
+          table: media__field_media_in_library
+          field: field_media_in_library
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Reusable
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: ✓
+            format_custom_false: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: 'Media name'
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            image: image
+          group: 1
+          exposed: false
+          expose:
+            operator_id: bundle_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
+        field_owner_target_id:
+          id: field_owner_target_id
+          table: media__field_owner
+          field: field_owner_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_owner_target_id_op
+            label: Section
+            description: ''
+            use_operator: false
+            operator: field_owner_target_id_op
+            identifier: field_owner_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              redirect_administrator: '0'
+              documentation_editor: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: administration
+          hierarchy: true
+          error_message: true
+          parent: 0
+          level_labels: ''
+          force_deepest: false
+          plugin_id: taxonomy_index_tid
+        field_media_in_library_value:
+          id: field_media_in_library_value
+          table: media__field_media_in_library
+          field: field_media_in_library_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Reusable
+            description: null
+            use_operator: false
+            operator: field_media_in_library_value_op
+            identifier: field_media_in_library_value
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: true
+          group_info:
+            label: 'Reusable?'
+            description: ''
+            identifier: field_media_in_library_value
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Reusable
+                operator: '='
+                value: '1'
+              2:
+                title: 'Not reusable'
+                operator: '='
+                value: '0'
+          plugin_id: boolean
+        image_alt:
+          id: image_alt
+          table: media__image
+          field: image_alt
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: image_alt_op
+            label: 'Alt text'
+            description: ''
+            use_operator: true
+            operator: image_alt_op
+            operator_limit_selection: true
+            operator_list:
+              empty: empty
+              'not empty': 'not empty'
+            identifier: image_alt
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: 'Alt text'
+            description: ''
+            identifier: image_alt
+            optional: true
+            widget: radios
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Missing
+                operator: empty
+                value: ''
+              2:
+                title: Present
+                operator: 'not empty'
+                value: ''
+          plugin_id: string
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          order: DESC
+          entity_type: media
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: 'Media - images export'
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No media available.'
+          plugin_id: text_custom
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      use_more: true
+      use_more_always: false
+      use_more_text: more
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags:
+        - 'config:field.storage.media.field_media_in_library'
+        - 'config:field.storage.media.field_owner'
+        - 'config:field.storage.media.image'
+  images_export:
+    display_plugin: data_export
+    id: images_export
+    display_title: 'Data export'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media/images-export.csv
+      filename: images-export.csv
+      automatic_download: false
+      store_in_public_file_directory: null
+      redirect_to_display: none
+      custom_redirect_path: false
+      include_query_params: false
+      style:
+        type: data_export
+        options:
+          formats:
+            csv: csv
+          csv_settings:
+            delimiter: ','
+            enclosure: '"'
+            escape_char: \
+            strip_tags: true
+            trim: true
+            encoding: utf8
+            utf8_bom: '0'
+            use_serializer_encode_only: false
+      export_method: batch
+      export_batch_size: 1000
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - user
+        - user.permissions
+      tags:
+        - 'config:field.storage.media.field_media_in_library'
+        - 'config:field.storage.media.field_owner'
+        - 'config:field.storage.media.image'
+  media_images:
+    display_plugin: page
+    id: media_images
+    display_title: Media
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media/images
+      display_description: ''
+      menu:
+        type: normal
+        title: 'Media library'
+        description: ''
+        expanded: false
+        parent: system.admin_content
+        weight: 3
+        context: '0'
+        menu_name: admin
+      header: {  }
+      defaults:
+        header: false
+        title: false
+      tab_options:
+        type: none
+        title: 'Media library'
+        description: ''
+        weight: 0
+      title: 'Media - images'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags:
+        - 'config:field.storage.media.field_media_in_library'
+        - 'config:field.storage.media.field_owner'
+        - 'config:field.storage.media.image'

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -35,6 +35,7 @@ Feature: Views
 | Local facilities entity reference view | local_facilities_entity_reference_view | Content | Enabled | An entity reference view that determines options for the Local Health Service descriptions |
 | Locked content | locked_content | Content | Enabled |  |
 | Media | media | Media | Enabled |  |
+| Media Images | media_images | Media | Enabled |  |
 | Media library | media_library | Media | Enabled | Find and manage media. |
 | Moderated content | moderated_content | Content revisions | Enabled | Find and moderate content. |
 | Moderation history | moderation_history | Content revisions | Enabled |  |
@@ -168,6 +169,9 @@ Feature: Views
 | Media | Media | media_page_list | Page |
 | Media | Downloadable document browser | entity_browser_3 | Entity browser |
 | Media | Media bulk edit | page_1 | Page |
+| Media Images | Master | default | Default |
+| Media Images | Media | media_images | Page |
+| Media Images | Data export | images_export | Data export |
 | Media library | Master | default | Default |
 | Media library | Page | page | Page |
 | Media library | Widget | widget | Page |

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -169,9 +169,9 @@ Feature: Views
 | Media | Media | media_page_list | Page |
 | Media | Downloadable document browser | entity_browser_3 | Entity browser |
 | Media | Media bulk edit | page_1 | Page |
-| Media - images | Default | default | Default |
-| Media - images | Media | media_images | Page |
-| Media - images export | Data export | images_export | Data export |
+| Media Images | Master | default | Default |
+| Media Images | Media | media_images | Page |
+| Media Images | Data export | images_export | Data export |
 | Media library | Master | default | Default |
 | Media library | Page | page | Page |
 | Media library | Widget | widget | Page |

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -169,9 +169,9 @@ Feature: Views
 | Media | Media | media_page_list | Page |
 | Media | Downloadable document browser | entity_browser_3 | Entity browser |
 | Media | Media bulk edit | page_1 | Page |
-| Media Images | Master | default | Default |
-| Media Images | Media | media_images | Page |
-| Media Images | Data export | images_export | Data export |
+| Media - images | Default | default | Default |
+| Media - images | Media | media_images | Page |
+| Media - images export | Data export | images_export | Data export |
 | Media library | Master | default | Default |
 | Media library | Page | page | Page |
 | Media library | Widget | widget | Page |


### PR DESCRIPTION
## Description

Closes #8103
Closes #6860 .  Kev and I refined this in a slightly different way the the original ticket's ACs. I created a copy of the media view, filtered it by images and added the alt text field, filter and export. We may add additional functionality to this audit at a later date. 

## Testing done
Views the media page and saw the alt text appearing.

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/153957845-8ca18af2-aac2-49e6-9c49-2a4dc7d142cf.png)


## QA steps

As a cms editor, I can
1. view the new media images page (`admin/content/media/images`) 
2. Then validate Acceptance Criteria from issue
- [x] View Alt text in the report

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [x] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
