### PR TITLE
VACMS-8085: Removes logspam from performance tests.

### DIFF
--- a/tests/phpunit/Content/CreateMediaTest.php
+++ b/tests/phpunit/Content/CreateMediaTest.php
@@ -60,9 +60,6 @@ class CreateMediaTest extends ExistingSiteBase {
     // Test assertion.
     $secs = number_format($microsecs, 3);
     $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
-
-    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
-    fwrite(STDERR, print_r($message, TRUE));
   }
 
   /**

--- a/tests/phpunit/Performance/CreateNodeTest.php
+++ b/tests/phpunit/Performance/CreateNodeTest.php
@@ -44,9 +44,6 @@ class CreateNodeTest extends ExistingSiteBase {
     // Test assertion.
     $secs = number_format($microsecs, 3);
     $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
-
-    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
-    fwrite(STDERR, print_r($message, TRUE));
   }
 
   /**

--- a/tests/phpunit/Performance/CreateTaxonomyTermTest.php
+++ b/tests/phpunit/Performance/CreateTaxonomyTermTest.php
@@ -41,9 +41,6 @@ class CreateTaxonomyTermTest extends ExistingSiteBase {
     // Test assertion.
     $secs = number_format($microsecs, 3);
     $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
-
-    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
-    fwrite(STDERR, print_r($message, TRUE));
   }
 
   /**

--- a/tests/phpunit/Performance/EditNodeTest.php
+++ b/tests/phpunit/Performance/EditNodeTest.php
@@ -47,9 +47,6 @@ class EditNodeTest extends ExistingSiteBase {
     // Test assertion.
     $secs = number_format($microsecs, 3);
     $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds for type " . $type . ".\n");
-
-    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds for type " . $type . ".\n";
-    fwrite(STDERR, print_r($message, TRUE));
   }
 
   /**

--- a/tests/phpunit/Performance/LoginTest.php
+++ b/tests/phpunit/Performance/LoginTest.php
@@ -50,9 +50,6 @@ class LoginTest extends ExistingSiteBase {
     // Test assertion.
     $secs = number_format($microsecs, 3);
     $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
-
-    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
-    fwrite(STDERR, print_r($message, TRUE));
   }
 
   /**

--- a/tests/phpunit/Performance/PreviewTest.php
+++ b/tests/phpunit/Performance/PreviewTest.php
@@ -100,9 +100,6 @@ class PreviewTest extends ExistingSiteBase {
     // Test assertion.
     $secs = number_format($microsecs, 3);
     $this->assertLessThan($benchmark, $secs, __METHOD__ . "\nOperation took " . $secs . " seconds which is longer than the benchmark of " . $benchmark . " seconds.\n");
-
-    $message = __METHOD__ . "\nOperation took " . $secs . " seconds compared to the benchmark of " . $benchmark . " seconds.\n";
-    fwrite(STDERR, print_r($message, TRUE));
   }
 
   /**


### PR DESCRIPTION
## Description

Closes #8085.  Just removes some messages that break the output and don't provide much (if any) useful information.

## Testing done
Only affects tests.

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Sitewide program`
- [ ] `Platform CMS Team`
- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS experience`
  - [ ] `⭐️ Public websites`
  - [ ] `⭐️ Facilities`
  - [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
