### PR TITLE
VACMS-7660: Unhide EHR and VA Health Connect fields.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -31,6 +31,7 @@ dependencies:
     - media_library
     - paragraphs
     - path
+    - telephone
     - textfield_counter
 third_party_settings:
   field_group:
@@ -40,7 +41,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -55,7 +56,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: fieldset
       format_settings:
         classes: ''
@@ -178,6 +179,21 @@ third_party_settings:
         id: ''
         description: ''
         required_fields: true
+    group_va_health_connect_and_heal:
+      children:
+        - field_va_health_connect_phone
+        - field_vamc_ehr_system
+      parent_name: ''
+      weight: 9
+      format_type: fieldset
+      region: content
+      format_settings:
+        description: ''
+        id: external-content
+        classes: ''
+        show_empty_fields: false
+        required_fields: false
+      label: 'VA Health Connect and Health Records System'
 id: node.health_care_region_page.default
 targetEntityType: node
 bundle: health_care_region_page
@@ -323,6 +339,19 @@ content:
       linkit_profile: default
       linkit_auto_link_text: false
     third_party_settings: {  }
+  field_va_health_connect_phone:
+    type: telephone_default
+    weight: 13
+    region: content
+    settings:
+      placeholder: 123-456-7890
+    third_party_settings: {  }
+  field_vamc_ehr_system:
+    type: options_select
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_vamc_system_official_name:
     type: string_textfield
     weight: 2
@@ -333,9 +362,9 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 8
-    region: content
+    weight: 11
     settings: {  }
+    region: content
     third_party_settings: {  }
   path:
     type: path
@@ -373,8 +402,6 @@ hidden:
   field_links: true
   field_meta_tags: true
   field_sign_up_for_emergency_emai: true
-  field_va_health_connect_phone: true
-  field_vamc_ehr_system: true
   promote: true
   sticky: true
   uid: true

--- a/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
@@ -25,10 +25,14 @@ dependencies:
     - image.style.large
     - node.type.health_care_region_page
   module:
-    - entity_reference_revisions
     - field_group
     - link
+    - linkit
     - media
+    - options
+    - paragraphs
+    - string_field_formatter
+    - telephone
     - user
 third_party_settings:
   field_group:
@@ -65,8 +69,8 @@ third_party_settings:
       children: {  }
       label: 'Blurbs for subpages'
       parent_name: ''
-      region: content
-      weight: 3
+      region: hidden
+      weight: 12
       format_type: fieldset
       format_settings:
         classes: ''
@@ -89,6 +93,40 @@ third_party_settings:
         classes: ''
         id: ''
         description: ''
+    group_va_health_connect_and_heal:
+      children:
+        - group_tooltip
+      label: 'VA Health Connect and Health Records System'
+      parent_name: ''
+      region: content
+      weight: 3
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+    group_tooltip:
+      children:
+        - field_va_health_connect_phone
+        - field_vamc_ehr_system
+      label: tooltip
+      parent_name: group_va_health_connect_and_heal
+      region: content
+      weight: 7
+      format_type: tooltip
+      format_settings:
+        show_empty_fields: 0
+        id: external-content
+        classes: 'not-editable '
+        element: div
+        show_label: '0'
+        label_element: h3
+        attributes: ''
+        description: ''
+        tooltip_description: 'Why can''t I edit this? The VA Health Connect number comes from a centralized database. The health records system is managed by the Cerner transition team.  For questions, contact the CMS helpdesk.'
+        open: false
+        required_fields: false
 id: node.health_care_region_page.default
 targetEntityType: node
 bundle: health_care_region_page
@@ -138,10 +176,10 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 12
+    weight: 9
     region: content
   field_flickr:
-    type: link
+    type: linkit
     label: above
     settings:
       trim_length: 80
@@ -149,27 +187,32 @@ content:
       url_plain: false
       rel: ''
       target: ''
+      linkit_profile: default
     third_party_settings: {  }
-    weight: 13
+    weight: 10
     region: content
   field_govdelivery_id_emerg:
-    type: string
+    type: plain_string_formatter
     label: above
     settings:
       link_to_entity: false
+      wrap_tag: _none
+      wrap_class: ''
     third_party_settings: {  }
     weight: 5
     region: content
   field_govdelivery_id_news:
-    type: string
+    type: plain_string_formatter
     label: above
     settings:
       link_to_entity: false
+      wrap_tag: _none
+      wrap_class: ''
     third_party_settings: {  }
     weight: 6
     region: content
   field_instagram:
-    type: link
+    type: linkit
     label: above
     settings:
       trim_length: 80
