### PR TITLE
VACMS-8956: Add new covid status taxonomy.

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
@@ -1,0 +1,109 @@
+uuid: cfdb1b6d-39b3-4803-8ab6-febcc0c15a09
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.facility_supplemental_status.field_administration
+    - field.field.taxonomy_term.facility_supplemental_status.field_guidance
+    - field.field.taxonomy_term.facility_supplemental_status.field_status_id
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - allowed_formats
+    - dynamic_entity_reference
+    - field_group
+    - text
+third_party_settings:
+  field_group:
+    group_section_settings:
+      children:
+        - field_administration
+      label: 'Section settings'
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
+    group_description:
+      children:
+        - description
+      label: 'Description settings'
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Veteran facing text to use when this status appears.'
+        required_fields: true
+    group_title:
+      children:
+        - name
+      label: Title
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Visible title of the status ie: Covid-Red'
+        required_fields: true
+id: taxonomy_term.facility_supplemental_status.default
+targetEntityType: taxonomy_term
+bundle: facility_supplemental_status
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
+  field_administration:
+    type: dynamic_entity_reference_options_select
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_guidance:
+    type: text_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_status_id:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  path: true
+  status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
@@ -4,14 +4,16 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.facility_supplemental_status.field_administration
+    - field.field.taxonomy_term.facility_supplemental_status.field_enforce_unique_id
     - field.field.taxonomy_term.facility_supplemental_status.field_guidance
     - field.field.taxonomy_term.facility_supplemental_status.field_status_id
     - taxonomy.vocabulary.facility_supplemental_status
   module:
+    - allow_only_one
     - allowed_formats
-    - dynamic_entity_reference
     - field_group
     - text
+    - textfield_counter
 third_party_settings:
   field_group:
     group_section_settings:
@@ -20,7 +22,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -42,7 +44,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        description: 'Veteran facing text to use when this status appears.'
+        description: 'Veteran facing text to use when this supplemental status is selected.'
         required_fields: true
     group_title:
       children:
@@ -75,22 +77,37 @@ content:
         hide_help: '0'
         hide_guidelines: '0'
   field_administration:
-    type: dynamic_entity_reference_options_select
-    weight: 5
+    type: options_select
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_enforce_unique_id:
+    type: allow_only_one_widget
+    weight: 3
+    region: content
+    settings:
+      size: 1
+    third_party_settings: {  }
   field_guidance:
-    type: text_textfield
+    type: text_textarea_with_counter
     weight: 2
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
-    third_party_settings: {  }
+      maxlength: 255
+      counter_position: after
+      js_prevent_submit: false
+      count_html_characters: false
+      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
   field_status_id:
     type: string_textfield
-    weight: 3
+    weight: 4
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -175,13 +175,13 @@ content:
     weight: 7
     region: content
   field_related_office:
+    type: entity_reference_entity_view
     label: above
     settings:
       view_mode: connect_with_us
       link: false
     third_party_settings: {  }
     weight: 16
-    type: entity_reference_entity_view
     region: content
   field_spokes:
     type: entity_reference_revisions_entity_view

--- a/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.default.yml
@@ -4,11 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.facility_supplemental_status.field_administration
+    - field.field.taxonomy_term.facility_supplemental_status.field_enforce_unique_id
     - field.field.taxonomy_term.facility_supplemental_status.field_guidance
     - field.field.taxonomy_term.facility_supplemental_status.field_status_id
     - taxonomy.vocabulary.facility_supplemental_status
   module:
-    - dynamic_entity_reference
     - text
 id: taxonomy_term.facility_supplemental_status.default
 targetEntityType: taxonomy_term
@@ -21,14 +21,6 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
-    region: content
-  field_administration:
-    type: dynamic_entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 3
     region: content
   field_guidance:
     type: text_default
@@ -46,4 +38,6 @@ content:
     weight: 2
     region: content
 hidden:
+  field_administration: true
+  field_enforce_unique_id: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.default.yml
@@ -1,0 +1,49 @@
+uuid: d1b7413e-4887-4c2b-8199-b234518d07dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.facility_supplemental_status.field_administration
+    - field.field.taxonomy_term.facility_supplemental_status.field_guidance
+    - field.field.taxonomy_term.facility_supplemental_status.field_status_id
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - dynamic_entity_reference
+    - text
+id: taxonomy_term.facility_supplemental_status.default
+targetEntityType: taxonomy_term
+bundle: facility_supplemental_status
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_administration:
+    type: dynamic_entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_guidance:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_status_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_administration.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_administration.yml
@@ -1,4 +1,4 @@
-uuid: 71b18950-9a5f-46a0-b247-6b78e0bb1e8e
+uuid: 65f96e67-ef51-4a16-ac37-7425a43b9eea
 langcode: en
 status: true
 dependencies:
