### PR TITLE
VACMS-7888: Append system name to facility in autocomplete.

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/src/Controller/EntityAutocompleteController.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Controller/EntityAutocompleteController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\va_gov_vamc\Controller;
+
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
+use Drupal\va_gov_vamc\EntityAutocompleteMatcher;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Component\Utility\Crypt;
+use Drupal\Component\Utility\Tags;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Site\Settings;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Defines a route controller for entity autocomplete form elements.
+ */
+class EntityAutocompleteController extends ControllerBase {
+
+  /**
+   * The autocomplete matcher for entity references.
+   *
+   * @var \Drupal\va_gov_vamc\EntityAutocompleteMatcher
+   */
+  protected $matcher;
+
+  /**
+   * The key value store.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface
+   */
+  protected $keyValue;
+
+  /**
+   * Constructs an EntityAutocompleteController object.
+   *
+   * @param \Drupal\va_gov_vamc\EntityAutocompleteMatcher $matcher
+   *   The autocomplete matcher.
+   * @param \Drupal\Core\KeyValueStore\KeyValueStoreInterface $key_value
+   *   The key value.
+   */
+  public function __construct(EntityAutocompleteMatcher $matcher, KeyValueStoreInterface $key_value) {
+    $this->matcher = $matcher;
+    $this->keyValue = $key_value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('va_gov_vamc.autocomplete_matcher'),
+      $container->get('keyvalue')->get('entity_autocomplete')
+    );
+  }
+
+  /**
+   * Autocomplete the label of an entity.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request object that contains the typed tags.
+   * @param string $target_type
+   *   The ID of the target entity type.
+   * @param string $selection_handler
+   *   The plugin ID of the entity reference selection handler.
+   * @param string $selection_settings_key
+   *   The hashed key of the key/value entry that holds the selection handler
+   *   settings.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The matched entity labels as a JSON response.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   *   Thrown if the selection settings key is not found in the key/value store
+   *   or if it does not match the stored data.
+   */
+  public function handleAutocomplete(Request $request, $target_type, $selection_handler, $selection_settings_key) {
+    $matches = [];
+    // Get the typed string from the URL, if it exists.
+    if ($input = $request->query->get('q')) {
+      $typed_string = Tags::explode($input);
+      $typed_string = mb_strtolower(array_pop($typed_string));
+
+      // Selection settings are passed in as a hashed key of a serialized array
+      // stored in the key/value store.
+      $selection_settings = $this->keyValue->get($selection_settings_key, FALSE);
+      if ($selection_settings !== FALSE) {
+        $selection_settings_hash = Crypt::hmacBase64(serialize($selection_settings) . $target_type . $selection_handler, Settings::getHashSalt());
+        if (!hash_equals($selection_settings_hash, $selection_settings_key)) {
+          // Disallow access when the selection settings hash does not match the
+          // passed-in key.
+          throw new AccessDeniedHttpException('Invalid selection settings key.');
+        }
+      }
+      else {
+        // Disallow access when the selection settings key is not found in the
+        // key/value store.
+        throw new AccessDeniedHttpException();
+      }
+
+      $matches = $this->matcher->getMatches($target_type, $selection_handler, $selection_settings, $typed_string);
+    }
+
+    return new JsonResponse($matches);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_vamc/src/Controller/EntityAutocompleteController.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Controller/EntityAutocompleteController.php
@@ -2,13 +2,13 @@
 
 namespace Drupal\va_gov_vamc\Controller;
 
-use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
-use Drupal\va_gov_vamc\EntityAutocompleteMatcher;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Component\Utility\Crypt;
 use Drupal\Component\Utility\Tags;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\va_gov_vamc\EntityAutocompleteMatcher;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;

--- a/docroot/modules/custom/va_gov_vamc/src/EntityAutocompleteMatcher.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EntityAutocompleteMatcher.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\va_gov_vamc;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Tags;
+use Drupal\Core\Entity\EntityAutocompleteMatcherInterface;
+use Drupal\Core\Entity\EntityRepository;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManagerInterface;
+
+/**
+ * Matcher class to get autocompletion results for entity reference.
+ */
+class EntityAutocompleteMatcher implements EntityAutocompleteMatcherInterface {
+
+  /**
+   * The Entity repository service.
+   *
+   * @var \Drupal\Core\Entity\EntityRepository
+   *   The Entity repository service.
+   */
+  private $entityRepository;
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   *  The entity manager.
+   */
+  private $entityTypeManager;
+
+  /**
+   * The entity reference selection handler plugin manager.
+   *
+   * @var \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManagerInterface
+   */
+  protected $selectionManager;
+
+  /**
+   * Constructs an EntityAutocompleteMatcher object.
+   *
+   * @param \Drupal\Core\Entity\EntityRepository $entity_repository
+   *   The entity repository service.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   The entity reference selection handler plugin manager.
+   * @param \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManagerInterface $selection_manager
+   *   The entity reference selection handler plugin manager.
+   */
+  public function __construct(EntityRepository $entity_repository, EntityTypeManager $entity_type_manager, SelectionPluginManagerInterface $selection_manager) {
+    $this->entityRepository = $entity_repository;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->selectionManager = $selection_manager;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getMatches($target_type, $selection_handler, $selection_settings, $string = '') {
+    $matches = [];
+
+    $options = $selection_settings + [
+      'target_type' => $target_type,
+      'handler' => $selection_handler,
+    ];
+    $handler = $this->selectionManager->getInstance($options);
+
+    // Get an array of matching entities.
+    $match_operator = !empty($selection_settings['match_operator']) ? $selection_settings['match_operator'] : 'CONTAINS';
+    $match_limit = isset($selection_settings['match_limit']) ? (int) $selection_settings['match_limit'] : 10;
+    $entity_labels = !empty($handler) ? $handler->getReferenceableEntities($string, $match_operator, $match_limit) : [];
+    $entity_repository = $this->entityRepository;
+    // Loop through the entities and convert them into autocomplete output.
+    foreach ($entity_labels as $values) {
+      foreach ($values as $entity_id => $label) {
+        $entity_loader = $this->entityTypeManager->getStorage($target_type)->load($entity_id);
+        /** @var \Drupal\node\Entity\Node $entity */
+        $entity = $entity_repository->getTranslationFromContext($entity_loader);
+        $system = NULL;
+        if ($target_type === 'node' && $entity->bundle() === 'health_care_local_facility') {
+          $tid = $entity->field_administration->getString();
+          /** @var \Drupal\taxonomy\Entity\Term $term */
+          $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
+          $system = ' - ' . $term->getName();
+        }
+        $key = $label . ' (' . $entity_id . ')';
+        // Strip starting/trailing white spaces, line breaks and tags.
+        $key = preg_replace('/\s\s+/', ' ', str_replace("\n", '', trim(Html::decodeEntities(strip_tags($key)))));
+        // Names containing commas or quotes must be wrapped in quotes.
+        $key = Tags::encode($key);
+        $label = $label . ' (' . $entity_id . ')' . $system;
+        $matches[] = ['value' => $key, 'label' => $label];
+      }
+    }
+
+    return $matches;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_vamc/src/Routing/AutocompleteRouteSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Routing/AutocompleteRouteSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\va_gov_vamc\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Autocomplete route subscriber.
+ */
+class AutocompleteRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('system.entity_autocomplete')) {
+      $route->setDefault('_controller', '\Drupal\va_gov_vamc\Controller\EntityAutocompleteController::handleAutocomplete');
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
@@ -7,3 +7,10 @@ services:
   va_gov_vamc.content_hardening_deduper:
     class: Drupal\va_gov_vamc\Service\ContentHardeningDeduper
     arguments: ['@current_user', '@entity_type.manager', '@logger.factory', '@messenger']
+  va_gov_vamc.route_subscriber:
+    class: Drupal\va_gov_vamc\Routing\AutocompleteRouteSubscriber
+    tags:
+      - { name: event_subscriber }
+  va_gov_vamc.autocomplete_matcher:
+    class: Drupal\va_gov_vamc\EntityAutocompleteMatcher
+    arguments: ['@entity.repository', '@entity_type.manager', '@plugin.manager.entity_reference_selection']


### PR DESCRIPTION
## Description
closes #7888

## Testing done
Visual

## QA steps
 - [ ] As an administrator, go to `node/add/vamc_operating_status_and_alerts` and open the `FACILITY OPERATING STATUSES` details element.
 - [ ] Add a new item by typing `hami`
 - [ ] Visually verify an id and a system name are appended to the ends of all three entries such that a clear distinction can be made between systems for a content editor when choosing a facility