### PR TITLE
VACMS-9047 facility status dupes

### DIFF
--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -6720,10 +6720,12 @@ display:
       defaults:
         empty: false
         title: false
+        relationships: false
         fields: false
         sorts: false
         filters: false
         filter_groups: false
+      relationships: {  }
       display_description: ''
       display_extenders: {  }
       path: admin/content/facilities/facility-status


### PR DESCRIPTION
## Description

Closes #9047

## Testing done
manual

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/167858899-cfa1b20f-2d4a-4395-bf51-00d6ff9b81e1.png)


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As a cms user, 
1. Go to the facility status view and search for pittsburgh (`/admin/content/facilities/facility-status?Title=pittsburgh`)
   - [ ] Validate that only unique results appear

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