@@ -7,9 +7,13 @@ dependencies:
     - taxonomy.vocabulary.administration
     - taxonomy.vocabulary.facility_supplemental_status
   module:
-    - dynamic_entity_reference
+    - entity_reference_validators
     - epp
 third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: false
   epp:
     value: ''
     on_update: 0
@@ -24,224 +28,13 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  taxonomy_term:
-    handler: 'default:taxonomy_term'
-    handler_settings:
-      target_bundles:
-        administration: administration
-      sort:
-        field: name
-        direction: asc
-      auto_create: false
-      auto_create_bundle: ''
-  advancedqueue_queue:
-    handler: 'default:advancedqueue_queue'
-    handler_settings: {  }
-  block:
-    handler: 'default:block'
-    handler_settings: {  }
-  block_content:
-    handler: 'default:block_content'
-    handler_settings: {  }
-  block_content_type:
-    handler: 'default:block_content_type'
-    handler_settings: {  }
-  corresponding_reference:
-    handler: 'default:corresponding_reference'
-    handler_settings: {  }
-  config_split:
-    handler: 'default:config_split'
-    handler_settings: {  }
-  consumer:
-    handler: 'default:consumer'
-    handler_settings: {  }
-  content_moderation_state:
-    handler: 'default:content_moderation_state'
-    handler_settings: {  }
-  crop:
-    handler: 'default:crop'
-    handler_settings: {  }
-  crop_type:
-    handler: 'default:crop_type'
-    handler_settings: {  }
-  danse_notification_action:
-    handler: 'default:danse_notification_action'
-    handler_settings: {  }
-  danse_event:
-    handler: 'default:danse_event'
-    handler_settings: {  }
-  danse_notification:
-    handler: 'default:danse_notification'
-    handler_settings: {  }
-  editor:
-    handler: 'default:editor'
-    handler_settings: {  }
-  embed_button:
-    handler: 'default:embed_button'
-    handler_settings: {  }
-  entity_browser:
-    handler: 'default:entity_browser'
-    handler_settings: {  }
-  entity_subqueue:
-    handler: 'default:entity_subqueue'
-    handler_settings: {  }
-  entity_queue:
-    handler: 'default:entity_queue'
-    handler_settings: {  }
-  environment_indicator:
-    handler: 'default:environment_indicator'
-    handler_settings: {  }
-  field_config:
-    handler: 'default:field_config'
-    handler_settings: {  }
-  field_storage_config:
-    handler: 'default:field_storage_config'
-    handler_settings: {  }
-  file:
-    handler: 'default:file'
-    handler_settings: {  }
-  filter_format:
-    handler: 'default:filter_format'
-    handler_settings: {  }
-  flagging:
-    handler: 'default:flagging'
-    handler_settings: {  }
-  flag:
-    handler: 'default:flag'
-    handler_settings: {  }
-  graphql_query_map:
-    handler: 'default:graphql_query_map'
-    handler_settings: {  }
-  hm_display_profile:
-    handler: 'default:hm_display_profile'
-    handler_settings: {  }
-  image_style:
-    handler: 'default:image_style'
-    handler_settings: {  }
-  jsonapi_resource_config:
-    handler: 'default:jsonapi_resource_config'
-    handler_settings: {  }
-  linkit_profile:
-    handler: 'default:linkit_profile'
-    handler_settings: {  }
-  media_type:
-    handler: 'default:media_type'
-    handler_settings: {  }
-  media:
-    handler: 'default:media'
-    handler_settings: {  }
-  metatag_defaults:
-    handler: 'default:metatag_defaults'
-    handler_settings: {  }
-  migration:
-    handler: 'default:migration'
-    handler_settings: {  }
-  migration_group:
-    handler: 'default:migration_group'
-    handler_settings: {  }
-  node:
-    handler: 'default:node'
-    handler_settings: {  }
-  node_type:
-    handler: 'default:node_type'
-    handler_settings: {  }
-  paragraphs_browser_type:
-    handler: 'default:paragraphs_browser_type'
-    handler_settings: {  }
-  password_policy:
-    handler: 'default:password_policy'
-    handler_settings: {  }
-  path_alias:
-    handler: 'default:path_alias'
-    handler_settings: {  }
-  rdf_mapping:
-    handler: 'default:rdf_mapping'
-    handler_settings: {  }
-  redirect:
-    handler: 'default:redirect'
-    handler_settings: {  }
-  rest_resource_config:
-    handler: 'default:rest_resource_config'
-    handler_settings: {  }
-  search_api_task:
-    handler: 'default:search_api_task'
-    handler_settings: {  }
-  search_api_server:
-    handler: 'default:search_api_server'
-    handler_settings: {  }
-  search_api_index:
-    handler: 'default:search_api_index'
-    handler_settings: {  }
-  site_alert:
-    handler: 'default:site_alert'
-    handler_settings: {  }
-  smart_date_format:
-    handler: 'default:smart_date_format'
-    handler_settings: {  }
-  action:
-    handler: 'default:action'
-    handler_settings: {  }
-  menu:
-    handler: 'default:menu'
-    handler_settings: {  }
-  taxonomy_vocabulary:
-    handler: 'default:taxonomy_vocabulary'
-    handler_settings: {  }
-  taxonomy_menu:
-    handler: 'default:taxonomy_menu'
-    handler_settings: {  }
-  toolbar_menu_element:
-    handler: 'default:toolbar_menu_element'
-    handler_settings: {  }
-  user_role:
-    handler: 'default:user_role'
-    handler_settings: {  }
-  user:
-    handler: 'default:user'
-    handler_settings: {  }
-  user_history:
-    handler: 'default:user_history'
-    handler_settings: {  }
-  access_scheme:
-    handler: 'default:access_scheme'
-    handler_settings: {  }
-  section_association:
-    handler: 'default:section_association'
-    handler_settings: {  }
-  workflow:
-    handler: 'default:workflow'
-    handler_settings: {  }
-  menu_link_content:
-    handler: 'default:menu_link_content'
-    handler_settings: {  }
-  pathauto_pattern:
-    handler: 'default:pathauto_pattern'
-    handler_settings: {  }
-  view:
-    handler: 'default:view'
-    handler_settings: {  }
-  paragraphs_type:
-    handler: 'default:paragraphs_type'
-    handler_settings: {  }
-  paragraph:
-    handler: 'default:paragraph'
-    handler_settings: {  }
-  base_field_override:
-    handler: 'default:base_field_override'
-    handler_settings: {  }
-  date_format:
-    handler: 'default:date_format'
-    handler_settings: {  }
-  entity_form_mode:
-    handler: 'default:entity_form_mode'
-    handler_settings: {  }
-  entity_view_mode:
-    handler: 'default:entity_view_mode'
-    handler_settings: {  }
-  entity_form_display:
-    handler: 'default:entity_form_display'
-    handler_settings: {  }
-  entity_view_display:
-    handler: 'default:entity_view_display'
-    handler_settings: {  }
-field_type: dynamic_entity_reference
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_administration.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_administration.yml
@@ -1,0 +1,247 @@
+uuid: 71b18950-9a5f-46a0-b247-6b78e0bb1e8e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_administration
+    - taxonomy.vocabulary.administration
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - dynamic_entity_reference
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.facility_supplemental_status.field_administration
+field_name: field_administration
+entity_type: taxonomy_term
+bundle: facility_supplemental_status
+label: Section
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings:
+      target_bundles:
+        administration: administration
+      sort:
+        field: name
+        direction: asc
+      auto_create: false
+      auto_create_bundle: ''
+  advancedqueue_queue:
+    handler: 'default:advancedqueue_queue'
+    handler_settings: {  }
+  block:
+    handler: 'default:block'
+    handler_settings: {  }
+  block_content:
+    handler: 'default:block_content'
+    handler_settings: {  }
+  block_content_type:
+    handler: 'default:block_content_type'
+    handler_settings: {  }
+  corresponding_reference:
+    handler: 'default:corresponding_reference'
+    handler_settings: {  }
+  config_split:
+    handler: 'default:config_split'
+    handler_settings: {  }
+  consumer:
+    handler: 'default:consumer'
+    handler_settings: {  }
+  content_moderation_state:
+    handler: 'default:content_moderation_state'
+    handler_settings: {  }
+  crop:
+    handler: 'default:crop'
+    handler_settings: {  }
+  crop_type:
+    handler: 'default:crop_type'
+    handler_settings: {  }
+  danse_notification_action:
+    handler: 'default:danse_notification_action'
+    handler_settings: {  }
+  danse_event:
+    handler: 'default:danse_event'
+    handler_settings: {  }
+  danse_notification:
+    handler: 'default:danse_notification'
+    handler_settings: {  }
+  editor:
+    handler: 'default:editor'
+    handler_settings: {  }
+  embed_button:
+    handler: 'default:embed_button'
+    handler_settings: {  }
+  entity_browser:
+    handler: 'default:entity_browser'
+    handler_settings: {  }
+  entity_subqueue:
+    handler: 'default:entity_subqueue'
+    handler_settings: {  }
+  entity_queue:
+    handler: 'default:entity_queue'
+    handler_settings: {  }
+  environment_indicator:
+    handler: 'default:environment_indicator'
+    handler_settings: {  }
+  field_config:
+    handler: 'default:field_config'
+    handler_settings: {  }
+  field_storage_config:
+    handler: 'default:field_storage_config'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  filter_format:
+    handler: 'default:filter_format'
+    handler_settings: {  }
+  flagging:
+    handler: 'default:flagging'
+    handler_settings: {  }
+  flag:
+    handler: 'default:flag'
+    handler_settings: {  }
+  graphql_query_map:
+    handler: 'default:graphql_query_map'
+    handler_settings: {  }
+  hm_display_profile:
+    handler: 'default:hm_display_profile'
+    handler_settings: {  }
+  image_style:
+    handler: 'default:image_style'
+    handler_settings: {  }
+  jsonapi_resource_config:
+    handler: 'default:jsonapi_resource_config'
+    handler_settings: {  }
+  linkit_profile:
+    handler: 'default:linkit_profile'
+    handler_settings: {  }
+  media_type:
+    handler: 'default:media_type'
+    handler_settings: {  }
+  media:
+    handler: 'default:media'
+    handler_settings: {  }
+  metatag_defaults:
+    handler: 'default:metatag_defaults'
+    handler_settings: {  }
+  migration:
+    handler: 'default:migration'
+    handler_settings: {  }
+  migration_group:
+    handler: 'default:migration_group'
+    handler_settings: {  }
+  node:
+    handler: 'default:node'
+    handler_settings: {  }
+  node_type:
+    handler: 'default:node_type'
+    handler_settings: {  }
+  paragraphs_browser_type:
+    handler: 'default:paragraphs_browser_type'
+    handler_settings: {  }
+  password_policy:
+    handler: 'default:password_policy'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+  rdf_mapping:
+    handler: 'default:rdf_mapping'
+    handler_settings: {  }
+  redirect:
+    handler: 'default:redirect'
+    handler_settings: {  }
+  rest_resource_config:
+    handler: 'default:rest_resource_config'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  search_api_server:
+    handler: 'default:search_api_server'
+    handler_settings: {  }
+  search_api_index:
+    handler: 'default:search_api_index'
+    handler_settings: {  }
+  site_alert:
+    handler: 'default:site_alert'
+    handler_settings: {  }
+  smart_date_format:
+    handler: 'default:smart_date_format'
+    handler_settings: {  }
+  action:
+    handler: 'default:action'
+    handler_settings: {  }
+  menu:
+    handler: 'default:menu'
+    handler_settings: {  }
+  taxonomy_vocabulary:
+    handler: 'default:taxonomy_vocabulary'
+    handler_settings: {  }
+  taxonomy_menu:
+    handler: 'default:taxonomy_menu'
+    handler_settings: {  }
+  toolbar_menu_element:
+    handler: 'default:toolbar_menu_element'
+    handler_settings: {  }
+  user_role:
+    handler: 'default:user_role'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+  user_history:
+    handler: 'default:user_history'
+    handler_settings: {  }
+  access_scheme:
+    handler: 'default:access_scheme'
+    handler_settings: {  }
+  section_association:
+    handler: 'default:section_association'
+    handler_settings: {  }
+  workflow:
+    handler: 'default:workflow'
+    handler_settings: {  }
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  pathauto_pattern:
+    handler: 'default:pathauto_pattern'
+    handler_settings: {  }
+  view:
+    handler: 'default:view'
+    handler_settings: {  }
+  paragraphs_type:
+    handler: 'default:paragraphs_type'
+    handler_settings: {  }
+  paragraph:
+    handler: 'default:paragraph'
+    handler_settings: {  }
+  base_field_override:
+    handler: 'default:base_field_override'
+    handler_settings: {  }
+  date_format:
+    handler: 'default:date_format'
+    handler_settings: {  }
+  entity_form_mode:
+    handler: 'default:entity_form_mode'
+    handler_settings: {  }
+  entity_view_mode:
+    handler: 'default:entity_view_mode'
+    handler_settings: {  }
+  entity_form_display:
+    handler: 'default:entity_form_display'
+    handler_settings: {  }
+  entity_view_display:
+    handler: 'default:entity_view_display'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_enforce_unique_id.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_enforce_unique_id.yml
@@ -1,0 +1,34 @@
+uuid: e1c51a28-6ae4-422b-b70d-9856d61d26c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_enforce_unique_id
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - allow_only_one
+    - epp
+third_party_settings:
+  allow_only_one:
+    field_administration: 0
+    field_guidance: 0
+    field_status_id: 1
+    title: 0
+    case_sensitive: '0'
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.facility_supplemental_status.field_enforce_unique_id
+field_name: field_enforce_unique_id
+entity_type: taxonomy_term
+bundle: facility_supplemental_status
+label: 'Enforce Unique Id'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_guidance.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_guidance.yml
@@ -1,4 +1,4 @@
-uuid: 7260772a-0ac3-4374-bf77-36c7cc31a258
+uuid: e5e50377-77d6-4e09-9f7b-e0b7fd2ea215
 langcode: en
 status: true
 dependencies:
