### PR TITLE
VACMS-8400: Add office hours widget to service location paragraph.

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.service_location.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.service_location.field_email_contacts
     - field.field.paragraph.service_location.field_facility_service_hours
     - field.field.paragraph.service_location.field_hours
+    - field.field.paragraph.service_location.field_office_hours
     - field.field.paragraph.service_location.field_phone
     - field.field.paragraph.service_location.field_service_location_address
     - field.field.paragraph.service_location.field_use_main_facility_phone
@@ -15,6 +16,8 @@ dependencies:
     - entity_browser_entity_form
     - field_group
     - ief_table_view_mode
+    - limited_field_widgets
+    - office_hours
     - paragraphs
     - tablefield
 third_party_settings:
@@ -22,6 +25,7 @@ third_party_settings:
     group_service_hours:
       children:
         - field_hours
+        - field_office_hours
         - field_facility_service_hours
         - field_additional_hours_info
       label: Hours
@@ -37,7 +41,6 @@ third_party_settings:
         required_fields: false
     group_address:
       children:
-        - field_service_location_facility
         - field_service_location_address
       label: Address
       region: content
@@ -71,7 +74,7 @@ third_party_settings:
       label: Email
       region: content
       parent_name: group_phone
-      weight: 23
+      weight: 28
       format_type: details
       format_settings:
         classes: ''
@@ -86,7 +89,7 @@ third_party_settings:
       label: Phone
       region: content
       parent_name: group_phone
-      weight: 20
+      weight: 27
       format_type: details
       format_settings:
         classes: phone-numbers-wrapper
@@ -101,7 +104,7 @@ mode: default
 content:
   field_additional_hours_info:
     type: string_textfield
-    weight: 2
+    weight: 3
     region: content
     settings:
       size: 60
@@ -129,7 +132,7 @@ content:
         entity_browser_id: _none
   field_facility_service_hours:
     type: tablefield
-    weight: 1
+    weight: 2
     region: content
     settings:
       input_type: textfield
@@ -140,9 +143,17 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_office_hours:
+    type: office_hours_default
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings:
+      limited_field_widgets:
+        limit_values: '0'
   field_phone:
     type: inline_entity_form_complex_table_view_mode
-    weight: 22
+    weight: 5
     region: content
     settings:
       form_mode: default
@@ -181,7 +192,7 @@ content:
     third_party_settings: {  }
   field_use_main_facility_phone:
     type: boolean_checkbox
-    weight: 21
+    weight: 4
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -120,8 +120,8 @@ content:
     type: office_hours_table
     label: above
     settings:
-      day_format: short
-      time_format: g
+      day_format: long
+      time_format: G
       compress: false
       grouped: false
       show_closed: all

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -121,7 +121,7 @@ content:
     label: above
     settings:
       day_format: long
-      time_format: G
+      time_format: g
       compress: false
       grouped: false
       show_closed: all

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -120,12 +120,12 @@ content:
     type: office_hours_table
     label: above
     settings:
-      day_format: long
-      time_format: G
+      day_format: short
+      time_format: g
       compress: false
       grouped: false
       show_closed: all
-      closed_format: Closed
+      closed_format: ''
       separator:
         days: '<br />'
         grouped_days: ' - '

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.service_location.field_email_contacts
     - field.field.paragraph.service_location.field_facility_service_hours
     - field.field.paragraph.service_location.field_hours
+    - field.field.paragraph.service_location.field_office_hours
     - field.field.paragraph.service_location.field_phone
     - field.field.paragraph.service_location.field_service_location_address
     - field.field.paragraph.service_location.field_use_main_facility_phone
@@ -14,6 +15,7 @@ dependencies:
   module:
     - entity_reference_revisions
     - field_group
+    - office_hours
     - options
     - tablefield
 third_party_settings:
@@ -21,6 +23,7 @@ third_party_settings:
     group_hours:
       children:
         - field_hours
+        - field_office_hours
         - field_facility_service_hours
         - field_additional_hours_info
       label: Hours
@@ -50,7 +53,6 @@ third_party_settings:
         open: true
     group_address:
       children:
-        - field_service_location_facility
         - field_service_location_address
       label: Address
       parent_name: group_service_location
@@ -87,7 +89,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   field_email_contacts:
     type: entity_reference_revisions_entity_view
