### PR TITLE
VACMS-8550: hide old service location field_facility_service_hours

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.service_location.default.yml
@@ -19,14 +19,12 @@ dependencies:
     - limited_field_widgets
     - office_hours
     - paragraphs
-    - tablefield
 third_party_settings:
   field_group:
     group_service_hours:
       children:
         - field_hours
         - field_office_hours
-        - field_facility_service_hours
         - field_additional_hours_info
       label: Hours
       region: content
@@ -130,13 +128,6 @@ content:
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none
-  field_facility_service_hours:
-    type: tablefield
-    weight: 2
-    region: content
-    settings:
-      input_type: textfield
-    third_party_settings: {  }
   field_hours:
     type: options_select
     weight: 0
@@ -199,4 +190,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_facility_service_hours: true
   status: true

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -17,14 +17,12 @@ dependencies:
     - field_group
     - office_hours
     - options
-    - tablefield
 third_party_settings:
   field_group:
     group_hours:
       children:
         - field_hours
         - field_office_hours
-        - field_facility_service_hours
         - field_additional_hours_info
       label: Hours
       parent_name: group_service_location
@@ -100,15 +98,6 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
-  field_facility_service_hours:
-    type: tablefield
-    label: visually_hidden
-    settings:
-      row_header: false
-      column_header: false
-    third_party_settings: {  }
-    weight: 4
-    region: content
   field_hours:
     type: list_default
     label: above
@@ -117,15 +106,15 @@ content:
     weight: 2
     region: content
   field_office_hours:
-    type: office_hours_table
+    type: office_hours
     label: above
     settings:
       day_format: long
-      time_format: g
+      time_format: G
       compress: false
       grouped: false
       show_closed: all
-      closed_format: ''
+      closed_format: Closed
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -172,4 +161,5 @@ content:
     weight: 3
     region: content
 hidden:
+  field_facility_service_hours: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -110,7 +110,7 @@ content:
     label: above
     settings:
       day_format: long
-      time_format: G
+      time_format: g
       compress: false
       grouped: false
       show_closed: all

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.storage.paragraph.field_address
     - field.storage.paragraph.field_building_name_number
     - field.storage.paragraph.field_clinic_name
-    - field.storage.paragraph.field_facility_service_hours
     - field.storage.paragraph.field_hours
     - field.storage.paragraph.field_office_hours
     - field.storage.paragraph.field_use_facility_address
@@ -27,7 +26,6 @@ dependencies:
     - options
     - paragraphs
     - string_field_formatter
-    - tablefield
     - taxonomy
     - views_conditional
 id: non_clinical_services
@@ -46,19 +44,19 @@ display:
     display_options:
       title: 'Medical records services'
       fields:
-        field_clinic_name:
-          id: field_clinic_name
-          table: paragraph__field_clinic_name
-          field: field_clinic_name
-          relationship: field_service_location_address
+        field_use_facility_address:
+          id: field_use_facility_address
+          table: paragraph__field_use_facility_address
+          field: field_use_facility_address
+          relationship: field_service_location
           group_type: group
           admin_label: ''
           plugin_id: field
           label: ''
-          exclude: false
+          exclude: true
           alter:
-            alter_text: true
-            text: '<strong>{{ field_clinic_name }}</strong>'
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -96,8 +94,11 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: string
-          settings: {  }
+          type: boolean
+          settings:
+            format: default
+            format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -173,345 +174,19 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_office_hours:
-          id: field_office_hours
-          table: node__field_office_hours
-          field: field_office_hours
-          relationship: field_facility_location
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: day
-          type: office_hours
-          settings:
-            day_format: long
-            time_format: g
-            compress: true
-            grouped: true
-            show_closed: open
-            closed_format: Closed
-            separator:
-              days: '<br />'
-              grouped_days: ' - '
-              day_hours: ': '
-              hours_hours: '-'
-              more_hours: ', '
-            current_status:
-              position: ''
-              open_text: 'Currently open!'
-              closed_text: 'Currently closed'
-            office_hours_first_day: ''
-            schema:
-              enabled: false
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        field_facility_service_hours:
-          id: field_facility_service_hours
-          table: paragraph__field_facility_service_hours
-          field: field_facility_service_hours
-          relationship: field_service_location
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: tablefield
-          settings:
-            row_header: false
-            column_header: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        field_hours:
-          id: field_hours
-          table: paragraph__field_hours
-          field: field_hours
-          relationship: field_service_location
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: list_default
-          settings: {  }
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        views_conditional_field:
-          id: views_conditional_field
-          table: views_conditional
-          field: views_conditional_field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: views_conditional_field
-          label: Hours
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          if: field_hours
-          condition: eq
-          equalto: 'Use the facility''s hours'
-          then: '{{ field_office_hours }}'
-          then_translate: 1
-          or: '{{ field_facility_service_hours }}'
-          or_translate: 1
-          strip_tags: 0
-        field_address:
-          id: field_address
-          table: node__field_address
-          field: field_address
-          relationship: field_facility_location
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: langcode
-          type: address_default
-          settings: {  }
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        field_address_1:
-          id: field_address_1
-          table: paragraph__field_address
-          field: field_address
+        field_clinic_name:
+          id: field_clinic_name
+          table: paragraph__field_clinic_name
+          field: field_clinic_name
           relationship: field_service_location_address
           group_type: group
           admin_label: ''
           plugin_id: field
           label: ''
