### PR TITLE
VACMS-5119: Disable the menu option of the "media_list_videos" content type

### DIFF
--- a/config/sync/node.type.media_list_videos.yml
+++ b/config/sync/node.type.media_list_videos.yml
@@ -3,20 +3,23 @@ langcode: en
 status: true
 dependencies:
   module:
+    - menu_force
     - menu_ui
     - node_revision_delete
     - node_title_help_text
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   node_title_help_text:
     title_help: 'Add a page title with sentence case capitalization. (<a href="https://design.va.gov/content-style-guide/capitalization" target="_blank">See further guidelines</a>) '
   node_revision_delete:
     minimum_revisions_to_keep: 200
     minimum_age_to_delete: 0
     when_to_delete: 0
+  menu_force:
+    menu_force: 0
+    menu_force_parent: 0
 name: 'Media list - Videos'
 type: media_list_videos
 description: ''


### PR DESCRIPTION
- Disabled the "media_list_videos" content type menu option.

## Description

closes #5119 

## Testing done

Passes all tests

## Screenshots
![VACMS-5119-node-add-media_list_videos-no-menu](https://user-images.githubusercontent.com/846871/154145449-91fedf71-bf2a-4794-9427-3741eb9055b5.png)

## QA steps

As user administrator
1. Go to `/node/add/media_list_videos` and
    - [x] Verify and confirm that the menu option section in the right sidebar is not available any more

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [x] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
