### PR TITLE
VACMS-0000 make sure storybook deps are installed for ddev container

### DIFF
--- a/.ddev/docker-compose.storybook.yaml
+++ b/.ddev/docker-compose.storybook.yaml
@@ -14,7 +14,7 @@ services:
     working_dir: /home/node/app
     volumes:
       - ../docroot/design-system:/home/node/app
-    command: "yarn storybook"
+    command: sh -c "yarn install && yarn storybook"
     environment:
       - VIRTUAL_HOST=va-gov-storybook.${DDEV_TLD}
       - HTTP_EXPOSE=80:6006


### PR DESCRIPTION
## Description
https://dsva.slack.com/archives/CT4GZBM8F/p1648478608924889?thread_ts=1648241355.099019&cid=CT4GZBM8F reports from @JayDarnell and @ndouglas that local dev was broken due to the container not installing dependencies. this ensures deps get installed before storybook tries to run locally in a docker container.

## Testing done
- deleted `docroot/design-system/node_modules` and `docroot/design-system/storybook-static` folders to simulate no dependencies installed, nothing generated by default.
- ran `ddev restart`

## Screenshots
Jay's report:
```
ddev start
Starting va-gov-cms...
Using custom PHP configuration: [/Users/jaydarnell/workspace/civicactions/va/va.gov-cms/.ddev/php/zzz-va-overrides.ini]
Custom configuration takes effect when container is created,
usually on start, use 'ddev restart' if you're not seeing it take effect.
Pushed mkcert rootca certs to ddev-global-cache/mkcert
Container ddev-va-gov-cms-db  Creating
Container ddev-va-gov-cms-storybook  Creating
Container ddev-va-gov-cms-memcached  Creating
Container ddev-va-gov-cms-memcached  Created
Container ddev-va-gov-cms-db  Created
Container ddev-va-gov-cms-dba  Creating
Container ddev-va-gov-cms-web  Creating
Container ddev-va-gov-cms-storybook  Created
Container ddev-va-gov-cms-dba  Created
Container ddev-va-gov-cms-web  Created
Container ddev-va-gov-cms-memcached  Starting
Container ddev-va-gov-cms-storybook  Starting
Container ddev-va-gov-cms-db  Starting
Container ddev-va-gov-cms-memcached  Started
Container ddev-va-gov-cms-storybook  Started
Container ddev-va-gov-cms-db  Started
Container ddev-va-gov-cms-web  Starting
Container ddev-va-gov-cms-dba  Starting
Container ddev-va-gov-cms-dba  Started
Container ddev-va-gov-cms-web  Started
Container ddev-router  Creating
Container ddev-router  Created
Container ddev-router  Starting
Container ddev-router  Started
Failed to start va-gov-cms: container failed to become healthy: err=container 'storybook' exited, please use 'ddev logs -s storybook' to find out why it failed
```


After my update to the dockerfile:
```
Container ddev-va-gov-cms-storybook  Creating
Container ddev-va-gov-cms-db  Creating
Container ddev-va-gov-cms-memcached  Creating
Container ddev-va-gov-cms-memcached  Created
Container ddev-va-gov-cms-storybook  Created
Container ddev-va-gov-cms-db  Created
Container ddev-va-gov-cms-dba  Creating
Container ddev-va-gov-cms-web  Creating
Container ddev-va-gov-cms-web  Created
Container ddev-va-gov-cms-dba  Created
Container ddev-va-gov-cms-storybook  Starting
Container ddev-va-gov-cms-memcached  Starting
Container ddev-va-gov-cms-db  Starting
Container ddev-va-gov-cms-db  Started
Container ddev-va-gov-cms-dba  Starting
Container ddev-va-gov-cms-memcached  Started
Container ddev-va-gov-cms-web  Starting
Container ddev-va-gov-cms-storybook  Started
Container ddev-va-gov-cms-dba  Started
Container ddev-va-gov-cms-web  Started
Starting mutagen sync process... This can take some time.
.....................................................................................................................................................................................................
Status: Scanning files
Status: Reconciling changes
Status: Staging files on beta
Status: Applying changes
Status: Saving archive
Status: Watching for changes
Status: Scanning files
Status: Reconciling changes
Status: Saving archive
Status: Watching for changes
Mutagen sync flush completed in 3m50s.
For details on sync status 'ddev mutagen status va-gov-cms --verbose'
Container ddev-router  Creating
Container ddev-router  Created
Container ddev-router  Starting
Container ddev-router  Started
Status: Scanning files
```

## QA steps

- pull branch, delete  `docroot/design-system/node_modules` and then run `ddev restart` or `ddev start` if you aren't already started. See that the containers build properly locally and that you can reach https://va-gov-storybook.ddev.site/ without error once built.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`
