### PR TITLE
VACMS-9054 Make covid status sort by term weight.

### DIFF
--- a/config/sync/views.view.health_care_service_names_and_descriptions.yml
+++ b/config/sync/views.view.health_care_service_names_and_descriptions.yml
@@ -1086,6 +1086,22 @@ display:
         options:
           offset: 0
           items_per_page: 0
+      sorts:
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       filters:
         vid:
           id: vid
@@ -1150,6 +1166,7 @@ display:
         style: false
         row: false
         fields: false
+        sorts: false
         filters: false
         filter_groups: false
       display_description: ''


### PR DESCRIPTION
## Description

Closes #9054

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As User admin
1. Go edit a VAMC facility /node/37668/edit
   - [x] Validate that sort reflects term sort order (weight) 
   - [ ] 
![image](https://user-images.githubusercontent.com/5752113/167918481-674883a4-dc20-483d-b45b-f5bb931e0e7f.png)

