### PR TITLE
VACMS-8949: Add covid status er select field.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
     - workflows.workflow.editorial
   module:
@@ -42,7 +43,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 8
+      weight: 10
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -58,7 +59,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 11
       format_type: fieldset
       format_settings:
         classes: ''
@@ -71,7 +72,7 @@ third_party_settings:
       label: '"Prepare for your visit"'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: details
       format_settings:
         classes: ''
@@ -86,7 +87,7 @@ third_party_settings:
       label: 'VAMC system'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -100,7 +101,7 @@ third_party_settings:
       label: 'Title and summary'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -112,7 +113,7 @@ third_party_settings:
       label: 'Social Media'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         classes: ''
@@ -126,12 +127,13 @@ third_party_settings:
       label: 'Operating status'
       region: content
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
-        description: 'Use this to communicate critical information about potential closures or other situations on the facility''s location page and on the operating status page.'
+        description: 'Use this for all other kinds of situations that might impact your facility''s operations. Information you edit here will show up on the facility''s location page as well as on the Operating Status page.'
         required_fields: true
     group_meta_tags:
       children:
@@ -139,7 +141,7 @@ third_party_settings:
       label: 'Meta Tags'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -186,6 +188,20 @@ third_party_settings:
         element: div
         label_element: h3
         attributes: ''
+    group_covid_19_safety_guidelines:
+      children:
+        - field_supplemental_status
+      label: 'COVID-19 safety guidelines'
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Help Veterans understand COVID-19 protocols at this facility. This will show up on the facility''s location page as well as on the Operating Status page.'
+        required_fields: false
 id: node.health_care_local_facility.default
 targetEntityType: node
 bundle: health_care_local_facility
@@ -205,7 +221,7 @@ content:
     third_party_settings: {  }
   field_description:
     type: string_textfield_with_counter
-    weight: 3
+    weight: 10
     region: content
     settings:
       size: 120
@@ -322,6 +338,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_supplemental_status:
+    type: options_select
+    weight: 21
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   flag:
     weight: 12
     region: content
@@ -335,7 +357,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
   module:
     - field_group
@@ -151,6 +152,7 @@ hidden:
   field_office_hours: true
   field_phone_number: true
   field_region_page: true
+  field_supplemental_status: true
   flag: true
   moderation_state: true
   path: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - image.style.crop_3_2
     - node.type.health_care_local_facility
   module:
@@ -54,7 +55,7 @@ third_party_settings:
       label: 'Operating status'
       parent_name: ''
       region: content
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -65,7 +66,7 @@ third_party_settings:
       label: 'Social media'
       parent_name: ''
       region: content
-      weight: 6
+      weight: 7
       format_type: details
       format_settings:
         classes: ''
@@ -79,7 +80,7 @@ third_party_settings:
       label: 'Prepare for your visit'
       parent_name: ''
       region: content
-      weight: 5
+      weight: 6
       format_type: details
       format_settings:
         classes: ''
@@ -92,7 +93,7 @@ third_party_settings:
       label: 'Locations and contact information'
       parent_name: ''
       region: content
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -124,6 +125,19 @@ third_party_settings:
         tooltip_description: "Why can’t I edit this?\r\nThis content is automatically populated from centralized databases, and helps maintain consistent information across all of VA.gov."
         open: false
         required_fields: false
+    group_covid_19_safety_guidelines:
+      children:
+        - field_supplemental_status
+      label: 'COVID-19 safety guidelines'
+      parent_name: ''
+      region: content
+      weight: 3
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Help Veterans understand COVID-19 protocols at this facility. This will show up on the facility''s location page as well as on the Operating Status page.'
 id: node.health_care_local_facility.default
 targetEntityType: node
 bundle: health_care_local_facility
@@ -166,7 +180,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 8
+    weight: 9
     region: content
   field_media:
     type: media_thumbnail
