### PR TITLE
VACMS-0000: Ignores AWS PHP SDK patch updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
   allow:
   - dependency-type: direct
   ignore:
+  - dependency-name: aws/aws-sdk-php
+    update-types:
+    - version-update:semver-patch
   - dependency-name: acquia/drupal-spec-tool
     versions:
     - ">= 3.a"


### PR DESCRIPTION
We get a large amount of PRs relating to the AWS PHP SDK.  

It's a good idea to stay updated, of course, but it's definitely not worth the amount of churn to update on every patch update, especially considering that the PHP SDK covers every AWS service and we only use a couple of them.

This PR instructs Dependabot to only open PRs for minor version updates, not patch updates, which should cut the noise down substantially.