### PR TITLE
VACMS-8446 Prevent node_link_report from scanning links to /static/.

### DIFF
--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -58,12 +58,13 @@ user_agent: 'VA.gov CMS link checker'
 path_patterns_to_skip: |-
   /admin/*
   /block/*
-  /node/add/*
+  /media/*
+  /media/*/edit
   /node/*/edit
+  /node/add/*
   /section/*
+  /static/*
   /user/*
-  media/*
-  media/*/edit
 decoupled_frontend: 'https://www.va.gov'
 enable_reporting_inaccessible_links: 1
 accessibility_guidance_url: 'https://design.va.gov/content-style-guide/links'


### PR DESCRIPTION
## Description
Closes #8446

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that 
2. Then 
   - [ ] Validate that 
3. Then validate Acceptance Criteria from issue
   - [ ] a 
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
