### PR TITLE
VACMS-8475: Broaden styles to target all field_office hours widgets.

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -111,7 +111,7 @@
 #edit-field-office-hours,
 #edit-field-hours-for-copay-inquiries-,
 #edit-field-service-location-0-subform-field-office-hours,
-.field--type-office-hours {
+.field--type-office-hours.form-wrapper {
   margin-bottom: 0;
 
   tr {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -110,7 +110,8 @@
 // Adjusting spacing on office hours fields
 #edit-field-office-hours,
 #edit-field-hours-for-copay-inquiries-,
-#edit-field-service-location-0-subform-field-office-hours {
+#edit-field-service-location-0-subform-field-office-hours,
+.field--type-office-hours {
   margin-bottom: 0;
 
   tr {


### PR DESCRIPTION
## Description
closes #8475

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/160155181-0f548686-6922-4373-bb74-62cd09f6cb35.png)
![image](https://user-images.githubusercontent.com/2404547/160182837-29bd34af-fe4e-43ee-bd66-b42aa73771f6.png)


## QA steps
 - [ ] As an administrator, go to `node/41988/edit` and visually verify hours field is formatted properly (table headers, etc.)
 - [ ] Add two more service locations.
 - [ ] Visually verify first and subordinate instances show hours fields formatted properly .
 - [ ] validate node view of the same node shows days, times and comments.