### PR TITLE
VACMS-9097 new facility notification

### DIFF
--- a/config/sync/core.entity_form_display.message.va_facility_new_facility.default.yml
+++ b/config/sync/core.entity_form_display.message.va_facility_new_facility.default.yml
@@ -1,0 +1,49 @@
+uuid: 75f4c045-8faa-4eb9-910f-934bc6351101
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.va_facility_new_facility.field_target_entity
+    - field.field.message.va_facility_new_facility.field_target_node_title
+    - message.template.va_facility_new_facility
+id: message.va_facility_new_facility.default
+targetEntityType: message
+bundle: va_facility_new_facility
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_target_entity:
+    type: entity_reference_autocomplete
+    weight: 13
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_target_node_title:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    '#group': advanced
+hidden: {  }

--- a/config/sync/core.entity_view_display.message.va_facility_new_facility.default.yml
+++ b/config/sync/core.entity_view_display.message.va_facility_new_facility.default.yml
@@ -1,0 +1,38 @@
+uuid: 2fde3825-37ea-4d6b-b214-2b224dc9d9f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.va_facility_new_facility.field_target_entity
+    - field.field.message.va_facility_new_facility.field_target_node_title
+    - message.template.va_facility_new_facility
+  module:
+    - user
+id: message.va_facility_new_facility.default
+targetEntityType: message
+bundle: va_facility_new_facility
+mode: default
+content:
+  field_target_entity:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_target_node_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.va_facility_new_facility.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.va_facility_new_facility.mail_body.yml
@@ -1,0 +1,33 @@
+uuid: 40d59eb2-4ec2-40c3-9624-34c6ae349dcf
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - field.field.message.va_facility_new_facility.field_target_entity
+    - field.field.message.va_facility_new_facility.field_target_node_title
+    - message.template.va_facility_new_facility
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: message.va_facility_new_facility.mail_body
+targetEntityType: message
+bundle: va_facility_new_facility
+mode: mail_body
+content:
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  field_target_entity: true
+  field_target_node_title: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.va_facility_new_facility.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.va_facility_new_facility.mail_subject.yml
@@ -1,0 +1,37 @@
+uuid: ff407bd9-09d1-46f6-8589-b09b689e1e3e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - field.field.message.va_facility_new_facility.field_target_entity
+    - field.field.message.va_facility_new_facility.field_target_node_title
+    - message.template.va_facility_new_facility
+  module:
+    - layout_builder
+    - string_field_formatter
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: message.va_facility_new_facility.mail_subject
+targetEntityType: message
+bundle: va_facility_new_facility
+mode: mail_subject
+content:
+  field_target_node_title:
+    type: plain_string_formatter
+    label: hidden
+    settings:
+      link_to_entity: false
+      wrap_tag: _none
+      wrap_class: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_target_entity: true
+  partial_0: true
+  partial_1: true
+  search_api_excerpt: true

--- a/config/sync/field.field.message.va_facility_new_facility.field_target_entity.yml
+++ b/config/sync/field.field.message.va_facility_new_facility.field_target_entity.yml
@@ -1,0 +1,50 @@
+uuid: 0412e93c-38b1-4f45-b1c8-5f007445fd9c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_target_entity
+    - message.template.va_facility_new_facility
+    - node.type.health_care_local_facility
+    - node.type.nca_facility
+    - node.type.vba_facility
+    - node.type.vet_center
+    - node.type.vet_center_mobile_vet_center
+    - node.type.vet_center_outstation
+  module:
+    - entity_reference_validators
+    - epp
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: false
+  epp:
+    value: ''
+    on_update: 0
+id: message.va_facility_new_facility.field_target_entity
+field_name: field_target_entity
+entity_type: message
+bundle: va_facility_new_facility
+label: target_entity
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      nca_facility: nca_facility
+      health_care_local_facility: health_care_local_facility
+      vba_facility: vba_facility
+      vet_center: vet_center
+      vet_center_mobile_vet_center: vet_center_mobile_vet_center
+      vet_center_outstation: vet_center_outstation
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: nca_facility
+field_type: entity_reference

