### PR TITLE
Enable base next module without adding any settings.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -45,6 +45,7 @@ module:
   datetime: 0
   datetime_range: 0
   dblog: 0
+  decoupled_router: 0
   diff: 0
   dropzonejs: 0
   dynamic_entity_reference: 0
@@ -125,6 +126,8 @@ module:
   migrate_tools: 0
   migration_tools: 0
   monolog: 0
+  next: 0
+  next_jsonapi: 0
   node: 0
   node_link_report: 0
   node_revision_delete: 0
@@ -158,6 +161,7 @@ module:
   search_api_db: 0
   seckit: 0
   serialization: 0
+  simple_oauth: 0
   simplesamlphp_auth: 0
   site_alert: 0
   slack: 0
@@ -166,6 +170,7 @@ module:
   social_media_links_field: 0
   string_field_formatter: 0
   styleguide: 0
+  subrequests: 0
   system: 0
   tablefield: 0
   taxonomy: 0

--- a/config/sync/next.settings.yml
+++ b/config/sync/next.settings.yml
@@ -1,0 +1,8 @@
+_core:
+  default_config_hash: xRrZztTZj9Lor1bWUC6p2aB3S29Vg8m94UrOwc5AZps
+langcode: en
+site_previewer: iframe
+site_previewer_configuration:
+  width: 100%
+  sync_route: false
+  sync_route_skip_routes: ''

--- a/config/sync/simple_oauth.oauth2_token.bundle.access_token.yml
+++ b/config/sync/simple_oauth.oauth2_token.bundle.access_token.yml
@@ -1,0 +1,10 @@
+uuid: b91707d8-2ea6-4bd7-8f0f-397084388e29
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: z9ULI9nj9yt73YKI3ZE8v9yXhkVfvQsDJToEDzijcxY
+id: access_token
+label: 'Access Token'
+description: 'The access token type.'
+locked: true

--- a/config/sync/simple_oauth.oauth2_token.bundle.auth_code.yml
+++ b/config/sync/simple_oauth.oauth2_token.bundle.auth_code.yml
@@ -1,0 +1,10 @@
+uuid: 52ff7d83-d68e-4c69-b543-bdb2ea98ad01
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: zYKaSl4QZrKMFj7aIhSGDRcBy4SoNjvY2EZlT7amrBk
+id: auth_code
+label: 'Auth code'
+description: 'The auth code type.'
+locked: true

--- a/config/sync/simple_oauth.oauth2_token.bundle.refresh_token.yml
+++ b/config/sync/simple_oauth.oauth2_token.bundle.refresh_token.yml
@@ -1,0 +1,10 @@
+uuid: bf1285dc-7280-4376-ad6d-95436993e9fa
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: YWMv3Do9fsPFhylyFkOwcqcFP4jSU6DLRootOlgrC0M
+id: refresh_token
+label: 'Refresh token'
+description: 'The refresh token type.'
+locked: true

--- a/config/sync/simple_oauth.settings.yml
+++ b/config/sync/simple_oauth.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: KsPFWSp6mgXIQgjBJEShfKUGn6VLRlbpIJ2EysXvXWM
+access_token_expiration: 300
+authorization_code_expiration: 300
+refresh_token_expiration: 1209600
+remember_clients: true
+token_cron_batch_size: 0
+use_implicit: false
+disable_openid_connect: false


### PR DESCRIPTION
## Description

#8649 

Decoupled router minimally is required for pull page node rendering for Next. 

No next node-specific configuration is present at this time, and so this should not interfere with existing CMS operations.