-          exclude: true
+          exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '<strong>{{ field_clinic_name }}</strong>'
             make_link: false
             path: ''
             absolute: false
@@ -548,10 +223,10 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: langcode
-          type: address_default
+          click_sort_column: value
+          type: string
           settings: {  }
-          group_column: ''
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -685,11 +360,11 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_use_facility_address:
-          id: field_use_facility_address
-          table: paragraph__field_use_facility_address
-          field: field_use_facility_address
-          relationship: field_service_location
+        field_address:
+          id: field_address
+          table: node__field_address
+          field: field_address
+          relationship: field_facility_location
           group_type: group
           admin_label: ''
           plugin_id: field
@@ -734,13 +409,72 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: boolean
-          settings:
-            format: default
-            format_custom_false: ''
-            format_custom_true: ''
-          group_column: value
+          click_sort_column: langcode
+          type: address_default
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_address_1:
+          id: field_address_1
+          table: paragraph__field_address
+          field: field_address
+          relationship: field_service_location_address
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: langcode
+          type: address_default
+          settings: {  }
+          group_column: ''
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -802,9 +536,347 @@ display:
           if: field_use_facility_address
           condition: eq
           equalto: 'On'
-          then: "{{ field_address }}\r\n{{ field_building_name_number }}\r\n{{ field_wing_floor_or_room_number }}"
+          then: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address }}"
           then_translate: 1
-          or: "{{ field_address_1 }}\r\n{{ field_building_name_number }}\r\n{{ field_wing_floor_or_room_number }}"
+          or: "{{ field_clinic_name }}\r\n<div class=\"location-details\">{{ field_building_name_number }}{{ field_wing_floor_or_room_number }}</div>\r\n{{ field_address_1 }}"
+          or_translate: 1
+          strip_tags: 0
+        field_office_hours:
+          id: field_office_hours
+          table: node__field_office_hours
+          field: field_office_hours
+          relationship: field_facility_location
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: day
+          type: office_hours
+          settings:
+            day_format: long
+            time_format: g
+            compress: true
+            grouped: true
+            show_closed: open
+            closed_format: Closed
+            separator:
+              days: '<br />'
+              grouped_days: ' - '
+              day_hours: ': '
+              hours_hours: '-'
+              more_hours: ', '
+            current_status:
+              position: ''
+              open_text: 'Currently open!'
+              closed_text: 'Currently closed'
+            office_hours_first_day: ''
+            schema:
+              enabled: false
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_office_hours_1:
+          id: field_office_hours_1
+          table: paragraph__field_office_hours
+          field: field_office_hours
+          relationship: field_service_location
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Service Location Hours'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: day
+          type: office_hours
+          settings:
+            day_format: long
+            time_format: g
+            compress: true
+            grouped: true
+            show_closed: all
+            closed_format: Closed
+            separator:
+              days: '<br />'
+              grouped_days: ' - '
+              day_hours: ': '
+              hours_hours: '-'
+              more_hours: ', '
+            current_status:
+              position: ''
+              open_text: 'Currently open!'
+              closed_text: 'Currently closed'
+            office_hours_first_day: ''
+            schema:
+              enabled: false
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hours:
+          id: field_hours
+          table: paragraph__field_hours
+          field: field_hours
+          relationship: field_service_location
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        views_conditional_field:
+          id: views_conditional_field
+          table: views_conditional
+          field: views_conditional_field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: views_conditional_field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          if: field_hours
+          condition: eq
+          equalto: 'Use the facility''s hours'
+          then: '{{ field_office_hours_1 }}'
+          then_translate: 1
+          or: ''
+          or_translate: 1
+          strip_tags: 0
+        views_conditional_field_2:
+          id: views_conditional_field_2
+          table: views_conditional
+          field: views_conditional_field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: views_conditional_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          if: field_hours
+          condition: eq
+          equalto: 'Use the facility''s hours'
+          then: '{{ field_office_hours }}'
+          then_translate: 1
+          or: '{{ views_conditional_field_3 }}'
           or_translate: 1
           strip_tags: 0
         moderation_state:
