### PR TITLE
VACMS-8504: Adjust Dropzone "Select files" button and "Add file" window text

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -499,6 +499,9 @@
             },
             "weitzman/drupal-test-traits": {
                 "Forbid connection reuse in PHPUnit tests": "patches/weitzman-drupal-test-traits-forbid-connection-reuse.patch"
+            },
+            "drupal/dropzonejs": {
+                "Select files button and Add media window text should respect field cardinality": "https://www.drupal.org/files/issues/2022-03-29/3174484-add-media-window-and-select-button-text-should-respect-field-cardinality-4.patch"
             }
         }
     },

--- a/patches/3174484-add-media-window-and-select-button-text-should-respect-field-cardinality-4.patch
+++ b/patches/3174484-add-media-window-and-select-button-text-should-respect-field-cardinality-4.patch
@@ -1,0 +1,48 @@
+diff --git a/dropzonejs.module b/dropzonejs.module
+index 004a256..b6df253 100644
+--- a/dropzonejs.module
++++ b/dropzonejs.module
+@@ -44,6 +44,7 @@ function dropzonejs_theme() {
+  *   - element: A render element representing the file.
+  */
+ function template_preprocess_dropzonejs(array &$variables) {
++  $translation = \Drupal::translation();
+   $element = $variables['element'];
+ 
+   $variables['attributes'] = [];
+@@ -53,10 +54,14 @@ function template_preprocess_dropzonejs(array &$variables) {
+   if (!empty($element['#attributes']['class'])) {
+     $variables['attributes']['class'] = (array) $element['#attributes']['class'];
+   }
++  $cardinality = 0;
++  if (isset($element['#max_files'])) {
++    $cardinality = $element['#max_files'];
++  }
+ 
+   $variables['dropzone_description'] = $element['#dropzone_description'];
+   $variables['or_text'] = t('or');
+-  $variables['select_files_button_text'] = t('Select files');
++  $variables['select_files_button_text'] = $translation->formatPlural($cardinality, 'Select file', 'Select files');
+   $variables['uploaded_files'] = $element['uploaded_files'];
+ }
+ 
+diff --git a/src/Form/DropzoneJsUploadForm.php b/src/Form/DropzoneJsUploadForm.php
+index e485a9c..c3ed390 100644
+--- a/src/Form/DropzoneJsUploadForm.php
++++ b/src/Form/DropzoneJsUploadForm.php
+@@ -55,11 +55,14 @@ class DropzoneJsUploadForm extends FileUploadForm {
+     $process = (array) $this->elementInfo->getInfoProperty('dropzonejs', '#process', []);
+     $form['container']['upload']['#type'] = 'dropzonejs';
+     $form['container']['upload']['#process'] = array_merge(['::validateUploadElement'], $process);
++    $translation = \Drupal::translation();
++    $cardinality = $slots < 1 ? 0 : $slots;
++    $dropzone_description = $translation->formatPlural($cardinality, 'Drop file here to upload it', 'Drop files here to upload them');
+     $dropzone_specific_properties = [
+       '#max_files' => $slots < 1 ? 0 : $slots,
+       '#max_filesize' => $settings['max_filesize'],
+       '#extensions' => $settings['file_extensions'],
+-      '#dropzone_description' => $this->t('Drop files here to upload them'),
++      '#dropzone_description' => $dropzone_description,
+     ];
+     $form['container']['upload'] += $dropzone_specific_properties;
+ 


### PR DESCRIPTION
- Added logic that check if the file upload is limited to only one file to fix the reported issue where text was displayed in plural when it should have been displayed in singular.
- Created patch that include these fixes: the select button text and the add media window text.

## Description

closes #8504 

## Testing done
Visual, behat and PHPUnit.

## Screenshots
**Add single file:**
![VACMS-8504-updated-add-media](https://user-images.githubusercontent.com/846871/160678710-3e8c2921-04ef-4878-855f-2e9f3bc072fe.png)

**Add multiple files:**
![VACMS-8504-add-multiple-files](https://user-images.githubusercontent.com/846871/160884455-1f1cb96b-ce5b-461f-aba1-2e05f4b6a20c.png)

## QA steps

As user administrator
1. Go to `/node/add/event` and
   - [x] In the "Event image" section click on the "Add media" button to verify and confirm that the "Add file" window text reads "Drop file here to upload it" and the button reads "Select file" when the file upload is limited to only one
   - [x] Upload an image by clicking the "Select file" button to verify and confirm the upload functionality works as expected
   - [x] Drag and drop an image into the "Drop file here to upload it" area to to verify and confirm the drag and drop functionality works as expected
   - [x] Go to `/admin/structure/types/manage/event/fields/node.event.field_media/storage` and switch the "Allowed number of values" from limited to one to unlimited and save (NOTE: this change is temporary for testing purposes)
   - [x] Upload some images (one at a time) via the "Select files" button to verify and confirm the upload functionality works as expected for multiple file uploads
   - [x] Drag and drop some images (one at a time) into the "Drop files here to upload them" area to to verify and confirm the drag and drop functionality works as expected


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
