### PR TITLE
VACMS-8518: Exclude parent item menu from accessibility tests.

### DIFF
--- a/tests/cypress/integration/accessibility/nodeCreationAccessibility.spec.js
+++ b/tests/cypress/integration/accessibility/nodeCreationAccessibility.spec.js
@@ -20,6 +20,7 @@ const routes = [
 before(() => {
   // @TODO Use Cypress.env variables for user/pass.
   // @TODO Use a content admin role.
+  // Ensure there is no active user session.
   cy.drupalLogout();
   cy.drupalLogin('axcsd452ksey', 'drupal8');
 

--- a/tests/cypress/integration/accessibility/nodeCreationAccessibility.spec.js
+++ b/tests/cypress/integration/accessibility/nodeCreationAccessibility.spec.js
@@ -3,9 +3,9 @@ const routes = [
   '/node/add/landing_page',
   '/node/add/documentation_page',
   '/node/add/event',
-  // '/node/add/health_care_local_facility',
-  // '/node/add/health_care_region_detail_page',
-  // '/node/add/health_care_region_page',
+  '/node/add/health_care_local_facility',
+  '/node/add/health_care_region_detail_page',
+  '/node/add/health_care_region_page',
   '/node/add/office',
   '/node/add/outreach_asset',
   '/node/add/person_profile',
@@ -20,6 +20,7 @@ const routes = [
 before(() => {
   // @TODO Use Cypress.env variables for user/pass.
   // @TODO Use a content admin role.
+  cy.drupalLogout();
   cy.drupalLogin('axcsd452ksey', 'drupal8');
 
   // Preserve the Drupal session cookie to avoid having to login
@@ -34,26 +35,30 @@ before(() => {
   })
 });
 
+
+const axeContext = {
+  include: [['body']],
+  exclude: [
+    [
+      '#edit-menu-menu-parent', // 8700-item select elements apparently break accessibility tests
+    ],
+  ],
+};
+
+const axeRuntimeOptions = {
+  runOnly: {
+    type: 'tag',
+    values: ['wcag2a', 'wcag2aa']
+  }
+};
+
 describe('Component accessibility test', () => {
   routes.forEach((route) => {
-
     const testName = `${route} has no detectable accessibility violations on load.`;
     it(testName, { retries: { runMode: 2 } }, () => {
       cy.visit(route);
       cy.injectAxe();
-
-      const axeRuntimeOptions = {
-        runOnly: {
-          type: 'tag',
-          values: ['wcag2a', 'wcag2aa']
-        }
-      };
-
-      cy.get('body').each((element, index) => {
-        cy.checkA11y(null, axeRuntimeOptions, cy.terminalLog);
-        cy.task('log', 'Accessibility check completed successfully.');
-      });
-
+      cy.checkA11y(axeContext, axeRuntimeOptions, cy.terminalLog);
     });
   });
 });


### PR DESCRIPTION
## Description

Closes #8518.

Turns out that the accessibility tests choke on the 8700+-item menu parent select element.

<img width="326" alt="Screen Shot 2022-05-05 at 11 58 57 AM" src="https://user-images.githubusercontent.com/1318579/166964354-d5b13ace-9be1-4f15-91dc-95af95ff8d30.png">

This PR excludes this element from the accessibility tests.