@@ -947,7 +1019,7 @@ display:
           entity_type: node
           plugin_id: entity_link_edit
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1218,8 +1290,8 @@ display:
         - 'config:field.storage.paragraph.field_address'
         - 'config:field.storage.paragraph.field_building_name_number'
         - 'config:field.storage.paragraph.field_clinic_name'
-        - 'config:field.storage.paragraph.field_facility_service_hours'
         - 'config:field.storage.paragraph.field_hours'
+        - 'config:field.storage.paragraph.field_office_hours'
         - 'config:field.storage.paragraph.field_use_facility_address'
         - 'config:field.storage.paragraph.field_wing_floor_or_room_number'
   admissions_offices:

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.storage.paragraph.field_clinic_name
     - field.storage.paragraph.field_facility_service_hours
     - field.storage.paragraph.field_hours
+    - field.storage.paragraph.field_office_hours
     - field.storage.paragraph.field_use_facility_address
     - field.storage.paragraph.field_wing_floor_or_room_number
     - node.type.vha_facility_nonclinical_service
@@ -1811,15 +1812,15 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_facility_service_hours:
-          id: field_facility_service_hours
-          table: paragraph__field_facility_service_hours
-          field: field_facility_service_hours
+        field_office_hours_1:
+          id: field_office_hours_1
+          table: paragraph__field_office_hours
+          field: field_office_hours
           relationship: field_service_location
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: 'Service Location Hours'
           exclude: true
           alter:
             alter_text: false
@@ -1852,7 +1853,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -1860,12 +1861,29 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: tablefield
+          click_sort_column: day
+          type: office_hours
           settings:
-            row_header: false
-            column_header: true
-          group_column: value
+            day_format: long
+            time_format: g
+            compress: true
+            grouped: true
+            show_closed: all
+            closed_format: Closed
+            separator:
+              days: '<br />'
+              grouped_days: ' - '
+              day_hours: ': '
+              hours_hours: '-'
+              more_hours: ', '
+            current_status:
+              position: ''
+              open_text: 'Currently open!'
+              closed_text: 'Currently closed'
+            office_hours_first_day: ''
+            schema:
+              enabled: false
+          group_column: ''
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -1989,7 +2007,7 @@ display:
           if: field_hours
           condition: eq
           equalto: 'Provide specific hours for this service'
-          then: '{{ field_facility_service_hours }}'
+          then: '{{ field_office_hours_1 }}'
           then_translate: 1
           or: ''
           or_translate: 1
@@ -2002,8 +2020,8 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: views_conditional_field
-          label: Hours
-          exclude: true
+          label: ''
+          exclude: false
           alter:
             alter_text: false
             text: ''
@@ -2035,7 +2053,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -2466,8 +2484,8 @@ display:
         - 'config:field.storage.paragraph.field_address'
         - 'config:field.storage.paragraph.field_building_name_number'
         - 'config:field.storage.paragraph.field_clinic_name'
-        - 'config:field.storage.paragraph.field_facility_service_hours'
         - 'config:field.storage.paragraph.field_hours'
+        - 'config:field.storage.paragraph.field_office_hours'
         - 'config:field.storage.paragraph.field_use_facility_address'
         - 'config:field.storage.paragraph.field_wing_floor_or_room_number'
   billing_and_insurance:
@@ -3060,15 +3078,15 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_facility_service_hours:
-          id: field_facility_service_hours
-          table: paragraph__field_facility_service_hours
-          field: field_facility_service_hours
+        field_office_hours_1:
+          id: field_office_hours_1
+          table: paragraph__field_office_hours
+          field: field_office_hours
           relationship: field_service_location
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: 'Service Location Hours'
           exclude: true
           alter:
             alter_text: false
