### PR TITLE
VACMS-000: Add label to covid fieldset.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -387,7 +387,8 @@
                 "2421145 - Text format wrapper does not take description_display into account": "https://www.drupal.org/files/issues/2021-12-03/2421445-18_0.patch",
                 "Internal Claro tweaks": "patches/claro-css-tweaks.patch",
                 "3176625 - Install from existing config with a theme that declares module dependencies fails": "https://www.drupal.org/files/issues/2021-05-18/fix_ConfigImportSubscriber_validateThemes-3176625-29.patch",
-                "3099026 - Claro's preprocessing of field multiple value form's table header cell removes potential changes by others": "https://www.drupal.org/files/issues/2020-02-20/3099026-9.patch"
+                "3099026 - Claro's preprocessing of field multiple value form's table header cell removes potential changes by others": "https://www.drupal.org/files/issues/2020-02-20/3099026-9.patch",
+                "2767243 - Create a theme suggestion for taxonomy terms by view mode": "https://www.drupal.org/files/issues/core-theme-suggestion-for-taxonomy-view-modes-2767243-14.patch"
             },
             "drupal/decoupled_router": {
                 "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2021-05-05/3111456-34.patch"

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
     - workflows.workflow.editorial
   module:
@@ -42,7 +43,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 8
+      weight: 10
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -58,7 +59,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 11
       format_type: fieldset
       format_settings:
         classes: ''
@@ -71,7 +72,7 @@ third_party_settings:
       label: '"Prepare for your visit"'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: details
       format_settings:
         classes: ''
@@ -86,7 +87,7 @@ third_party_settings:
       label: 'VAMC system'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -100,7 +101,7 @@ third_party_settings:
       label: 'Title and summary'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -112,7 +113,7 @@ third_party_settings:
       label: 'Social Media'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         classes: ''
@@ -126,12 +127,13 @@ third_party_settings:
       label: 'Operating status'
       region: content
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
-        description: 'Use this to communicate critical information about potential closures or other situations on the facility''s location page and on the operating status page.'
+        description: 'Use this for all other kinds of situations that might impact your facility''s operations. Information you edit here will show up on the facility''s location page as well as on the Operating Status page.'
         required_fields: true
     group_meta_tags:
       children:
@@ -139,7 +141,7 @@ third_party_settings:
       label: 'Meta Tags'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -186,6 +188,20 @@ third_party_settings:
         element: div
         label_element: h3
         attributes: ''
+    group_covid_19_safety_guidelines:
+      children:
+        - field_supplemental_status
+      label: 'COVID-19 safety guidelines'
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Help Veterans understand COVID-19 protocols at this facility. This will show up on the facility''s location page as well as on the Operating Status page.'
+        required_fields: false
 id: node.health_care_local_facility.default
 targetEntityType: node
 bundle: health_care_local_facility
@@ -205,7 +221,7 @@ content:
     third_party_settings: {  }
   field_description:
     type: string_textfield_with_counter
-    weight: 3
+    weight: 10
     region: content
     settings:
       size: 120
@@ -322,6 +338,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_supplemental_status:
+    type: options_select
+    weight: 21
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   flag:
     weight: 12
     region: content
@@ -335,7 +357,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -133,7 +133,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        description: 'Use this status for weather or other events that impact your facility''s operations. Don’t use this for COVID-19-related information. This status will display on the facility’s location page and operating status page.'
+        description: 'Use this status for weather or other events that impact your facility''s operations. Don''t duplicate information contained in your COVID-19 status. This status will display on the facility''s location page and operating status page.'
         required_fields: true
     group_meta_tags:
       children:

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -307,7 +307,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_operating_status_facility:
-    type: options_select
+    type: options_buttons
     weight: 5
     region: content
     settings: {  }
@@ -339,7 +339,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_supplemental_status:
-    type: options_select
+    type: options_buttons
     weight: 21
     region: content
     settings: {  }

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -133,7 +133,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        description: 'Use this for all other kinds of situations that might impact your facility''s operations. Information you edit here will show up on the facility''s location page as well as on the Operating Status page.'
+        description: 'Use this status for weather or other events that impact your facility''s operations. Don’t use this for COVID-19-related information. This status will display on the facility’s location page and operating status page.'
         required_fields: true
     group_meta_tags:
       children:
@@ -191,7 +191,7 @@ third_party_settings:
     group_covid_19_safety_guidelines:
       children:
         - field_supplemental_status
-      label: 'COVID-19 safety guidelines'
+      label: 'COVID-19 health protection guidelines'
       region: content
       parent_name: ''
       weight: 1
@@ -200,7 +200,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        description: 'Help Veterans understand COVID-19 protocols at this facility. This will show up on the facility''s location page as well as on the Operating Status page.'
+        description: 'Use these levels to help Veterans understand the current COVID-19 health protection guidelines at your facility. The preset guidelines will appear on your facility’s location and operating status pages.'
         required_fields: false
 id: node.health_care_local_facility.default
 targetEntityType: node

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
   module:
     - field_group
@@ -151,6 +152,7 @@ hidden:
   field_office_hours: true
   field_phone_number: true
   field_region_page: true
+  field_supplemental_status: true
   flag: true
   moderation_state: true
   path: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -129,7 +129,7 @@ third_party_settings:
     group_covid_19_safety_guidelines:
       children:
         - field_supplemental_status
-      label: 'COVID-19 health protection guidelines'
+      label: ''
       parent_name: ''
       region: content
       weight: 3
@@ -261,7 +261,7 @@ content:
     region: content
   field_supplemental_status:
     type: entity_reference_entity_view
-    label: above
+    label: hidden
     settings:
       view_mode: name_with_term
       link: false

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -129,7 +129,7 @@ third_party_settings:
     group_covid_19_safety_guidelines:
       children:
         - field_supplemental_status
-      label: ''
+      label: 'COVID-19 guidelines'
       parent_name: ''
       region: content
       weight: 3

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -59,6 +59,7 @@ third_party_settings:
       format_type: fieldset
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         description: ''
     group_social_media:
@@ -128,7 +129,7 @@ third_party_settings:
     group_covid_19_safety_guidelines:
       children:
         - field_supplemental_status
-      label: 'COVID-19 safety guidelines'
+      label: 'COVID-19 health protection guidelines'
       parent_name: ''
       region: content
       weight: 3
@@ -137,7 +138,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        description: 'Help Veterans understand COVID-19 protocols at this facility. This will show up on the facility''s location page as well as on the Operating Status page.'
+        description: ''
 id: node.health_care_local_facility.default
 targetEntityType: node
 bundle: health_care_local_facility
@@ -259,10 +260,11 @@ content:
     weight: 17
     region: content
   field_supplemental_status:
-    type: entity_reference_label
+    type: entity_reference_entity_view
     label: above
     settings:
-      link: true
+      view_mode: name_with_term
+      link: false
     third_party_settings: {  }
     weight: 18
     region: content

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - image.style.crop_3_2
     - node.type.health_care_local_facility
   module:
@@ -54,7 +55,7 @@ third_party_settings:
       label: 'Operating status'
       parent_name: ''
       region: content
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -65,7 +66,7 @@ third_party_settings:
       label: 'Social media'
       parent_name: ''
       region: content
-      weight: 6
+      weight: 7
       format_type: details
       format_settings:
         classes: ''
@@ -79,7 +80,7 @@ third_party_settings:
       label: 'Prepare for your visit'
       parent_name: ''
       region: content
-      weight: 5
+      weight: 6
       format_type: details
       format_settings:
         classes: ''
@@ -92,7 +93,7 @@ third_party_settings:
       label: 'Locations and contact information'
       parent_name: ''
       region: content
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -124,6 +125,19 @@ third_party_settings:
         tooltip_description: "Why can’t I edit this?\r\nThis content is automatically populated from centralized databases, and helps maintain consistent information across all of VA.gov."
         open: false
         required_fields: false
+    group_covid_19_safety_guidelines:
+      children:
+        - field_supplemental_status
+      label: 'COVID-19 safety guidelines'
+      parent_name: ''
+      region: content
+      weight: 3
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Help Veterans understand COVID-19 protocols at this facility. This will show up on the facility''s location page as well as on the Operating Status page.'
 id: node.health_care_local_facility.default
 targetEntityType: node
 bundle: health_care_local_facility
@@ -166,7 +180,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 8
+    weight: 9
     region: content
   field_media:
     type: media_thumbnail
@@ -183,7 +197,7 @@ content:
     settings:
       title: ''
     third_party_settings: {  }
-    weight: 19
+    weight: 20
     region: content
   field_mobile:
     type: boolean
@@ -193,7 +207,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 18
+    weight: 19
     region: content
   field_office_hours:
     type: office_hours
@@ -220,21 +234,21 @@ content:
       schema:
         enabled: false
     third_party_settings: {  }
-    weight: 20
+    weight: 21
     region: content
   field_operating_status_facility:
     type: list_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 19
     region: content
   field_operating_status_more_info:
     type: basic_string
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 20
     region: content
   field_phone_number:
     type: telephone_link
@@ -243,6 +257,14 @@ content:
       title: ''
     third_party_settings: {  }
     weight: 17
+    region: content
+  field_supplemental_status:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 18
     region: content
 hidden:
   content_moderation_control: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
   module:
     - address
@@ -256,6 +257,7 @@ hidden:
   field_operating_status_facility: true
   field_operating_status_more_info: true
   field_region_page: true
+  field_supplemental_status: true
   flag_changed_name: true
   flag_changed_title: true
   flag_new: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - image.style.thumbnail
     - node.type.health_care_local_facility
   module:
@@ -109,6 +110,7 @@ hidden:
   field_office_hours: true
   field_phone_number: true
   field_region_page: true
+  field_supplemental_status: true
   flag_changed_name: true
   flag_changed_title: true
   flag_new: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_operating_status_more_info
     - field.field.node.health_care_local_facility.field_phone_number
     - field.field.node.health_care_local_facility.field_region_page
+    - field.field.node.health_care_local_facility.field_supplemental_status
     - node.type.health_care_local_facility
   module:
     - user
@@ -31,6 +32,21 @@ targetEntityType: node
 bundle: health_care_local_facility
 mode: teaser
 content:
+  flag_changed_name:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  flag_new:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  flag_removed_from_source:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -57,4 +73,5 @@ hidden:
   field_operating_status_more_info: true
   field_phone_number: true
   field_region_page: true
+  field_supplemental_status: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.name_with_term.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.facility_supplemental_status.name_with_term.yml
@@ -1,0 +1,38 @@
+uuid: 29935c46-b5a4-453f-b492-d8e205495648
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.name_with_term
+    - field.field.taxonomy_term.facility_supplemental_status.field_administration
+    - field.field.taxonomy_term.facility_supplemental_status.field_cms_option_label
+    - field.field.taxonomy_term.facility_supplemental_status.field_enforce_unique_id
+    - field.field.taxonomy_term.facility_supplemental_status.field_guidance
+    - field.field.taxonomy_term.facility_supplemental_status.field_status_id
+    - taxonomy.vocabulary.facility_supplemental_status
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: taxonomy_term.facility_supplemental_status.name_with_term
+targetEntityType: taxonomy_term
+bundle: facility_supplemental_status
+mode: name_with_term
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_administration: true
+  field_cms_option_label: true
+  field_enforce_unique_id: true
+  field_guidance: true
+  field_status_id: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_mode.taxonomy_term.name_with_term.yml
+++ b/config/sync/core.entity_view_mode.taxonomy_term.name_with_term.yml
@@ -1,0 +1,10 @@
+uuid: 5e24b5bd-0685-4c3d-b1cc-892a212edd4a
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.name_with_term
+label: 'Name with term'
+targetEntityType: taxonomy_term
+cache: true

--- a/config/sync/field.field.node.health_care_local_facility.field_operating_status_facility.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_operating_status_facility.yml
@@ -6,13 +6,18 @@ dependencies:
     - field.storage.node.field_operating_status_facility
     - node.type.health_care_local_facility
   module:
+    - epp
     - options
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: node.health_care_local_facility.field_operating_status_facility
 field_name: field_operating_status_facility
 entity_type: node
 bundle: health_care_local_facility
 label: Status
-description: 'Use "Limited hours and services" if in-facility services are closed but Veterans can still get telehealth appointments, and make a note in the details.'
+description: 'Use this status for non-Covid-19 related situations, such as weather events.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.node.health_care_local_facility.field_operating_status_facility.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_operating_status_facility.yml
@@ -17,7 +17,7 @@ field_name: field_operating_status_facility
 entity_type: node
 bundle: health_care_local_facility
 label: Status
-description: 'Use this status for non-Covid-19 related situations, such as weather events.'
+description: 'Select the status that reflects your facility’s current operations.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.node.health_care_local_facility.field_operating_status_more_info.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_operating_status_more_info.yml
@@ -16,7 +16,7 @@ field_name: field_operating_status_more_info
 entity_type: node
 bundle: health_care_local_facility
 label: Details
-description: 'Add further details about how the status will impact visitors to the facility. Don''t include any information about masks, screening, or visitor policies due to Covid-19. This will be communicated to the visitors through the Covid-19 status.'
+description: 'Add relevant details about how this status will impact Veterans and visitors. Don’t include any information about masks, screening, or visitor policies due to COVID-19. This information is now covered in the COVID-19 health protection guidelines.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_local_facility.field_operating_status_more_info.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_operating_status_more_info.yml
@@ -5,12 +5,18 @@ dependencies:
   config:
     - field.storage.node.field_operating_status_more_info
     - node.type.health_care_local_facility
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: node.health_care_local_facility.field_operating_status_more_info
 field_name: field_operating_status_more_info
 entity_type: node
 bundle: health_care_local_facility
 label: Details
-description: 'Add further details about how the status will impact visitors to the facility.'
+description: 'Add further details about how the status will impact visitors to the facility. Don''t include any information about masks, screening, or visitor policies due to Covid-19. This will be communicated to the visitors through the Covid-19 status.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
@@ -21,7 +21,7 @@ field_name: field_supplemental_status
 entity_type: node
 bundle: health_care_local_facility
 label: 'COVID-19 status'
-description: 'Select the level set by your facility’s leadership. Learn more about COVID-19 safety guidelines <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status" target="_blank">Learn more about COVID-19 safety guidelines</a>.(opens in a new window)'
+description: 'Select the level set by your facility’s leadership. Learn more about COVID-19 safety guidelines <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status" target="_blank">Learn more about COVID-19 safety guidelines(opens in a new window)</a>.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
@@ -21,7 +21,7 @@ field_name: field_supplemental_status
 entity_type: node
 bundle: health_care_local_facility
 label: 'COVID-19 status'
-description: 'Select the status that most closely matches your facility''s protocols. <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status">Learn more about COVID statuses</a>.'
+description: 'Select the level set by your facility’s leadership. Learn more about COVID-19 safety guidelines <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status" target="_blank">Learn more about COVID-19 safety guidelines</a>.(opens in a new window)'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
@@ -1,0 +1,36 @@
+uuid: 8974f0fa-0818-4459-a769-8800e1b76aeb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_supplemental_status
+    - node.type.health_care_local_facility
+  module:
+    - entity_reference_validators
+    - epp
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: true
+  epp:
+    value: ''
+    on_update: 0
+id: node.health_care_local_facility.field_supplemental_status
+field_name: field_supplemental_status
+entity_type: node
+bundle: health_care_local_facility
+label: 'COVID-19 status'
+description: 'Select the status that most closely matches your facility''s protocols. <a href="/">Learn more about COVID statuses.</a>'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: views
+  handler_settings:
+    view:
+      view_name: health_care_service_names_and_descriptions
+      display_name: facility_supplemental_status
+      arguments: {  }
+field_type: entity_reference

--- a/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
@@ -21,7 +21,7 @@ field_name: field_supplemental_status
 entity_type: node
 bundle: health_care_local_facility
 label: 'COVID-19 status'
-description: 'Select the status that most closely matches your facility''s protocols. <a href="/">Learn more about COVID statuses.</a>'
+description: 'Select the status that most closely matches your facility''s protocols. <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status">Learn more about COVID statuses</a>.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_supplemental_status.yml
@@ -21,7 +21,7 @@ field_name: field_supplemental_status
 entity_type: node
 bundle: health_care_local_facility
 label: 'COVID-19 status'
-description: 'Select the level set by your facility’s leadership. Learn more about COVID-19 safety guidelines <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status" target="_blank">Learn more about COVID-19 safety guidelines(opens in a new window)</a>.'
+description: 'Select the level set by your facility’s leadership. Learn more about COVID-19 safety guidelines <a href="/help/vamc/about-locations-content-for-vamcs/about-alerts-and-operating-statuses/how-to-edit-a-vamc-facility-covid-status" target="_blank">Learn more about COVID-19 safety guidelines (opens in a new window)</a>.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.storage.node.field_supplemental_status.yml
+++ b/config/sync/field.storage.node.field_supplemental_status.yml
@@ -1,0 +1,20 @@
+uuid: 06db6a2f-af56-4574-9547-8942bb5449dd
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_supplemental_status
+field_name: field_supplemental_status
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -6720,10 +6720,12 @@ display:
       defaults:
         empty: false
         title: false
+        relationships: false
         fields: false
         sorts: false
         filters: false
         filter_groups: false
+      relationships: {  }
       display_description: ''
       display_extenders: {  }
       path: admin/content/facilities/facility-status

--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -6219,6 +6219,54 @@ display:
           exposed: false
           granularity: second
       filters:
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            nca_facility: nca_facility
+            health_care_local_facility: health_care_local_facility
+            vba_facility: vba_facility
+            vet_center: vet_center
+            vet_center_cap: vet_center_cap
+            vet_center_mobile_vet_center: vet_center_mobile_vet_center
+            vet_center_outstation: vet_center_outstation
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         title:
           id: title
           table: node_field_data

--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.storage.node.field_referral_required
     - field.storage.node.field_region_page
     - field.storage.node.field_service_name_and_descripti
+    - field.storage.node.field_supplemental_status
     - field.storage.node.field_va_health_connect_phone
     - field.storage.node.field_vamc_ehr_system
     - field.storage.node.field_vamc_system_official_name
@@ -34,6 +35,7 @@ dependencies:
     - node.type.vet_center_outstation
     - node.type.vha_facility_nonclinical_service
     - taxonomy.vocabulary.administration
+    - taxonomy.vocabulary.facility_supplemental_status
     - taxonomy.vocabulary.health_care_service_taxonomy
     - user.role.administrator
     - user.role.content_admin
@@ -853,25 +855,24 @@ display:
           row_class: ''
           default_row_class: true
           columns:
+            views_bulk_operations_bulk_form_1: views_bulk_operations_bulk_form_1
             title: title
             nid: nid
-            type: type
-            field_facility_location: field_facility_location
-            name_1: name_1
-            field_administration: field_administration
-            id: id
-            field_referral_required: field_referral_required
-            field_walk_ins_accepted: field_walk_ins_accepted
-            field_online_scheduling_availabl: field_online_scheduling_availabl
-            revision_uid: revision_uid
-            changed: changed
-            name: name
-            timestamp: timestamp
-            break: break
-            is_locked: is_locked
             edit_node: edit_node
+            field_facility_locator_api_id: field_facility_locator_api_id
+            field_operating_status_facility: field_operating_status_facility
+            field_operating_status_more_info: field_operating_status_more_info
+            field_supplemental_status: field_supplemental_status
+            field_administration: field_administration
+            moderation_state: moderation_state
+            changed: changed
           default: changed
           info:
+            views_bulk_operations_bulk_form_1:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             title:
               sortable: true
               default_sort_order: asc
@@ -886,21 +887,35 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-            type:
+            edit_node:
               sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-            field_facility_location:
-              sortable: true
+            field_facility_locator_api_id:
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-            name_1:
+            field_operating_status_facility:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_operating_status_more_info:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_supplemental_status:
               sortable: true
               default_sort_order: asc
               align: ''
@@ -914,35 +929,7 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-            id:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_referral_required:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_walk_ins_accepted:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_online_scheduling_availabl:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            revision_uid:
+            moderation_state:
               sortable: false
               default_sort_order: asc
               align: ''
@@ -956,41 +943,6 @@ display:
               separator: by
               empty_column: false
               responsive: priority-low
-            name:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            timestamp:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            break:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            is_locked:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            edit_node:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
           override: true
           sticky: true
           summary: ''
@@ -5980,6 +5932,69 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_supplemental_status:
+          id: field_supplemental_status
+          table: node__field_supplemental_status
+          field: field_supplemental_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Supplemental status'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         field_administration:
           id: field_administration
           table: node__field_administration
@@ -6204,64 +6219,6 @@ display:
           exposed: false
           granularity: second
       filters:
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          operator: in
-          value:
-            nca_facility: nca_facility
-            health_care_local_facility: health_care_local_facility
-            vba_facility: vba_facility
-            vet_center: vet_center
-            vet_center_cap: vet_center_cap
-            vet_center_outstation: vet_center_outstation
-          group: 1
-          exposed: false
-          expose:
-            operator_id: type_op
-            label: 'Content type'
-            description: ''
-            use_operator: false
-            operator: type_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              content_api_consumer: '0'
-              content_creator_benefits_hubs: '0'
-              vamc_content_creator: '0'
-              content_editor: '0'
-              content_reviewer: '0'
-              content_publisher: '0'
-              content_admin: '0'
-              redirect_administrator: '0'
-              admnistrator_users: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
         title:
           id: title
           table: node_field_data
@@ -6477,6 +6434,126 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_supplemental_status_target_id:
+          id: field_supplemental_status_target_id
+          table: node__field_supplemental_status
+          field: field_supplemental_status_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_supplemental_status_target_id_op
+            label: 'Supplemental status'
+            description: ''
+            use_operator: false
+            operator: field_supplemental_status_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_supplemental_status_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: facility_supplemental_status
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            nca_facility: nca_facility
+            health_care_local_facility: health_care_local_facility
+            vba_facility: vba_facility
+            vet_center: vet_center
+            vet_center_cap: vet_center_cap
+            vet_center_outstation: vet_center_outstation
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: 'Facility type'
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            reduce: true
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         moderation_state:
           id: moderation_state
           table: node_field_data
@@ -6623,6 +6700,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.roles
       tags:
@@ -6630,6 +6708,7 @@ display:
         - 'config:field.storage.node.field_facility_locator_api_id'
         - 'config:field.storage.node.field_operating_status_facility'
         - 'config:field.storage.node.field_operating_status_more_info'
+        - 'config:field.storage.node.field_supplemental_status'
         - 'config:workflow_list'
   vamc_facility_health_services_export:
     id: vamc_facility_health_services_export

--- a/config/sync/views.view.health_care_service_names_and_descriptions.yml
+++ b/config/sync/views.view.health_care_service_names_and_descriptions.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.taxonomy_term.field_also_known_as
+    - field.storage.taxonomy_term.field_cms_option_label
     - field.storage.taxonomy_term.field_guidance
     - field.storage.taxonomy_term.field_service_type_of_care
     - field.storage.taxonomy_term.field_vet_center_type_of_care
@@ -922,7 +923,7 @@ display:
             more_link: false
             more_link_text: ''
             more_link_path: ''
-            strip_tags: true
+            strip_tags: false
             trim: false
             preserve_tags: ''
             html: false
@@ -951,6 +952,69 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_cms_option_label:
+          id: field_cms_option_label
+          table: taxonomy_term__field_cms_option_label
+          field: field_cms_option_label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         name:
           id: name
           table: taxonomy_term_field_data
@@ -965,7 +1029,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '{{ name }} - {{ field_guidance }}'
+            text: '{{ field_cms_option_label }}{% if field_guidance %} - {{ field_guidance }}{% endif %}'
             make_link: false
             path: ''
             absolute: false
@@ -1097,4 +1161,5 @@ display:
         - 'languages:language_interface'
         - user.permissions
       tags:
+        - 'config:field.storage.taxonomy_term.field_cms_option_label'
         - 'config:field.storage.taxonomy_term.field_guidance'

--- a/config/sync/views.view.health_care_service_names_and_descriptions.yml
+++ b/config/sync/views.view.health_care_service_names_and_descriptions.yml
@@ -4,13 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.taxonomy_term.field_also_known_as
+    - field.storage.taxonomy_term.field_guidance
     - field.storage.taxonomy_term.field_service_type_of_care
     - field.storage.taxonomy_term.field_vet_center_type_of_care
+    - taxonomy.vocabulary.facility_supplemental_status
     - taxonomy.vocabulary.health_care_service_taxonomy
   module:
     - entity_reference_revisions
     - options
     - taxonomy
+    - text
     - user
 id: health_care_service_names_and_descriptions
 label: 'Health care service names and descriptions'
@@ -879,3 +882,219 @@ display:
         - 'languages:language_interface'
         - user.permissions
       tags: {  }
+  facility_supplemental_status:
+    id: facility_supplemental_status
+    display_title: 'Facility Supplemental Status - entity reference'
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      fields:
+        field_guidance:
+          id: field_guidance
+          table: taxonomy_term__field_guidance
+          field: field_guidance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ name }} - {{ field_guidance }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 0
+      filters:
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+          operator: in
+          value:
+            facility_supplemental_status: facility_supplemental_status
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+      row:
+        type: entity_reference_revisions
+        options:
+          default_field_elements: true
+          inline:
+            name: name
+          separator: ''
+          hide_empty: false
+      defaults:
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.taxonomy_term.field_guidance'

--- a/config/sync/views.view.health_care_service_names_and_descriptions.yml
+++ b/config/sync/views.view.health_care_service_names_and_descriptions.yml
@@ -1086,6 +1086,22 @@ display:
         options:
           offset: 0
           items_per_page: 0
+      sorts:
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       filters:
         vid:
           id: vid
@@ -1150,6 +1166,7 @@ display:
         style: false
         row: false
         fields: false
+        sorts: false
         filters: false
         filter_groups: false
       display_description: ''

--- a/docroot/themes/custom/vagovclaro/templates/taxonomy/taxonomy-term--name-with-term.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/taxonomy/taxonomy-term--name-with-term.html.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * @file
+ * Theme override to display a taxonomy term for view mode name_with_term.
+ *
+ * Available variables:
+ * - url: URL of the current term.
+ * - name: (optional) Name of the current term.
+ * - content: Items for the content of the term (fields and description).
+ *   Use 'content' to print them all, or print a subset such as
+ *   'content.description'. Use the following code to exclude the
+ *   printing of a given child element:
+ *   @code
+ *   {{ content|without('description') }}
+ *   @endcode
+ * - attributes: HTML attributes for the wrapper.
+ * - page: Flag for the full page state.
+ * - term: The taxonomy term entity, including:
+ *   - id: The ID of the taxonomy term.
+ *   - bundle: Machine name of the current vocabulary.
+ * - view_mode: View mode, e.g. 'full', 'teaser', etc.
+ *
+ * @see template_preprocess_taxonomy_term()
+ */
+#}
+{%
+  set classes = [
+    'taxonomy-term',
+    'vocabulary-' ~ term.bundle|clean_class,
+  ]
+%}
+<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
+
+  {{ name }}
+  <div class="content">
+    {{ content }}
+  </div>
+</div>

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -123,6 +123,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility | Details | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC Facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | VAMC Facility | What health care system does the facility belong to? | field_region_page | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC Facility | COVID-19 status | field_supplemental_status | Entity reference | Required | 1 | Select list |  |
 | Content type | VAMC Facility Health Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility Health Service | Appointments help text | field_appointments_help_text | Markup |  | 1 | Markup |  |
 | Content type | VAMC Facility Health Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget |  |

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -119,11 +119,11 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility | Meta tags | field_meta_tags | Meta tags |  | 1 | -- Disabled -- | Translatable |
 | Content type | VAMC Facility | Mobile | field_mobile | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | VAMC Facility | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) | Translatable |
