### PR TITLE
VACMS-8330: Adjust time format from "01 through 12" to "1 through 12"

### DIFF
--- a/config/sync/core.date_format.long.yml
+++ b/config/sync/core.date_format.long.yml
@@ -7,4 +7,4 @@ _core:
 id: long
 label: 'Default long date'
 locked: false
-pattern: 'l, F j, Y - h:i a'
+pattern: 'l, F j, Y - g:i a'

--- a/config/sync/core.date_format.medium.yml
+++ b/config/sync/core.date_format.medium.yml
@@ -7,4 +7,4 @@ _core:
 id: medium
 label: 'Default medium date'
 locked: false
-pattern: 'D, m/d/Y - h:i a'
+pattern: 'D, m/d/Y - g:i a'

--- a/config/sync/core.date_format.short.yml
+++ b/config/sync/core.date_format.short.yml
@@ -7,4 +7,4 @@ _core:
 id: short
 label: 'Default short date'
 locked: false
-pattern: 'm/d/Y - h:i a'
+pattern: 'm/d/Y - g:i a'

--- a/config/sync/core.date_format.standard.yml
+++ b/config/sync/core.date_format.standard.yml
@@ -5,4 +5,4 @@ dependencies: {  }
 id: standard
 label: Standard
 locked: false
-pattern: 'm/d/y h:i a T'
+pattern: 'm/d/y g:i a T'


### PR DESCRIPTION
- Adjusted various time formats, changed from "01 through 12" to "1 through 12".

## Description
closes #8330 

## Testing done
Passes all tests

## Screenshots
![VACMS-8330-time-formats](https://user-images.githubusercontent.com/846871/159082319-d4b00a5d-ac11-4be4-9504-c87f63e3132d.png)

![VACMS-8330-content-with-time-format-adjusted](https://user-images.githubusercontent.com/846871/159082327-682cb55c-62c4-45ff-859d-054c11cab085.png)

## QA steps

As user administrator
1. Go to `/admin/config/regional/date-time` and
   - [ ] Verify and confirm that the time formats are now using "1 through 12" instead of "01 through 12"
2. Then go to `/admin/content` and
   - [ ] Verify and confirm that the time shows as "4:30 pm" instead of "04:30 pm"

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