@@ -3101,7 +3119,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -3109,12 +3127,29 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: tablefield
+          click_sort_column: day
+          type: office_hours
           settings:
-            row_header: false
-            column_header: true
-          group_column: value
+            day_format: long
+            time_format: g
+            compress: true
+            grouped: true
+            show_closed: all
+            closed_format: Closed
+            separator:
+              days: '<br />'
+              grouped_days: ' - '
+              day_hours: ': '
+              hours_hours: '-'
+              more_hours: ', '
+            current_status:
+              position: ''
+              open_text: 'Currently open!'
+              closed_text: 'Currently closed'
+            office_hours_first_day: ''
+            schema:
+              enabled: false
+          group_column: ''
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -3238,7 +3273,7 @@ display:
           if: field_hours
           condition: eq
           equalto: 'Provide specific hours for this service'
-          then: '{{ field_facility_service_hours }}'
+          then: '{{ field_office_hours_1 }}'
           then_translate: 1
           or: ''
           or_translate: 1
@@ -3251,8 +3286,8 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: views_conditional_field
-          label: Hours
-          exclude: true
+          label: ''
+          exclude: false
           alter:
             alter_text: false
             text: ''
@@ -3284,7 +3319,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -3780,8 +3815,8 @@ display:
         - 'config:field.storage.paragraph.field_address'
         - 'config:field.storage.paragraph.field_building_name_number'
         - 'config:field.storage.paragraph.field_clinic_name'
-        - 'config:field.storage.paragraph.field_facility_service_hours'
         - 'config:field.storage.paragraph.field_hours'
+        - 'config:field.storage.paragraph.field_office_hours'
         - 'config:field.storage.paragraph.field_use_facility_address'
         - 'config:field.storage.paragraph.field_wing_floor_or_room_number'
   medical_records_offices:
@@ -4374,15 +4409,15 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_facility_service_hours:
-          id: field_facility_service_hours
-          table: paragraph__field_facility_service_hours
-          field: field_facility_service_hours
+        field_office_hours_1:
+          id: field_office_hours_1
+          table: paragraph__field_office_hours
+          field: field_office_hours
           relationship: field_service_location
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: 'Service Location Hours'
           exclude: true
           alter:
             alter_text: false
@@ -4415,7 +4450,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -4423,12 +4458,29 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: tablefield
+          click_sort_column: day
+          type: office_hours
           settings:
-            row_header: false
-            column_header: true
-          group_column: value
+            day_format: long
+            time_format: g
+            compress: true
+            grouped: true
+            show_closed: all
+            closed_format: Closed
+            separator:
+              days: '<br />'
+              grouped_days: ' - '
+              day_hours: ': '
+              hours_hours: '-'
+              more_hours: ', '
+            current_status:
+              position: ''
+              open_text: 'Currently open!'
+              closed_text: 'Currently closed'
+            office_hours_first_day: ''
+            schema:
+              enabled: false
+          group_column: ''
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -4552,7 +4604,7 @@ display:
           if: field_hours
           condition: eq
           equalto: 'Provide specific hours for this service'
-          then: '{{ field_facility_service_hours }}'
+          then: '{{ field_office_hours_1 }}'
           then_translate: 1
           or: ''
           or_translate: 1
@@ -4565,8 +4617,8 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: views_conditional_field
-          label: Hours
-          exclude: true
+          label: ''
+          exclude: false
           alter:
             alter_text: false
             text: ''
@@ -4598,7 +4650,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -5067,7 +5119,7 @@ display:
         - 'config:field.storage.paragraph.field_address'
         - 'config:field.storage.paragraph.field_building_name_number'
         - 'config:field.storage.paragraph.field_clinic_name'
-        - 'config:field.storage.paragraph.field_facility_service_hours'
         - 'config:field.storage.paragraph.field_hours'
+        - 'config:field.storage.paragraph.field_office_hours'
         - 'config:field.storage.paragraph.field_use_facility_address'
         - 'config:field.storage.paragraph.field_wing_floor_or_room_number'

