### PR TITLE
VACMS-8518: Disable nested-interactive wcag2a rule.

### DIFF
--- a/tests/cypress/integration/accessibility/nodeCreationAccessibility.spec.js
+++ b/tests/cypress/integration/accessibility/nodeCreationAccessibility.spec.js
@@ -3,9 +3,9 @@ const routes = [
   '/node/add/landing_page',
   '/node/add/documentation_page',
   '/node/add/event',
-  // '/node/add/health_care_local_facility',
-  // '/node/add/health_care_region_detail_page',
-  // '/node/add/health_care_region_page',
+  '/node/add/health_care_local_facility',
+  '/node/add/health_care_region_detail_page',
+  '/node/add/health_care_region_page',
   '/node/add/office',
   '/node/add/outreach_asset',
   '/node/add/person_profile',
@@ -34,26 +34,23 @@ before(() => {
   })
 });
 
+const axeRuntimeOptions = {
+  runOnly: {
+    type: 'tag',
+    values: ['wcag2a', 'wcag2aa']
+  },
+  rules: {
+    'nested-interactive': { enabled: false },
+  },
+};
+
 describe('Component accessibility test', () => {
   routes.forEach((route) => {
-
     const testName = `${route} has no detectable accessibility violations on load.`;
-    it(testName, { retries: { runMode: 2 } }, () => {
+    it(testName, () => {
       cy.visit(route);
       cy.injectAxe();
-
-      const axeRuntimeOptions = {
-        runOnly: {
-          type: 'tag',
-          values: ['wcag2a', 'wcag2aa']
-        }
-      };
-
-      cy.get('body').each((element, index) => {
-        cy.checkA11y(null, axeRuntimeOptions, cy.terminalLog);
-        cy.task('log', 'Accessibility check completed successfully.');
-      });
-
+      cy.checkA11y('body', axeRuntimeOptions, cy.terminalLog);
     });
   });
 });


### PR DESCRIPTION
## Description

Relates to #8518.

`axe-core`'s test for the `nested-interactive` `wcag2a` rule, as dispatched by Cypress-Axe, behaves pathologically on some of our tested pages.  I have not yet determined why this is.  When I have, I'll open an issue in the appropriate place.

The pathological behavior in this case is that it seems not to resolve at all; perhaps there's an infinite loop or some other logical error, or a bug in the DOM traversal.  When this happens, Cypress does not seem to recognize that there is an issue, and will therefore sit and spin for eternity.  This does not seem to be the fault of Cypress-Axe, but possibly a quirk of how Axe's queue function is implemented, or how it interacts with Cypress's own command queue.

This PR disables the `nested-interactive` test and re-enables the tests disabled in #8873.  This is to restore accessibility testing for as much of the content as possible while disabling the specific rules that cause problems for developers.

I'll continue to investigate why this specific rule is causing so much trouble.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