@@ -105,7 +107,7 @@ content:
       row_header: false
       column_header: false
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   field_hours:
     type: list_default
@@ -113,6 +115,33 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_office_hours:
+    type: office_hours_table
+    label: above
+    settings:
+      day_format: long
+      time_format: G
+      compress: false
+      grouped: false
+      show_closed: all
+      closed_format: Closed
+      separator:
+        days: '<br />'
+        grouped_days: ' - '
+        day_hours: ': '
+        hours_hours: '-'
+        more_hours: ', '
+      current_status:
+        position: ''
+        open_text: 'Currently open!'
+        closed_text: 'Currently closed'
+      timezone_field: ''
+      office_hours_first_day: ''
+      schema:
+        enabled: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_phone:
     type: entity_reference_revisions_entity_view

--- a/config/sync/field.field.paragraph.service_location.field_office_hours.yml
+++ b/config/sync/field.field.paragraph.service_location.field_office_hours.yml
@@ -1,0 +1,26 @@
+uuid: e0a26800-942d-4507-8857-1be30d039351
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_office_hours
+    - paragraphs.paragraphs_type.service_location
+  module:
+    - epp
+    - office_hours
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: paragraph.service_location.field_office_hours
+field_name: field_office_hours
+entity_type: paragraph
+bundle: service_location
+label: Hours
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: office_hours

--- a/config/sync/field.storage.node.field_hours_for_copay_inquiries_.yml
+++ b/config/sync/field.storage.node.field_hours_for_copay_inquiries_.yml
@@ -10,15 +10,15 @@ field_name: field_hours_for_copay_inquiries_
 entity_type: node
 type: office_hours
 settings:
-  time_format: G
+  time_format: g
   element_type: office_hours_datelist
-  increment: 30
+  increment: 1
   required_start: false
   limit_start: ''
   required_end: false
   limit_end: ''
-  comment: 0
-  valhrs: false
+  comment: 1
+  valhrs: true
   cardinality_per_day: 1
 module: office_hours
 locked: false

--- a/config/sync/field.storage.node.field_office_hours.yml
+++ b/config/sync/field.storage.node.field_office_hours.yml
@@ -10,7 +10,7 @@ field_name: field_office_hours
 entity_type: node
 type: office_hours
 settings:
-  time_format: h
+  time_format: g
   element_type: office_hours_datetime
   increment: 1
   required_start: false

--- a/config/sync/field.storage.node.field_office_hours.yml
+++ b/config/sync/field.storage.node.field_office_hours.yml
@@ -11,7 +11,7 @@ entity_type: node
 type: office_hours
 settings:
   time_format: g
-  element_type: office_hours_datelist
+  element_type: office_hours_datetime
   increment: 15
   required_start: false
   limit_start: ''

--- a/config/sync/field.storage.node.field_office_hours.yml
+++ b/config/sync/field.storage.node.field_office_hours.yml
@@ -10,9 +10,9 @@ field_name: field_office_hours
 entity_type: node
 type: office_hours
 settings:
-  time_format: g
+  time_format: h
   element_type: office_hours_datetime
-  increment: 15
+  increment: 1
   required_start: false
   limit_start: ''
   required_end: false

--- a/config/sync/field.storage.paragraph.field_office_hours.yml
+++ b/config/sync/field.storage.paragraph.field_office_hours.yml
@@ -1,0 +1,29 @@
+uuid: 9d88f878-ff9a-489b-b58b-e89172d4c2e0
+langcode: en
+status: true
+dependencies:
+  module:
+    - office_hours
+    - paragraphs
+id: paragraph.field_office_hours
+field_name: field_office_hours
+entity_type: paragraph
+type: office_hours
+settings:
+  time_format: g
+  element_type: office_hours_datelist
+  increment: 15
+  required_start: false
+  limit_start: ''
+  required_end: false
+  limit_end: ''
+  comment: 1
+  valhrs: true
+  cardinality_per_day: 1
+module: office_hours
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_office_hours.yml
+++ b/config/sync/field.storage.paragraph.field_office_hours.yml
@@ -10,7 +10,7 @@ field_name: field_office_hours
 entity_type: paragraph
 type: office_hours
 settings:
-  time_format: h
+  time_format: g
   element_type: office_hours_datetime
   increment: 1
   required_start: false