--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
@@ -501,9 +501,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   public function formWidgetAlter(WidgetSingleElementFormAlterEvent $event): void {
     $form = &$event->getElement();
-    $form_state = $event->getFormState();
     $this->removeCollapseButton($form);
-    $this->toggleFieldOfficeHours($form, $form_state);
   }
 
   /**
@@ -515,39 +513,6 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   public function removeCollapseButton(array &$form) {
     if (!empty($form['#paragraph_type']) && $form['#paragraph_type'] === 'button') {
       unset($form['top']['actions']['actions']['collapse_button']);
-    }
-  }
-
-  /**
-   * SHow or hide field_office_hours on service_location paragraph widget forms.
-   *
-   * @param array $form
-   *   The form.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The form state.
-   */
-  public function toggleFieldOfficeHours(array &$form, FormStateInterface $form_state) {
-    /** @var \Drupal\node\NodeForm $form_object $form_object */
-    $form_object = $form_state->getFormObject();
-    if (method_exists($form_object, 'getEntity')) {
-      $entity = $form_object->getEntity();
-      if ($entity instanceof NodeInterface) {
-        // The new use of field_office_hours on service location paragraphs
-        // should be visible to admins only except on non-clinical service
-        // pages, where it should be the only hours field used.
-        if (!empty($form['#paragraph_type'])
-        && $form['#paragraph_type'] === 'service_location'
-        && !$this->userPermsService->hasAdminRole(TRUE)) {
-          if ($entity->bundle() === 'vha_facility_nonclinical_service') {
-            // We are on the new version, remove the old version of the field.
-            unset($form['subform']['field_facility_service_hours']);
-          }
-          else {
-            // We are not using the new version yet, so remove it.
-            unset($form['subform']['field_office_hours']);
-          }
-        }
-      }
     }
   }
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1171,17 +1171,6 @@ function va_gov_backend_field_widget_paragraphs_form_alter(&$element, FormStateI
       ];
     }
   }
