### PR TITLE
VACMS-000: Adding patch to prevent validation errors on closed days.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -442,7 +442,7 @@
                 "3249493 - Not able to delete a revision via the interface": "https://www.drupal.org/files/issues/2022-02-21/3249493-9.patch"
             },
             "drupal/office_hours": {
-                "3227169 - Form fields in table cell missing labels causes accessibility warnings": "https://www.drupal.org/files/issues/2022-03-28/labels-for-accessibility-3227169-11.patch"
+                "3273363 - Validation errors on closed days": "https://www.drupal.org/files/issues/2022-04-04/validation-err-on-close-3273363-1.patch"
             },
             "drupal/openapi_jsonapi": {
                 "3110109 - Support renamed resource types Part 1": "https://git.drupalcode.org/project/openapi_jsonapi/-/commit/17070f1ef70ff89f732619a11c29730107a2083e.patch",


### PR DESCRIPTION
## Description
relates to #8485 
**This patch:**
1. fixes issue with office hours discovered during testing: leaving start / end times blank when validation is on, but start and end time requirements are not throws notices

## Testing done
Visual, composer install, behat

## QA steps
 - [ ] As Crystal.Davis-Noble3@va.gov, go to `/node/1524/edit` and change the start value and end value of two different fields, and add a comment to a third.
 - [x] Save as published, and visually verify form successfully saves and appears as expected on node view
 - [x] Edit the field, setting the start value of one field after the end value of the same field, and visually verify form provides meaningful error messages on save.
 - [x] As an administrator, go to `/admin/structure/types/manage/health_care_local_facility/fields/node.health_care_local_facility.field_office_hours/storage` and set start and end times to required
 - [x] As Crystal.Davis-Noble3@va.gov, go to `/node/1524/edit` and visually verify at least one start date and one end date is empty on the office hours field.
 - [x] Save form, and visually verify meaningful notices appear, indicating that start and end times are required.
