### PR TITLE
VACMS-0000: Dumps status-error test to stdout.

### DIFF
--- a/tests.yml
+++ b/tests.yml
@@ -173,6 +173,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
+          drush $DRUSH_ALIAS core-requirements --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1
           lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
           line_count=\$(grep -c "\S" <<< \$lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
@@ -180,7 +181,7 @@ tasks:
               github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success: No Drupal status requirement errors were found.'
             else
               github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description="Failed: \${line_count} Drupal status requirements found."
-              [ "\${GITHUB_COMMENT_TYPE}" == "pr" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="{{ .TASK }}:<br /><br /><pre>\$(drush $DRUSH_ALIAS core-requirements --severity=2)</pre>"
+              [ "\${GITHUB_COMMENT_TYPE}" == "pr" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="{{ .TASK }}:<br /><br /><pre>\$(drush $DRUSH_ALIAS core-requirements --severity=2 --ignore='update_core,update_contrib,"update status"' 2>&1)</pre>"
             fi
           fi
           if [ "$RETURN_EXIT_CODE" -ne 0 ]; then

--- a/tests.yml
+++ b/tests.yml
@@ -173,15 +173,16 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          drush $DRUSH_ALIAS core-requirements --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1
-          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
+          ignore_arg=--ignore='update_core,update_contrib,"update status"'
+          table_output=\$(drush $DRUSH_ALIAS core-requirements \${ignore_arg} --severity=2 2>&1 | tee \$output)
+          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list \${ignore_arg} --severity=2 2>&1 | tee \$output)
           line_count=\$(grep -c "\S" <<< \$lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$line_count" -eq 0 ]; then
               github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success: No Drupal status requirement errors were found.'
             else
               github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description="Failed: \${line_count} Drupal status requirements found."
-              [ "\${GITHUB_COMMENT_TYPE}" == "pr" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="{{ .TASK }}:<br /><br /><pre>\$(drush $DRUSH_ALIAS core-requirements --severity=2 --ignore='update_core,update_contrib,"update status"' 2>&1)</pre>"
+              [ "\${GITHUB_COMMENT_TYPE}" == "pr" ] && github-commenter -delete-comment-regex="{{ .TASK }}" -comment="{{ .TASK }}:<br /><br /><pre>\${table_output}</pre>"
             fi
           fi
           if [ "$RETURN_EXIT_CODE" -ne 0 ]; then

--- a/tests.yml
+++ b/tests.yml
@@ -173,9 +173,8 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          ignore_arg=--ignore='update_core,update_contrib,"update status"'
-          table_output=\$(drush $DRUSH_ALIAS core-requirements \${ignore_arg} --severity=2 2>&1 | tee \$output)
-          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list \${ignore_arg} --severity=2 2>&1 | tee \$output)
+          table_output=\$(drush $DRUSH_ALIAS core-requirements --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
+          lines=\$(drush $DRUSH_ALIAS core-requirements --format=list --ignore='update_core,update_contrib,"update status"' --severity=2 2>&1 | tee \$output)
           line_count=\$(grep -c "\S" <<< \$lines)
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$line_count" -eq 0 ]; then


### PR DESCRIPTION
## Description

Currently, the output of `va/tests/status-error` isn't output in a human-readable way.  This fixes that, and also ensures that irrelevant output doesn't clutter the PR comment text (i.e. ignores the conditions for output that we already ignore within the test itself.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
