### PR TITLE
VACMS-8424 reduce content builds in tests

### DIFF
--- a/READMES/testing.md
+++ b/READMES/testing.md
@@ -55,7 +55,7 @@ There are 4 main types of tests:
 
     See the [hooks/pre-commit file](../hooks/pre-commit) for the exact
     command run before git commit.
-    
+
     Each static test should also be run by a corresponding [Github action](https://docs.github.com/en/actions) and block PR merges on failure. Github actions are added and edited in the [Github workflows directory](../.github/workflows). When adding a new Github action, our preferred process to minimize technical debt and maintenance is the following:
     1. When possible, use a well-supported action from the open-source community. The [reviewdog](https://github.com/reviewdog) organization on Github is often a good place to start looking.
     1. If the action cannot meet our requirements without modifications, resolve in this order:
@@ -75,10 +75,7 @@ There are 4 main types of tests:
 
 1.  **WEB Integration Tests**
 
-    1. `va/web/build` - Build the front-end from the current site. (Alias for
-       `composer va:web:build`).
-    1. `va/web/unit` - Run the front-end unit tests. (Not yet merged. See
-       [PR547](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/547))
+    1. Behat Decoupled.feature runs a content build and test for content changes.
 
     The long term goal is to run _all_ of the **WEB** project's tests in our
     test
@@ -321,11 +318,11 @@ Whether these third party libraries are secure involves multiple factors (and ha
 PHPStan performs static analysis on the codebase and reports issues such as references to unknown/undeclared properties, incorrect argument types in function calls, functions that are too long or too complex, etc.
 
 ### Magic Properties and Other Annoyances
-Developing with Drupal idiomatically tends to conflict with PHPStan.  
+Developing with Drupal idiomatically tends to conflict with PHPStan.
 
 For instance, you might type code like `$node->field_address->zip_code`.  If `$node` is declared as or implied to be a `\Drupal\node\Entity\Node` object, then PHPStan will look for a property named `$field_address` on `\Drupal\node\Entity\Node`.  `$node` might also be interpreted as `\Drupal\node\NodeInterface`, or `\Drupal\Core\Entity\EntityInterface`, or any of several other interfaces.  But functionality for accessing fields via constructs like `$node->field_address` is implemented via "magic properties," to which PHPStan does not and cannot have access.  As a consequence, PHPStan will view the use of these magic properties as errors.
 
-To permit both idiomatic Drupaling and good static analysis, we simply whitelist errors that arise from this sort of use.  
+To permit both idiomatic Drupaling and good static analysis, we simply whitelist errors that arise from this sort of use.
 
 This can be done by adding new expressions to the `parameters.ignoreErrors` array in [phpstan.neon](../phpstan.neon).
 

--- a/tests.yml
+++ b/tests.yml
@@ -215,31 +215,6 @@ tasks:
           fi
         EOF
 
-  va/web/build:
-    desc: Build VA.gov Front-end
-    cmds:
-      - |
-        cat <<EOF | bash
-          : "${SKIP_REPORTING:=0}"
-          : "${RETURN_EXIT_CODE:=0}"
-          set -o pipefail
-          output="\$(mktemp -d)/output"
-          mkfifo \$output
-          (cat \$output&)
-          result="\$(./tests/scripts/build-web.sh 2>&1 | tee \$output)"
-          exit_code=\$?
-          if [ "$SKIP_REPORTING" -ne 1 ]; then
-            if [ "\$exit_code" -eq 0 ]; then
-              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-            else
-              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
-            fi
-          fi
-          if [ "$RETURN_EXIT_CODE" -ne 0 ]; then
-            exit "\$exit_code";
-          fi
-        EOF
-
   set-check-status:
     cmds:
       - |
@@ -303,7 +278,6 @@ tasks:
   default:
     cmds:
       - task: set-all-tests-pending
-      - task: va/web/build
       - task: va/tests
 
   va/tests:
@@ -317,4 +291,3 @@ tasks:
       - task: va/tests/phpunit
       - task: va/tests/revision-log
       - task: va/tests/status-error
-

--- a/tests/behat/features/decoupled.feature
+++ b/tests/behat/features/decoupled.feature
@@ -4,19 +4,11 @@ Feature: The VA Website is generated inside the Drupal CMS code.
   As anyone involved in the project
   I need to run tests against the CMS and the WEB site in one shot.
 
-@frontend
-  Scenario: Ensure the static site builds an index.html file with content "Access and manage your VA benefits and health care"
-    Given I am at "/static/"
-    Then I should see "Access and manage your VA benefits and health care" in the "h1.homepage-heading" element
-    Then print current URL
-
   @errors @cms_in_static @frontend
   Scenario: Log in, edit, publish, unpublish, and save nodes and see changes in the CMS and the front end website. Confirm cms menu items are in static site build.
     When I am logged in as a user with the "administrator" role
 
     # Test content editing and publishing.
-    And I am at "/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services"
-    Then I should see "VA blind and low vision rehabilitation services"
     And I am at "node/2/edit"
     And I fill in "Page title" with "VA blind and low vision rehabilitation services - EDITED"
     And I select "Published" from "edit-moderation-state-0-state"
@@ -25,13 +17,12 @@ Feature: The VA Website is generated inside the Drupal CMS code.
     Then I should see "VA blind and low vision rehabilitation services - EDITED\u003C\/a\u003E\u003C\/em\u003E has been updated."
     And I should see "Recent changes" in the ".view-right-sidebar-latest-revision" element
 
-    # Test content unpublishing.
-    Then I set the node with title "VA health care" to "unpublished"
-    Then print current URL
-
     # Build the static site.
     When I run "cd .. && composer va:web:build"
-    And I am at "/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services"
+    When I am at "/static/"
+    Then I should see "Access and manage your VA benefits and health care" in the "h1.homepage-heading" element
+    Then print current URL
+    When I am at "/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services"
     Then I should see "VA blind and low vision rehabilitation services - EDITED"
 
     # Test preview functionality.
@@ -45,10 +36,3 @@ Feature: The VA Website is generated inside the Drupal CMS code.
     And I am at "/static/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services"
     Then I should see "VA blind and low vision rehabilitation services - EDITED"
     Then print current URL
-    And I am on "/static/health-care"
-    Then the response status code should be 403
-
-    # Re-publish the VA health care page to prevent broken link warnings.
-    Then I set the node with title "VA health care" to "published"
-    And I am on "/health-care"
-    Then I should see "Published" in the ".view-id-right_sidebar_latest_revision" element


### PR DESCRIPTION
## Description

Closes #8424
This PR does the following

- Removes the redundant content build
- Moves the behat decoupled tests that relied on the previously existing content built to AFTER the content build is called by the behat test.  
- Removes some related documentation and some documentation of a [PR that never landed](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/547). 

The only decouple test that was removed was connected to the existing state of content before a save.  It did not test anything explicitly and offered no additional test coverage.  It is fully covered by the remaining tests.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

This PR is completely covered by its own tests.
- [ ] Validate all tests pass

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
