### PR TITLE
Add every minute task

### DIFF
--- a/tasks-periodic.yml
+++ b/tasks-periodic.yml
@@ -50,6 +50,24 @@ tasks:
           exit \$exit_code;
         EOF
 
+  # Run with: ./bin/task --taskfile=tasks-periodic.yml every_minute
+  # http://jenkins.vfs.va.gov/job/cms/job/cms-every-minute
+  every_minute:
+    cmds:
+      - |
+        cat <<EOF | bash
+          exit_code=0
+          tasks=(
+            "va/noop"
+          )
+          trap '{ (( exit_code |=\$? )); }' ERR
+          for i in "\${tasks[@]}"; do
+            task --taskfile=./tasks-periodic.yml \$i
+          done
+          trap - ERR
+          exit \$exit_code;
+        EOF
+
   va/background/daily/migrate_copy/va_forms_csv_source:
     desc: This is because we cannot access the server on the SOCKS proxy right now.
     cmds:
@@ -111,3 +129,8 @@ tasks:
     desc: Run cron every 15 min as called by Jenkins.
     cmds:
       - drush $DRUSH_ALIAS core:cron
+
+  va/noop:
+    desc: Placeholder command
+    cmds:
+      - 'true'


### PR DESCRIPTION
## Description

Relates to #8108

Adds an every minute task (which will be called by https://github.com/department-of-veterans-affairs/devops/pull/10878). We need this so that we can run the content release queues. Ideally, we can remove this in the future in favor of https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8849 .

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
