### PR TITLE
VACMS-8139: hide operations field for all office hours widgets

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -59,13 +59,6 @@
   }
 }
 
-.field--name-field-office-hours #edit-field-office-hours-value tr {
-  th:last-child,
-  td:last-child {
-    display: none;
-  }
-}
-
 #edit-group-facility-api {
   .field--name-field-facility-hours {
     input {
@@ -110,8 +103,16 @@
 }
 
 // Adjusting spacing on office hours fields
-#edit-field-office-hours {
+#edit-field-office-hours,
+#edit-field-hours-for-copay-inquiries- {
   margin-bottom: 0;
+
+  tr {
+    th:last-child,
+    td:last-child {
+      display: none;
+    }
+  }
 
   td {
     padding: 0;


### PR DESCRIPTION
## Description

Closes #8139 

## Testing done

Visual Testing

## Screenshots

<img width="1791" alt="Screen Shot 2022-02-24 at 5 39 33 PM" src="https://user-images.githubusercontent.com/21045418/155619520-ae0d0d64-c423-443a-af94-a6a93991b7c1.png">


## QA steps

As an admin user
- [x] Visit node/1464/edit (VAMC Facility) and verify the operations column is not displayed for the hours field
- [x] Visit node/42283/edit (VAMC System Billing and Insurance) and verify the operations column is not displayed for the hours field

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`
