### PR TITLE
VACMS-8135: Flag theming breaks some views config

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_flags.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_flags.scss
@@ -1,28 +1,29 @@
-//Styling for Flags
-.flag {
-  background: var(--va-gray-lighter);
-  border-radius: 30px;
-  display: inline-block;
-  padding: 4px 16px;
-  white-space: nowrap;
+// Styling for Flags
+.view-flagged-content {
+  .flag {
+    background: var(--va-gray-lighter);
+    border-radius: 30px;
+    display: inline-block;
+    padding: 4px 16px;
+    white-space: nowrap;
 
-  &.new {
-    background: var(--va-blue-light);
+    &.new {
+      background: var(--va-blue-light);
+    }
+
+    &.changed_filename,
+    &.changed_title,
+    &.changed {
+      background: var(--va-gold-lightest);
+    }
+
+    &.deleted,
+    &.removed-from-source {
+      background: var(--va-red-lightest);
+    }
+
+    &.removal-complete {
+      background: var(--va-green-lightest);
+    }
   }
-
-  &.changed_filename,
-  &.changed_title,
-  &.changed {
-    background: var(--va-gold-lightest);
-  }
-
-  &.deleted,
-  &.removed-from-source {
-    background: var(--va-red-lightest);
-  }
-
-  &.removal-complete {
-    background: var(--va-green-lightest);
-  }
-
 }

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
@@ -97,3 +97,15 @@
     margin-top: 0;
   }
 }
+
+// Flag in Views.
+// The "flag" CSS is incorrectly been applied to the Views tables (e.x.: relationships section) thus breaking the table.
+// Adding specificity to override default "flag" CSS in Views.
+.views-filterable-options {
+  .flag {
+    background: inherit;
+    border-radius: 0;
+    display: table-row;
+    padding: initial;
+  }
+}

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
@@ -107,5 +107,11 @@
     border-radius: 0;
     display: table-row;
     padding: initial;
+
+    &:hover,
+    &:focus {
+      background: var(--color-bgblue-hover);
+      color: var(--color-text);
+    }
   }
 }

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
@@ -97,21 +97,3 @@
     margin-top: 0;
   }
 }
-
-// Flag in Views.
-// The "flag" CSS is incorrectly been applied to the Views tables (e.x.: relationships section) thus breaking the table.
-// Adding specificity to override default "flag" CSS in Views.
-.views-filterable-options {
-  .flag {
-    background: inherit;
-    border-radius: 0;
-    display: table-row;
-    padding: initial;
-
-    &:hover,
-    &:focus {
-      background: var(--color-bgblue-hover);
-      color: var(--color-text);
-    }
-  }
-}


### PR DESCRIPTION
- Updated _views.scss and added CSS specificity to override default "flag" CSS in Views.

## Description

closes #8135 

## Testing done
Passes all tests

## Screenshots
![VACMS-8135-flag-row](https://user-images.githubusercontent.com/846871/157347836-6f7f487f-85b2-4c6b-be8f-6d13977992ab.png)

![VACMS-8135-flag-row-hover](https://user-images.githubusercontent.com/846871/157347872-85e31cac-7fbf-488b-95fd-e2efd3e58d90.png)

![VACMS-8135-flagged-content](https://user-images.githubusercontent.com/846871/157690350-6c48ed31-c4c4-4184-a5a8-be5ff47bb610.png)

## QA steps

As user administrator
1. Go to `/admin/structure/views/view/content` (or any node related view):
    - [x] In the right column under "Advanced" click the "Add" button next to "Relationships" and scroll down until you find the "Content flag" and visually inspect to verify and confirm that the table row ins't broken any more and that the hover and focus effects works the same as other table rows
2. Go to `/admin/content/flagged` (or in `/admin/content` click on the "Flagged" tab):
    - [x] Verify and confirm that the "flags" CSS styling isn't broken or odd looking

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
