### PR TITLE
VACMS-8563: Remove sortable edit header and update link to button.

### DIFF
--- a/config/sync/views.view.vha_health_service_taxonomy.yml
+++ b/config/sync/views.view.vha_health_service_taxonomy.yml
@@ -1335,18 +1335,7 @@ display:
           plugin_id: entity_reverse
           required: false
       group_by: true
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: false
-          content: '<p><a class="button" href="/vha-healthcare-services/export?_format=csv">Download as a CSV</a></p>'
-          tokenize: false
+      header: {  }
       footer: {  }
       display_extenders: {  }
     cache_metadata:

--- a/config/sync/views.view.vha_health_service_taxonomy.yml
+++ b/config/sync/views.view.vha_health_service_taxonomy.yml
@@ -1185,9 +1185,10 @@ display:
             field_vet_center_type_of_care: field_vet_center_type_of_care
             nothing_1: nothing_1
             nothing: nothing
+            nothing_2: nothing_2
+            nothing_3: nothing_3
             field_vet_center_required_servic: field_vet_center_required_servic
             nid_1: nid_1
-            nothing_2: nothing_2
           default: name
           info:
             name:
@@ -1198,7 +1199,7 @@ display:
               empty_column: false
               responsive: ''
             edit_taxonomy_term:
-              sortable: true
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
@@ -1282,6 +1283,16 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
+            nothing_2:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nothing_3:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             field_vet_center_required_servic:
               sortable: true
               default_sort_order: asc
@@ -1292,11 +1303,6 @@ display:
             nid_1:
               sortable: true
               default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            nothing_2:
               align: ''
               separator: ''
               empty_column: false
@@ -2359,16 +2365,16 @@ display:
           alter:
             alter_text: false
             text: ''
-            make_link: false
+            make_link: true
             path: ''
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
+            alt: Edit
             rel: ''
-            link_class: ''
+            link_class: button
             prefix: ''
             suffix: ''
             target: ''


### PR DESCRIPTION
## Description

Closes #8563 

## Testing done
manual

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/161818132-231cf9ca-8084-4f51-8805-31dad7d9a025.png)



## QA steps

As a cms user
1. Go to the VHA taxonomy view (`/admin/structure/views/view/vha_health_service_taxonomy`)
   - [x] Validate that the edit column is not sortable
   - [x] The edit link is now a button
   - [x] alidate there is only one csv button at the top of the page

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide CMS Team`
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS Experience`
  - [ ] `⭐️ Offices`
  - [ ] `⭐️ Product Support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
