### PR TITLE
VACMS-8092: push children of service terms and system services on change

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -103,6 +103,89 @@ class PostFacilityService extends PostFacilityBase {
   }
 
   /**
+   * Adds facility service data to Post API queue by term.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   *
+   * @return int
+   *   The count of the number of items queued.
+   */
+  public function queueServiceTermRelatedServices(EntityInterface $entity) {
+    $queued_count = 0;
+    if (($entity->getEntityTypeId() === 'taxonomy_term') && ($entity->bundle() === 'health_care_service_taxonomy')) {
+      // Find all VAMC System Health Services referencing this term.
+      $storage_handler = $this->entityTypeManager->getStorage("node");
+      $result = \Drupal::entityQuery('node')
+        ->condition('type', 'regional_health_care_service_des')
+        ->condition('field_service_name_and_descripti', $entity->id())
+        ->execute();
+
+      if (!empty($result)) {
+        try {
+          $total = count($result);
+          $current = 0;
+
+          while ($current < $total) {
+            // Run through a batch of 50.
+            $nids = array_slice($result, $current, 50, FALSE);
+
+            $nodes = $storage_handler->loadMultiple($nids);
+            foreach ($nodes as $node) {
+              // Process each VAMC System Health Service using this term.
+              $queued_count += $this->queueSystemRelatedServices($node, TRUE);
+            }
+
+            $current = $current + count($nids);
+            $message = sprintf('VA.gov Post API: %s of %d regional_health_care_service_des nodes processed. Queued %s health_care_local_health_service nodes for sync to Lighthouse.', $current, $total, $queued_count);
+            $this->loggerChannelFactory->get('va_gov_post_api')->info($message);
+
+          }
+        }
+        catch (\Exception $e) {
+          $message = sprintf('VA.gov Post API: Failed queuing items of type regional_health_care_service_des. %e', $e->getMessage());
+          $this->loggerChannelFactory->get('va_gov_post_api')->error($message);
+        }
+      }
+    }
+
+    return $queued_count;
+  }
+
+  /**
+   * Adds facility service data to Post API queue by system health service.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   * @param bool $force
+   *   Process regardless of published status.
+   *
+   * @return int
+   *   The count of the number of items queued.
+   */
+  public function queueSystemRelatedServices(EntityInterface $entity, bool $force = FALSE) {
+    $queued_count = 0;
+    if (($entity->getEntityTypeId() === 'node') && ($entity->bundle() === 'regional_health_care_service_des')) {
+      if ($this->shouldPush($entity, $force)) {
+        // Find all VAMC Facility Health Services referencing this node.
+        $storage_handler = $this->entityTypeManager->getStorage("node");
+        $nids = \Drupal::entityQuery('node')
+          ->condition('type', 'health_care_local_health_service')
+          ->condition('field_regional_health_service', $entity->id())
+          ->execute();
+
+        $nodes = $storage_handler->loadMultiple($nids);
+        foreach ($nodes as $node) {
+          // Process each VAMC Facility Health Service referencing this node.
+          $queued_count += $this->queueFacilityService($node);
+        }
+      }
+    }
+
+    return $queued_count;
+  }
+
+  /**
    * Compose and return payload array for facility service.
    *
    * @return array
@@ -112,7 +195,7 @@ class PostFacilityService extends PostFacilityBase {
     // Default payload is an empty array.
     $payload = [];
 
-    if (empty($this->errors) && $this->shouldPush()) {
+    if (empty($this->errors) && $this->shouldPush($this->facilityService)) {
       $service = new \stdClass();
       $service->name = $this->serviceTerm->getName();
       $service->active = ($this->facilityService->isPublished()) ? TRUE : FALSE;
@@ -239,19 +322,26 @@ class PostFacilityService extends PostFacilityBase {
   /**
    * Determines if the data says a payload should be assembled and pushed.
    *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   * @param bool $force
+   *   Process due to referenced entity updates.
+   *
    * @return bool
    *   TRUE if should be pushed, FALSE otherwise.
    */