@@ -20,11 +20,11 @@ id: taxonomy_term.facility_supplemental_status.field_guidance
 field_name: field_guidance
 entity_type: taxonomy_term
 bundle: facility_supplemental_status
-label: 'Editor facing guidance on when to use this status.'
-description: ''
+label: Guidance
+description: 'Editor facing guidance on when to use this status.'
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: text
+field_type: text_long

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_guidance.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_guidance.yml
@@ -1,0 +1,30 @@
+uuid: 7260772a-0ac3-4374-bf77-36c7cc31a258
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_guidance
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - allowed_formats
+    - epp
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - rich_text_limited
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.facility_supplemental_status.field_guidance
+field_name: field_guidance
+entity_type: taxonomy_term
+bundle: facility_supplemental_status
+label: 'Editor facing guidance on when to use this status.'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_status_id.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_status_id.yml
@@ -15,9 +15,9 @@ id: taxonomy_term.facility_supplemental_status.field_status_id
 field_name: field_status_id
 entity_type: taxonomy_term
 bundle: facility_supplemental_status
-label: 'Identifier for this status that will never change. ie. covid_red'
-description: ''
-required: false
+label: 'Status ID'
+description: 'Identifier for this status that will never change. ie. covid_red'
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_status_id.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_status_id.yml
@@ -1,0 +1,25 @@
+uuid: db8b5b2b-2ece-479d-889c-e65d76429998
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_status_id
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.facility_supplemental_status.field_status_id
+field_name: field_status_id
+entity_type: taxonomy_term
+bundle: facility_supplemental_status
+label: 'Identifier for this status that will never change. ie. covid_red'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.taxonomy_term.field_administration.yml
+++ b/config/sync/field.storage.taxonomy_term.field_administration.yml
@@ -1,0 +1,22 @@
+uuid: 67cdcc9f-ad58-4567-904d-6fbdf51ad0bf
+langcode: en
+status: true
+dependencies:
+  module:
+    - dynamic_entity_reference
+    - taxonomy
+id: taxonomy_term.field_administration
+field_name: field_administration
+entity_type: taxonomy_term
+type: dynamic_entity_reference
+settings:
+  exclude_entity_types: false
+  entity_type_ids:
+    taxonomy_term: taxonomy_term
+module: dynamic_entity_reference
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_enforce_unique_id.yml
+++ b/config/sync/field.storage.taxonomy_term.field_enforce_unique_id.yml
@@ -1,16 +1,16 @@
-uuid: a242f12f-09d0-4a95-9230-677e6cc55af9
+uuid: a9e5b47a-633b-459a-b73b-8c54377653cd
 langcode: en
 status: true
 dependencies:
   module:
+    - allow_only_one
     - taxonomy
-id: taxonomy_term.field_administration
-field_name: field_administration
+id: taxonomy_term.field_enforce_unique_id
+field_name: field_enforce_unique_id
 entity_type: taxonomy_term
-type: entity_reference
-settings:
-  target_type: taxonomy_term
-module: core
+type: allow_only_one
+settings: {  }
+module: allow_only_one
 locked: false
 cardinality: 1
 translatable: true

--- a/config/sync/field.storage.taxonomy_term.field_guidance.yml
+++ b/config/sync/field.storage.taxonomy_term.field_guidance.yml
@@ -1,4 +1,4 @@
-uuid: ae082e8b-f538-40bd-879f-0027b0586b85
+uuid: 9a4b373e-dba9-431d-af8d-77b31d730c8b
 langcode: en
 status: true
 dependencies:
@@ -8,9 +8,8 @@ dependencies:
 id: taxonomy_term.field_guidance
 field_name: field_guidance
 entity_type: taxonomy_term
-type: text
-settings:
-  max_length: 255
+type: text_long
+settings: {  }
 module: text
 locked: false
 cardinality: 1

--- a/config/sync/field.storage.taxonomy_term.field_guidance.yml
+++ b/config/sync/field.storage.taxonomy_term.field_guidance.yml
@@ -1,0 +1,20 @@
+uuid: ae082e8b-f538-40bd-879f-0027b0586b85
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - text
+id: taxonomy_term.field_guidance
+field_name: field_guidance
+entity_type: taxonomy_term
+type: text
+settings:
+  max_length: 255
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_status_id.yml
+++ b/config/sync/field.storage.taxonomy_term.field_status_id.yml
@@ -1,0 +1,21 @@
+uuid: ce6a8870-e02d-4e58-8b29-7cc47e7ed8d4
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_status_id
+field_name: field_status_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -11,9 +11,11 @@ domains_to_skip: |-
   dartfirststate.com
   databus.org
   deldot.gov