--- a/config/sync/field.storage.paragraph.field_office_hours.yml
+++ b/config/sync/field.storage.paragraph.field_office_hours.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 type: office_hours
 settings:
   time_format: g
-  element_type: office_hours_datelist
+  element_type: office_hours_datetime
   increment: 15
   required_start: false
   limit_start: ''

--- a/config/sync/field.storage.paragraph.field_office_hours.yml
+++ b/config/sync/field.storage.paragraph.field_office_hours.yml
@@ -10,9 +10,9 @@ field_name: field_office_hours
 entity_type: paragraph
 type: office_hours
 settings:
-  time_format: g
+  time_format: h
   element_type: office_hours_datetime
-  increment: 15
+  increment: 1
   required_start: false
   limit_start: ''
   required_end: false

--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
@@ -480,7 +480,9 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public function formWidgetAlter(WidgetSingleElementFormAlterEvent $event): void {
     $form = &$event->getElement();
+    $form_state = $event->getFormState();
     $this->removeCollapseButton($form);
+    $this->removeFieldOfficeHours($form, $form_state);
   }
 
   /**
@@ -492,6 +494,33 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   public function removeCollapseButton(array &$form) {
     if (!empty($form['#paragraph_type']) && $form['#paragraph_type'] === 'button') {
       unset($form['top']['actions']['actions']['collapse_button']);
+    }
+  }
+
+  /**
+   * Remove field_office_hours on service_location paragraph widget forms.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function removeFieldOfficeHours(array &$form, FormStateInterface $form_state) {
+    /** @var \Drupal\node\NodeForm $form_object $form_object */
+    $form_object = $form_state->getFormObject();
+    /** @var \Drupal\node\Entity\Node $entity */
+    $entity = $form_object->getEntity();
+    if (!empty($form['#paragraph_type'])
+    && $form['#paragraph_type'] === 'service_location'
+    && !$this->userPermsService->hasAdminRole(TRUE)
+    && $entity->bundle() !== 'vha_facility_nonclinical_service') {
+      unset($form['subform']['field_office_hours']);
+    }
+    if (!empty($form['#paragraph_type'])
+    && $form['#paragraph_type'] === 'service_location'
+    && !$this->userPermsService->hasAdminRole(TRUE)
+    && $entity->bundle() === 'vha_facility_nonclinical_service') {
+      unset($form['subform']['field_facility_service_hours']);
     }
   }
 

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -104,7 +104,8 @@
 
 // Adjusting spacing on office hours fields
 #edit-field-office-hours,
-#edit-field-hours-for-copay-inquiries- {
+#edit-field-hours-for-copay-inquiries-,
+#edit-field-service-location-0-subform-field-office-hours {
   margin-bottom: 0;
 
   tr {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -122,6 +122,17 @@
 
   td {
     padding: 0;
+
+    &:nth-child(4) label {
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+    }
   }
 
   table,

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -102,6 +102,11 @@
   }
 }
 
+// Hide old office hours field on node view
+.vha-facility-nonclinical-service .field--name-field-facility-service-hours {
+  display: none;
+}
+
 // Adjusting spacing on office hours fields
 #edit-field-office-hours,
 #edit-field-hours-for-copay-inquiries-,

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_services.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_services.scss
@@ -30,8 +30,8 @@
     }
   }
 
-  // Hide redundant Service Location thead
-  thead {
+  // Hide comments label
+  .office-hours-slot td:nth-child(4) label {
     display: none;
   }
 

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_services.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_services.scss
@@ -30,11 +30,6 @@
     }
   }
 
-  // Hide comments label
-  .office-hours-slot td:nth-child(4) label {
-    display: none;
-  }
-
   // Hide row weights (shouldn't be draggable)
   .tabledrag-toggle-weight-wrapper {
     display: none;

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -104,6 +104,7 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Service location | Use the facility's hours | field_hours | List (text) | Required | 1 | Select list |  |
 | Paragraph type | Service location | Other phone numbers | field_phone | Entity reference revisions |  | 5 | Inline entity form - Complex - Table View Mode |  |
 | Paragraph type | Service location | Use the general facility phone number | field_use_main_facility_phone | Boolean |  | 1 | Single on/off checkbox |  |
+| Paragraph type | Service location | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) |  |
 | Paragraph type | Service location address | Address | field_address | Address |  | 1 | Address | Translatable |
 | Paragraph type | Service location address | Building name/number | field_building_name_number | Text (plain) |  | 1 | Textfield with counter |  |
 | Paragraph type | Service location address | Name of office or location | field_clinic_name | Text (plain) |  | 1 | Textfield with counter |  |
