### PR TITLE
VACMS-8295: Update default sort for flagged view.

### DIFF
--- a/config/sync/views.view.flagged_content.yml
+++ b/config/sync/views.view.flagged_content.yml
@@ -1257,7 +1257,7 @@ display:
           entity_type: user
           entity_field: changed
           plugin_id: date
-          order: ASC
+          order: DESC
           expose:
             label: ''
             field_identifier: changed
@@ -1776,7 +1776,7 @@ display:
             timestamp: timestamp
             break: break
             is_locked: is_locked
-          default: '-1'
+          default: changed
           info:
             title:
               sortable: true
@@ -1869,7 +1869,7 @@ display:
               responsive: ''
             changed:
               sortable: true
-              default_sort_order: asc
+              default_sort_order: desc
               align: ''
               separator: ''
               empty_column: false


### PR DESCRIPTION
## Description
Closes #8295 .

## Testing done
navigated to flagged content view and verified newest results appeared first in the list.

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/157317132-b5c12005-2190-4f15-828b-bdd2593c73bd.png)


## QA steps

As a cms admin i can
1. navigated to the flagged content view (`/admin/content/flagged`)
2. Then validate Acceptance Criteria from issue
- [x]  /admin/content/flagged is sorted by Updated DESC by default.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