+  etssponsorship.com
   ez-rider.org
   federalregister.gov
   hamptoninn3.hilton.com
+  help.id.me
   hiltongardeninn3.hilton.com
   imablefoundation.org
   loyola.donorscreen.org
@@ -21,6 +23,7 @@ domains_to_skip: |-
   milvets.nc.gov
   music4veterans.org
   patriots-path.org
+  provisions4patriots.com
   ridelats.com
   teampossabilities.org
   tinyurl.com
@@ -28,6 +31,7 @@ domains_to_skip: |-
   uvbh.org
   vaww.va.gov
   veteranscornerok.org
+  veteransofchathamcountyga.org
   visitutah.com
   webex.com
   woundedwarriorsmammoth.org
@@ -36,6 +40,7 @@ domains_to_skip: |-
   www.bmcc.cuny.edu
   www.choicehotels.com
   www.dartfirststate.com
+  www.etssponsorship.com
   www.ez-rider.org
   www.federalregister.gov
   www.hilton.com
@@ -47,6 +52,7 @@ domains_to_skip: |-
   www.milvets.nc.gov
   www.music4veterans.org
   www.portauthority.org
+  www.provisions4patriots.com
   www.qualityinn.com
   www.redroof.com
   www.ridelats.com

--- a/config/sync/taxonomy.vocabulary.facility_supplemental_status.yml
+++ b/config/sync/taxonomy.vocabulary.facility_supplemental_status.yml
@@ -1,0 +1,8 @@
+uuid: b29221fd-60b5-4826-ac55-e96977099a6d
+langcode: en
+status: true
+dependencies: {  }
+name: 'Facility Supplemental Status'
+vid: facility_supplemental_status
+description: 'Supplemental statuses to be used with facilities.'
+weight: 0

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -111,8 +111,8 @@ Feature: Content model bundles
 | Sections | administration | Vocabulary | Represents a hierarchy of the VA, partly for governance purposes. |
 | Audience - Beneficiaries | audience_beneficiaries | Vocabulary |  |
 | Audience - Non-beneficiaries | audience_non_beneficiaries | Vocabulary |  |
