### PR TITLE
VACMS-9022 Convert VAMC facilty statuses to radio buttons.

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -307,7 +307,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_operating_status_facility:
-    type: options_select
+    type: options_buttons
     weight: 5
     region: content
     settings: {  }
@@ -339,7 +339,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_supplemental_status:
-    type: options_select
+    type: options_buttons
     weight: 21
     region: content
     settings: {  }

--- a/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
@@ -21,7 +21,7 @@ field_name: field_supplemental_status
 entity_type: node
 bundle: health_care_local_facility
 label: 'COVID-19 status'
-description: 'Select the status that most closely matches your facility''s protocols. <a href="/">Learn more about COVID statuses.</a>'
+description: 'Select the status that most closely matches your facility''s protocols. <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status">Learn more about COVID statuses</a>.'
 required: true
 translatable: false
 default_value: {  }

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -119,11 +119,11 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | VAMC Facility | Mobile | field_mobile | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC Facility | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) | Translatable |
-| Content type | VAMC Facility | Status | field_operating_status_facility | List (text) | Required | 1 | Select list |  |
+| Content type | VAMC Facility | Status | field_operating_status_facility | List (text) | Required | 1 | Check boxes/radio buttons |  |
 | Content type | VAMC Facility | Details | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC Facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | VAMC Facility | What health care system does the facility belong to? | field_region_page | Entity reference | Required | 1 | Select list |  |
-| Content type | VAMC Facility | COVID-19 status | field_supplemental_status | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC Facility | COVID-19 status | field_supplemental_status | Entity reference | Required | 1 | Check boxes/radio buttons |  |
 | Content type | VAMC Facility Health Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility Health Service | Appointments help text | field_appointments_help_text | Markup |  | 1 | Markup |  |
 | Content type | VAMC Facility Health Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget |  |
@@ -240,4 +240,3 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Register for Care | Non-clinical Services | field_non_clinical_services | Viewfield |  | 1 | Viewfield |  |
 | Content type | VAMC System Register for Care | VAMC System | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Register for Care | Service | field_service_name_and_descripti | Entity reference |  | 1 | -- Disabled -- | Translatable |
-


### PR DESCRIPTION
## Description

closes #9022

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/5752113/167476064-05eb71b7-abb9-46fd-9479-b40319f4964c.png)


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As Ryan.Stubblebine@va.  gov
![image](https://user-images.githubusercontent.com/5752113/167477320-a04106bb-69bf-42da-8400-e13fbe80f40c.png)

1. Do this
   -  Edit a the facility in your system https://va-gov-cms.ddev.site/node/89/edit
   - [ ] validate that 'Covid-19 status" is a set of radio buttons. (may not appear if the taxonomy terms are missing)
   - [ ] Validate the link points to '/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status'
   - [ ] validate that 'Operating status - Status has radio buttons.


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