--- a/config/sync/field.field.message.va_facility_new_facility.field_target_node_title.yml
+++ b/config/sync/field.field.message.va_facility_new_facility.field_target_node_title.yml
@@ -1,0 +1,25 @@
+uuid: 51a80aea-6a7f-4f8f-a47c-9a1418806adb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_target_node_title
+    - message.template.va_facility_new_facility
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: message.va_facility_new_facility.field_target_node_title
+field_name: field_target_node_title
+entity_type: message
+bundle: va_facility_new_facility
+label: 'Target Node Title'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/message.template.va_facility_new_facility.yml
+++ b/config/sync/message.template.va_facility_new_facility.yml
@@ -1,0 +1,19 @@
+uuid: 62c7d69d-aa48-4e1a-81dd-74eab6357095
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.rich_text
+template: va_facility_new_facility
+label: 'VA Facility new facility'
+description: 'Message sent to the help desk when a new facility is created.'
+text:
+  -
+    value: "<p>Hello CMS Help Desk!</p>\r\n\r\n<p>A new [message:field_target_entity:entity:content-type] &lt;a href=\\\"[message:field_target_entity:entity:url]\\\"&gt;[message:field_target_node_title]&lt;/a&gt; was added to&nbsp;[site:name]&nbsp;[message:field_target_entity:entity:created].</p>\r\n\r\n<ul>\r\n\t<li>\r\n\t<p>Here is a link to the Knowledge Base article about the steps editors must take in order for a new VAMC facility to be added to&nbsp;<a href=\"http://va.gov/\" target=\"_blank\">VA.gov</a>:&nbsp;<a href=\"https://prod.cms.va.gov/help/vamc/about-locations-content-for-vamcs/how-do-i-add-a-facility-to-my-health-care-system\" target=\"_blank\">https://prod.cms.va.gov/help/vamc/about-locations-content-for-vamcs/how-do-i-add-a-facility-to-my-health-care-system</a></p>\r\n\t</li>\r\n</ul>\r\n\r\n<ul>\r\n\t<li>\r\n\t<p>Please also review the internal Github runbook for adding a new facility to the site:&nbsp;<a href=\"https://github.com/department-of-veterans-affairs/va.gov-cms/blob/main/.github/ISSUE_TEMPLATE/runbook-facility-new.md\" target=\"_blank\">https://github.com/department-of-veterans-affairs/va.gov-cms/blob/main/.github/ISSUE_TEMPLATE/runbook-facility-new.md</a></p>\r\n\t</li>\r\n</ul>\r\n"
+    format: rich_text
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1865,7 +1865,7 @@ function va_gov_backend_raven_options_alter(array &$options) {
  */
 function va_gov_backend_theme_suggestions_form_element_alter(array &$suggestions, array $variables) {
 
-  if ($variables['element']['#type'] == 'textarea') {
+  if (isset($variables['element']['#type']) && $variables['element']['#type'] == 'textarea') {
     $suggestions[] = 'form_element__textarea';
   }
 }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
@@ -17,6 +17,9 @@ use Drupal\va_gov_vamc\Service\ContentHardeningDeduper;
 use Drupal\va_gov_workflow\Service\Flagger;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+// The UID of the CMS Help Desk account subscribing to facility messages.
+const USER_CMS_HELP_DESK_NOTIFICATIONS = 4050;
+
 /**
  * VA.gov VAMC Entity Event Subscriber.
  */
@@ -175,6 +178,9 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       // $message_fields = $this->notificationsManager->buildMessageFields($entity, 'New facility:');
       // $this->notificationsManager->send('va_facility_new_facility', 1215, $message_fields);
       // @codingStandardsIgnoreEnd
+
+      $message_fields = $this->notificationsManager->buildMessageFields($entity, 'New facility:');
+      $this->notificationsManager->send('va_facility_new_facility', USER_CMS_HELP_DESK_NOTIFICATIONS, $message_fields);
     }
   }
 


### PR DESCRIPTION
## Description

Relates to #9097. First of four use cases for "dogfooding" the messages stack with our CMS Help Desk.

- Sends out a template message using the newly created CMS Help Desk notifications user to support@va-gov.atlassian.net with a message about any new facility created so that the appropriate follow-up steps may happen. 
- Coordinated with Stefanie on the desired wording of the email template.
- Created view modes to display email subject/body correctly.

## Testing done
Created new facilities of the 6 types locally, verified that an email was sent in mailhog ( https://va-gov-cms.ddev.site:8026/ )

## Screenshots
Email generated from a new facility being created:
<img width="1135" alt="Screen Shot 2022-05-31 at 2 05 15 PM" src="https://user-images.githubusercontent.com/11279744/171284260-419ff76d-87c3-4b64-a9c4-1f3e27deced5.png">

I'm not sure it's set up 100% correctly (or if it is mailhog changing something somewhere), because the `from:` and `to:` fields look a little off to me... but it's using the same setup as both @swirtSJW's example and the example in the module 🤔

## QA steps

What needs to be checked to prove this works?  
- create a new facility (any of the 6 facility types: VAMC Facility, VBA Facility, NCA Facility, Vet Center, Vet Center Mobile Vet Center, or Vet Center Outstation) and save it. exact section and menu things don't really matter for this initial step.
- as an admin user: check `/admin/content/message` and see that a new message was created for the facility creation. I am not sure how to check mailhog on tugboat, but if you are testing locally, visit mailhog at https://va-gov-cms.ddev.site:8026/ and see a corresponding email captured.
<img width="1401" alt="Screen Shot 2022-05-31 at 2 11 27 PM" src="https://user-images.githubusercontent.com/11279744/171285389-03451074-cf48-47d3-961c-753a629d74b0.png">


What needs to be checked to prove it didn't break any related things? 
- No emails should be sent for any other actions at this time.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`
