### PR TITLE
VACMS-0000 no pseudoelement icons

### DIFF
--- a/docroot/design-system/components/button/button.scss
+++ b/docroot/design-system/components/button/button.scss
@@ -23,17 +23,4 @@ a.button--outline,
   svg {
     margin-right: var(--spacing-s);
   }
-  &::before {
-    display: none;
-    font-family: 'Font Awesome 5 Solid';
-  }
-
-  // pseudoelement icons need added individually. Use the fa classes whenever possible instead.
-  &-trash::before {
-    content: "\f1f8"; // trash icon
-  }
-
-  &-chevron::before {
-    content: "\f078"; // chevron icon
-  }
 }

--- a/docroot/design-system/components/button/sb-buttons.twig
+++ b/docroot/design-system/components/button/sb-buttons.twig
@@ -24,7 +24,7 @@
 <h3>Button with an Icon</h3>
 <a href="#" class="button button--outline button--icon"><i class="fas fa-trash"></i>Button</a>
 <a href="#" class="button button--primary button--icon"><i class="fas fa-chevron-down"></i>Button</a>
-
+<p>Use these classes: <code>button button--icon</code> and add an icon tag with appropriate classes inside your button.</p>
 
 
 <h3>Small Button</h3>

--- a/docroot/design-system/components/button/sb-buttons.twig
+++ b/docroot/design-system/components/button/sb-buttons.twig
@@ -22,9 +22,9 @@
 
 
 <h3>Button with an Icon</h3>
-<a href="#" class="button button--outline button--icon button--icon-trash">Button</a>
-<a href="#" class="button button--primary button--icon button--icon-chevron">Button</a>
-<p>Use these classes: <code>button button--icon button--icon-trash</code></p>
+<a href="#" class="button button--outline button--icon"><i class="fas fa-trash"></i>Button</a>
+<a href="#" class="button button--primary button--icon"><i class="fas fa-chevron-down"></i>Button</a>
+
 
 
 <h3>Small Button</h3>

--- a/docroot/design-system/components/icon/index.js
+++ b/docroot/design-system/components/icon/index.js
@@ -1,5 +1,5 @@
 // fontawesome api methods
-import { library, dom, config } from '@fortawesome/fontawesome-svg-core';
+import { library, dom } from '@fortawesome/fontawesome-svg-core';
 // import specific icons as needed to keep final bundle small. fa icon name in comment.
 import {
   faBan, // ban
@@ -23,9 +23,6 @@ import './icon.scss';
 
 // Import module template
 import './icon.twig';
-
-// Allow font awesome icons in pseudo elements.
-config.searchPseudoElements = true;
 
 // Add icons to our library.
 library.add(


### PR DESCRIPTION
## Description

Relates to #8994, removes pseudoelement searching from fontawesome. icons need to be rendered inside button text instead of pseudoelements, there's a huge performance hit.

## Testing done
I couldn't reproduce the performance hit locally but it does seem to be affecting certain pages with lots of elements. This stackoverflow also notes that pseudoelements + svg js core (what we're using) is the slowest method. https://stackoverflow.com/questions/50976897/fontawesome-5-svg-icons-data-search-pseudo-elements-causes-100x-slowdown-in-ren

## Screenshots
<img width="1029" alt="Screen Shot 2022-05-17 at 11 50 41 AM" src="https://user-images.githubusercontent.com/11279744/168888332-bac7aab6-6beb-4c3f-8381-ebcf3e0da905.png">


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
