### PR TITLE
VACMS-8046: add patch to stop graphql throwing notices.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -405,7 +405,8 @@
                 "1482958-47 Allow field_group with empty fields to be displayed via setting": "https://www.drupal.org/files/issues/2020-06-24/field_group-empty-config-1482958-47.patch"
             },
             "drupal/graphql": {
-                "Fix Explorer with Layout Builder enabled - https://github.com/drupal-graphql/graphql/pull/1144": "patches/graphql_8x3x_layout_builder_incompat.patch"
+                "Fix Explorer with Layout Builder enabled - https://github.com/drupal-graphql/graphql/pull/1144": "patches/graphql_8x3x_layout_builder_incompat.patch",
+                "Remove outdated RouteQueryEnhancer controller reference - https://github.com/drupal-graphql/graphql/pull/1230": "patches/graphql_8x3x_query_route_enhancer_update.patch"
             },
             "drupal/health_check_url": {
                 "3147740 - Make d9 compatible": "https://www.drupal.org/files/issues/2020-06-06/health_check_url.2.x-dev.rector.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4633f7e3737a6891d3a7f169f7bf5404",
+    "content-hash": "6b01d92ec66a854fe34db7a173c6c523",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",

--- a/patches/graphql_8x3x_query_route_enhancer_update.patch
+++ b/patches/graphql_8x3x_query_route_enhancer_update.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Routing/QueryRouteEnhancer.php b/src/Routing/QueryRouteEnhancer.php
+index 1bfe27f..0aea321 100644
+--- a/src/Routing/QueryRouteEnhancer.php
++++ b/src/Routing/QueryRouteEnhancer.php
+@@ -27,11 +27,7 @@ class QueryRouteEnhancer implements EnhancerInterface {
+     $query = $this->extractQuery($request);
+     $operations = $helper->parseRequestParams($method, $body, $query);
+ 
+-    // By default we assume a 'single' request. This is going to fail in the
+-    // graphql processor due to a missing query string but at least provides
+-    // the right format for the client to act upon.
+     return $defaults + [
+-      '_controller' => $defaults['_graphql']['single'],
+       'operations' => $operations,
+     ];
+   }


### PR DESCRIPTION
## Description

Relates to #8046. See that issue for tests, screenshots, etc.

