### PR TITLE
VACMS-9097 facility deleted notification

### DIFF
--- a/config/sync/core.entity_form_display.message.va_facility_removed_from_source.default.yml
+++ b/config/sync/core.entity_form_display.message.va_facility_removed_from_source.default.yml
@@ -1,0 +1,49 @@
+uuid: 2a697274-f316-440f-ab1d-8e2e62776c25
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.va_facility_removed_from_source.field_target_entity
+    - field.field.message.va_facility_removed_from_source.field_target_node_title
+    - message.template.va_facility_removed_from_source
+id: message.va_facility_removed_from_source.default
+targetEntityType: message
+bundle: va_facility_removed_from_source
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_target_entity:
+    type: entity_reference_autocomplete
+    weight: 12
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_target_node_title:
+    type: string_textfield
+    weight: 13
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    '#group': advanced
+hidden: {  }

--- a/config/sync/core.entity_view_display.message.va_facility_removed_from_source.default.yml
+++ b/config/sync/core.entity_view_display.message.va_facility_removed_from_source.default.yml
@@ -1,0 +1,38 @@
+uuid: fe98d6fa-47a2-446f-93cc-f273ded4c78c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.va_facility_removed_from_source.field_target_entity
+    - field.field.message.va_facility_removed_from_source.field_target_node_title
+    - message.template.va_facility_removed_from_source
+  module:
+    - user
+id: message.va_facility_removed_from_source.default
+targetEntityType: message
+bundle: va_facility_removed_from_source
+mode: default
+content:
+  field_target_entity:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_target_node_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.va_facility_removed_from_source.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.va_facility_removed_from_source.mail_body.yml
@@ -1,0 +1,33 @@
+uuid: 5c36dc38-3be7-4491-af2d-8945607944b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - field.field.message.va_facility_removed_from_source.field_target_entity
+    - field.field.message.va_facility_removed_from_source.field_target_node_title
+    - message.template.va_facility_removed_from_source
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: message.va_facility_removed_from_source.mail_body
+targetEntityType: message
+bundle: va_facility_removed_from_source
+mode: mail_body
+content:
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  field_target_entity: true
+  field_target_node_title: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.va_facility_removed_from_source.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.va_facility_removed_from_source.mail_subject.yml
@@ -1,0 +1,37 @@
+uuid: 7736a381-afea-48ac-8a47-fe11f188acec
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - field.field.message.va_facility_removed_from_source.field_target_entity
+    - field.field.message.va_facility_removed_from_source.field_target_node_title
+    - message.template.va_facility_removed_from_source
+  module:
+    - layout_builder
+    - string_field_formatter
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: message.va_facility_removed_from_source.mail_subject
+targetEntityType: message
+bundle: va_facility_removed_from_source
+mode: mail_subject
+content:
+  field_target_node_title:
+    type: plain_string_formatter
+    label: hidden
+    settings:
+      link_to_entity: false
+      wrap_tag: _none
+      wrap_class: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_target_entity: true
+  partial_0: true
+  partial_1: true
+  search_api_excerpt: true

--- a/config/sync/field.field.message.va_facility_removed_from_source.field_target_entity.yml
+++ b/config/sync/field.field.message.va_facility_removed_from_source.field_target_entity.yml
@@ -1,0 +1,50 @@
+uuid: 8176fb88-e240-4cee-88af-8f00135c38b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_target_entity
+    - message.template.va_facility_removed_from_source
+    - node.type.health_care_local_facility
+    - node.type.nca_facility
+    - node.type.vba_facility
+    - node.type.vet_center
+    - node.type.vet_center_mobile_vet_center
+    - node.type.vet_center_outstation
+  module:
+    - entity_reference_validators
+    - epp
+third_party_settings:
+  entity_reference_validators:
+    circular_reference: false
+    circular_reference_deep: false
+    duplicate_reference: false
+  epp:
+    value: ''
+    on_update: 0
+id: message.va_facility_removed_from_source.field_target_entity
+field_name: field_target_entity
+entity_type: message
+bundle: va_facility_removed_from_source
+label: target_entity
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      nca_facility: nca_facility
+      health_care_local_facility: health_care_local_facility
+      vba_facility: vba_facility
+      vet_center: vet_center
+      vet_center_mobile_vet_center: vet_center_mobile_vet_center
+      vet_center_outstation: vet_center_outstation
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: nca_facility
+field_type: entity_reference