@@ -177,8 +220,9 @@ content:
       url_plain: false
       rel: ''
       target: ''
+      linkit_profile: default
     third_party_settings: {  }
-    weight: 14
+    weight: 11
     region: content
   field_intro_text:
     type: basic_string
@@ -206,7 +250,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 11
+    weight: 8
     region: content
   field_other_va_locations:
     type: string
@@ -217,16 +261,14 @@ content:
     weight: 8
     region: content
   field_related_links:
-    type: entity_reference_revisions_entity_view
+    type: paragraph_summary
     label: above
-    settings:
-      view_mode: default
-      link: ''
+    settings: {  }
     third_party_settings: {  }
-    weight: 16
+    weight: 13
     region: content
   field_twitter:
-    type: link
+    type: linkit
     label: above
     settings:
       trim_length: 80
@@ -234,8 +276,24 @@ content:
       url_plain: false
       rel: ''
       target: ''
+      linkit_profile: default
     third_party_settings: {  }
-    weight: 15
+    weight: 12
+    region: content
+  field_va_health_connect_phone:
+    type: telephone_link
+    label: above
+    settings:
+      title: ''
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_vamc_ehr_system:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
     region: content
   field_vamc_system_official_name:
     type: string
@@ -248,7 +306,5 @@ content:
 hidden:
   content_moderation_control: true
   field_meta_tags: true
-  field_va_health_connect_phone: true
-  field_vamc_ehr_system: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.health_care_region_page.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.external_content.yml
@@ -1,0 +1,168 @@
+uuid: 2e9b7b4d-143c-4039-8ef2-94a32fa2ceed
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.external_content
+    - field.field.node.health_care_region_page.field_administration
+    - field.field.node.health_care_region_page.field_appointments_online
+    - field.field.node.health_care_region_page.field_clinical_health_services
+    - field.field.node.health_care_region_page.field_description
+    - field.field.node.health_care_region_page.field_facebook
+    - field.field.node.health_care_region_page.field_flickr
+    - field.field.node.health_care_region_page.field_govdelivery_id_emerg
+    - field.field.node.health_care_region_page.field_govdelivery_id_news
+    - field.field.node.health_care_region_page.field_instagram
+    - field.field.node.health_care_region_page.field_intro_text
+    - field.field.node.health_care_region_page.field_media
+    - field.field.node.health_care_region_page.field_meta_tags
+    - field.field.node.health_care_region_page.field_operating_status
+    - field.field.node.health_care_region_page.field_other_va_locations
+    - field.field.node.health_care_region_page.field_related_links
+    - field.field.node.health_care_region_page.field_twitter
+    - field.field.node.health_care_region_page.field_va_health_connect_phone
+    - field.field.node.health_care_region_page.field_vamc_ehr_system
+    - field.field.node.health_care_region_page.field_vamc_system_official_name
+    - node.type.health_care_region_page
+  module:
+    - field_group
+    - layout_builder
+    - options
+    - telephone
+    - user
+third_party_settings:
+  field_group:
+    group_meta:
+      children:
+        - field_description
+      parent_name: ''
+      weight: 10
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: Meta
+      region: hidden
+    group_content:
+      children:
+        - field_appointments_online
+        - field_clinical_health_services
+        - field_intro_text
+        - field_media
+        - field_other_va_locations
+        - field_vamc_system_official_name
+      parent_name: ''
+      weight: 9
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: Content
+      region: hidden
+    group_blurbs_for_subpages:
+      children: {  }
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: 'Blurbs for subpages'
+      region: hidden
+    group_social_media_and_links:
+      children:
+        - field_facebook
+        - field_flickr
+        - field_instagram
+        - field_meta_tags
+        - field_operating_status
+        - field_related_links
+        - field_twitter
+      parent_name: ''
+      weight: 11
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: 'Social media and links'
+      region: hidden
+    group_va_health_connect_and_heal:
+      children:
+        - field_va_health_connect_phone
+        - field_vamc_ehr_system
+      parent_name: group_va_health_connect
+      weight: 1
+      format_type: tooltip
+      region: content
+      format_settings:
+        show_empty_fields: '1'
+        show_label: '0'
+        tooltip_description: 'Why can''t I edit this? The VA Health Connect number comes from a centralized database. The health records system is managed by the Cerner transition team.  For questions, contact the CMS helpdesk. '
+        description: ''
+        id: ''
+        classes: 'not-editable '
+        element: div
+        label_element: h3
+        attributes: ''
+      label: tooltip
+    group_va_health_connect:
+      children:
+        - group_va_health_connect_and_heal
+      parent_name: ''
+      weight: 0
+      format_type: fieldset
+      region: content
+      format_settings:
+        description: ''
+        show_empty_fields: true
+        id: ''
+        classes: ''
+      label: 'VA Health Connect and Health Records System'
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: node.health_care_region_page.external_content
+targetEntityType: node
+bundle: health_care_region_page
+mode: external_content
+content:
+  field_va_health_connect_phone:
+    type: telephone_link
+    weight: 21
+    region: content
+    label: above
+    settings:
+      title: ''
+    third_party_settings: {  }
+  field_vamc_ehr_system:
+    type: list_default
+    weight: 22
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  content_moderation_control: true
+  field_administration: true
+  field_appointments_online: true
+  field_clinical_health_services: true
+  field_description: true
+  field_facebook: true
+  field_flickr: true
+  field_govdelivery_id_emerg: true
+  field_govdelivery_id_news: true
+  field_instagram: true
+  field_intro_text: true
+  field_media: true
+  field_meta_tags: true
+  field_operating_status: true
+  field_other_va_locations: true
+  field_related_links: true
+  field_twitter: true
+  field_vamc_system_official_name: true
+  links: true
+  search_api_excerpt: true

