### PR TITLE
VACMS-8485 office hours upgrade et

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -439,7 +439,7 @@
                 "3113461 - Allow properties in str_replace process plugin.": "https://www.drupal.org/files/issues/2020-03-16/migrate_plus-properties_str_replace-2.patch"
             },
             "drupal/office_hours": {
-                "3227169 - Form fields in table cell missing labels causes accessibility warnings": "https://www.drupal.org/files/issues/2021-08-09/labels-for-accessibility-3227169-3.patch"
+                "3227169 - Form fields in table cell missing labels causes accessibility warnings": "https://www.drupal.org/files/issues/2022-03-28/labels-for-accessibility-3227169-11.patch"
             },
             "drupal/openapi_jsonapi": {
                 "3110109 - Support renamed resource types Part 1": "https://git.drupalcode.org/project/openapi_jsonapi/-/commit/17070f1ef70ff89f732619a11c29730107a2083e.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -8176,17 +8176,17 @@
         },
         {
             "name": "drupal/office_hours",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/office_hours.git",
-                "reference": "8.x-1.5"
+                "reference": "8.x-1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/office_hours-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "745079dfca40222a034da0475e516c0aa1317c67"
+                "url": "https://ftp.drupal.org/files/projects/office_hours-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "97f46cdc0673d3354496888b71aaf330715d94d0"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8194,8 +8194,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1623916796",
+                    "version": "8.x-1.6",
+                    "datestamp": "1648134032",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Description
closes #8485 
**This patch:**
1. rerolls original accessibility fix in https://www.drupal.org/project/office_hours/issues/3227169
2. addresses https://www.drupal.org/project/office_hours/issues/3227169#comment-14214820 
3. fixes an additional issue with office hours discovered during testing: leaving start / end times blank when validation is on, but start and end time requirements are not throws notices

## Testing done
Visual, composer install, behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/160500815-8e9a250b-0fb6-4b0d-8959-723acbf7dba8.png)
![image](https://user-images.githubusercontent.com/2404547/160500828-db392bf1-31e5-4650-9221-ff41f59d1fd9.png)
![image](https://user-images.githubusercontent.com/2404547/160500838-599fb9dc-20d0-4614-b2dd-9ad6a4fa2c76.png)

## QA steps
 - [ ] As Crystal.Davis-Noble3@va.gov, go to `/node/1524/edit` and change the start value and end value of two different fields, and add a comment to a third.
 - [x] Save as published, and visually verify form successfully saves and appears as expected on node view
 - [x] Edit the field, setting the start value of one field after the end value of the same field, and visually verify form provides meaningful error messages on save.
 - [x] As an administrator, go to `/admin/structure/types/manage/health_care_local_facility/fields/node.health_care_local_facility.field_office_hours/storage` and set start and end times to required
 - [x] As Crystal.Davis-Noble3@va.gov, go to `/node/1524/edit` and visually verify at least one start date and one end date is empty on the office hours field.
 - [x] Save form, and visually verify meaningful notices appear, indicating that start and end times are required.
