### PR TITLE
Adds field_office_id and field_parent_office to Office content type

### DIFF
--- a/config/sync/core.entity_form_display.node.office.default.yml
+++ b/config/sync/core.entity_form_display.node.office.default.yml
@@ -10,6 +10,8 @@ dependencies:
     - field.field.node.office.field_external_link
     - field.field.node.office.field_meta_tags
     - field.field.node.office.field_meta_title
+    - field.field.node.office.field_office_id
+    - field.field.node.office.field_parent_office
     - field.field.node.office.field_social_media_links
     - node.type.office
     - workflows.workflow.editorial
@@ -26,107 +28,107 @@ third_party_settings:
     group_governance:
       children:
         - field_administration
-      label: 'Section settings'
-      region: content
       parent_name: ''
       weight: 8
       format_type: details_sidebar
       format_settings:
-        classes: ''
         id: ''
-        open: true
+        classes: ''
         description: ''
+        open: true
         required_fields: true
         weight: -10
+      label: 'Section settings'
+      region: content
     group_meta_tags:
       children:
         - field_meta_title
         - field_description
-      label: 'Meta Tags'
-      region: content
       parent_name: group_tabs
       weight: 22
       format_type: tab
       format_settings:
-        classes: ''
         id: ''
-        formatter: closed
+        classes: ''
         description: ''
         required_fields: true
+        formatter: closed
+      label: 'Meta Tags'
+      region: content
     group_editorial_workflow:
       children:
         - moderation_state
         - revision_log
-      label: 'Editorial workflow'
-      region: content
       parent_name: ''
       weight: 9
       format_type: fieldset
       format_settings:
-        classes: ''
         id: ''
+        classes: ''
         description: ''
-        required_fields: true
         open: true
+        required_fields: true
+      label: 'Editorial workflow'
+      region: content
     group_tabs:
       children:
         - group_content
         - group_connect_with_us
         - group_meta_tags
-      label: tabs
-      region: content
       parent_name: ''
       weight: 1
       format_type: tabs
+      region: content
       format_settings:
-        classes: ''
         show_empty_fields: false
         id: ''
+        classes: ''
         direction: vertical
         width_breakpoint: '640'
+      label: tabs
     group_content:
       children:
         - field_body
-      label: Content
-      region: content
       parent_name: group_tabs
       weight: 20
       format_type: tab
+      region: content
       format_settings:
-        classes: ''
         show_empty_fields: false
         id: ''
-        formatter: closed
+        classes: ''
         description: ''
+        formatter: closed
         required_fields: true
+      label: Content
     group_connect_with_us:
       children:
         - field_external_link
         - field_email_updates_link
         - field_social_media_links
-      label: 'Connect with Us'
-      region: content
       parent_name: group_tabs
       weight: 21
       format_type: tab
+      region: content
       format_settings:
+        description: 'The content entered below is shown in the ''Connect with Us'' sidebar on related Benefits Hub Landing pages and in bottom CTA on Campaign Landing pages. '
+        formatter: closed
+        required_fields: true
+        id: ''
         classes: ''
         show_empty_fields: false
-        id: ''
-        formatter: closed
-        description: 'The content entered below is shown in the ''Connect with Us'' sidebar on related Benefits Hub Landing pages and in bottom CTA on Campaign Landing pages. '
-        required_fields: true
+      label: 'Connect with Us'
 id: node.office.default
 targetEntityType: node
 bundle: office
 mode: default
 content:
   field_administration:
-    type: options_select
     weight: 15
-    region: content
     settings: {  }
     third_party_settings: {  }
+    type: options_select
+    region: content
   field_body:
     type: text_textarea
     weight: 2
@@ -136,33 +138,31 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_description:
-    type: string_textfield
     weight: 2
-    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_email_updates_link:
-    type: link_default
     weight: 27
-    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-  field_external_link:
     type: link_default
-    weight: 26
     region: content
+  field_external_link:
+    weight: 26
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-  field_meta_title:
-    type: string_textfield_with_counter
-    weight: 1
+    type: link_default
     region: content
+  field_meta_title:
+    weight: 1
     settings:
       size: 60
       placeholder: ' | Veterans Affairs'
@@ -170,20 +170,40 @@ content:
       maxlength: 0
       counter_position: after
       js_prevent_submit: true
-      count_html_characters: false
       textcount_status_message: 'Remaining: <span class="remaining_count">@remaining_count</span>'
+      count_html_characters: false
     third_party_settings: {  }
-  field_social_media_links:
-    type: social_media_links_field_default
-    weight: 28
+    type: string_textfield_with_counter
     region: content
+  field_office_id:
+    weight: 29
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_parent_office:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_social_media_links:
+    weight: 28
     settings: {  }
     third_party_settings: {  }
+    type: social_media_links_field_default
+    region: content
   moderation_state:
     type: moderation_state_default
     weight: 6
