### PR TITLE
VACMS-000: Change alert link color to black.

### DIFF
--- a/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
+++ b/docroot/themes/custom/vagovadmin/assets/scss/styles.scss
@@ -141,14 +141,14 @@
 
     .views-row {
       margin: 2em 0;
-  
+
       .location-details span:not(:first-child)::before {
         content: ', ';
       }
-  
+
       .address {
         margin-top: 0;
-  
+
         br,
         span {
           &:last-child {
@@ -420,6 +420,19 @@ p.vc-help-text {
 
     &:hover {
       opacity: 0.8;
+    }
+  }
+}
+
+#block-sitealert {
+  .site-alert {
+    a {
+      color: #004795;
+      text-decoration: underline;
+
+      &:hover {
+        color: #212121;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Fixes accessibility error caused by blue link appearing on blue background.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/154701852-f66f9286-3c84-45e0-9a1e-083f7c0f8974.png)

## QA steps
 - [ ] The site alert link `Learn more` text should be black.