### PR TITLE
Rename shouldTriggerFrontendBuild to contentEditsShouldTriggerFrontentBuild

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentDiscovery.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentDiscovery.php
@@ -136,15 +136,15 @@ class EnvironmentDiscovery {
   }
 
   /**
-   * Should the front end build be triggered?
+   * Should the front end build be triggered from a content edit?
    *
    * @return bool
    *   Whether the front end build should be triggered.
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
-  public function shouldTriggerFrontendBuild() : bool {
-    return $this->getEnvironment()->shouldTriggerFrontendBuild();
+  public function contentEditsShouldTriggerFrontendBuild() : bool {
+    return $this->getEnvironment()->contentEditsShouldTriggerFrontendBuild();
   }
 
   /**

--- a/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentInterface.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentInterface.php
@@ -36,7 +36,7 @@ interface EnvironmentInterface extends PluginInspectionInterface {
    * @return bool
    *   Should we trigger a front end deploy
    */
-  public function shouldTriggerFrontendBuild() : bool;
+  public function contentEditsShouldTriggerFrontendBuild() : bool;
 
   /**
    * The Build Trigger Form Class.

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
@@ -111,7 +111,7 @@ class BRD extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function shouldTriggerFrontendBuild(): bool {
+  public function contentEditsShouldTriggerFrontendBuild(): bool {
     return TRUE;
   }
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -110,7 +110,7 @@ class BRDGHA extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function shouldTriggerFrontendBuild() : bool {
+  public function contentEditsShouldTriggerFrontendBuild() : bool {
     return TRUE;
   }
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
@@ -78,7 +78,7 @@ class Lando extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function shouldTriggerFrontendBuild(): bool {
+  public function contentEditsShouldTriggerFrontendBuild(): bool {
     return FALSE;
   }
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Tugboat.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Tugboat.php
@@ -78,7 +78,7 @@ class Tugboat extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function shouldTriggerFrontendBuild() : bool {
+  public function contentEditsShouldTriggerFrontendBuild() : bool {
     return FALSE;
   }
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
@@ -172,7 +172,7 @@ class BuildFrontend implements BuildFrontendInterface {
         '%type' => $node->getType(),
         '%user' => $this->currentUser->getAccountName(),
       ];
-      if (!$this->environmentDiscovery->shouldTriggerFrontendBuild()) {
+      if (!$this->environmentDiscovery->contentEditsShouldTriggerFrontendBuild()) {
         $message = $this->t('A content release would have been triggered by a change to %type: %link_to_node , but this environment has it disabled.', $msg_vars);
         $this->messenger->addStatus($message);
         return;

--- a/tests/phpunit/FrontendBuild/BuildFrontendTest.php
+++ b/tests/phpunit/FrontendBuild/BuildFrontendTest.php
@@ -174,7 +174,7 @@ class BuildFrontendTest extends ExistingSiteBase {
     $nodeProphecy = $this->prophesize(NodeInterface::class);
     $userProphecy = $this->prophesize(AccountInterface::class);
 
-    $environmentDiscoveryProphecy->shouldTriggerFrontendBuild()->willReturn(FALSE);
+    $environmentDiscoveryProphecy->contentEditsShouldTriggerFrontendBuild()->willReturn(FALSE);
     $environmentDiscoveryProphecy->triggerFrontendBuild()->shouldNotBeCalled();
 
     $nodeProphecy->isPublished()->willReturn(FALSE)->shouldBeCalled();
@@ -223,7 +223,7 @@ class BuildFrontendTest extends ExistingSiteBase {
     $userProphecy = $this->prophesize(AccountInterface::class);
     $linkProphecy = $this->prophesize(Link::class);
 
-    $environmentDiscoveryProphecy->shouldTriggerFrontendBuild()->willReturn(TRUE);
+    $environmentDiscoveryProphecy->contentEditsShouldTriggerFrontendBuild()->willReturn(TRUE);
     if ($expected) {
       $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::exact(NULL), Argument::exact(FALSE))->shouldBeCalled();
     }


### PR DESCRIPTION
I've tripped over this method name more times than I care to admit. Let's name the method what it actually does.

## Description

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Sitewide program`
- [x] `Platform CMS Team`
- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS experience`
  - [ ] `⭐️ Public websites`
  - [ ] `⭐️ Facilities`
  - [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
