### PR TITLE
VACMS-0000: Downgrades Cypress to ~8.3.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3360,10 +3360,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
-      "optional": true
+      "version": "14.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -5634,9 +5633,9 @@
       "integrity": "sha1-f1x7cACbwrZmWRv+ZIVFeL7e6Fo="
     },
     "cypress": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.5.0.tgz",
-      "integrity": "sha512-MMkXIS+Ro2KETn4gAlG3tIc/7FiljuuCZP0zpd9QsRG6MZSyZW/l1J3D4iQM6WHsVxuX4rFChn5jPFlC2tNSvQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.3.1.tgz",
+      "integrity": "sha512-1v6pfx+/5cXhaT5T6QKOvnkawmEHWHLiVzm3MYMoQN1fkX2Ma1C32STd3jBStE9qT5qPSTILjGzypVRxCBi40g==",
       "requires": {
         "@cypress/request": "^2.88.6",
         "@cypress/xvfb": "^1.2.4",
@@ -5672,7 +5671,6 @@
         "minimist": "^1.2.5",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
-        "proxy-from-env": "1.0.0",
         "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
@@ -5682,28 +5680,12 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "14.18.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
-          "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
-        },
         "debug": {
           "version": "4.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
           }
         },
         "has-flag": {
@@ -5723,11 +5705,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         }
       }
     },
@@ -9626,11 +9603,6 @@
         "react-is": "^16.8.1"
       }
     },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
-    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -10069,9 +10041,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.3.tgz",
-      "integrity": "sha512-6162iC/N7L7K8q3UvdOMWix1ju+esADGrDaPrTu5XJmCv69YNdYoUaop/iatN8GHK+YHOdszPP+qygA0yi04zQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@testing-library/cypress": "^8.0.2",
     "axe-core": "^4.4.1",
     "axe-reports": "^1.1.11",
-    "cypress": "^8.5.0",
+    "cypress": "~8.3.0",
     "cypress-axe": "^0.14.0",
     "cypress-cucumber-preprocessor": "^4.3.1",
     "cypress-real-events": "^1.6.0",


### PR DESCRIPTION
Likely fix for stalling issues.

See:
- https://dsva.slack.com/archives/CT4GZBM8F/p1645704377446089
- https://dsva.slack.com/archives/CT4GZBM8F/p1645710803574719?thread_ts=1645704377.446089&cid=CT4GZBM8F