-| Content type | VAMC Facility | Status | field_operating_status_facility | List (text) | Required | 1 | Select list |  |
+| Content type | VAMC Facility | Status | field_operating_status_facility | List (text) | Required | 1 | Check boxes/radio buttons |  |
 | Content type | VAMC Facility | Details | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter |  |
 | Content type | VAMC Facility | Phone Number | field_phone_number  | Telephone number |  | 1 | Telephone number | Translatable |
 | Content type | VAMC Facility | What health care system does the facility belong to? | field_region_page | Entity reference | Required | 1 | Select list |  |
-| Content type | VAMC Facility | COVID-19 status | field_supplemental_status | Entity reference | Required | 1 | Select list |  |
+| Content type | VAMC Facility | COVID-19 status | field_supplemental_status | Entity reference | Required | 1 | Check boxes/radio buttons |  |
 | Content type | VAMC Facility Health Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC Facility Health Service | Appointments help text | field_appointments_help_text | Markup |  | 1 | Markup |  |
 | Content type | VAMC Facility Health Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget |  |
@@ -240,4 +240,3 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Register for Care | Non-clinical Services | field_non_clinical_services | Viewfield |  | 1 | Viewfield |  |
 | Content type | VAMC System Register for Care | VAMC System | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Register for Care | Service | field_service_name_and_descripti | Entity reference |  | 1 | -- Disabled -- | Translatable |
