### PR TITLE
VACMS-8721 add new form message

### DIFF
--- a/config/sync/core.entity_form_display.message.va_form_new_form.default.yml
+++ b/config/sync/core.entity_form_display.message.va_form_new_form.default.yml
@@ -1,0 +1,49 @@
+uuid: 0f4b3c3c-947e-4991-817e-a47cfa1b4ab5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.va_form_new_form.field_target_entity
+    - field.field.message.va_form_new_form.field_target_node_title
+    - message.template.va_form_new_form
+id: message.va_form_new_form.default
+targetEntityType: message
+bundle: va_form_new_form
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_target_entity:
+    type: entity_reference_autocomplete
+    weight: 13
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_target_node_title:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    '#group': advanced
+hidden: {  }


### PR DESCRIPTION
## Description

Relates to #8721
This adds in a message template that was having an odd dependency timing problem with config import in the messages stack.   It can be merged after the messages stack makes it to prod. 


## Testing done


## Screenshots


## QA steps
was  already tested aas part of 8721 and was only separated out do to a config import timing issue.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
