### PR TITLE
VACMS-8016 recurring events claro

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
@@ -176,8 +176,17 @@ p.vc-help-text {
   }
 }
 
-.ui-widget {
+// modal updates
+.ui-widget,
+.ui-widget input,
+.ui-widget select,
+.ui-widget textarea,
+.ui-widget button {
   font-family: var(--font-family-sans);
+}
+
+.ui-widget button:hover {
+  font-weight: 700;
 }
 
 // linkit results should be scrollable

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -74,7 +74,6 @@ Feature: CMS Users may effectively create & edit content
     # Confirm that the va.gov url is not shown for nodes without a published revision.
     Then I should see "Content Type: Office" in the "#block-entitymetadisplay" element
     And I should not see "VA.gov URL" in the "#block-entitymetadisplay" element
-    And I should not see "VA.gov URL" in the "#block-vagovclaro-entitymetadisplay" element
 
     # Publish the node.
     Then I visit the "edit" page for a node with the title "Test Office - BeHaT"
@@ -84,8 +83,8 @@ Feature: CMS Users may effectively create & edit content
 
     # Confirm that the va.gov url is shown for nodes with a published revision.
     Then I should see "Published" in the ".view-right-sidebar-latest-revision" element
-    And I should see "VA.gov URL" in the "#block-vagovclaro-entitymetadisplay" element
-    And I should not see "(pending)" in the "#block-vagovclaro-entitymetadisplay" element
+    And I should see "VA.gov URL" in the "#block-entitymetadisplay" element
+    And I should not see "(pending)" in the "#block-entitymetadisplay" element
 
     # Confirm that the va.gov url is not clickable when updating a node.
     Then I visit the "edit" page for a node with the title "Test Office - BeHaT"
@@ -93,7 +92,7 @@ Feature: CMS Users may effectively create & edit content
     And I select "Published" from "edit-moderation-state-0-state"
     And I fill in "Revision log message" with "Test publishing"
     And I press "Save"
-    And I should see "VA.gov URL" in the "#block-vagovclaro-entitymetadisplay" element
+    And I should see "VA.gov URL" in the "#block-entitymetadisplay" element
 
     # (Re-)Publish the node.
     Then I visit the "edit" page for a node with the title "Test Office - BeHaT 404"
@@ -108,8 +107,8 @@ Feature: CMS Users may effectively create & edit content
     And I fill in "Revision log message" with "Test archiving"
     And I press "Save"
     Then I should see "has been updated."
-    And I should see "Content Type: Office" in the "#block-vagovclaro-entitymetadisplay" element
-    And I should not see "VA.gov URL" in the "#block-vagovclaro-entitymetadisplay" element
+    And I should see "Content Type: Office" in the "#block-entitymetadisplay" element
+    And I should not see "VA.gov URL" in the "#block-entitymetadisplay" element
 
   @content_editing
   Scenario: Confirm that press release country fields are shown correctly


### PR DESCRIPTION
## Description

Relates to #8016. fixes the button behavior inside the modal when editing a recurring event series.

PR is targeting the `integration-recurring-events` branch.

## Testing done

- log in as admin
- create an event node with a recurring event. save the node.
- edit the saved node, edit the event series
- cancel any event
- hover over the buttons and see that the behavior is fixed

## Screenshots
<img width="816" alt="Screen Shot 2022-02-14 at 4 03 00 PM" src="https://user-images.githubusercontent.com/11279744/153967959-5614be4e-d735-4721-9830-5a12391f4ba3.png">


## QA steps
- log in as admin
- create an event node with a recurring event. save the node.
- edit the saved node, edit the event series
- cancel any event
- hover over the buttons and see that the behavior is fixed

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
