### PR TITLE
Removes platform-overrides section from composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -25113,8 +25113,6 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.3"
-    },
+    "platform-overrides": {},
     "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## Description

This is causing PHPStan failures and Tugboat deployment failures when packages require PHP 7.4.
