### PR TITLE
Fix "The default master branch will be renamed to main" message on local (Remove post-merge hook from .git folder)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -519,6 +519,7 @@
         ],
         "post-install-cmd": [
             "mkdir --parents docroot/profiles",
+            "rm -r .git/hooks/post-merge 2> /dev/null",
             "cp -r 'hooks/git/.' '.git/hooks/'",
             "php -r \"chmod('.git/hooks/pre-commit', 0777);\"",
             "ln -snf 'docroot/vendor/simplesamlphp/simplesamlphp/' 'simplesamlphp'",

--- a/composer.json
+++ b/composer.json
@@ -519,6 +519,7 @@
         ],
         "post-install-cmd": [
             "mkdir --parents docroot/profiles",
+            "# The rm post-merge command below can be removed after we think all engineers have run composer install.",
             "rm -r .git/hooks/post-merge 2> /dev/null",
             "cp -r 'hooks/git/.' '.git/hooks/'",
             "php -r \"chmod('.git/hooks/pre-commit', 0777);\"",

--- a/composer.json
+++ b/composer.json
@@ -520,7 +520,7 @@
         "post-install-cmd": [
             "mkdir --parents docroot/profiles",
             "# The rm post-merge command below can be removed after we think all engineers have run composer install.",
-            "rm -r .git/hooks/post-merge 2> /dev/null",
+            "rm -rf .git/hooks/post-merge",
             "cp -r 'hooks/git/.' '.git/hooks/'",
             "php -r \"chmod('.git/hooks/pre-commit', 0777);\"",
             "ln -snf 'docroot/vendor/simplesamlphp/simplesamlphp/' 'simplesamlphp'",


### PR DESCRIPTION
## Description

Follow up of https://github.com/department-of-veterans-affairs/va.gov-cms/pull/6912

Fixes this message from showing on local DEV. 

```shell
.git/hooks/post-merge: line 3: @cms-devops-engineers: command not found
.git/hooks/post-merge: line 3: #cms-team: command not found

******************************ATTN*******************************
* IMPORTANT: The default master branch will be renamed to main! *
* This will happen 11/4/2021                                    *
* You will have to update your local env                        *
* instructions will be provided by       *                             
* in  Slack                                         *
******************************ATTN*******************************
```


## Testing done
Tested locally with a composer install, message is gone and local .git/hooks/post-merge hook file is gone now too. 

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that 
2. Then 
   - [ ] Validate that 
3. Then validate Acceptance Criteria from issue
   - [ ] a 
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
