### PR TITLE
VACMS-9039: remove care we provide feature flag

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -9,4 +9,3 @@ features:
   feature_change_leadership_link: FEATURE_CHANGE_LEADERSHIP_LINK
   feature_health_connect_number: FEATURE_HEALTH_CONNECT_NUMBER
   feature_recurring_events: FEATURE_RECURRING_EVENTS
-  feature_care_we_provide: FEATURE_CARE_WE_PROVIDE


### PR DESCRIPTION
## Description

Closes #9039 

## Testing done

Visual Testing

## QA steps

As an admin user

- [ ] Navigate to /admin/config/system/feature_toggle
- [ ] The care we provide feature flag should no longer be present.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
