### PR TITLE
Run test tasks in parallel

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -180,7 +180,7 @@ services:
 
         # We only want tests running on PRs, not branches like the base preview build of master.
         # This sets the commit status checks to pending all at once.
-        - if [ "$TUGBOAT_PREVIEW_TYPE" = "pullrequest" ]; then bash -lc 'task --taskfile=tests.yml'; fi
+        - if [ "$TUGBOAT_PREVIEW_TYPE" = "pullrequest" ]; then bash -lc 'time task --taskfile=tests.yml'; fi
 
         # Set file permissions so web based build calls work.  This must run after all web builds are done in tests.
         - chown -R www-data:www-data "${DOCROOT}/vendor/va-gov/content-build"

--- a/tests.yml
+++ b/tests.yml
@@ -22,7 +22,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(time composer va:test:accessibility 2>&1 | tee \$output)"
+          result="\$(composer va:test:accessibility 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -48,7 +48,7 @@ tasks:
           mkfifo \$output
           (cat \$output&)
           cd tests/behat
-          result="\$(time behat --strict --colors 2>&1 | tee \$output)"
+          result="\$(behat --strict --colors 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -73,7 +73,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(time composer va:test:behavioral 2>&1 | tee \$output)"
+          result="\$(composer va:test:behavioral 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -98,7 +98,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="{{ .TASK }}:<br/><br/>\$(time ./tests/scripts/check-cer.sh 2>&1 | tee \$output)"
+          result="{{ .TASK }}:<br/><br/>\$(./tests/scripts/check-cer.sh 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -123,7 +123,7 @@ tasks:
           exit_code=0
           result="{{ .TASK }}<br/><br/>"
           trap '{ (( exit_code |=\$? )); result+="\$output_text<br/>"; }' ERR
-          output_text=\$(time find docroot/modules/custom docroot/themes -name '*.inc' -o -name '*.php' -o -name '*.module' -o -name '*.install' -print0 | xargs -0 -n1 php -l 2>&1)
+          output_text=\$(find docroot/modules/custom docroot/themes -name '*.inc' -o -name '*.php' -o -name '*.module' -o -name '*.install' -print0 | xargs -0 -n1 php -l 2>&1)
           trap - ERR
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -149,7 +149,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(time phpunit --exclude-group disabled tests/phpunit --colors=always 2>&1 | tee \$output)"
+          result="\$(phpunit --exclude-group disabled tests/phpunit --colors=always 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -174,7 +174,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(time ./tests/scripts/check-revision-logs.sh 2>&1 | tee \$output)"
+          result="\$(./tests/scripts/check-revision-logs.sh 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -199,7 +199,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          lines=\$(time drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
+          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
           line_count=\$(grep -c "\S" <<< \$lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$line_count" -eq 0 ]; then

--- a/tests.yml
+++ b/tests.yml
@@ -22,7 +22,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(composer va:test:accessibility 2>&1 | tee \$output)"
+          result="\$(time composer va:test:accessibility 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -48,7 +48,7 @@ tasks:
           mkfifo \$output
           (cat \$output&)
           cd tests/behat
-          result="\$(behat --strict --colors 2>&1 | tee \$output)"
+          result="\$(time behat --strict --colors 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -73,7 +73,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(composer va:test:behavioral 2>&1 | tee \$output)"
+          result="\$(time composer va:test:behavioral 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -98,7 +98,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="{{ .TASK }}:<br/><br/>\$(./tests/scripts/check-cer.sh 2>&1 | tee \$output)"
+          result="{{ .TASK }}:<br/><br/>\$(time ./tests/scripts/check-cer.sh 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -123,10 +123,7 @@ tasks:
           exit_code=0
           result="{{ .TASK }}<br/><br/>"
           trap '{ (( exit_code |=\$? )); result+="\$output_text<br/>"; }' ERR
-          output_text=\$(find docroot/modules/custom docroot/themes -name '*.inc' -print0 | xargs -0 -n1 php -l 2>&1)
-          output_text=\$(find docroot/modules/custom docroot/themes -name '*.php' -print0 | xargs -0 -n1 php -l 2>&1)
-          output_text=\$(find docroot/modules/custom docroot/themes -name '*.module' -print0 | xargs -0 -n1 php -l 2>&1)
-          output_text=\$(find docroot/modules/custom docroot/themes -name '*.install' -print0 | xargs -0 -n1 php -l 2>&1)
+          output_text=\$(time find docroot/modules/custom docroot/themes -name '*.inc' -o -name '*.php' -o -name '*.module' -o -name '*.install' -print0 | xargs -0 -n1 php -l 2>&1)
           trap - ERR
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -152,7 +149,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(phpunit --exclude-group disabled tests/phpunit --colors=always 2>&1 | tee \$output)"
+          result="\$(time phpunit --exclude-group disabled tests/phpunit --colors=always 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -177,7 +174,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(./tests/scripts/check-revision-logs.sh 2>&1 | tee \$output)"
+          result="\$(time ./tests/scripts/check-revision-logs.sh 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then
@@ -202,7 +199,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
+          lines=\$(time drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
           line_count=\$(grep -c "\S" <<< \$lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$line_count" -eq 0 ]; then

--- a/tests.yml
+++ b/tests.yml
@@ -5,6 +5,8 @@ version: '3'
 
 dotenv: ['.env']
 
+output: 'group'
+
 tasks:
 
   # Any changes to test names or additions or removals must be updated in set-all-tests-pending as well for the Pending status to work.
@@ -282,12 +284,12 @@ tasks:
 
   va/tests:
     desc:
-    cmds:
-      - task: va/tests/accessibility
-      - task: va/tests/behat
-      - task: va/tests/behavioral
-      - task: va/tests/check-cer
-      - task: va/tests/phplint
-      - task: va/tests/phpunit
-      - task: va/tests/revision-log
-      - task: va/tests/status-error
+    deps:
+      - va/tests/accessibility
+      - va/tests/behat
+      - va/tests/behavioral
+      - va/tests/check-cer
+      - va/tests/phplint
+      - va/tests/phpunit
+      - va/tests/revision-log
+      - va/tests/status-error

--- a/tests.yml
+++ b/tests.yml
@@ -222,7 +222,7 @@ tasks:
         fi
 
   set-all-tests-pending:
-    cmds:
+    deps:
 
       # Any changes to test names or additions or removals above must be updated here as well for the Pending status to work.
 


### PR DESCRIPTION
## Description

Relates to #4963.

Setting tasks as _dependencies_ rather than sub commands will run them in parallel. By default, the output will be interleaved which is a PITA. The `group` setting forces all of the output to be grouped for easy reading.

The downside here is that you won't get output for any individual task until the entire task is complete (so you wouldn't be able to e.g. watch the output to see how far along it is).

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Sitewide program`
- [x] `Platform CMS Team`
- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS experience`
  - [ ] `⭐️ Public websites`
  - [ ] `⭐️ Facilities`
  - [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