--- a/config/sync/field.field.message.va_facility_removed_from_source.field_target_node_title.yml
+++ b/config/sync/field.field.message.va_facility_removed_from_source.field_target_node_title.yml
@@ -1,0 +1,25 @@
+uuid: 9cf21eaa-3976-43b3-a811-f5b4afa67fd6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_target_node_title
+    - message.template.va_facility_removed_from_source
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: message.va_facility_removed_from_source.field_target_node_title
+field_name: field_target_node_title
+entity_type: message
+bundle: va_facility_removed_from_source
+label: 'Target Node Title'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/message.template.va_facility_removed_from_source.yml
+++ b/config/sync/message.template.va_facility_removed_from_source.yml
@@ -1,0 +1,19 @@
+uuid: d8673740-2510-4e2e-9aef-f166239d0246
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.rich_text
+template: va_facility_removed_from_source
+label: 'VA Facility removed from source'
+description: 'Informs the CMS Help Desk when a facility has been removed upstream.'
+text:
+  -
+    value: "<p>Hello CMS Help Desk!</p>\r\n\r\n<p>An existing [message:field_target_entity:entity:content-type] named &lt;a href=\\\"[message:field_target_entity:entity:url]\\\"&gt;[message:field_target_entity:entity:title]&lt;/a&gt;&nbsp;was flagged as removed from the upstream Facility API on [message:field_target_entity:entity:changed].</p>\r\n\r\n<p><br />\r\nPlease follow up with the editor of the above facility and ask them to make sure they have completed all steps listed here:&nbsp;<a href=\"https://prod.cms.va.gov/help/vamc/about-locations-content-for-vamcs/how-to-archive-a-closed-facility\" target=\"_blank\">https://prod.cms.va.gov/help/vamc/about-locations-content-for-vamcs/how-to-archive-a-closed-facility</a><br />\r\n<br />\r\nThank you!</p>\r\n"
+    format: rich_text
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/docroot/modules/custom/va_gov_migrate/drush.services.yml
+++ b/docroot/modules/custom/va_gov_migrate/drush.services.yml
@@ -7,5 +7,6 @@ services:
       - '@va_gov_workflow.flagger'
       - '@plugin.manager.migrate_plus.data_fetcher'
       - '@logger.channel.va_gov_migrate'
+      - '@va_gov_notifications.notifications_manager'
     tags:
       - { name: drush.command }

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -8,10 +8,14 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\migrate_plus\DataFetcherPluginManager;
 use Drupal\migrate_plus\Entity\Migration;
 use Drupal\node\NodeInterface;
+use Drupal\va_gov_notifications\Service\NotificationsManager;
 use Drupal\va_gov_workflow\Service\Flagger;
 use Drush\Commands\DrushCommands;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+
