### PR TITLE
Disable content build dispatch in local, dev, and staging because they do not currently work

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -85,6 +85,7 @@ class BRDGHA extends EnvironmentPluginBase {
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
     // We shouldn't request a GHA build on dev or staging because the GHA
     // workflow only supports a production deployment.
+    // phpcs:ignore
     // See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8797
     $env = $this->settings->get('github_actions_deploy_env');
     if ($env === 'dev' || $env === 'staging') {

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -83,9 +83,9 @@ class BRDGHA extends EnvironmentPluginBase {
    * {@inheritDoc}
    */
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
-    // We shouldn't request a GHA build on dev or staging because the GHA workflow
-    // only supports a production deployment.
-    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8797
+    // We shouldn't request a GHA build on dev or staging because the GHA
+    // workflow only supports a production deployment.
+    // See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8797
     $env = $this->settings->get('github_actions_deploy_env');
     if ($env === 'dev' || $env === 'staging') {
       $message = $this->t('Build not dispatched because the content release workflow only supports production deployment.');

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -83,6 +83,17 @@ class BRDGHA extends EnvironmentPluginBase {
    * {@inheritDoc}
    */
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
+    // We shouldn't request a GHA build on dev or staging because the GHA workflow
+    // only supports a production deployment.
+    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/xxxx
+    $env = $this->settings->get('github_actions_deploy_env');
+    if ($env === 'dev' || $env === 'staging') {
+      $message = $this->t('Build not dispatched because the content release workflow only supports production deployment.');
+      $this->messenger()->addStatus($message);
+      $this->logger->info($message);
+      return;
+    }
+
     $front_end_git_ref = $front_end_git_ref ?? "master";
 
     try {

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -85,7 +85,7 @@ class BRDGHA extends EnvironmentPluginBase {
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
     // We shouldn't request a GHA build on dev or staging because the GHA workflow
     // only supports a production deployment.
-    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/xxxx
+    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8797
     $env = $this->settings->get('github_actions_deploy_env');
     if ($env === 'dev' || $env === 'staging') {
       $message = $this->t('Build not dispatched because the content release workflow only supports production deployment.');

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
@@ -65,7 +65,7 @@ class Lando extends EnvironmentPluginBase {
    * {@inheritDoc}
    */
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
-    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8796
+    // See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8796
     $message = $this->t('Build not dispatched because the content build is not currently working on ddev.');
     $this->messenger()->addStatus($message);
     $this->logger->info($message);

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
@@ -65,7 +65,7 @@ class Lando extends EnvironmentPluginBase {
    * {@inheritDoc}
    */
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
-    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/xxxx
+    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8796
     $message = $this->t('Build not dispatched because the content build is not currently working on ddev.');
     $this->messenger()->addStatus($message);
     $this->logger->info($message);

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
@@ -65,6 +65,12 @@ class Lando extends EnvironmentPluginBase {
    * {@inheritDoc}
    */
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
+    // @todo: See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/xxxx
+    $message = $this->t('Build not dispatched because the content build is not currently working on ddev.');
+    $this->messenger()->addStatus($message);
+    $this->logger->info($message);
+    return;
+
     /** @var \Drupal\advancedqueue\Entity\QueueInterface $queue */
     $queue = $this->queueLoader->load('command_runner');
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
@@ -65,6 +65,7 @@ class Lando extends EnvironmentPluginBase {
    * {@inheritDoc}
    */
   public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
+    // phpcs:ignore
     // See issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8796
     $message = $this->t('Build not dispatched because the content build is not currently working on ddev.');
     $this->messenger()->addStatus($message);


### PR DESCRIPTION
Dispatching a GHA content build in the BRD dev or staging environments shouldn't happen right now. The content release workflow currently only supports production. Let's disable it until it's safe to actually perform that action.

Dispatching a content build in a local ddev environment doesn't work either (the advanced queue stuff needs some work + maybe some path fiddling somewhere). Devs can still run it manually -- just not through the UI.

## Description


## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Sitewide program`
- [x] `Platform CMS Team`
- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS experience`
  - [ ] `⭐️ Public websites`
  - [ ] `⭐️ Facilities`
  - [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