-| VA Services | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |
 | Facility Supplemental Status | facility_supplemental_status | Vocabulary | Supplemental statuses to be used with facilities. |
+| VA Services | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |
 | Resources and support Categories | lc_categories | Vocabulary |  |
 | Products | products | Vocabulary |  |
 | Topics | topics | Vocabulary |  |

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -112,6 +112,7 @@ Feature: Content model bundles
 | Audience - Beneficiaries | audience_beneficiaries | Vocabulary |  |
 | Audience - Non-beneficiaries | audience_non_beneficiaries | Vocabulary |  |
 | VA Services | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |
+| Facility Supplemental Status | facility_supplemental_status | Vocabulary | Supplemental statuses to be used with facilities. |
 | Resources and support Categories | lc_categories | Vocabulary |  |
 | Products | products | Vocabulary |  |
 | Topics | topics | Vocabulary |  |

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -10,6 +10,10 @@ Feature: Content model: Vocabulary fields
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Vocabulary | Audience - Beneficiaries | Promoted to Resources and Support Homepage | field_audience_rs_homepage | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | Audience - Non-beneficiaries | Promoted to Resources and Support Homepage | field_audience_rs_homepage | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Vocabulary | Facility Supplemental Status | Section | field_administration | Entity reference | Required | 1 | Select list |  |
+| Vocabulary | Facility Supplemental Status | Enforce Unique Id | field_enforce_unique_id | Allow Only One |  | 1 | Allow Only One widget |  |
+| Vocabulary | Facility Supplemental Status | Guidance | field_guidance | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
+| Vocabulary | Facility Supplemental Status | Status ID | field_status_id | Text (plain) | Required | 1 | Textfield |  |
 | Vocabulary | Products | Knowledge base landing page | field_kb_landing_page | Entity reference |  | 1 | Autocomplete |  |
 | Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | Sections | Product | field_product | Entity reference |  | 1 | Select list |  |
