### PR TITLE
VACMS-9043 Add option label to facility supplemental status vocab.

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.facility_supplemental_status.field_administration
+    - field.field.taxonomy_term.facility_supplemental_status.field_cms_option_label
     - field.field.taxonomy_term.facility_supplemental_status.field_enforce_unique_id
     - field.field.taxonomy_term.facility_supplemental_status.field_guidance
     - field.field.taxonomy_term.facility_supplemental_status.field_status_id
@@ -22,7 +23,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -82,16 +83,24 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_cms_option_label:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_enforce_unique_id:
     type: allow_only_one_widget
-    weight: 3
+    weight: 4
     region: content
     settings:
       size: 1
     third_party_settings: {  }
   field_guidance:
     type: text_textarea_with_counter
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -107,7 +116,7 @@ content:
         hide_guidelines: '0'
   field_status_id:
     type: string_textfield
-    weight: 4
+    weight: 5
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.facility_supplemental_status.field_administration
+    - field.field.taxonomy_term.facility_supplemental_status.field_cms_option_label
     - field.field.taxonomy_term.facility_supplemental_status.field_enforce_unique_id
     - field.field.taxonomy_term.facility_supplemental_status.field_guidance
     - field.field.taxonomy_term.facility_supplemental_status.field_status_id
@@ -22,22 +23,10 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_guidance:
-    type: text_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
-  field_status_id:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
 hidden:
   field_administration: true
+  field_cms_option_label: true
   field_enforce_unique_id: true
+  field_guidance: true
+  field_status_id: true
   search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_cms_option_label.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_cms_option_label.yml
@@ -1,0 +1,25 @@
+uuid: b41d3974-e1d5-4cc6-a9d1-e7310820c988
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_cms_option_label
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.facility_supplemental_status.field_cms_option_label
+field_name: field_cms_option_label
+entity_type: taxonomy_term
+bundle: facility_supplemental_status
+label: 'CMS Option Label'
+description: 'This is what shows up in status chooser.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_guidance.yml
+++ b/config/sync/field.field.taxonomy_term.facility_supplemental_status.field_guidance.yml
@@ -21,7 +21,7 @@ field_name: field_guidance
 entity_type: taxonomy_term
 bundle: facility_supplemental_status
 label: Guidance
-description: 'Editor facing guidance on when to use this status.'
+description: 'Editor facing guidance on when to use this status.  (Leave blank if no guidance should be shown.)'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.storage.taxonomy_term.field_cms_option_label.yml
+++ b/config/sync/field.storage.taxonomy_term.field_cms_option_label.yml
@@ -1,0 +1,21 @@
+uuid: 64c232e7-28ad-4e77-8d85-ef4ade19dcf6
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_cms_option_label
+field_name: field_cms_option_label
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -11,6 +11,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | Audience - Beneficiaries | Promoted to Resources and Support Homepage | field_audience_rs_homepage | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | Audience - Non-beneficiaries | Promoted to Resources and Support Homepage | field_audience_rs_homepage | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Vocabulary | Facility Supplemental Status | Section | field_administration | Entity reference | Required | 1 | Select list |  |
+| Vocabulary | Facility Supplemental Status | CMS Option Label | field_cms_option_label | Text (plain) | Required | 1 | Textfield |  |
 | Vocabulary | Facility Supplemental Status | Enforce Unique Id | field_enforce_unique_id | Allow Only One |  | 1 | Allow Only One widget |  |
 | Vocabulary | Facility Supplemental Status | Guidance | field_guidance | Text (formatted, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Vocabulary | Facility Supplemental Status | Status ID | field_status_id | Text (plain) | Required | 1 | Textfield |  |


### PR DESCRIPTION
## Description

Relates to #9043 but does not close.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As an admin
1. Go to https://pr9046-ekkjt7zsdqxtharhdv6t0mflm8stb1jh.ci.cms.va.gov/taxonomy/term/1035/edit
   - [x] Validate that CMS Option Label is present and is a required field.
   
![image](https://user-images.githubusercontent.com/5752113/167729301-16c34a87-e223-4bb3-8479-fcbdd523cb47.png)

2. Visit https://pr9046-ekkjt7zsdqxtharhdv6t0mflm8stb1jh.ci.cms.va.gov//taxonomy/term/1035/
   - [x] Validate that only Term name and description are visible.
![image](https://user-images.githubusercontent.com/5752113/167729275-66a6f6ba-613d-41a2-9c35-7ba281db10fa.png)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
