### PR TITLE
VACMS-9249: Add publish function for update hooks.

### DIFF
--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -225,6 +225,49 @@ function _va_gov_db_create_redirect_by_path($old_path, $new_path) {
 }
 
 /**
+ * Publishes latest node revision.
+ *
+ * @param array $nids
+ *   An array of node ids to publish.
+ *
+ * @return string
+ *   A message of confirmation of node titles published.
+ *
+ * @throws Drupal\Core\Utility\UpdateException
+ */
+function _va_gov_db_publish_nodes(array $nids) {
+  $nodes_published = [];
+  foreach ($nids as $nid) {
+    // Get latest revision ID.
+    $node_storage = \Drupal::entityTypeManager()
+      ->getStorage('node');
+    $latest_vid = $node_storage->getLatestRevisionId($nid);
+    if (empty($latest_vid)) {
+      throw new UpdateException("Failed to find nid: {$nid}");
+    }
+    // Load latest revision.
+    /** @var \Drupal\node\Entity\Node $latest_vid_loaded */
+    $latest_vid_loaded = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadRevision($latest_vid);
+    // Create a new revision and publish.
+    $latest_vid_loaded->status = 1;
+    $latest_vid_loaded->revision_log = t("Automatically published by code update.");
+    $latest_vid_loaded->set('moderation_state', "published");
+    $latest_vid_loaded->setNewRevision();
+    $latest_vid_loaded->isDefaultRevision(TRUE);
+    $latest_vid_loaded->setRevisionUserId(1317);
+    $latest_vid_loaded->setOwnerId(1317);
+    $latest_vid_loaded->setRevisionCreationTime(time());
+    $latest_vid_loaded->save();
+    $nodes_published[] = "{$nid} - {$latest_vid_loaded->getTitle()}";
+
+  }
+  $nids_list = implode(', ', $nodes_published);
+  return "Published these nodes: {$nids_list}";
+}
+
+/**
  * Modify field_facility_locator_api_id field to be longer.
  */
 function va_gov_db_update_8001(&$sandbox) {


### PR DESCRIPTION
## Description
closes #9249

## Testing done
Visual / drush updb

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/170595395-f7aa720e-f510-4f52-9e27-94fb52741971.png)

## QA steps
 - [ ] Checkout this pr branch locally
 - [ ] Go to `/node/6457/how-to-edit-an-event`
 - [ ] Edit the latest revision title and save as draft
 - [ ] Add the code snippet below to va_gov_db.install
 ```
/**
 * Publish KB events article.
 */
function va_gov_db_update_9006(&$sandbox) {
  $nids = [6483];
  return _va_gov_db_publish_nodes($nids);
}
```
- [ ] Run `drush updb`
- [ ] Verify terminal message akin to one in screenshot
- [ ] Go to `/node/6457/how-to-edit-an-event` and visually verify your changes saved, and have been published by `CMS migrator` as the latest revision

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
