### PR TITLE
VACMS-8988: Disable status id field for non admins.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
@@ -312,6 +312,9 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     if (!$this->userPermsService->hasAdminRole(TRUE) && $bundle === 'health_care_service_taxonomy') {
       $form['field_health_service_api_id']['#disabled'] = TRUE;
     }
+    if (!$this->userPermsService->hasAdminRole(TRUE) && $bundle === 'facility_supplemental_status') {
+      $form['field_status_id']['#disabled'] = TRUE;
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
closes #8988

## Testing done
Visual / behat

## Screenshots
Logged in as user selina.cooper@va.gov (content admin)
![image](https://user-images.githubusercontent.com/2404547/167402881-80dbfe30-f871-4185-8fb2-fa07853de8eb.png)

Logged in as ethan.teague (administrator)
![image](https://user-images.githubusercontent.com/2404547/167403058-56f77ce5-0936-4fd5-9b7f-f9267f858d68.png)

## QA steps
 - [ ] As an administrator, go to `admin/structure/taxonomy/manage/facility_supplemental_status/overview` and add a new term (add values to every field).
 - [ ] After saving, visually verify the Status ID field is editable when viewing the term form.
 - [ ] Login as selina.cooper@va.gov (content admin), and visit the edit form for the term you created as an administrator.
 - [ ] Visually verify Status ID field is not editable.