@@ -25,6 +29,3 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Service description | field_vet_center_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VA Services | Type of Care | field_vet_center_type_of_care | List (text) |  | 1 | Select list |  |
 | Vocabulary | VA Services | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |
-| Vocabulary | Facility Supplemental Status | Identifier for this status that will never change. ie. covid_red | field_status_id | Text (plain) | | 1 | Textfield |  |
-| Vocabulary | Facility Supplemental Status | Section | field_administration | Dynamic entity reference | Required | 1 | Select list |  |
-| Vocabulary | Facility Supplemental Status | Editor facing guidance on when to use this status. | field_guidance | Text (formatted) |  | 1 | Text field |  |

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -25,3 +25,6 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Service description | field_vet_center_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VA Services | Type of Care | field_vet_center_type_of_care | List (text) |  | 1 | Select list |  |
 | Vocabulary | VA Services | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |
+| Vocabulary | Facility Supplemental Status | Identifier for this status that will never change. ie. covid_red | field_status_id | Text (plain) | | 1 | Textfield |  |
+| Vocabulary | Facility Supplemental Status | Section | field_administration | Dynamic entity reference | Required | 1 | Select list |  |
+| Vocabulary | Facility Supplemental Status | Editor facing guidance on when to use this status. | field_guidance | Text (formatted) |  | 1 | Text field |  |


### PR DESCRIPTION
## Description
closes #8956

## Testing done
Visual / behat

## Screenshots
Vocabulary listing view
![image](https://user-images.githubusercontent.com/2404547/166986221-bd819846-cfd7-42c0-a183-97194eefa844.png)

Form view
![image](https://user-images.githubusercontent.com/2404547/166987596-259bceba-cea5-49bd-b342-d8a53645c7a5.png)

Node view
![image](https://user-images.githubusercontent.com/2404547/166987694-c158dc88-efc8-4937-996b-8c8cd6c60551.png)

## QA steps
 - [x] As an administrator, go to `/admin/people/pfm-permissions` and select Taxonomy from modules, and all roles. Search page for `Facility Supplemental ` and visually verify only administrator can perform any operations (matches health_care_service_taxonomy perm scheme)
 - [x] As an administrator, go to https://pr8963-5dpcxs15ghurgq2tqdxjf19lclvte3h7.ci.cms.va.gov/admin/structure/taxonomy/manage/facility_supplemental_status/add and add a term
 - [x] Visually verify form matches screenshot, above
 - [x] Fill in all fields, and visually verify node view experience is in line with screenshot, above
 -  Go to https://pr8963-5dpcxs15ghurgq2tqdxjf19lclvte3h7.ci.cms.va.gov/admin/structure/taxonomy/manage/facility_supplemental_status/add

 and add a new term but use the same status ID you used in the first term. 
- [x] Validate that a validation error warns of a repeated id and prevents save
 ![image](https://user-images.githubusercontent.com/5752113/167233410-957803c9-a6c4-462d-8d49-ca3bdc7b6e3b.png)