-
-  // If we have a field ref'ing service location paragraphs, fire function.
-  $vha_paragraphs = [
-    'field_service_location',
-    'field_service_location_address',
-    'field_phone_numbers_paragraph',
-    'field_phone',
-  ];
-  if (in_array($paragraph_entity_reference_field_name, $vha_paragraphs)) {
-    _va_gov_backend_modify_paragraph_interactions($element, $form_state, $context, $paragraph_entity_reference_field_name);
-  }
 }
 
 /**
@@ -1289,59 +1278,6 @@ function _va_gov_backend_modify_contact_information_states(array &$element, Form
       ];
     }
   }
-}
-
-/**
- * Toggles service_location fields depending on parent selector.
- *
- * Adds Validation constraint error id match to html.
- *
- * @param array $element
- *   The widget.
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- *   The form state.
- * @param array $context
- *   The context.
- * @param string $paragraph_entity_reference_field_name
- *   The reference field name.
- */
-function _va_gov_backend_modify_paragraph_interactions(array &$element, FormStateInterface &$form_state, array &$context, $paragraph_entity_reference_field_name) {
-  $field_definition = $context['items']->getFieldDefinition();
-
-  /**
-   * @var \Drupal\field\Entity\FieldConfig $field_definition */
-  $paragraph_entity_reference_field_name = $field_definition->getName();
-  $widget_state = WidgetBase::getWidgetState($element['#field_parents'], $paragraph_entity_reference_field_name, $form_state);
-
-  $paragraph_instance = $widget_state['paragraphs'][$element['#delta']]['entity'];
-  $paragraph_type = $paragraph_instance->bundle();
-
-  // Toggle hours fields depending on "Use facility hours" select.
-  // field_service_location[0][subform][field_service_location_address][0][subform][field_use_facility_address][value].
-  if ($paragraph_type === 'service_location') {
-    // If use facility hours option is not selected, show address entry fields.
-    $toggle_fields = [
-      'field_facility_service_hours',
-    ];
-    $selector = sprintf(':input[name="field_service_location[%1$d][subform][field_hours]"]', $element['#delta']);
-    foreach ($toggle_fields as $field) {
-      $element['subform'][$field]['#states'] = [
-        'visible' => [
-          $selector => ['value' => "2"],
-        ],
-      ];
-    }
-    // Remove caption, rows, and import fields from address tablefield.
-    if (isset($element['subform']['field_facility_service_hours']['widget'][0]['caption'])) {
-      unset($element['subform']['field_facility_service_hours']['widget'][0]['#description']);
-      unset($element['subform']['field_facility_service_hours']['widget'][0]['caption']);
-    }
-    $element['subform']['field_facility_service_hours']['widget'][0]['prefix']['#markup'] = t('<div class="description">Format: "8:00 a.m. to 5:30 p.m. ET" or "24/7"</div>');
-    $element['subform']['field_facility_service_hours']['widget'][0]['#import'] = FALSE;
-    $element['subform']['field_facility_service_hours']['widget'][0]['#addrow'] = FALSE;
-    $element['subform']['field_facility_service_hours']['widget'][0]['#rebuild'] = FALSE;
-  }
-
 }
 
 /**

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -104,11 +104,9 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Rich text - char limit 1000 | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Service location | Additional Hours options (e.g. On-Call, Appointments may be available outside these hours, please call.) | field_additional_hours_info | Text (plain) |  | 1 | Textfield |  |
 | Paragraph type | Service location | Email contacts | field_email_contacts | Entity reference revisions |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
-| Paragraph type | Service location | Address | field_service_location_address | Entity reference revisions |  | 1 | Paragraphs (stable) |  |
-| Paragraph type | Service location | Hours | field_facility_service_hours | Table Field |  | 1 | -- Disabled -- |  |
 | Paragraph type | Service location | Use the facility's hours | field_hours | List (text) | Required | 1 | Select list |  |
 | Paragraph type | Service location | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) |  |
-| Paragraph type | Service location | Hours | field_facility_service_hours | Table Field |  | 1 | Table Field |  |
+| Paragraph type | Service location | Hours | field_facility_service_hours | Table Field |  | 1 | -- Disabled -- |  |
 | Paragraph type | Service location | Other phone numbers | field_phone | Entity reference revisions |  | 5 | Inline entity form - Complex - Table View Mode |  |
 | Paragraph type | Service location | Address | field_service_location_address | Entity reference revisions |  | 1 | Paragraphs (stable) |  |
 | Paragraph type | Service location | Use the general facility phone number | field_use_main_facility_phone | Boolean |  | 1 | Single on/off checkbox |  |

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -104,6 +104,8 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Rich text - char limit 1000 | Text | field_wysiwyg | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
 | Paragraph type | Service location | Additional Hours options (e.g. On-Call, Appointments may be available outside these hours, please call.) | field_additional_hours_info | Text (plain) |  | 1 | Textfield |  |
 | Paragraph type | Service location | Email contacts | field_email_contacts | Entity reference revisions |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
+| Paragraph type | Service location | Address | field_service_location_address | Entity reference revisions |  | 1 | Paragraphs (stable) |  |
+| Paragraph type | Service location | Hours | field_facility_service_hours | Table Field |  | 1 | -- Disabled -- |  |
 | Paragraph type | Service location | Use the facility's hours | field_hours | List (text) | Required | 1 | Select list |  |
 | Paragraph type | Service location | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) |  |
 | Paragraph type | Service location | Hours | field_facility_service_hours | Table Field |  | 1 | Table Field |  |


### PR DESCRIPTION
## Description

Closes #8550 

## Testing done

Visual Testing

## Screenshots

![Screen Shot 2022-03-30 at 11 31 04 AM](https://user-images.githubusercontent.com/21045418/160875707-bc20003d-1a4b-48a1-8bcd-a1d9bd9c7de0.png)

![Screen Shot 2022-03-30 at 11 30 56 AM](https://user-images.githubusercontent.com/21045418/160875719-b6ab5fd5-f9bb-472d-913d-4e4567a0c02f.png)

![Screen Shot 2022-03-30 at 11 30 49 AM](https://user-images.githubusercontent.com/21045418/160875638-1f51ef5f-3877-4212-8805-a97878596bc1.png)

![Screen Shot 2022-03-30 at 11 31 45 AM](https://user-images.githubusercontent.com/21045418/160875736-1edaf996-4641-4689-9419-fca42494c4cd.png)

## QA steps

- [ ] View /eastern-colorado-health-care/register-for-care-0 (service location should show time)
- [ ] View /eastern-colorado-health-care/medical-records-office-0 (service location should show time)
- [ ] View /eastern-colorado-health-care/billing-and-insurance-0 (service location should show time)
- [ ] Edit a non-clinical service node (example: /node/42057/edit) 
  - [ ] the old table field for hours should no longer be visible
  - [ ] the new office hours field should be visible
  - [ ] the **Use the facility's hours** field should toggle the new office hours field visibility

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [x] `⭐️ Product Support`
