### PR TITLE
VACMS-9117: Update sup status filters.

### DIFF
--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -6492,7 +6492,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: taxonomy_index_tid
-          operator: 'not empty'
+          operator: or
           value: {  }
           group: 1
           exposed: true
@@ -6504,6 +6504,7 @@ display:
             operator: field_supplemental_status_target_id_op
             operator_limit_selection: true
             operator_list:
+              or: or
               empty: empty
               'not empty': 'not empty'
             identifier: field_supplemental_status_target_id

--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -6492,7 +6492,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: taxonomy_index_tid
-          operator: or
+          operator: 'not empty'
           value: {  }
           group: 1
           exposed: true
@@ -6500,10 +6500,12 @@ display:
             operator_id: field_supplemental_status_target_id_op
             label: 'Supplemental status'
             description: ''
-            use_operator: false
+            use_operator: true
             operator: field_supplemental_status_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
+            operator_limit_selection: true
+            operator_list:
+              empty: empty
+              'not empty': 'not empty'
             identifier: field_supplemental_status_target_id
             required: false
             remember: false
@@ -6539,7 +6541,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: facility_supplemental_status
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true


### PR DESCRIPTION
## Description
closes #9117

## Testing done
Visual / behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/169111522-aeaaabb8-6d29-4c96-b826-395a4ed0dee3.png)

![image](https://user-images.githubusercontent.com/2404547/169111580-4adc5c81-d436-41ab-bda8-e25183147ceb.png)

## QA steps
 - [x] As an administrator, go to `admin/structure/views/view/facility_services/edit/facility_status_page`
 - [x] Set supplemental status filters to `Is empty (NULL) | - Any - ` and click filter - verify result set of `46209` items
 - [x] Set supplemental status filters to `Is not empty (NOT NULL) | - Any - ` and click filter - verify result set of `3` items