### PR TITLE
VACMS-6318: on facility status save for normal push NULL for more info

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -155,7 +155,7 @@ class PostFacilityStatus extends PostFacilityBase {
       $payload = [
         'operating_status' => [
           'code' => strtoupper($this->statusToPush),
-          'additional_info' => $this->additionalInfoToPush,
+          'additional_info' => (strtoupper($this->statusToPush) != 'NORMAL') ? $this->additionalInfoToPush : NULL,
         ],
       ];
 


### PR DESCRIPTION
## Description

Closes #6318 

## Testing done

Manual testing

## Screenshots

![Screen Shot 2022-05-18 at 11 48 17 AM](https://user-images.githubusercontent.com/21045418/169086276-0b42ea2d-3066-4957-9404-55a25faa410f.png)

## QA steps

As an admin user:

1. Using the Facility Status view: /admin/content/facilities/facility-status ...
2. Find a VAMC Facility with operating status set to notice
3. Edit this Facility and set the status to normal
4. Find a VAMC Facility with operating status set to normal
5. Edit this Facility and set the status to notice, be sure the more info (details) field has a value
6. Check the queue for both items: /admin/config/post-api/queue
7. The item set to normal should show NULL for more info while the item set to notice should show the text for more info

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