--- a/config/sync/field.field.node.health_care_region_page.field_va_health_connect_phone.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_va_health_connect_phone.yml
@@ -16,8 +16,8 @@ id: node.health_care_region_page.field_va_health_connect_phone
 field_name: field_va_health_connect_phone
 entity_type: node
 bundle: health_care_region_page
-label: 'VA health connect phone number'
-description: 'To request changes, <a href="mailto:support@va-gov.atlassian.net?subject=Inaccurate map thumbnail&amp;body=My VA health connect phone number is incorrect.">Email the CMS Support Team</a>.'
+label: 'VA Health Connect phone number'
+description: ''
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_region_page.field_vamc_ehr_system.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_vamc_ehr_system.yml
@@ -6,12 +6,17 @@ dependencies:
     - field.storage.node.field_vamc_ehr_system
     - node.type.health_care_region_page
   module:
+    - epp
     - options
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
 id: node.health_care_region_page.field_vamc_ehr_system
 field_name: field_vamc_ehr_system
 entity_type: node
 bundle: health_care_region_page
-label: 'Electronic Health Records system'
+label: 'Electronic health records system'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.storage.node.field_vamc_ehr_system.yml
+++ b/config/sync/field.storage.node.field_vamc_ehr_system.yml
@@ -16,7 +16,7 @@ settings:
       label: VistA
     -
       value: cerner_staged
-      label: 'Cerner - staged'
+      label: 'Converting to Cerner'
     -
       value: cerner
       label: Cerner

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -13,6 +13,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  */
 function va_gov_consumers_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   _vagov_consumers_modify_va_form_fields($form, $form_id, $form_state);
+  _vagov_consumers_modify_vamc_system_fields($form, $form_id, $form_state);
   _vagov_consumers_modify_vet_center_fields($form, $form_id, $form_state);
   _vagov_consumers_disable_vha_api_form_fields($form, $form_id);
   _vagov_consumers_disable_non_vha_facilities_api_form_fields($form, $form_id);
