### PR TITLE
VACMS-0000: remove parameters to GHA content-release workflow request that are no longer expected.

### DIFF
--- a/.ddev/docker-compose.m1.yaml
+++ b/.ddev/docker-compose.m1.yaml
@@ -1,0 +1,6 @@
+# For non-M1 users, the platform settings here are the default.
+# For M1 users, this will force the use of the amd64 containers instead of
+# the arm64 or aarch64 containers.
+services:
+  web:
+    platform: linux/amd64

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -93,10 +93,7 @@ class BRDGHA extends EnvironmentPluginBase {
         $message = $this->t('Changes will be included in a content release to VA.gov that\'s already in progress. <a href="@job_link">Check status</a>.', $vars);
       }
       else {
-        $this->githubAdapter->triggerWorkflow('content-release.yml', $front_end_git_ref, [
-          'release_wait' => "0",
-          'deploy_environment' => $this->settings->get('github_actions_deploy_env'),
-        ]);
+        $this->githubAdapter->triggerWorkflow('content-release.yml', $front_end_git_ref);
         $vars = [
           '@job_link' => 'https://github.com/department-of-veterans-affairs/content-build/actions/workflows/content-release.yml',
         ];


### PR DESCRIPTION
## Description

Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8310


In #8310, we added a change to the content-release workflow that removed environment and time to wait until release as parameters for that workflow. However, the Github adaptor in the CMS that was sending release requests to the GHA workflow was still passing those parameters, which caused an invalid API response.
