### PR TITLE
VACMS-8935: Add script to remove tz in hours comments.

### DIFF
--- a/scripts/content/VACMS-8935-scrub-tz-in-hours-field-comment.php
+++ b/scripts/content/VACMS-8935-scrub-tz-in-hours-field-comment.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @file
+ * Remove timezones in hours field comments.
+ *
+ * VACMS-8935-scrub-tz-in-hours-field-comment.php.
+ */
+
+use Psr\Log\LogLevel;
+
+$sandbox = ['#finished' => 0];
+do {
+  print(va_gov_force_save_remove_timezones_in_comments($sandbox));
+} while ($sandbox['#finished'] < 1);
+// Node processing complete.  Call this done.
+return;
+
+/**
+ * Remove timezones from hours field comments.
+ *
+ * @param array $sandbox
+ *   Modeling the structure of hook_update_n sandbox.
+ *
+ * @return string
+ *   Status message.
+ */
+function va_gov_force_save_remove_timezones_in_comments(array &$sandbox) {
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  // Get the node count for nodes with timezones in hours comments.
+  // This runs only once.
+  if (!isset($sandbox['total'])) {
+    // Hours field is attached to service_locations in all places,
+    // save for facilities.
+    // Facilities db search returned 0 results for timezones in comments.
+    $paragraph_query = Drupal::database()->select('paragraph__field_office_hours', 'pfoh');
+    $paragraph_query->join('node__field_service_location', 'nfsl', 'pfoh.entity_id = nfsl.field_service_location_target_id');
+    $paragraph_query->fields('nfsl', ['entity_id']);
+    $paragraph_query->groupBy('entity_id');
+    $paragraph_query->condition('pfoh.field_office_hours_comment', '^[ecmp]s?t$|[^a-z0-9][ecmp]s?t[^a-z0-9]/i', 'REGEXP');
+    $nids_to_update = $paragraph_query->execute()->fetchCol();
+    $result_count = count($nids_to_update);
+    $sandbox['total'] = $result_count;
+    $sandbox['current'] = 0;
+    // Create non-numeric keys to accurately remove each nid when processed.
+    $sandbox['nids_to_update'] = array_combine(
+      array_map('_va_gov_stringifynid', array_values($nids_to_update)),
+      array_values($nids_to_update));
+  }
+
+  // Do not continue if no nodes are found.
+  if (empty($sandbox['total'])) {
+    $sandbox['#finished'] = 1;
+    return "No nodes found for processing.\n";
+  }
+
+  $limit = 25;
+
+  // Load entities.
+  $node_ids = array_slice($sandbox['nids_to_update'], 0, $limit, TRUE);
+  $nodes = $node_storage->loadMultiple($node_ids);
+  foreach ($nodes as $node) {
+    // Make this change a new revision.
+    /** @var \Drupal\node\NodeInterface $node */
+    $node->setNewRevision(TRUE);
+
+    // Wipe out comments that have timezones.
+    foreach ($node->field_service_location->entity->field_office_hours as $key => $comment_field) {
+      $comment_field->comment = preg_replace("/^[ecmp]s?t$|[^a-z0-9][ecmp]s?t[^a-z0-9]/i", "", $comment_field->comment);
+    }
+
+    // Set revision author to uid 1317 (CMS Migrator user).
+    $node->setRevisionUserId(1317);
+    $node->setChangedTime(time());
+    $node->setRevisionCreationTime(time());
+    $node->setRevisionLogMessage('Saved to remove timezone from hours comments.');
+    $node->setSyncing(TRUE);
+    $node->save();
+
+    unset($sandbox['nids_to_update']["node_{$node->id()}"]);
+    $nids[] = $node->id();
+    $sandbox['current'] = $sandbox['total'] - count($sandbox['nids_to_update']);
+  }
+
+  // Log the processed nodes.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'Nodes: %current nodes hours comments updated. Nodes processed: %nids', [
+      '%current' => $sandbox['current'],
+      '%nids' => implode(', ', $nids),
+    ]);
+
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+  // Log the all-finished notice.
+  if ($sandbox['#finished'] == 1) {
+    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'RE-saving all %count nodes completed by va_gov_force_save_remove_timezones_in_comments', [
+      '%count' => $sandbox['total'],
+    ]);
+    return "Node updates complete. {$sandbox['current']} / {$sandbox['total']}\n";
+  }
+
+  return "Processed nodes... {$sandbox['current']} / {$sandbox['total']}.\n";
+}
+
+/**
+ * Callback function to concat node ids with string.
+ *
+ * @param int $nid
+ *   The node id.
+ *
+ * @return string
+ *   The node id concatenated to the end of node_
+ */
+function _va_gov_stringifynid($nid) {
+  return "node_$nid";
+}


### PR DESCRIPTION
## Description
closes #8935

## Testing done
`ddev drush scr scripts/content/VACMS-8935-scrub-tz-in-hours-field-comment.php`

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/170878092-313169a5-c41c-4c39-b49c-5462bd723b4f.png)

![image](https://user-images.githubusercontent.com/2404547/170878109-4d7321bd-f702-472c-a765-b8a6b6fcb511.png)

![image](https://user-images.githubusercontent.com/2404547/170878220-213de132-db4d-48a2-8614-0308f43beae5.png)

## QA steps
 - [x] Visit `/node/46377/edit` & `/node/46293/edit` & open the hours fieldset, taking note of the appearance of timezones in hours comments fields
 - [x] run `ddev drush scr scripts/content/VACMS-8935-scrub-tz-in-hours-field-comment.php` on local
 - [x] Visually verify increments of 25 are logged as being processed in terminal, and completion message is displayed after run of ~900 items.
 - [x] Reload `/node/46377/edit` & `/node/46293/edit` & open the hours fieldset, taking note of the lack of appearance of timezones in hours comments fields
 - [x] Visit `admin/reports/dblog` and visually verify logged results of script processing


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