@@ -222,6 +223,31 @@ function _vagov_consumers_modify_vet_center_fields(array &$form, $form_id, FormS
 }
 
 /**
+ * Modify the display of the fields on vamc system form.
+ *
+ * @param array $form
+ *   A drupal form array by reference.
+ * @param string $form_id
+ *   The machine name for the form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state by reference.
+ */
+function _vagov_consumers_modify_vamc_system_fields(array &$form, $form_id, FormStateInterface &$form_state) {
+
+  // We want to modify display of fields for specific form id's.
+  $external_content_form_ids = [
+    'node_health_care_region_page_form',
+    'node_health_care_region_page_edit_form',
+  ];
+
+  // We want to confirm we are on a specific form.
+  if (in_array($form_id, $external_content_form_ids)) {
+    _va_gov_consumers_disable_external_content_editing($form, $form_state, TRUE);
+  }
+
+}
+
+/**
  * Displays selected content as text, not form fields.
  *
  * Adds node rendered as 'external_content' to form and removes the first
@@ -231,14 +257,22 @@ function _vagov_consumers_modify_vet_center_fields(array &$form, $form_id, FormS
  *   The form content.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
- * @param string $display_if_empty_field
- *   The field to check for empty.  If empty, external content fields appear.
+ * @param string|bool $display_if_empty_field
+ *   The field to check for empty. If empty, external content fields appear.
+ *   TRUE indicates absence of field and external content should appear.
  */
 function _va_gov_consumers_disable_external_content_editing(array &$form, FormStateInterface $form_state, $display_if_empty_field) {
   $node = $form_state->getformObject()->getEntity();
 
   $is_admin = in_array('administrator', \Drupal::currentUser()->getRoles());
-  $has_field_value = !empty($node->get($display_if_empty_field)->value);
+  // TRUE means to skip field value check.
+  if ($display_if_empty_field === TRUE) {
+    // TRUE indicates we need to use external content.
+    $has_field_value = TRUE;
+  }
+  else {
+    $has_field_value = !empty($node->get($display_if_empty_field)->value);
+  }
 
   // If the user is not admin or and there is migrated data, hide the fields.
   // We want admins to have access to fields in case they have to temporarily
@@ -263,7 +297,6 @@ function _va_gov_consumers_disable_external_content_editing(array &$form, FormSt
 
     $form['external_content'] = [
       '#markup' => \Drupal::service('renderer')->render($readonly_content),
-      '#weight' => 1,
     ];
 
     // We want to modify display of fields for specific node id's.
@@ -275,7 +308,15 @@ function _va_gov_consumers_disable_external_content_editing(array &$form, FormSt
     ];
 
     // We want the external content to appear in the fieldgroup
-    // group_locations_and_contact_info on specific node types.
+    // group_ehr_info on the bottom of system forms.
+    if ($node->getType() === 'health_care_region_page') {
+      $form['group_ehr_info']['#weight'] = 10;
+      $form['group_ehr_info']['external_content'] = $form['external_content'];
+      unset($form['external_content']);
+    }
+
+    // We want the external content to appear in the fieldgroup
+    // group_locations_and_contact_info on other node types.
     if (in_array($node->getType(), $external_content_node_ids)) {
       $form['group_locations_and_contact_info']['external_content'] = $form['external_content'];
       unset($form['external_content']);

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_external_content.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_external_content.scss
@@ -17,3 +17,12 @@
 #external-content h3 {
   text-transform: uppercase;
 }
+
+#block-vagovclaro-content {
+  .field--name-field-va-health-connect-phone,
+  .field--name-field-vamc-ehr-system {
+    .field__label {
+      text-transform: none;
+    }
+  }
+}

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -166,8 +166,8 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System | Regional Health Service Offerings. | field_clinical_health_services | Entity reference |  | Unlimited | -- Disabled -- |  |
 | Content type | VAMC System | Twitter | field_twitter | Link |  | 1 | Linkit | Translatable |
 | Content type | VAMC System | VAMC system official name | field_vamc_system_official_name | Text (plain) |  | 1 | Textfield |  |
-| Content type | VAMC System | Electronic Health Records system | field_vamc_ehr_system | List (text) |  | 1 | -- Disabled -- |  |
-| Content type | VAMC System | VA health connect phone number | field_va_health_connect_phone | Telephone number |  | 1 | -- Disabled -- |  |
+| Content type | VAMC System | Electronic health records system | field_vamc_ehr_system | List (text) |  | 1 | Select list |  |
+| Content type | VAMC System | VA Health Connect phone number | field_va_health_connect_phone | Telephone number |  | 1 | Telephone number |  |
 | Content type | VAMC System Banner Alert with Situation Updates | Alert body | field_body | Text (formatted, long) | Required | 1 | Text area (multiple rows) | Translatable |
 | Content type | VAMC System Banner Alert with Situation Updates | Alert dismissable? | field_alert_dismissable | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC System Banner Alert with Situation Updates | Alert type | field_alert_type | List (text) | Required | 1 | Select list |  |


### PR DESCRIPTION
## Description
closes #7660

## Testing done
Visual / behat

## Screenshots
Editor:
![image](https://user-images.githubusercontent.com/2404547/155374663-b0e0c3d1-df11-4c1d-9ad5-e87d8c259245.png)

Admin:
![image](https://user-images.githubusercontent.com/2404547/155374807-a89d86d4-71cc-4e2d-b190-9faa2ca8f7f0.png)


## QA steps
 - [ ] As an admin, assign an editor to Pittsburgh Health Care (sections on user page)
 - [ ] As admin, go to `node/318/edit` and enter values for VA Health Connect phone number & Electronic health records system fields, visually verifying that the fields are editable, and appear as above in screenshot.
 - [ ] Set Editorial Workflow to `Published` then Save, and login as the user you assigned to Pittsburgh, visiting `node/318/edit` 
 - [ ] Visually verify the fields are not editable and appear as above in screenshot
 - [ ] Go to `/pittsburgh-health-care` and visually verify fields are present