### PR TITLE
VACMS-4787: Disable "Administer media" permission for "Content Admin" role

### DIFF
--- a/config/sync/user.role.content_admin.yml
+++ b/config/sync/user.role.content_admin.yml
@@ -20,8 +20,6 @@ permissions:
   - 'access taxonomy overview'
   - 'access user profiles'
   - 'access vamc_operating_statuses entity browser pages'
-  - 'administer cms custom menu access'
-  - 'administer media'
   - 'administer menu'
   - 'administer nodes'
   - 'administer taxonomy'

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -100,8 +100,6 @@ class RolesPermissionsTest extends ExistingSiteBase {
           'access taxonomy overview',
           'access user profiles',
           'access vamc_operating_statuses entity browser pages',
-          'administer cms custom menu access',
-          'administer media',
           'administer menu',
           'administer nodes',
           'administer taxonomy',


### PR DESCRIPTION
- Disabled the "Administer media" and "Administer cms custom menu access" permissions for the "Content Admin" role.

## Description

closes #4787 

## Testing done

Passes all tests

## Screenshots

**Content Admin user without the configuration menu:**
![VACMS-4787-disable-administer-media-permission-for-content-admin-role](https://user-images.githubusercontent.com/846871/154561741-dc31decf-f206-4cc4-a662-16c125f1ac9f.png)

**Media:** 
![VACMS-4787-administer-media-permission](https://user-images.githubusercontent.com/846871/154562557-b87f8710-6354-4a3a-9bdf-e2ae72b8d6a0.png)

**VA.gov Menu Access:**
![VACMS-4787-administer-cms-custom-menu-access-permission](https://user-images.githubusercontent.com/846871/154562580-bb0b58a1-6260-4211-9031-025a4f75c4c7.png)

## QA steps

As user administrator
1. Go to `/admin/people/permissions` to verify and confirm that the "Content Admin" role
    - [ ] _Administer media_ permission have been disabled
    - [ ] _Administer cms custom menu access_ permission have been disabled
2. Then login as `suzanne.middaugh@va.gov` (Content Admin role) to verify and confirm the "Configuration" menu isn't available for this role

- See screen shots for reference.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [x] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
