### PR TITLE
VACMS-0000: Behavioral test waits for five seconds prior to trying to acquire the CKeditor text field.

### DIFF
--- a/tests/behavioral/cypress/support/commands.js
+++ b/tests/behavioral/cypress/support/commands.js
@@ -102,6 +102,7 @@ Cypress.Commands.add('iframe', { prevSubject: 'element' }, ($iframe, callback = 
 });
 
 Cypress.Commands.add("type_ckeditor", (element, content) => {
+  cy.wait(5000);
   cy.window().then((win) => {
     const elements = Object.keys(win.CKEDITOR.instances);
     if (elements.indexOf(element) === -1) {


### PR DESCRIPTION
This test is very flaky and needs a delay.  I don't know why it has recently started failing so frequently and spectacularly.

Waiting for a fixed amount of time is suboptimal.  However, Cypress [does not and will never have a concept of catching errors](https://github.com/cypress-io/cypress/issues/395), so we effectively can't test for the presence of certain fields without asserting that those fields should exist.  Since paragraphs and normal fields behave differently with CKeditor, there's no one-size-fits-all approach that I can find for making Cypress wait for the CKEditor field to appear and be editable.