### PR TITLE
VACMS-8942 fix button placement for content deploy form

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/css/build_trigger_form.css
+++ b/docroot/modules/custom/va_gov_build_trigger/css/build_trigger_form.css
@@ -35,3 +35,8 @@ fieldset.form-item {
 .form-item-cta.button--primary a {
   color: #fff;
 }
+
+/* ensures button to release content is on its own line */
+.va-gov-build-trigger-build-trigger-form .form-actions {
+  flex-direction: column;
+}


### PR DESCRIPTION
## Description
Closes #8942. Adds one line of css to the build_trigger module css to fix placement from inline after the checkbox field to underneath.

## Testing done
Verified that the form looked as expected locally and on prod (changed my local env type) with these updates. Slightly different forms get rendered per environment, the css functions the same for them all.

## Screenshots
prod:
<img width="1193" alt="Screen Shot 2022-05-04 at 2 31 21 PM" src="https://user-images.githubusercontent.com/11279744/166830086-b352fdbf-027a-4906-8b3a-029d246e5a10.png">

local:
<img width="1194" alt="Screen Shot 2022-05-04 at 2 38 42 PM" src="https://user-images.githubusercontent.com/11279744/166830092-4dd73ddd-64fb-4624-b46c-c3050c619f70.png">


## QA steps
Visit `/admin/content/deploy` and see that the form appears as expected. No functional changes to the form in this PR.

### Definition of Done
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`