### PR TITLE
add no-op placeholder routes for content release notifications

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Controller/PlaceholderController.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Controller/PlaceholderController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\va_gov_build_trigger\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Placeholder for content release.
+ *
+ * @todo Remove this in #8934.
+ */
+class PlaceholderController extends ControllerBase {
+
+  /**
+   * Return an HTTP 200.
+   *
+   * @return Symfony\Component\HttpFoundation\Response
+   *   An HTTP response.
+   */
+  public function placeholder() {
+    return Response::create('placeholder', 200);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_build_trigger/src/Controller/PlaceholderController.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Controller/PlaceholderController.php
@@ -15,7 +15,7 @@ class PlaceholderController extends ControllerBase {
   /**
    * Return an HTTP 200.
    *
-   * @return Symfony\Component\HttpFoundation\Response
+   * @return \Symfony\Component\HttpFoundation\Response
    *   An HTTP response.
    */
   public function placeholder() {

--- a/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.routing.yml
+++ b/docroot/modules/custom/va_gov_build_trigger/va_gov_build_trigger.routing.yml
@@ -20,3 +20,32 @@ va_gov_build_trigger.content_release_status_block_controller_get_block:
     _controller: '\Drupal\va_gov_build_trigger\Controller\ContentReleaseStatusBlockController::getBlock'
   requirements:
     _permission: "va gov deploy content build"
+
+# The following routes are temporary and will be replaced in #8934.
+va_gov_build_trigger.content_release_placeholder_starting:
+  path: '/api/content_release/starting'
+  defaults:
+    _controller: '\Drupal\va_gov_build_trigger\Controller\PlaceholderController::placeholder'
+  requirements:
+    _permission: "access bulletin queue trigger api"
+
+va_gov_build_trigger.content_release_placeholder_inprogress:
+  path: '/api/content_release/inprogress'
+  defaults:
+    _controller: '\Drupal\va_gov_build_trigger\Controller\PlaceholderController::placeholder'
+  requirements:
+    _permission: "access bulletin queue trigger api"
+
+va_gov_build_trigger.content_release_placeholder_complete:
+  path: '/api/content_release/complete'
+  defaults:
+    _controller: '\Drupal\va_gov_build_trigger\Controller\PlaceholderController::placeholder'
+  requirements:
+    _permission: "access bulletin queue trigger api"
+
+va_gov_build_trigger.content_release_placeholder_ready:
+  path: '/api/content_release/ready'
+  defaults:
+    _controller: '\Drupal\va_gov_build_trigger\Controller\PlaceholderController::placeholder'
+  requirements:
+    _permission: "access bulletin queue trigger api"


### PR DESCRIPTION
## Description

Relates to #9008 

Adds no-op routes for content release notifications. This is needed so that we can add the HTTP requests to content release and have them not fail. This code will be replaced in the near future.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
