### PR TITLE
VACMS-8142 fix node link report layout for long links

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_alerts.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_alerts.scss
@@ -13,6 +13,11 @@
   display: none;
 }
 
+// Fixes super long links breaking layout in the node link report.
+.va-alert a {
+  word-break: break-all;
+}
+
 .va-alert.messages--warning {
   background-color: var(--va-gold-lightest);
   border-color: var(--va-gold-med);
@@ -43,6 +48,10 @@
 
 .va-alert.messages--error a {
   background-color: var(--va-red-lightest);
+}
+
+.messages {
+  margin-top: 0;
 }
 
 .messages-list {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_centralized_content.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_centralized_content.scss
@@ -136,6 +136,7 @@
 }
 
 // adjust view page proofing styles for centralized content
+#block-vagovclaro-content .centralized .paragraph,
 #block-vagovclaro-content .node--type-centralized-content .paragraph {
   border: unset;
   padding: 0;


### PR DESCRIPTION
## Description

Closes #8142. Wraps extra long links in the node link report, so the layout is not broken.

Also fixes this regression with centralized content that was reported by @kevwalsh here: https://dsva.slack.com/archives/CDKB88PS8/p1645707959170909

## Testing done
admin looking at:
`/nebraska-western-iowa-health-care/work-with-us/jobs-and-careers/nursing-careers/nursing-careers`
- verified broken links dont break the node link wrapper layout

as witt.cook@va.gov
`node/3877/edit?destination=/section/vha/vet-centers/nashville-vet-center#edit-field-health-services`
- scroll down and see that there's no weird border displayed inside of centralized content anymore

## Screenshots
long broken links layout fixed:
<img width="1178" alt="Screen Shot 2022-02-24 at 1 01 29 PM" src="https://user-images.githubusercontent.com/11279744/155607797-372ccfc9-afa1-4420-8734-5646bb4b20b9.png">


before:
<img width="960" alt="Screen Shot 2022-02-24 at 1 00 47 PM" src="https://user-images.githubusercontent.com/11279744/155607793-74e45cf1-0aa5-4d98-bcee-f052718b12f4.png">

after:
<img width="720" alt="Screen Shot 2022-02-24 at 1 00 37 PM" src="https://user-images.githubusercontent.com/11279744/155607790-a73116fb-157c-44cf-8b8a-e0f2538b8249.png">


## QA steps
admin looking at:
`/nebraska-western-iowa-health-care/work-with-us/jobs-and-careers/nursing-careers/nursing-careers`
- verified broken links dont break the node link wrapper layout

as witt.cook@va.gov
`node/3877/edit?destination=/section/vha/vet-centers/nashville-vet-center#edit-field-health-services`
- scroll down and see that there's no weird border displayed inside of centralized content anymore


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [x] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