@@ -183,7 +197,7 @@ content:
     settings:
       title: ''
     third_party_settings: {  }
-    weight: 19
+    weight: 20
     region: content
   field_mobile:
     type: boolean
@@ -193,7 +207,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 18
+    weight: 19
     region: content
   field_office_hours:
     type: office_hours
@@ -220,21 +234,21 @@ content:
       schema:
         enabled: false
     third_party_settings: {  }
-    weight: 20
+    weight: 21
     region: content
   field_operating_status_facility:
     type: list_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 19
     region: content
   field_operating_status_more_info:
     type: basic_string
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 20
     region: content
   field_phone_number:
     type: telephone_link
@@ -243,6 +257,14 @@ content:
       title: ''
     third_party_settings: {  }
     weight: 17
+    region: content
+  field_supplemental_status:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 18
     region: content
 hidden:
   content_moderation_control: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
   module:
     - address
@@ -256,6 +257,7 @@ hidden:
   field_operating_status_facility: true
   field_operating_status_more_info: true
   field_region_page: true
+  field_supplemental_status: true
   flag_changed_name: true
   flag_changed_title: true
   flag_new: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - image.style.thumbnail
     - node.type.health_care_local_facility
   module:
@@ -109,6 +110,7 @@ hidden:
   field_office_hours: true
   field_phone_number: true
   field_region_page: true
+  field_supplemental_status: true
   flag_changed_name: true
   flag_changed_title: true
   flag_new: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
   module:
     - user
@@ -31,6 +32,21 @@ targetEntityType: node
 bundle: health_care_local_facility
 mode: teaser
 content:
+  flag_changed_name:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  flag_new:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  flag_removed_from_source:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -57,4 +73,5 @@ hidden:
   field_operating_status_more_info: true
   field_phone_number: true
   field_region_page: true
+  field_supplemental_status: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.health_care_local_facility.field_operating_status_facility.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_operating_status_facility.yml
@@ -6,13 +6,18 @@ dependencies:
     - field.storage.node.field_operating_status_facility
     - node.type.health_care_local_facility
   module:
+    - epp
     - options
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: node.health_care_local_facility.field_operating_status_facility
 field_name: field_operating_status_facility
 entity_type: node
 bundle: health_care_local_facility
 label: Status
-description: 'Use "Limited hours and services" if in-facility services are closed but Veterans can still get telehealth appointments, and make a note in the details.'
+description: 'Use this status for non-Covid-19 related situations, such as weather events.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.node.health_care_local_facility.field_operating_status_more_info.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_operating_status_more_info.yml
@@ -5,12 +5,18 @@ dependencies:
   config:
     - field.storage.node.field_operating_status_more_info
     - node.type.health_care_local_facility
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: node.health_care_local_facility.field_operating_status_more_info
 field_name: field_operating_status_more_info
 entity_type: node
 bundle: health_care_local_facility
 label: Details
-description: 'Add further details about how the status will impact visitors to the facility.'
+description: 'Add further details about how the status will impact visitors to the facility. Don''t include any information about masks, screening, or visitor policies due to Covid-19. This will be communicated to the visitors through the Covid-19 status.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
@@ -1,0 +1,36 @@
+uuid: 8974f0fa-0818-4459-a769-8800e1b76aeb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_supplemental_status
+    - node.type.health_care_local_facility
+  module:
+    - entity_reference_validators
+    - epp
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: true
+  epp:
+    value: ''
+    on_update: 0
+id: node.health_care_local_facility.field_supplemental_status
+field_name: field_supplemental_status
+entity_type: node
+bundle: health_care_local_facility
+label: 'COVID-19 status'
+description: 'Select the status that most closely matches your facility''s protocols. <a href="/">Learn more about COVID statuses.</a>'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: views
+  handler_settings:
+    view:
+      view_name: health_care_service_names_and_descriptions
+      display_name: facility_supplemental_status
+      arguments: {  }
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_supplemental_status.yml
+++ b/config/sync/field.storage.node.field_supplemental_status.yml
@@ -1,0 +1,20 @@
+uuid: 06db6a2f-af56-4574-9547-8942bb5449dd
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_supplemental_status
+field_name: field_supplemental_status
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.health_care_service_names_and_descriptions.yml
+++ b/config/sync/views.view.health_care_service_names_and_descriptions.yml
@@ -4,13 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.taxonomy_term.field_also_known_as
+    - field.storage.taxonomy_term.field_guidance
     - field.storage.taxonomy_term.field_service_type_of_care
     - field.storage.taxonomy_term.field_vet_center_type_of_care
