### PR TITLE
VACMS-8455 add margin to centralized fieldgroups

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_centralized_content.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_centralized_content.scss
@@ -4,6 +4,7 @@
 
 .centralized {
   background-color: var(--va-gray-lightest) !important;
+  margin-bottom: var(--spacing-l);
 
   .data-updated a {
     float: right;


### PR DESCRIPTION
## Description

Closes #8455. Adds spacing to centralized content fieldgroups.

## Testing done

went to https://va-gov-cms.ddev.site/node/add/vamc_system_medical_records_offi and saw there was no spacing, added margin bottom to class and saw that there was spacing.

## Screenshots
<img width="762" alt="Screen Shot 2022-03-24 at 10 21 51 AM" src="https://user-images.githubusercontent.com/11279744/159976471-bbc130a5-e8d4-48ac-b26d-5207ff2c9a26.png">
<img width="772" alt="Screen Shot 2022-03-24 at 10 22 18 AM" src="https://user-images.githubusercontent.com/11279744/159976479-8d72ffb7-51e6-40e2-ba5f-f6f48c8c7084.png">


## QA steps
visit `/node/add/vamc_system_medical_records_offi` and see that the spacing between fieldgroups with borders (centralized content) is present again.

### Definition of Done

- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [x] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`