### PR TITLE
VACMS-7871: Fix the "Learn how to correct or update centrally-managed data" broken link

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -53,6 +53,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
         - flag
       parent_name: ''
       weight: 9

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -53,7 +53,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
         - flag
       parent_name: ''
       weight: 9
@@ -177,7 +176,7 @@ third_party_settings:
       format_settings:
         show_label: '1'
         tooltip_description: "Why can’t I edit this?\r\nThis content is automatically populated from centralized databases, and helps maintain consistent information across all of VA.gov."
-        description: '<a class="admin-help-email-tpl" href="/vamc/how-do-i-update-my-vamc-facilitys-basic-location-data">Learn how to correct or update centrally-managed data</a>.'
+        description: '<a class="admin-help-email-tpl" href="/help/vamc/how-do-i-update-my-vamc-facilitys-basic-location-data">Learn how to correct or update centrally-managed data</a>.'
         required_fields: '1'
         id: external-content
         classes: ''


### PR DESCRIPTION
- Updated the "Learn how to correct or update centrally-managed data" link in the "Facility data" section of the "VAMC Facility" content type in "Manage form display" default display.

## Description

closes #7871 

## Testing done

Passes all tests

## Screenshots

**VAMC Facility content type "Manage form display"**
![VACMS-7871-VAMC-Facility-Facility-data-link-update](https://user-images.githubusercontent.com/846871/154336549-e772af76-036d-43ac-9704-58339ea885c0.png)

## QA steps

As user administrator
1. Go to `/admin/structure/types/manage/health_care_local_facility/form-display` to:
    - [ ] Verify and confirm the link "href" attribute is updated with the correct URL
2. Then go to `/node/1271/edit` (or any other VAMC Facility node) and:
    - [ ] Hover over the "Learn how to correct or update centrally-managed data" link underneath the "Facility data" heading to verify and confirm the link URL have been corrected
    - [ ] Click on the "Learn how to correct or update centrally-managed data" link to verify and confirm it's properly linking to the correct page

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