+    - taxonomy.vocabulary.facility_supplemental_status
     - taxonomy.vocabulary.health_care_service_taxonomy
   module:
     - entity_reference_revisions
     - options
     - taxonomy
+    - text
     - user
 id: health_care_service_names_and_descriptions
 label: 'Health care service names and descriptions'
@@ -879,3 +882,219 @@ display:
         - 'languages:language_interface'
         - user.permissions
       tags: {  }
+  facility_supplemental_status:
+    id: facility_supplemental_status
+    display_title: 'Facility Supplemental Status - entity reference'
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      fields:
+        field_guidance:
+          id: field_guidance
+          table: taxonomy_term__field_guidance
+          field: field_guidance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ name }} - {{ field_guidance }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 0
+      filters:
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+          operator: in
+          value:
+            facility_supplemental_status: facility_supplemental_status
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+      row:
+        type: entity_reference_revisions
+        options:
+          default_field_elements: true
+          inline:
+            name: name
+          separator: ''
+          hide_empty: false
+      defaults:
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.taxonomy_term.field_guidance'

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -123,6 +123,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility | Details | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC Facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | VAMC Facility | What health care system does the facility belong to? | field_region_page | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC Facility | COVID-19 status | field_supplemental_status | Entity reference | Required | 1 | Select list |  |
 | Content type | VAMC Facility Health Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility Health Service | Appointments help text | field_appointments_help_text | Markup |  | 1 | Markup |  |
 | Content type | VAMC Facility Health Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget |  |

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -172,6 +172,7 @@ Feature: Views
 | Glossary | Attachment | attachment_1 | Attachment |
 | Glossary | Master | default | Default |
 | Glossary | Page | page_1 | Page |
+| Health care service names and descriptions | Facility Supplemental Status - entity reference | facility_supplemental_status | Entity Reference |
 | Health care service names and descriptions | Master | default | Default |
 | Health care service names and descriptions | Non clinical service | entity_reference_non_clinical_services | Entity Reference |
 | Health care service names and descriptions | VAMC health service and type of care - entity reference | entity_reference_vamc_services | Entity Reference |


### PR DESCRIPTION
## Description
closes #8949

## TBD / To be implemented
@swirtSJW @rachel-kauff @JayDarnell
Need link destination for `Learn more about COVID statuses.` - currently paths to `/`

## Testing done
Visual / behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/167321357-94614596-3978-4394-b30c-80833bc06f87.png)
![image](https://user-images.githubusercontent.com/2404547/167321364-d057d82b-23a4-42d6-9668-fdf6f8718107.png)

## QA steps
 - [x] As an administrator, go to `admin/structure/taxonomy/manage/facility_supplemental_status/overview` and add at least two new terms, filling in all fields.
 - [x] Go to `node/1650/edit` and visually verify the presence of required `COVID-19 status` field in COVID-19 safety guidelines fieldset, with all help and description text matching the form screenshot above
 - [x] Visually verify the two terms added in step one appear in the drop down
 - [x] Visually verify Operating status fieldset and all fields contained within have help text and descriptions matching above form screenshot.
 - [x] Select a value for `Covid-19 status` and save the form.
 - [x] Visually verify node view weights match the node view screenshot, above.