### PR TITLE
VACMS-7657: update script from 7662 to update text format to apply fo…

### DIFF
--- a/scripts/content/VACMS-7662-node-regional_health_care_service_des-force-limited-rich-text.php
+++ b/scripts/content/VACMS-7662-node-regional_health_care_service_des-force-limited-rich-text.php
@@ -62,13 +62,13 @@ function va_gov_force_save_limited_html_on_service_descriptions(array &$sandbox)
     // Make this change a new revision.
     /** @var \Drupal\node\NodeInterface $node */
     $node->setNewRevision(TRUE);
+    $filtered = check_markup($node->get('field_body')->value, 'rich_text_limited', '');
 
     // Update field_body with the new value.
     $node->field_body->setValue(
         [
-          'value' => $node->get('field_body')->value,
+          'value' => $filtered,
           'format' => 'rich_text_limited',
-          'allowed_formats' => ['rich_text_limited'],
         ]
       );
 
@@ -77,6 +77,7 @@ function va_gov_force_save_limited_html_on_service_descriptions(array &$sandbox)
     $node->setChangedTime(time());
     $node->setRevisionCreationTime(time());
     $node->setRevisionLogMessage('Saved to set body description to limited rich text.');
+    $node->setSyncing(TRUE);
     $node->save();
 
     unset($sandbox['nids_to_update']["node_{$node->id()}"]);


### PR DESCRIPTION
…rmat to database content

## Description

Closes #7657 

While testing the dry run for the Care we provide update #7657 I realized that the script originally created for this work in #7662 was not applying the text format changes to the data in the database. The format was being applied insofar as viewing the node or editing the node would no longer display any heading tags (h2, h3, h4, etc) However, the headings were still present in the data and weren't officially overwritten until an editor performed a manual save. 

By updating the script to use the check_markup function on the body field prior to node save the changes were saved to the database.

## Testing done

Visual testing - in a tugboat environment I directly modified the script and ran it again. After running with the changes the heading tags were no longer present when using the VAMC System Service Audit view: /admin/content/facilities/vamc-system-service-audit
### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
