### PR TITLE
VACMS-7557: Enable allow only one on health services.

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_also_known_as
     - field.field.taxonomy_term.health_care_service_taxonomy.field_commonly_treated_condition
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_enforce_unique_combo_servi
     - field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id
     - field.field.taxonomy_term.health_care_service_taxonomy.field_owner
     - field.field.taxonomy_term.health_care_service_taxonomy.field_service_type_of_care
@@ -16,6 +17,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode
     - taxonomy.vocabulary.health_care_service_taxonomy
   module:
+    - allow_only_one
     - field_group
     - path
     - text
@@ -57,7 +59,6 @@ third_party_settings:
     group_vamc:
       children:
         - field_service_type_of_care
-        - field_non_clinical_service
         - field_also_known_as
         - field_commonly_treated_condition
         - description
@@ -102,9 +103,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_enforce_unique_combo_servi:
+    type: allow_only_one_widget
+    weight: 1
+    region: content
+    settings:
+      size: 1
+    third_party_settings: {  }
   field_health_service_api_id:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -118,7 +126,7 @@ content:
     third_party_settings: {  }
   field_vet_center_com_conditions:
     type: string_textfield
-    weight: 10
+    weight: 11
     region: content
     settings:
       size: 60
@@ -134,14 +142,14 @@ content:
     third_party_settings: {  }
   field_vet_center_required_servic:
     type: boolean_checkbox
-    weight: 12
+    weight: 13
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_vet_center_service_descrip:
     type: string_textarea
-    weight: 11
+    weight: 12
     region: content
     settings:
       rows: 5
@@ -155,7 +163,7 @@ content:
     third_party_settings: {  }
   field_vha_healthservice_stopcode:
     type: number
-    weight: 2
+    weight: 3
     region: content
     settings:
       placeholder: ''

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_also_known_as
     - field.field.taxonomy_term.health_care_service_taxonomy.field_commonly_treated_condition
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_enforce_unique_combo_servi
     - field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id
     - field.field.taxonomy_term.health_care_service_taxonomy.field_owner
     - field.field.taxonomy_term.health_care_service_taxonomy.field_service_type_of_care
@@ -16,6 +17,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode
     - taxonomy.vocabulary.health_care_service_taxonomy
   module:
+    - allow_only_one
     - layout_builder
     - options
     - text
@@ -50,6 +52,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_enforce_unique_combo_servi:
+    type: allow_only_one
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 11
     region: content
   field_health_service_api_id:
     type: string

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_enforce_unique_combo_servi.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_enforce_unique_combo_servi.yml
@@ -1,0 +1,42 @@
+uuid: b9746a12-2907-48ad-b37f-29989c07bd25
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_enforce_unique_combo_servi
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - allow_only_one
+    - epp
+third_party_settings:
+  allow_only_one:
+    field_also_known_as: 0
+    field_commonly_treated_condition: 0
+    field_health_service_api_id: 1
+    field_owner: 0
+    field_service_type_of_care: 0
+    field_vet_center_com_conditions: 0
+    field_vet_center_friendly_name: 0
+    field_vet_center_required_servic: 0
+    field_vet_center_service_descrip: 0
+    field_vet_center_type_of_care: 0
+    field_vha_healthservice_stopcode: 0
+    title: 0
+    case_sensitive: null
+  epp:
+    value: ''
+    on_update: 1
+id: taxonomy_term.health_care_service_taxonomy.field_enforce_unique_combo_servi
+field_name: field_enforce_unique_combo_servi
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Enforce unique combo service'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id.yml
@@ -5,13 +5,19 @@ dependencies:
   config:
     - field.storage.taxonomy_term.field_health_service_api_id
     - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
 id: taxonomy_term.health_care_service_taxonomy.field_health_service_api_id
 field_name: field_health_service_api_id
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
 label: 'Health Service API ID'
 description: "The \"Health Service API ID\" is used to match the health service with the data result set that comes back from calling the endpoint that retrieves the facility data.\r\nThis is used to display data such as appointment wait times on the local facility page.\r\nThis value must be exact, or else the desired data will not appear.\r\nHere is a list of known \"Health Service API ID\"s that come back from the facility API we are currently using:\r\naudiology,\r\ncardiology,\r\ndermatology,\r\ngastroenterology,\r\ngynecology,\r\nmentalHealth,\r\nophthalmology,\r\noptometry,\r\northopedics,\r\nprimaryCare,\r\nspecialtyCare,\r\nurology."
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_owner.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_owner.yml
@@ -7,7 +7,18 @@ dependencies:
     - taxonomy.vocabulary.administration
     - taxonomy.vocabulary.health_care_service_taxonomy
   content:
-    - 'taxonomy_term:administration:0e30e74c-76b9-4c25-aa12-745086f02e37'
+    - 'taxonomy_term:administration:867e4dcf-2f99-401a-977a-adb441d53350'
+  module:
+    - entity_reference_validators
+    - epp
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: false
+  epp:
+    value: ''
+    on_update: 1
 id: taxonomy_term.health_care_service_taxonomy.field_owner
 field_name: field_owner
 entity_type: taxonomy_term