+// The UID of the CMS Help Desk account subscribing to facility messages.
+const USER_CMS_HELP_DESK_NOTIFICATIONS = 4050;
 
 /**
  * Drush commands related to migrations.
@@ -54,6 +58,13 @@ class Commands extends DrushCommands {
   protected $flagger;
 
   /**
+   * The VA gov NotificationsManager.
+   *
+   * @var \Drupal\va_gov_notifications\Service\NotificationsManager
+   */
+  protected $notificationsManager;
+
+  /**
    * Constructor for this set of drush commands.
    *
    * @param \Drupal\Core\Database\Connection $data_base
@@ -66,13 +77,16 @@ class Commands extends DrushCommands {
    *   DataFetcherPluginManager.
    * @param \Psr\Log\LoggerInterface $migrate_channel_logger
    *   LoggerChannel for va_gov_migrate.
+   * @param \Drupal\va_gov_notifications\Service\NotificationsManager $notifications_manager
+   *   VA gov NotificationsManager service.
    */
   public function __construct(
     Connection $data_base,
     EntityTypeManagerInterface $entity_type_manager,
     Flagger $flaggerservice,
     DataFetcherPluginManager $data_fetcher_plugin_manager,
-    LoggerInterface $migrate_channel_logger
+    LoggerInterface $migrate_channel_logger,
+    NotificationsManager $notifications_manager
   ) {
     parent::__construct();
     $this->database = $data_base;
@@ -80,6 +94,7 @@ class Commands extends DrushCommands {
     $this->flagger = $flaggerservice;
     $this->dataFetcherPluginManager = $data_fetcher_plugin_manager;
     $this->migrateChannelLogger = $migrate_channel_logger;
+    $this->notificationsManager = $notifications_manager;
   }
 
   /**
@@ -147,6 +162,10 @@ class Commands extends DrushCommands {
       foreach ($facility_nodes_to_flag as $facility_node_to_flag) {
         $this->addNodeRevision($facility_node_to_flag);
         $this->flagger->setFlag('removed_from_source', $facility_node_to_flag);
+
+        // Send email to CMS Help Desk for follow-up steps.
+        $message_fields = $this->notificationsManager->buildMessageFields($facility_node_to_flag, 'Facility removed:');
+        $this->notificationsManager->send('va_facility_removed_from_source', USER_CMS_HELP_DESK_NOTIFICATIONS, $message_fields);
       }
 
       // Log amount to be processed.


### PR DESCRIPTION
## Description
Relates to #9097, companion to #9280. This contains the last of 4 use cases from the ticket.

Sends an email to the help desk when facilities are flagged as removed from the facility API. Collaborated with Stefanie on the email template.

## Testing done
- Created a new facility (any type, a newly created facility won't be in the facility API) and then ran the following command:

```sh 
$ ddev drush va_gov_migrate:flag-missing-facilities
[success] Flagged 2 facilities as removed from Facility API.
```

Checked mailhog locally @ https://va-gov-cms.ddev.site:8026/ to see that the notification was triggered.

Checked that the node in the email was correctly flagged as "removed from source" in Drupal flags. 

## Screenshots
mailhog:
<img width="654" alt="Screen Shot 2022-06-02 at 2 47 00 PM" src="https://user-images.githubusercontent.com/11279744/171743874-4dab12e2-4730-4480-a5f2-cfa8dcfa60dc.png">
For some reason, this template renders the site url as "default" despite using the same url token from the referenced entity as the other templates. My thinking is this is due to this particular case being triggered by a drush command versus the entity event subscriber, but I haven't dug in to confirm yet.... the node url is correct below in the message log itself.

drupal message log (bottom of `/admin/content/message`. `/admin/content/messages` is also a valid route with a slightly similar view :thinking:):
<img width="1216" alt="Screen Shot 2022-06-02 at 2 52 22 PM" src="https://user-images.githubusercontent.com/11279744/171745194-9aa814bc-702d-4522-88b4-bd4ac05134de.png">


revision from migration command that flags the node:
<img width="317" alt="Screen Shot 2022-06-02 at 2 54 21 PM" src="https://user-images.githubusercontent.com/11279744/171744842-300a7692-7461-474b-be65-1c923a023cab.png">


## QA steps

What needs to be checked to prove this works? 
- The places in the testing steps above. Mailhog, messages, and the node revision.
What needs to be checked to prove it didn't break any related things?  
- This email template should only trigger for flaggable facilities from the migration command
What variations of circumstances (users, actions, values) need to be checked?  


As an admin user,
- create a new facility with a bogus facility id (VBA facility doesn't have many required fields). you can flag it as a new facility  if you want (no email should be sent for that action in this branch).
- run this drush command to flag missing facilities: `ddev drush va_gov_migrate:flag-missing-facilities`. you should see at least one facility flagged (your new bogus facility)
- Check mailhog to see the email
- Check `/admin/content/message/` (you may need to scroll to the bottom)
- Check the node itself that a revision was created & it was flagged correctly (this functionality shouldn't have changed in this PR)


### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`
