### PR TITLE
[docs] VACMS-8585: Conslidate Content Ops and CMS experience into one label to reflect singular scrum team.

### DIFF
--- a/.github/ISSUE_TEMPLATE/cms-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/cms-bug-report.md
@@ -43,11 +43,9 @@ Add any other context about the problem here. Reach out to the Product Managers 
 ### CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide CMS Team ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/cms-devops.md
+++ b/.github/ISSUE_TEMPLATE/cms-devops.md
@@ -15,9 +15,8 @@ assignees: ''
 Please check the team(s) that will do this work.
 
 - [x] `Platform CMS Team`
-- [ ] `Sitewide crew `
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/cms-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/cms-enhancement.md
@@ -44,11 +44,9 @@ Editor-centered
 ### CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/cms-epic.md
+++ b/.github/ISSUE_TEMPLATE/cms-epic.md
@@ -86,11 +86,9 @@ Editor-centered
 ### CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/cms-section-request.md
+++ b/.github/ISSUE_TEMPLATE/cms-section-request.md
@@ -81,11 +81,9 @@ Examples:
 ### CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/cms-task.md
+++ b/.github/ISSUE_TEMPLATE/cms-task.md
@@ -19,11 +19,9 @@ assignees: ''
 ### CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/cms-ux-writing.md
+++ b/.github/ISSUE_TEMPLATE/cms-ux-writing.md
@@ -42,11 +42,9 @@ E.g. *As a user who may be making changes to content, I'd like a message that wa
 ### CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
@@ -93,11 +93,9 @@ If this facility has been removed from VAST in error, please notify our Support 
 ## CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [x] `⭐️ Facilities`
-  - [x] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [x] `⭐️ Facilities`
+- [x] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/runbook-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-name-change.md
@@ -53,11 +53,9 @@ assignees: ''
 ## CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [x] `⭐️ Facilities`
-  - [x] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [x] `⭐️ Facilities`
+- [x] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/runbook-facility-new.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-new.md
@@ -53,11 +53,9 @@ CMS Help desk
 ## CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [x] `⭐️ Facilities`
-  - [x] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [x] `⭐️ Facilities`
+- [x] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
@@ -36,11 +36,9 @@ Timing around these is critical and we may need more detail here.
 ## CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [x] `⭐️ Facilities`
-  - [x] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [x] `⭐️ Facilities`
+- [x] `⭐️ User support`

--- a/.github/ISSUE_TEMPLATE/tier-1-or-2-ongoing-work.md
+++ b/.github/ISSUE_TEMPLATE/tier-1-or-2-ongoing-work.md
@@ -24,11 +24,9 @@ Tier 2 expectations here: https://docs.google.com/document/d/15oe0wtGI_MdaScYpjJ
 ### CMS Team
 Please check the team(s) that will do this work.
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [x] `⭐️ Facilities`
-  - [x] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [x] `⭐️ Facilities`
+- [x] `⭐️ User support`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,14 +35,12 @@ As user _uid_ with _user_role_
 
 ### Select Team for PR review
 
-- [ ] `Sitewide program`
 - [ ] `Platform CMS Team`
-- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
-  - [ ] `⭐️ Content ops`
-  - [ ] `⭐️ CMS experience`
-  - [ ] `⭐️ Public websites`
-  - [ ] `⭐️ Facilities`
-  - [ ] `⭐️ User support`
+- [ ] `Sitewide program`
+- [ ] `⭐️ Sitewide CMS`
+- [ ] `⭐️ Public websites`
+- [ ] `⭐️ Facilities`
+- [ ] `⭐️ User support`
 
 
 ### Is this PR blocked by another PR?


### PR DESCRIPTION
## Description

Relates to #8585

## Testing done

None, this is just markdown for github templates.

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Sitewide program`
- [ ] `Platform CMS Team`
- [ ] `Sitewide crew ` (leave Sitewide unchecked and check the specific team instead)
  - [ ] `⭐️ Content ops`
  - [ ] `⭐️ CMS experience`
  - [ ] `⭐️ Public websites`
  - [ ] `⭐️ Facilities`
  - [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