@@ -126,3 +127,4 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Featured content | Call to Action | field_cta | Entity reference revisions |  | 1 | Paragraphs (stable) |  |
 | Paragraph type | Featured content | Description | field_description | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter |  |
 | Paragraph type | Featured content | Section Header | field_section_header | Text (plain) | Required | 1 | Textfield with counter | Translatable |
+


### PR DESCRIPTION
## Description
closes #8400

## Testing done
Visual / Behat

## Screenshots
As an editor / content admin not on a `VAMC Facility Non-clinical Service` page
![image](https://user-images.githubusercontent.com/2404547/159573466-0ca2118d-32f3-4706-86b3-7f6e198f207d.png)

As an admin not on a `VAMC Facility Non-clinical Service` page
![image](https://user-images.githubusercontent.com/2404547/159573545-a7266b00-e7af-46ca-9d14-86950e85ac91.png)

As an editor / content admin on a `VAMC Facility Non-clinical Service` page
![image](https://user-images.githubusercontent.com/2404547/159573096-4076d38f-4679-47ad-a07e-c62c870a4f85.png)

Node view
![image](https://user-images.githubusercontent.com/2404547/159573412-8bfabc9b-30ff-45db-92c4-450780deb38a.png)


## QA steps
**Admin test**
 - [x] Non clinical service: go to `https://pr8435-cunes7rsm9rifo1ypfj5fnybl6l0trl1.ci.cms.va.gov/node/44181/edit`and visually two hours fieldsets appear in the hours section (one table, the other in office hours html5 time inputs format - display will be funky until we get rid of the old table field)
 - [x] Health service: go to `https://pr8435-cunes7rsm9rifo1ypfj5fnybl6l0trl1.ci.cms.va.gov/node/1017/edit` and visually two hours fieldsets appear in the hours section (one table, the other in office hours html5 time inputs format - display will be funky until we get rid of the old table field)
 
**Content Admin / Editor tests**
 - [x] As the same administrator, go to `user/34/workbench_access` and assign Ryan to Chillicothe (this is where a `VAMC Facility Non-clinical Service` exists / can be used for testing)
 ~- [ ] As Ryan.stubblebine@va.gov, go to `node/1017/edit` and visually verify the `Use the facility hours` field does not show hours table when option is set to `Provide specific hours for this service`~ This is a `VAMC Facility Health Service` and is covered by `VAMC Facility Health Service` bundle test in next step
 - [x] as RS  go to this page https://pr8435-cunes7rsm9rifo1ypfj5fnybl6l0trl1.ci.cms.va.gov/node/1058/edit and validate he can still edit / add hours to the facility health service.
 - [x] Login back in as administrator, go to `user/34/edit` and assign Ryan the `Content admin` role
 - [x] Login again as Ryan.stubblebine@va.gov, go to `/node/44181/edit` and visually verify the `Use the facility hours` field shows a single hours table when option is set to `Provide specific hours for this service`
 - [x] on node view of https://pr8435-cunes7rsm9rifo1ypfj5fnybl6l0trl1.ci.cms.va.gov/chillicothe-health-care/locations/chillicothe-va-medical-center-0  no one can see the output from the tablefield.
 - [x] Add some time data to the new hours field, and save
 - [x] Visually verify the node view looks reasonably formatted.
 - [x] time is in 12 hr format matching Vet center cap

**QA Copied from closed pr https://github.com/department-of-veterans-affairs/va.gov-cms/pull/8430**

1. VAMC Facility
2. VAMC System Billing and Insurance
3. Vet Center
4. Vet Center - CAP
5. Vet Center - Mobile
6. Vet Center - Outstation

As cms admin viewing office hours field for the above types, confirm the following settings for office hours field
- [ ] 12 hour time with am/pm
- [ ] Has comments field enabled with HTML disallowed
- [ ] Time increments by 1 minute increments
- [ ] Hours validation is checked