### PR TITLE
Remove the full rebuild param. It is not actually used for anything.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Commands/WebBuildCommands.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Commands/WebBuildCommands.php
@@ -93,8 +93,6 @@ class WebBuildCommands extends DrushCommands {
    *
    * @param string|null $reference
    *   A git reference, or null.
-   * @param string $fullRebuild
-   *   Will be coerced to a boolean.
    * @param array $options
    *   Command-line options.
    *
@@ -105,30 +103,27 @@ class WebBuildCommands extends DrushCommands {
    */
   public function buildFrontend(
     string $reference = NULL,
-    string $fullRebuild = 'FALSE',
     array $options = [
       'dry-run' => FALSE,
     ]
   ) {
     if (filter_var($reference, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== NULL) {
-      $fullRebuild = $reference;
       $reference = NULL;
     }
     if (empty($reference)) {
       $reference = NULL;
     }
-    $fullRebuild = filter_var($fullRebuild, FILTER_VALIDATE_BOOLEAN);
     if ($options['dry-run']) {
       $buildCommands = [];
 
-      $newCommands = $this->getWebBuildCommandBuilder()->buildCommands($reference, $fullRebuild);
+      $newCommands = $this->getWebBuildCommandBuilder()->buildCommands($reference);
       $buildCommands = array_merge($buildCommands, $newCommands);
       foreach ($buildCommands as $buildCommand) {
         echo $buildCommand . PHP_EOL;
       }
     }
     else {
-      $this->buildService->triggerFrontendBuild($reference, $fullRebuild);
+      $this->buildService->triggerFrontendBuild($reference);
     }
   }
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentDiscovery.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentDiscovery.php
@@ -152,13 +152,11 @@ class EnvironmentDiscovery {
    *
    * @param string $front_end_git_ref
    *   Front end git reference to build (branch name or PR number)
-   * @param bool $full_rebuild
-   *   Trigger a full rebuild of the content.
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
-    $this->getEnvironment()->triggerFrontendBuild($front_end_git_ref, $full_rebuild);
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void {
+    $this->getEnvironment()->triggerFrontendBuild($front_end_git_ref);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentInterface.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Environment/EnvironmentInterface.php
@@ -22,10 +22,8 @@ interface EnvironmentInterface extends PluginInspectionInterface {
    *
    * @param string $front_end_git_ref
    *   Front end git reference to build (branch name or PR number)
-   * @param bool $full_rebuild
-   *   Trigger a full rebuild of the content.
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void;
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void;
 
   /**
    * Should this environment trigger a frontend content deploy?

--- a/docroot/modules/custom/va_gov_build_trigger/src/Form/TugboatBuildTriggerForm.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Form/TugboatBuildTriggerForm.php
@@ -121,14 +121,13 @@ class TugboatBuildTriggerForm extends BuildTriggerForm {
    *   Object containing current form state.
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $full_rebuild = (bool) $form_state->getValue('full_rebuild');
     $git_ref = NULL;
     $git_ref_value = $form_state->getValue('git_ref');
     if ($git_ref_value && preg_match("/.+\\s\\(([^\\)]+)\\)/", $git_ref_value, $matches)) {
       $git_ref = $matches[1];
     }
 
-    $this->buildFrontend->triggerFrontendBuild($git_ref, $full_rebuild);
+    $this->buildFrontend->triggerFrontendBuild($git_ref);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
@@ -82,9 +82,9 @@ class BRD extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE): void {
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL): void {
     try {
-      $this->jenkinsClient->requestFrontendBuild($front_end_git_ref, $full_rebuild);
+      $this->jenkinsClient->requestFrontendBuild($front_end_git_ref);
       $jenkinsJobUrl = $this->settings->get('jenkins_build_job_url');
       $jenkinsJobHost = $this->settings->get('jenkins_build_job_host');
       $jenkinsJobPath = $this->settings->get('jenkins_build_job_path');

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -82,7 +82,6 @@ class BRDGHA extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-
   public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void {
     // We shouldn't request a GHA build on dev or staging because the GHA
     // workflow only supports a production deployment.

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRDGHA.php
@@ -82,7 +82,7 @@ class BRDGHA extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void {
     $front_end_git_ref = $front_end_git_ref ?? "master";
 
     try {

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Lando.php
@@ -64,7 +64,7 @@ class Lando extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void {
     /** @var \Drupal\advancedqueue\Entity\QueueInterface $queue */
     $queue = $this->queueLoader->load('command_runner');
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Tugboat.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/Tugboat.php
@@ -64,7 +64,7 @@ class Tugboat extends EnvironmentPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void {
     /** @var \Drupal\advancedqueue\Entity\QueueInterface $queue */
     $queue = $this->queueLoader->load('command_runner');
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontend.php
@@ -86,9 +86,9 @@ class BuildFrontend implements BuildFrontendInterface {
   /**
    * {@inheritdoc}
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void {
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void {
     try {
-      $this->environmentDiscovery->triggerFrontendBuild($front_end_git_ref, $full_rebuild);
+      $this->environmentDiscovery->triggerFrontendBuild($front_end_git_ref);
     }
     catch (PluginException $e) {
       // In an unaccounted for environment without a plugin.

--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontendInterface.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildFrontendInterface.php
@@ -14,10 +14,8 @@ interface BuildFrontendInterface {
    *
    * @param string $front_end_git_ref
    *   Front end git reference to build (branch name or PR number).
-   * @param bool $full_rebuild
-   *   Trigger a full front end rebuild.
    */
-  public function triggerFrontendBuild(string $front_end_git_ref = NULL, bool $full_rebuild = FALSE) : void;
+  public function triggerFrontendBuild(string $front_end_git_ref = NULL) : void;
 
   /**
    * Set the config state of build pending.

--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/JenkinsClient.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/JenkinsClient.php
@@ -116,7 +116,7 @@ class JenkinsClient implements JenkinsClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function requestFrontendBuild(string $frontendGitRef = NULL, bool $fullRebuild = FALSE): void {
+  public function requestFrontendBuild(string $frontendGitRef = NULL): void {
     $jenkinsJobUrl = $this->settings->get('jenkins_build_job_url');
     $githubUsername = $this->settings->get('va_cms_bot_github_username');
     $jenkinsJobHost = $this->settings->get('jenkins_build_job_host');

--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/JenkinsClientInterface.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/JenkinsClientInterface.php
@@ -12,11 +12,9 @@ interface JenkinsClientInterface {
    *
    * @param string $frontendGitRef
    *   The git ref of the frontend.
-   * @param bool $fullRebuild
-   *   Whether or not a full rebuild should be requested.
    *
    * @throws \Drupal\va_gov_build_trigger\Exception\JenkinsClientException
    */
-  public function requestFrontendBuild(string $frontendGitRef = NULL, bool $fullRebuild = FALSE): void;
+  public function requestFrontendBuild(string $frontendGitRef = NULL): void;
 
 }

--- a/tests/phpunit/FrontendBuild/BuildFrontendTest.php
+++ b/tests/phpunit/FrontendBuild/BuildFrontendTest.php
@@ -63,13 +63,13 @@ class BuildFrontendTest extends ExistingSiteBase {
     $webBuildStatusProphecy->enableWebBuildStatus()->shouldNotBeCalled();
     $userProphecy = $this->prophesize(AccountInterface::class);
     if ($permitted) {
-      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::any(), Argument::any())->shouldBeCalled();
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::any())->shouldBeCalled();
       $loggerProphecy->warning(Argument::any())->shouldNotBeCalled();
       $messengerProphecy->addWarning(Argument::any())->shouldNotBeCalled();
       $webBuildStatusProphecy->disableWebBuildStatus()->shouldNotBeCalled();
     }
     else {
-      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::any(), Argument::any())->willThrow(PluginException::class);
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::any())->willThrow(PluginException::class);
       $loggerProphecy->warning(Argument::type(TranslatableMarkup::class))->shouldBeCalled();
       $messengerProphecy->addWarning(Argument::type(TranslatableMarkup::class))->shouldBeCalled();
       $webBuildStatusProphecy->disableWebBuildStatus()->shouldBeCalled();
@@ -86,7 +86,7 @@ class BuildFrontendTest extends ExistingSiteBase {
     $environmentDiscovery = $environmentDiscoveryProphecy->reveal();
     $buildFrontend = new BuildFrontend($messenger, $loggerFactory, $webBuildStatus, $environmentDiscovery, $currentUser);
 
-    $buildFrontend->triggerFrontendBuild('no', FALSE);
+    $buildFrontend->triggerFrontendBuild('no');
   }
 
   /**
@@ -225,10 +225,10 @@ class BuildFrontendTest extends ExistingSiteBase {
 
     $environmentDiscoveryProphecy->shouldTriggerFrontendBuild()->willReturn(TRUE);
     if ($expected) {
-      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::exact(NULL), Argument::exact(FALSE))->shouldBeCalled();
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::exact(NULL))->shouldBeCalled();
     }
     else {
-      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::exact(NULL), Argument::exact(FALSE))->shouldNotBeCalled();
+      $environmentDiscoveryProphecy->triggerFrontendBuild(Argument::exact(NULL))->shouldNotBeCalled();
     }
 
     $nodeProphecy->isPublished()->willReturn($isPublished);


### PR DESCRIPTION
The `$full_rebuild` param is present in many of the methods in va_gov_build_trigger, but despite being passed through several layers of abstraction in some places, it's not actually used for anything. It appears to have been added in c6511ac431b39f7b63e15715617aa16a23a4c362 when there was a distinction between a full rebuild and a partial rebuild, but that distinction no longer exists.

## Description

Relates to #_issueid_. (or closes?)

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Sitewide program`
- [x] `Platform CMS Team`
- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS experience`
  - [ ] `⭐️ Public websites`
  - [ ] `⭐️ Facilities`
  - [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