@@ -18,7 +29,7 @@ required: true
 translatable: false
 default_value:
   -
-    target_uuid: 0e30e74c-76b9-4c25-aa12-745086f02e37
+    target_uuid: 867e4dcf-2f99-401a-977a-adb441d53350
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.storage.taxonomy_term.field_enforce_unique_combo_servi.yml
+++ b/config/sync/field.storage.taxonomy_term.field_enforce_unique_combo_servi.yml
@@ -1,0 +1,19 @@
+uuid: edb6dfc5-946d-4911-b628-9d8b9c8880eb
+langcode: en
+status: true
+dependencies:
+  module:
+    - allow_only_one
+    - taxonomy
+id: taxonomy_term.field_enforce_unique_combo_servi
+field_name: field_enforce_unique_combo_servi
+entity_type: taxonomy_term
+type: allow_only_one
+settings: {  }
+module: allow_only_one
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
@@ -186,6 +186,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
     $this->lockTitleEditing($form, $form_state);
+    $this->lockApiIdEditing($form, $form_state);
   }
 
   /**
@@ -290,6 +291,25 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     ];
     if (!$this->userPermsService->hasAdminRole() && in_array($bundle, $bundles_with_standardized_titles)) {
       $form['title']['#disabled'] = TRUE;
+    }
+  }
+
+  /**
+   * Locks down API Id for non-admins.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function lockApiIdEditing(array &$form, FormStateInterface $form_state) {
+    $form_object = $form_state->getFormObject();
+    $bundle = NULL;
+    if ($form_object instanceof ContentEntityForm) {
+      $bundle = $form_object->getEntity()->bundle();
+    }
+    if (!$this->userPermsService->hasAdminRole() && $bundle === 'health_care_service_taxonomy') {
+      $form['field_health_service_api_id']['#disabled'] = TRUE;
     }
   }
 

--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
@@ -308,7 +308,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     if ($form_object instanceof ContentEntityForm) {
       $bundle = $form_object->getEntity()->bundle();
     }
-    if (!$this->userPermsService->hasAdminRole() && $bundle === 'health_care_service_taxonomy') {
+    if (!$this->userPermsService->hasAdminRole(TRUE) && $bundle === 'health_care_service_taxonomy') {
       $form['field_health_service_api_id']['#disabled'] = TRUE;
     }
   }

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -13,7 +13,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | Sections | Product | field_product | Entity reference |  | 1 | Select list |  |
 | Vocabulary | VHA health service taxonomy | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VHA health service taxonomy | Health Service API ID | field_health_service_api_id | Text (plain) | Required | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Section | field_owner | Entity reference | Required | 1 | -- Disabled -- |  |
 | Vocabulary | VHA health service taxonomy | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VHA health service taxonomy | Type of care | field_service_type_of_care | List (text) |  | 1 | Select list |  |
@@ -23,4 +23,6 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VHA health service taxonomy | Service description | field_vet_center_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VHA health service taxonomy | Type of Care | field_vet_center_type_of_care | List (text) |  | 1 | Select list |  |
 | Vocabulary | VHA health service taxonomy | This is a required Vet Center service | field_vet_center_required_servic | Boolean |  | 1 | Single on/off checkbox |  |
+| Vocabulary | VHA health service taxonomy | Enforce unique combo service | field_enforce_unique_combo_servi | Allow Only One |  | 1 | Allow Only One widget |  |
 | Vocabulary | Products | Knowledge base landing page | field_kb_landing_page | Entity reference |  | 1 | Autocomplete |  |
+

--- a/tests/behat/features/content_editing.feature
+++ b/tests/behat/features/content_editing.feature
@@ -218,6 +218,7 @@ Feature: CMS Users may effectively create & edit content
     And I am at "admin/structure/taxonomy/manage/health_care_service_taxonomy/add"
     And the "path[0][pathauto]" checkbox should be checked
     And I fill in "Name" with "BeHat URL Alias Term Title Published"
+    And I fill in "Health Service API ID" with "1234"
     And I press "Save"
     Then I should see "BeHat URL Alias Term Title Published"
     Then I visit the "edit" page for a term with the title "BeHat URL Alias Term Title Published"


### PR DESCRIPTION
## Description
closes #7557

## Testing done
Visual/Behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/158240372-871b5b5e-faa4-4e2e-b7af-c5bd18efbac9.png)

## QA steps
 - [x] As an administrator, go to `/taxonomy/term/112/edit` and change `Health Service API ID` field to `addiction` and visually verify `1 error has been found: Enforce unique combo service` message appears on save.
 - [x] As a non administrator who has access to health services taxonomy, go to `/taxonomy/term/112/edit` and visually verify  `Health Service API ID` field is disabled.