### PR TITLE
VACMS-9099: Add rev log messages on covid status change.

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/js/set_covid_term_text.es6.js
+++ b/docroot/modules/custom/va_gov_vamc/js/set_covid_term_text.es6.js
@@ -4,11 +4,14 @@
 
 ((Drupal) => {
   let statusId;
-  const textSetter = () => {
+  const textSetter = (e) => {
     // The targeted tooltip fieldset.
     const fieldset = document.getElementById(
       "covid-safety-guidelines-status-text"
     );
+
+    // The revision log.
+    const revisionLog = document.getElementById("edit-revision-log-0-value");
 
     // Remove the previous setting = sanity reset.
     if (document.getElementById("covid-safety-guidelines-status-text-target")) {
@@ -18,6 +21,11 @@
       document
         .getElementById("covid-safety-guidelines-status-text-prefix")
         .remove();
+      if (e.type === "click") {
+        drupalSettings.vamcCovidStatusTermText.replace.forEach((element) => {
+          revisionLog.value = revisionLog.value.replace(element, "");
+        });
+      }
     }
 
     const covidStatusValue = document.querySelectorAll(
@@ -51,6 +59,12 @@
       covidStatusTextDivPrefix.innerHTML =
         '<h5>Guidelines</h5><div class="fieldset__description">Site visitors will see the following message for the level you selected.</div>';
       fieldset.before(covidStatusTextDivPrefix);
+
+      if (e.type === "click") {
+        // Revision log message.
+        revisionLog.value +=
+          drupalSettings.vamcCovidStatusTermText[statusId].log;
+      }
     }
   };
 

--- a/docroot/modules/custom/va_gov_vamc/js/set_covid_term_text.js
+++ b/docroot/modules/custom/va_gov_vamc/js/set_covid_term_text.js
@@ -7,12 +7,17 @@
 
 (function (Drupal) {
   var statusId = void 0;
-  var textSetter = function textSetter() {
+  var textSetter = function textSetter(e) {
     var fieldset = document.getElementById("covid-safety-guidelines-status-text");
+
+    var revisionLog = document.getElementById("edit-revision-log-0-value");
 
     if (document.getElementById("covid-safety-guidelines-status-text-target")) {
       document.getElementById("covid-safety-guidelines-status-text-target").remove();
       document.getElementById("covid-safety-guidelines-status-text-prefix").remove();
+      if (e.type === "click") {
+        revisionLog.value = "";
+      }
     }
 
     var covidStatusValue = document.querySelectorAll(".form-item--field-supplemental-status input");
@@ -37,6 +42,10 @@
       covidStatusTextDivPrefix.id = "covid-safety-guidelines-status-text-prefix";
       covidStatusTextDivPrefix.innerHTML = '<h5>Guidelines</h5><div class="fieldset__description">Site visitors will see the following message for the level you selected.</div>';
       fieldset.before(covidStatusTextDivPrefix);
+
+      if (e.type === "click") {
+        revisionLog.value += drupalSettings.vamcCovidStatusTermText[statusId].log;
+      }
     }
   };
 

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
@@ -222,9 +222,12 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       1035,
     ];
     $terms_text = [];
-    foreach ($covid_status as $status) {
-      $terms_text[$status]['name'] = $term_storage->load($status)->getName();
-      $terms_text[$status]['description'] = $term_storage->load($status)->getDescription();
+    foreach ($covid_status as $key) {
+      $loaded_term = $term_storage->load($key);
+      $terms_text[$key]['name'] = $loaded_term->getName();
+      $terms_text[$key]['description'] = $loaded_term->getDescription();
+      $terms_text[$key]['log'] = $loaded_term->label();
+      $terms_text['replace'][] = $loaded_term->label();
     }
     $form['#attached']['library'][] = 'va_gov_vamc/set_covid_term_text';
     $form['#attached']['drupalSettings']['vamcCovidStatusTermText'] = $terms_text;


### PR DESCRIPTION
## Description
closes #9099

## Testing done
Visual

## QA steps
 - [ ] As an administrator, go to `node/1410/edit` and visually verify revision log is empty.
 - [ ] Change the covid status to a different level, and visually verify text matching the level appears in the revision log
 - [ ] Change the covid status again, and visually verify the old message is replaced by a new one appropriate to the new level
 - [ ] Add some text manually to the rev log around covid status set by radio toggle, then toggle covid status to different value.
 - [ ] Confirm previous value was removed and replaced by new value, but existing manual text was not munged. (formatting will be bad, but this is an edge case test and can be fixed manually by editor).
 - [ ] Save the node and visually verify covid status is added to revision message list

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