-    region: content
     settings: {  }
+    region: content
     third_party_settings: {  }
   path:
     type: path

--- a/config/sync/core.entity_form_display.node.office.default.yml
+++ b/config/sync/core.entity_form_display.node.office.default.yml
@@ -28,107 +28,107 @@ third_party_settings:
     group_governance:
       children:
         - field_administration
+      label: 'Section settings'
+      region: content
       parent_name: ''
       weight: 8
       format_type: details_sidebar
       format_settings:
-        id: ''
         classes: ''
-        description: ''
+        id: ''
         open: true
+        description: ''
         required_fields: true
         weight: -10
-      label: 'Section settings'
-      region: content
     group_meta_tags:
       children:
         - field_meta_title
         - field_description
+      label: 'Meta Tags'
+      region: content
       parent_name: group_tabs
       weight: 22
       format_type: tab
       format_settings:
-        id: ''
         classes: ''
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
-        formatter: closed
-      label: 'Meta Tags'
-      region: content
     group_editorial_workflow:
       children:
         - moderation_state
         - revision_log
+      label: 'Editorial workflow'
+      region: content
       parent_name: ''
       weight: 9
       format_type: fieldset
       format_settings:
-        id: ''
         classes: ''
+        id: ''
         description: ''
-        open: true
         required_fields: true
-      label: 'Editorial workflow'
-      region: content
+        open: true
     group_tabs:
       children:
         - group_content
         - group_connect_with_us
         - group_meta_tags
+      label: tabs
+      region: content
       parent_name: ''
       weight: 1
       format_type: tabs
-      region: content
       format_settings:
+        classes: ''
         show_empty_fields: false
         id: ''
-        classes: ''
         direction: vertical
         width_breakpoint: '640'
-      label: tabs
     group_content:
       children:
         - field_body
+      label: Content
+      region: content
       parent_name: group_tabs
       weight: 20
       format_type: tab
-      region: content
       format_settings:
+        classes: ''
         show_empty_fields: false
         id: ''
-        classes: ''
-        description: ''
         formatter: closed
+        description: ''
         required_fields: true
-      label: Content
     group_connect_with_us:
       children:
         - field_external_link
         - field_email_updates_link
         - field_social_media_links
+      label: 'Connect with Us'
+      region: content
       parent_name: group_tabs
       weight: 21
       format_type: tab
-      region: content
       format_settings:
-        description: 'The content entered below is shown in the ''Connect with Us'' sidebar on related Benefits Hub Landing pages and in bottom CTA on Campaign Landing pages. '
-        formatter: closed
-        required_fields: true
-        id: ''
         classes: ''
         show_empty_fields: false
-      label: 'Connect with Us'
+        id: ''
+        formatter: closed
+        description: 'The content entered below is shown in the ''Connect with Us'' sidebar on related Benefits Hub Landing pages and in bottom CTA on Campaign Landing pages. '
+        required_fields: true
 id: node.office.default
 targetEntityType: node
 bundle: office
 mode: default
 content:
   field_administration:
+    type: options_select
     weight: 15
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_select
-    region: content
   field_body:
     type: text_textarea
     weight: 2
@@ -138,31 +138,33 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_description:
+    type: string_textfield
     weight: 2
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_email_updates_link:
+    type: link_default
     weight: 27
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_external_link:
+    type: link_default
     weight: 26
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_meta_title:
+    type: string_textfield_with_counter
     weight: 1
+    region: content
     settings:
       size: 60
       placeholder: ' | Veterans Affairs'
@@ -170,40 +172,38 @@ content:
       maxlength: 0
       counter_position: after
       js_prevent_submit: true
-      textcount_status_message: 'Remaining: <span class="remaining_count">@remaining_count</span>'
       count_html_characters: false
+      textcount_status_message: 'Remaining: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
-    type: string_textfield_with_counter
-    region: content
   field_office_id:
+    type: string_textfield
     weight: 29
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_parent_office:
+    type: entity_reference_autocomplete
     weight: 30
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_social_media_links:
+    type: social_media_links_field_default
     weight: 28
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: social_media_links_field_default
-    region: content
   moderation_state:
     type: moderation_state_default
     weight: 6
-    settings: {  }
     region: content
+    settings: {  }
     third_party_settings: {  }
   path:
     type: path

--- a/config/sync/core.entity_view_display.node.office.default.yml
+++ b/config/sync/core.entity_view_display.node.office.default.yml
@@ -88,20 +88,20 @@ content:
     weight: 4
     region: content
   field_office_id:
-    weight: 10
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 10
     region: content
   field_parent_office:
-    weight: 11
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 11
     region: content
   field_social_media_links:
     type: social_media_links_field_default

