### PR TITLE
VACMS-8510 small screen issues

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
@@ -250,3 +250,7 @@ p.vc-help-text {
 .no-wrap {
   white-space: nowrap;
 }
+
+.entities-list.sortable .item-container:hover {
+  opacity: 1; // entity browser module sets 0.6 for some reason, looks funky
+}

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -71,6 +71,11 @@
   margin: 0;
 }
 
+// Fix autocomplete fields breaking container on smaller screens
+.claro-autocomplete input {
+  width: 100%;
+}
+
 // Right rail field fixes
 #edit-field-links-wrapper {
   .claro-autocomplete input {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
@@ -69,11 +69,18 @@
   margin-bottom: var(--spacing-m);
 }
 
+// !important here to beat some nonsense core is doing that we inherit as claro subtheme
 .vagovclaro .layout-container {
   margin-left: 2rem !important;
   margin-right: 2rem !important;
+
+  @include breakpoint('lg') {
+    margin-left: 3rem !important;
+    margin-right: 3rem !important;
+  }
 }
 
+// see node-edit-form.html.twig
 .layout--edit {
   display: grid;
   grid-auto-rows: minmax(min-content, max-content);
@@ -113,9 +120,13 @@
 
     .layout-region__content {
       position: sticky;
-      top: 90px; // height from top of viewport to start sticky
+      top: 50px; // height from top of viewport to start sticky
     }
   }
+}
+
+.toolbar-tray-open .layout--node-secondary .layout-region__content {
+  top: 90px; // slighter lower sticky position if toolbar open
 }
 
 .layout--node-footer {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
@@ -43,10 +43,6 @@
   }
 }
 
-.layout-region--node-secondary {
-  margin-top: 0;
-}
-
 // editorial fields above form footer
 #edit-group-e,
 #edit-group-editorial-workflow {
@@ -54,18 +50,6 @@
 
   .form-item {
     margin-bottom: var(--spacing-xs);
-  }
-}
-
-// Adjust layout for very wide screens.
-// MQ matches docroot/core/themes/claro/css/layout/node-add.css
-// 120 x 16 = 1920px min width
-@media screen and (min-width: 120rem) {
-  .layout-region--node-main .layout-region__content,
-  .layout-region--node-footer .layout-region__content {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 54rem;
   }
 }
 
@@ -83,4 +67,59 @@
 
 .region-help {
   margin-bottom: var(--spacing-m);
+}
+
+.vagovclaro .layout-container {
+  margin-left: 2rem !important;
+  margin-right: 2rem !important;
+}
+
+.layout--edit {
+  display: grid;
+  grid-auto-rows: minmax(min-content, max-content);
+  grid-gap: 1rem;
+  grid-template-columns: 1fr;
+
+  @include breakpoint('sm') {
+    grid-template-columns: 1fr 300px;
+  }
+  @include breakpoint('md') {
+    grid-gap: 2rem;
+  }
+  @include breakpoint('lg') {
+    grid-template-columns: 1fr 360px;
+  }
+}
+
+.layout--node-main {
+  min-width: 0;
+
+  @include breakpoint('sm') {
+    grid-area: 1 / 1 / 1 / 2;
+  }
+
+  .layout-region__content {
+    margin: 0 auto;
+    max-width: 52rem;
+  }
+}
+
+.layout--node-secondary {
+  min-width: 0;
+
+  @include breakpoint('sm') {
+    grid-area: 1 / 2 / 1 / 3;
+    max-width: 100%;
+
+    .layout-region__content {
+      position: sticky;
+      top: 90px; // height from top of viewport to start sticky
+    }
+  }
+}
+
+.layout--node-footer {
+  @include breakpoint('sm') {
+    grid-area: 2 / 1 / 2 / 3;
+  }
 }

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_paragraphs.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_paragraphs.scss
@@ -86,3 +86,24 @@
 .js .draggable:hover .paragraphs-collapsed-description::after {
   background: linear-gradient(to right, rgba(247, 252, 255, 0) 0%, var(--va-blue-light) 100%);
 }
+
+// fix spacing for link teaser paragraphs on all screen sizes
+.paragraph-type--link-teaser {
+  fieldset {
+    border: unset;
+    box-shadow: unset;
+    margin: 0;
+  }
+
+  .fieldset__label {
+    padding: 0;
+  }
+
+  .fieldset__wrapper {
+    margin: 0;
+  }
+
+  .form-element--type-text {
+    width: 100%;
+  }
+}

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
@@ -99,14 +99,14 @@
 }
 
 //Adding button css to views