-

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -172,6 +172,7 @@ Feature: Views
 | Glossary | Attachment | attachment_1 | Attachment |
 | Glossary | Master | default | Default |
 | Glossary | Page | page_1 | Page |
+| Health care service names and descriptions | Facility Supplemental Status - entity reference | facility_supplemental_status | Entity Reference |
 | Health care service names and descriptions | Master | default | Default |
 | Health care service names and descriptions | Non clinical service | entity_reference_non_clinical_services | Entity Reference |
 | Health care service names and descriptions | VAMC health service and type of care - entity reference | entity_reference_vamc_services | Entity Reference |


### PR DESCRIPTION
## Description

- Adds fieldset label on facility node view to covid status 
- Expands link on help text on covid field on help form / moves period after parenthesis
- Updates form operating status help text

closes #9064 

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/168117744-236fbe68-1be1-4d25-8a21-7988f87bd3d4.png)

![image](https://user-images.githubusercontent.com/2404547/168129465-20030688-eda9-42cb-9a9b-ad88f462a313.png)

![image](https://user-images.githubusercontent.com/2404547/168159894-bafde111-9fa1-43a5-973b-23f74dd07db3.png)

## QA steps
 - [ ] As an administrator, go to `pittsburgh-health-care/locations/belmont-county-va-clinic` and visually verify Covid status fieldset has `COVID-19 guidelines` label
 - [ ] Go to `node/90/edit` and visually verify `COVID-19 status` field help text link extends to end of parenthesis and period appears after.
 - [ ] On `node/90/edit` visually verify Operating status fieldset helptext has `Don’t use this for COVID-19-related information.` replaced with `Don’t duplicate information contained in your COVID-19 status.`