--- a/config/sync/core.entity_view_display.node.office.default.yml
+++ b/config/sync/core.entity_view_display.node.office.default.yml
@@ -10,6 +10,8 @@ dependencies:
     - field.field.node.office.field_external_link
     - field.field.node.office.field_meta_tags
     - field.field.node.office.field_meta_title
+    - field.field.node.office.field_office_id
+    - field.field.node.office.field_parent_office
     - field.field.node.office.field_social_media_links
     - node.type.office
   module:
@@ -84,6 +86,22 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_office_id:
+    weight: 10
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_parent_office:
+    weight: 11
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_social_media_links:
     type: social_media_links_field_default

--- a/config/sync/core.entity_view_display.node.office.teaser.yml
+++ b/config/sync/core.entity_view_display.node.office.teaser.yml
@@ -11,6 +11,8 @@ dependencies:
     - field.field.node.office.field_external_link
     - field.field.node.office.field_meta_tags
     - field.field.node.office.field_meta_title
+    - field.field.node.office.field_office_id
+    - field.field.node.office.field_parent_office
     - field.field.node.office.field_social_media_links
     - node.type.office
   module:
@@ -34,5 +36,7 @@ hidden:
   field_external_link: true
   field_meta_tags: true
   field_meta_title: true
+  field_office_id: true
+  field_parent_office: true
   field_social_media_links: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.office.field_office_id.yml
+++ b/config/sync/field.field.node.office.field_office_id.yml
@@ -1,0 +1,25 @@
+uuid: f49eac31-26e8-4c8d-8b66-8caebd363b03
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_office_id
+    - node.type.office
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: node.office.field_office_id
+field_name: field_office_id
+entity_type: node
+bundle: office
+label: 'Office ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.office.field_parent_office.yml
+++ b/config/sync/field.field.node.office.field_parent_office.yml
@@ -1,0 +1,39 @@
+uuid: 55413327-b554-4568-9e52-8b6ba9ecba97
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_parent_office
+    - node.type.office
+  module:
+    - entity_reference_validators
+    - epp
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: false
+  epp:
+    value: ''
+    on_update: 1
+id: node.office.field_parent_office
+field_name: field_parent_office
+entity_type: node
+bundle: office
+label: 'Parent Office'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      office: office
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_office_id.yml
+++ b/config/sync/field.storage.node.field_office_id.yml
@@ -10,8 +10,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/config/sync/field.storage.node.field_office_id.yml
+++ b/config/sync/field.storage.node.field_office_id.yml
@@ -1,0 +1,21 @@
+uuid: cf07dd29-dcf6-4f7c-9c0a-892f85512140
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_office_id
+field_name: field_office_id
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_parent_office.yml
+++ b/config/sync/field.storage.node.field_parent_office.yml
@@ -1,0 +1,19 @@
+uuid: 047d702b-78c0-41c7-adfb-1afd1e14f6b3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_parent_office
+field_name: field_parent_office
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model_outreach_hub_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_outreach_hub_content_type_fields.feature
@@ -12,6 +12,8 @@ Feature: Content model: Outreach hub Content Type fields
 | Content type | Office | Meta description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Office | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+| Content type | Office | Office ID | field_office_id | Text (plain) |  |  | Text field |  |
+| Content type | Office | Parent Office | field_parent_office | Entity reference |  | 1 | Autocomplete |  |
 | Content type | Office | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Office | Email updates link | field_email_updates_link | Link |  | 1 | Link |  |
 | Content type | Office | Social media links | field_social_media_links | Social Media Links Field  |  | 1 | List with all available platforms |  |

--- a/tests/behat/drupal-spec-tool/content_model_outreach_hub_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_outreach_hub_content_type_fields.feature
@@ -12,7 +12,7 @@ Feature: Content model: Outreach hub Content Type fields
 | Content type | Office | Meta description | field_description | Text (plain) |  | 1 | Textfield | Translatable |
 | Content type | Office | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | Office | Meta title tag | field_meta_title | Text (plain) | Required | 1 | Textfield with counter | Translatable |
-| Content type | Office | Office ID | field_office_id | Text (plain) |  |  | Text field |  |
+| Content type | Office | Office ID | field_office_id | Text (plain) |  | 1 | Textfield |  |
 | Content type | Office | Parent Office | field_parent_office | Entity reference |  | 1 | Autocomplete |  |
 | Content type | Office | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Office | Email updates link | field_email_updates_link | Link |  | 1 | Link |  |


### PR DESCRIPTION
## Description
Adds two fields to existing content type Office.

Relates to #7772.

## Screenshots
![image](https://user-images.githubusercontent.com/6863534/153941111-39a84f72-7d5e-4a2e-b385-c876adf8d913.png)


## QA steps

As a CMS admin:
1. Visit `admin/structure/types/manage/office/fields`
2. Confirm existence of two new fields
- [ ] field_office_id
- [ ] field_parent_office

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [x] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