-  protected function shouldPush() {
+  protected function shouldPush(EntityInterface $entity, bool $force = FALSE) {
     // Moderation state of what is being saved.
-    $moderationState = $this->facilityService->moderation_state->value;
+    $moderationState = $entity->moderation_state->value;
     $isArchived = ($moderationState === 'archived') ? TRUE : FALSE;
-    $thisRevisionIsPublished = $this->facilityService->isPublished();
-    $defaultRevisionIsPublished = (isset($this->facilityService->original) && ($this->facilityService->original instanceof EntityInterface)) ? (bool) $this->facilityService->original->status->value : (bool) $this->facilityService->status->value;
-    $isNew = $this->facilityService->isNew();
+    $thisRevisionIsPublished = $entity->isPublished();
+    $defaultRevisionIsPublished = (isset($entity->original) && ($entity->original instanceof EntityInterface)) ? (bool) $entity->original->status->value : (bool) $entity->status->value;
+    $isNew = $entity->isNew();
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
+      case $force && $thisRevisionIsPublished:
+        // Forced push from updates to referenced entity.
       case $isNew:
         // A new node, should be pushed to initiate the value.
       case $thisRevisionIsPublished:

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -24,13 +24,6 @@ class PostFacilityService extends PostFacilityBase {
   protected $facilityService;
 
   /**
-   * Processing forced by referenced system service.
-   *
-   * @var bool
-   */
-  protected $forcePush;
-
-  /**
    * The related system service node.
    *
    * @var \Drupal\Core\Entity\EntityInterface
@@ -88,7 +81,7 @@ class PostFacilityService extends PostFacilityBase {
         $data['uid'] = "facility_service_{$this->Facility->id()}_{$this->facilityService->id()}";
         $facilityApiId = $this->Facility->hasField('field_facility_locator_api_id') ? $this->Facility->get('field_facility_locator_api_id')->value : NULL;
         $data['endpoint_path'] = ($facilityApiId) ? "/services/va_facilities/v0/facilities/{$facilityApiId}/cms-overlay" : NULL;
-        $data['payload'] = $this->getPayload();
+        $data['payload'] = $this->getPayload($forcePush);
 
         // Only add to queue if payload is not empty.
         // If its empty, it means that there is no new information to send to
@@ -199,14 +192,17 @@ class PostFacilityService extends PostFacilityBase {
   /**
    * Compose and return payload array for facility service.
    *
+   * @param bool $forcePush
+   *   Processing forced by referenced system service.
+   *
    * @return array
    *   Payload array.
    */
-  protected function getPayload() {
+  protected function getPayload(bool $forcePush = FALSE) {
     // Default payload is an empty array.
     $payload = [];
 
-    if (empty($this->errors) && $this->shouldPush($this->facilityService, $this->forcePush)) {
+    if (empty($this->errors) && $this->shouldPush($this->facilityService, $forcePush)) {
       $service = new \stdClass();
       $service->name = $this->serviceTerm->getName();
       $service->active = ($this->facilityService->isPublished()) ? TRUE : FALSE;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -66,7 +66,6 @@ class PostFacilityService extends PostFacilityBase {
     if (($entity->getEntityTypeId() === 'node') && ($entity->bundle() === 'health_care_local_health_service')) {
       // This is an appropriate service so begin gathering data to process.
       $this->facilityService = $entity;
-      $this->forcePush = $forcePush;
 
       // Many service details do not reside with the facility service node.
       // They must be derived from the facility and system service nodes

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -115,9 +115,8 @@ class PostFacilityService extends PostFacilityBase {
     $queued_count = 0;
     if (($entity->getEntityTypeId() === 'taxonomy_term') && ($entity->bundle() === 'health_care_service_taxonomy')) {
       // Find all VAMC System Health Services referencing this term.
-      $storage_handler = $this->entityTypeManager->getStorage("node");
-      $result = \Drupal::entityQuery('node')
-        ->condition('type', 'regional_health_care_service_des')
+      $query = $this->entityTypeManager->getStorage('node')->getQuery();
+      $result = $query->condition('type', 'regional_health_care_service_des')
         ->condition('field_service_name_and_descripti', $entity->id())
         ->execute();
 
@@ -130,7 +129,7 @@ class PostFacilityService extends PostFacilityBase {
             // Run through a batch of 50.
             $nids = array_slice($result, $current, 50, FALSE);
 
-            $nodes = $storage_handler->loadMultiple($nids);
+            $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
             foreach ($nodes as $node) {
               // Process each VAMC System Health Service using this term.
               $queued_count += $this->queueSystemRelatedServices($node, TRUE);
@@ -168,13 +167,12 @@ class PostFacilityService extends PostFacilityBase {
     if (($entity->getEntityTypeId() === 'node') && ($entity->bundle() === 'regional_health_care_service_des')) {
       if ($this->shouldPush($entity, $force)) {
         // Find all VAMC Facility Health Services referencing this node.
-        $storage_handler = $this->entityTypeManager->getStorage("node");
-        $nids = \Drupal::entityQuery('node')
-          ->condition('type', 'health_care_local_health_service')
+        $query = $this->entityTypeManager->getStorage('node')->getQuery();
+        $nids = $query->condition('type', 'health_care_local_health_service')
           ->condition('field_regional_health_service', $entity->id())
           ->execute();
 
-        $nodes = $storage_handler->loadMultiple($nids);
+        $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
         foreach ($nodes as $node) {
           // Process each VAMC Facility Health Service referencing this node.
           $queued_count += $this->queueFacilityService($node);

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -48,11 +48,17 @@ function _post_api_add_facility_status_to_queue(EntityInterface $entity) {
  *   Entity.
  *
  * @return int
- *   The count of the number of items queued (1,0).
+ *   The count of the number of items queued.
  */
 function _post_api_add_facility_service_to_queue(EntityInterface $entity) {
   if ($entity->bundle() === 'health_care_local_health_service') {
     return Drupal::service('va_gov_post_api.queue_service_updates')->queueFacilityService($entity);
+  }
+  elseif ($entity->bundle() === 'health_care_service_taxonomy') {
+    return Drupal::service('va_gov_post_api.queue_service_updates')->queueServiceTermRelatedServices($entity);
+  }
+  elseif ($entity->bundle() === 'regional_health_care_service_des') {
+    return Drupal::service('va_gov_post_api.queue_service_updates')->queueSystemRelatedServices($entity);
   }
 
   return 0;


### PR DESCRIPTION
## Description

Closes #8092 

## Testing done

Manual / visual testing

## Screenshots

**Updating at the Term level**

<img width="1684" alt="Screen Shot 2022-03-07 at 5 48 58 PM" src="https://user-images.githubusercontent.com/21045418/157132037-eb471a2e-84dc-471f-bfa7-3a47994a7a3e.png">

<img width="1700" alt="Screen Shot 2022-03-07 at 6 01 52 PM" src="https://user-images.githubusercontent.com/21045418/157132809-0525a812-c001-4ef8-9c28-bbee78b23fd9.png">

<img width="1689" alt="Screen Shot 2022-03-07 at 6 02 32 PM" src="https://user-images.githubusercontent.com/21045418/157132867-7db12aed-1803-4a61-b008-d77bb27f914e.png">

<img width="1695" alt="Screen Shot 2022-03-07 at 6 03 17 PM" src="https://user-images.githubusercontent.com/21045418/157132950-b3bca5da-8f4f-45d1-a675-c09f8575dcdf.png">

**Updating at the System Health Service level**

<img width="1683" alt="Screen Shot 2022-03-07 at 6 08 45 PM" src="https://user-images.githubusercontent.com/21045418/157133502-598c5fd5-21a2-4865-ae95-db6e3efe8fd6.png">

<img width="1691" alt="Screen Shot 2022-03-07 at 6 09 55 PM" src="https://user-images.githubusercontent.com/21045418/157133619-40f0fa90-e5fe-44b8-94aa-64206ffd432c.png">

## QA steps

As an admin user
**Check single facility save**
- [x] VIsit here and run the queue if it has anything in it to make sure it is empty https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/admin/config/post-api/queue
- [x] save a draft change to this facility service https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/node/39788/edit
- [x] validate that no service has been queued https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/admin/config/post-api/queue
- [x] publish a change to the same node. https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/node/39788/edit
- [x] validate that one item was queued.

**Check system service save**
- [x] Make a draft revision for https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/node/15194/edit and save.
- [x] Validate that no items were queued https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/admin/config/post-api/queue
- [x] Publish a new revision of the **COVID-19 vaccines at VA Boston Health Care** System Health Service: https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/node/15194/edit
- [x] Check the displayed message to be sure the 3 Facility Health Services for Boston are queued for Lighthouse
- [x] VIsit here https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/admin/config/post-api/queue and validate it contains 3 items for Boston.

**Check Service term save**
- [x] Resave the COVID-19 vaccines term: [/term/321/edit](https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/taxonomy/term/321/edit) (saving will take some time)
- [x] Check the drupal logs to be sure all 314 Facility Health Services using this term are queued for Lighthouse
- [x] visit https://pr8280-nxqyr663btgw7w0gpsnghpecmzimcbnj.ci.cms.va.gov/admin/config/post-api/queue  and validate that it contains 314 facility health services.   


### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`
