### PR TITLE
VACMS-8410: update drupal core and friends to 9.3.9.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4098,7 +4098,7 @@
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "9.3.8",
+            "version": "9.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -4142,7 +4142,7 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.3.8"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.3.9"
             },
             "time": "2022-02-24T17:40:56+00:00"
         },


### PR DESCRIPTION
## Description

#8410