-.views-field {
+.views-field-field-content-block {
   @include va-basic-styling;
 }
 
 //fixes export button
 .csv-feed .feed-icon {
   @include button(var(--button-bg-color--primary), var(--button-fg-color--primary), var(--button--hover-bg-color--primary), var(--button--active-bg-color--primary));
-  
+
   background-image: none;
   text-indent: unset;
   width: auto;

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_views.scss
@@ -99,6 +99,7 @@
 }
 
 //Adding button css to views
+.views-field-nothing,
 .views-field-field-content-block {
   @include va-basic-styling;
 }

--- a/docroot/themes/custom/vagovclaro/templates/node/node-edit-form.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/node/node-edit-form.html.twig
@@ -15,18 +15,37 @@
  * @see claro_form_node_form_alter()
  */
 #}
-<div class="layout-node-form clearfix">
-  <div class="layout-region layout-region--node-main">
+{#<div class="layout-node-form clearfix">#}
+{#  <div class="layout-region layout-region--node-main">#}
+{#    <div class="layout-region__content">#}
+{#      {{ form|without('advanced', 'footer', 'actions') }}#}
+{#    </div>#}
+{#  </div>#}
+{#  <div class="layout-region layout-region--node-secondary">#}
+{#    <div class="layout-region__content">#}
+{#      {{ form.advanced }}#}
+{#    </div>#}
+{#  </div>#}
+{#  <div class="layout-region layout-region--node-footer">#}
+{#    <div class="layout-region__content">#}
+{#      {{ form.footer }}#}
+{#      {{ form.actions }}#}
+{#    </div>#}
+{#  </div>#}
+{#</div>#}
+
+<div class="layout--edit">
+  <div class="layout-region layout--node-main">
     <div class="layout-region__content">
       {{ form|without('advanced', 'footer', 'actions') }}
     </div>
   </div>
-  <div class="layout-region layout-region--node-secondary">
+  <div class="layout-region layout--node-secondary">
     <div class="layout-region__content">
       {{ form.advanced }}
     </div>
   </div>
-  <div class="layout-region layout-region--node-footer">
+  <div class="layout-region layout--node-footer">
     <div class="layout-region__content">
       {{ form.footer }}
       {{ form.actions }}


### PR DESCRIPTION
## Description

Closes #8510. Closes #8338. Cleans up node edit form layout, particularly concerned with the range of screen sizes from ~800px-1000px based on feedback received from editors in the claro survey. See #8336 for further context.  I also made the right column sticky in an effort to make it more visible to editors as a stab at #8513 while I was here... I can remove this sticky behavior if it is undesired.

This PR also fixes regression in admin/content/* view table styles.

## Testing done
Resized browser from ranges between mobile -> very wide. Verified that new layout styles responded appropriately at all sizes, elements stayed within container as expected (some tables may still get a little cramped at smaller screen sizes before the one-column stack)

## Screenshots
regression in table styles:
<img width="1279" alt="Screen Shot 2022-03-31 at 1 31 57 PM" src="https://user-images.githubusercontent.com/11279744/161146387-897bf8e0-15f0-4c13-8335-01ac4b085776.png">
<img width="1283" alt="Screen Shot 2022-03-31 at 1 32 06 PM" src="https://user-images.githubusercontent.com/11279744/161146390-bfdf5d7d-8200-4162-9a66-0665b5ee3f5e.png">

fixed:
<img width="1647" alt="Screen Shot 2022-03-31 at 1 31 39 PM" src="https://user-images.githubusercontent.com/11279744/161146377-50daf329-de17-4802-845e-a4fa0455e713.png">
<img width="1609" alt="Screen Shot 2022-03-31 at 1 31 50 PM" src="https://user-images.githubusercontent.com/11279744/161146383-9f9c0b77-46e3-4310-82d5-0e69d04a9bd4.png">

media contacts safely inside container:
<img width="820" alt="Screen Shot 2022-03-31 at 10 14 08 AM" src="https://user-images.githubusercontent.com/11279744/161146394-e079c516-96cd-4ff3-84c6-0642c371c01e.png">

multiple value paragraphs fields sitting inside container now at smaller screen sizes:
<img width="971" alt="Screen Shot 2022-03-31 at 1 48 05 PM" src="https://user-images.githubusercontent.com/11279744/161146719-1ac4f3de-19c8-44e1-9243-90380d1f05c6.png">


## QA steps
Log in as admin user, view `admin/content` and see the styles are correct. Verify button styles are still present in the view table when looking at `admin/content/audit/buttons`

Visit `/node/18161/edit` and scroll down to the media contacts field. See that it is inside the container at all screen sizes.

Visit `/node/44718/edit` and resize screen size. See that paragraphs tables with multiple values don't break out of the container at all screen sizes. Link teaser paragraph ("Related Information") was the main offender here.

See that the right rail is sticky as a user scrolls down the page, making the required fields more visible

### Select Team for PR review

- [ ] `Platform CMS Team`
- [x] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [x] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`