### PR TITLE
VACMS-4101: Add some debugging information to drupalSettings for nodes to make JSON:API development easier.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1381,6 +1381,11 @@ function va_gov_backend_page_attachments(array &$attachments) {
 
   // Pass our relevant data to settings.
   $attachments['#attached']['drupalSettings']['gtm_data'] = _va_gov_backend_gtm_settings();
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof NodeInterface) {
+    $attachments['#attached']['drupalSettings']['node'] = _va_gov_backend_node_data($node);
+  }
+
   $attachments['#cache']['tags'][] = 'config:workbench_access.access_scheme.section';
 
   // Move our help text from the wrapper to below the label.
@@ -1405,6 +1410,26 @@ function va_gov_backend_page_attachments(array &$attachments) {
 
     return;
   }
+}
+
+/**
+ * Builds some useful node data for development.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   Some valid node.
+ *
+ * @return array
+ *   Keyed array of useful node info.
+ */
+function _va_gov_backend_node_data(NodeInterface $node) {
+  return [
+    'id' => $node->id(),
+    'uuid' => $node->uuid(),
+    'title' => $node->getTitle(),
+    'path' => $node->toUrl()->toString(),
+    'contentType' => $node->bundle(),
+    'jsonApiPath' => "/jsonapi/node/{$node->bundle()}/{$node->uuid()}",
+  ];
 }
 
 /**


### PR DESCRIPTION
## Description

Closes #4101, realistically.  See [this thread](https://dsva.slack.com/archives/CT4GZBM8F/p1653521229339479).

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Go to https://cms-xgwacix07qvn8uojceu8i6bhn5q80lql.ci.cms.va.gov/washington-dc-health-care/stories/fast-response-is-key-to-preventing-permanent-disability-after-stroke
2. Open developer console and type `drupalSettings.node`.
3. Observe that there is now useful debugging information, including the node UUID and JSON:API path.
