### PR TITLE
VACMS-0000: Skip certain tests on BRD.

### DIFF
--- a/tests/cypress/integration/behavioral/content_release.feature
+++ b/tests/cypress/integration/behavioral/content_release.feature
@@ -3,7 +3,7 @@ Feature: Content Release
   As anyone involved in the project
   I need the content release page to manage and reflect an orderly underlying release process
 
-  @ignore
+  @skip_on_brd
   Scenario: The content release page should normally display no in-process releases
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -11,7 +11,7 @@ Feature: Content Release
     Then I should see "No recent updates"
     Then I clear the web build queue
 
-  @ignore
+  @skip_on_brd
   Scenario: The content release page should show a pending default release initiated within the browser
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -19,7 +19,7 @@ Feature: Content Release
     Then I should see "Pending"
     Then I clear the web build queue
 
-  @ignore
+  @skip_on_brd
   Scenario: The content release page should show a pending chosen release initiated within the browser
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -27,7 +27,7 @@ Feature: Content Release
     And I should see "Pending"
     Then I clear the web build queue
 
-  @ignore
+  @skip_on_brd
   Scenario: The content release page should show a pending default release initiated from the command line
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -36,7 +36,7 @@ Feature: Content Release
     Then I should see "Pending"
     Then I clear the web build queue
 
-  @ignore
+  @skip_on_brd
   Scenario: The content release page should show a pending chosen release initiated from the command line
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue

--- a/tests/cypress/integration/behavioral/content_release.feature
+++ b/tests/cypress/integration/behavioral/content_release.feature
@@ -3,6 +3,7 @@ Feature: Content Release
   As anyone involved in the project
   I need the content release page to manage and reflect an orderly underlying release process
 
+  @ignore
   Scenario: The content release page should normally display no in-process releases
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -10,6 +11,7 @@ Feature: Content Release
     Then I should see "No recent updates"
     Then I clear the web build queue
 
+  @ignore
   Scenario: The content release page should show a pending default release initiated within the browser
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -17,6 +19,7 @@ Feature: Content Release
     Then I should see "Pending"
     Then I clear the web build queue
 
+  @ignore
   Scenario: The content release page should show a pending chosen release initiated within the browser
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -24,6 +27,7 @@ Feature: Content Release
     And I should see "Pending"
     Then I clear the web build queue
 
+  @ignore
   Scenario: The content release page should show a pending default release initiated from the command line
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue
@@ -32,6 +36,7 @@ Feature: Content Release
     Then I should see "Pending"
     Then I clear the web build queue
 
+  @ignore
   Scenario: The content release page should show a pending chosen release initiated from the command line
     Given I am logged in as a user with the "content_admin" role
     And I clear the web build queue


### PR DESCRIPTION
## Description
It didn't occur to me, but these tests are for lower environments only and won't pass on BRD because of the different content-release page.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
