### PR TITLE
VACMS-8168: Uses a Cypress logging statement to force timeouts in too-long-running tests.

### DIFF
--- a/tests/accessibility/cypress/integration/nodeCreationAccessibility.spec.js
+++ b/tests/accessibility/cypress/integration/nodeCreationAccessibility.spec.js
@@ -51,6 +51,7 @@ describe('Component accessibility test', () => {
 
       cy.get('body').each((element, index) => {
         cy.checkA11y(null, axeRuntimeOptions, cy.terminalLog);
+        cy.task('log', 'Accessibility check completed successfully.');
       });
 
     });

--- a/tests/accessibility/cypress/integration/nodeCreationAccessibility.spec.js
+++ b/tests/accessibility/cypress/integration/nodeCreationAccessibility.spec.js
@@ -38,7 +38,7 @@ describe('Component accessibility test', () => {
   routes.forEach((route) => {
 
     const testName = `${route} has no detectable accessibility violations on load.`;
-    it(testName, () => {
+    it(testName, { retries: { runMode: 2 } }, () => {
       cy.visit(route);
       cy.injectAxe();
 


### PR DESCRIPTION
## Description

Relates to #8168.  This is not a fix for the underlying issue; I'll need to look deeper into that.

This PR adds a task to log that the accessibility test completed successfully.  This adds a small amount of log spam to each of the accessibility tests.  However, and more importantly, it also appears to short-circuit accessibility tests that get stuck.

I _think_ it works like the following:
1. The accessibility test for a problematic page (say, `/node/add/health_care_local_facility`) completes normally.
2. For whatever reason, Cypress-Axe does not process the end of the test successfully, but it does invoke the following `cy.task()` expression.
3. The `cy.task()` expression is invoked, and its timeout (`taskTimeout`) is set up.  But the expression cannot complete, and consequently the test fails.

In addition, this PR adds automatic retries to these accessibility tests.  Thus if a test fails (whether because it ran for too long, or for actual accessibility failures), it will be retried automatically up to two times before the test as a whole fails.

This isn't a perfect solution, but I'm opening the PR so that it can stop the hemorrhaging of developer time while I try to identify the root cause of this problem.

I've run a few hundred trials of this method in another PR and had no failures or unanticipated side effects.  However, I cleared my terminal scrollbacks this morning 🤦 so I can't show examples.  I'll run some more trials on this PR, which is just good practice anyway after making a number of changes in my test environment.

## Testing done


## Screenshots

### Tests failing due to timeouts
<img width="1037" alt="Screen Shot 2022-03-03 at 9 26 07 AM" src="https://user-images.githubusercontent.com/1318579/156584092-d0125f7a-f63a-4282-b752-799973ea7339.png">

### Tests passing normally
<img width="849" alt="Screen Shot 2022-03-03 at 9 35 12 AM" src="https://user-images.githubusercontent.com/1318579/156585888-6337a1e2-31ec-4f70-a4eb-f1b32b767d61.png">

### Tests failing due to timeouts and passing on retries
I'm working on this.

## QA steps

As user _uid_ with _user_role_
1. Do this
5. Then that
6. Then validate Acceptance Criteria from issue
- [ ] This
- [ ] That
- [ ] The other thing

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
