### PR TITLE
VACMS-7279: add facility_url and Lovell overrides to Facility API

### DIFF
--- a/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
+++ b/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
@@ -17,10 +17,12 @@ class LovellOps {
   const TRICARE_NAME = 'Lovell Federal health care - TRICARE';
   const TRICARE_PATH = 'lovell-federal-health-care-tricare';
   const TRICARE_VALUE = 'tricare';
+  const TRICARE_SYSTEM_ID = '49011';
   const VA_ID = '1040';
   const VA_NAME = 'Lovell Federal health care - VA';
   const VA_PATH = 'lovell-federal-health-care-va';
   const VA_VALUE = 'va';
+  const VA_SYSTEM_ID = '49451';
   const LOVELL_MENU_ID = 'lovell-federal-health-care';
   const LOVELL_FEDERAL_SYSTEM_ID = '15007';
   const LOVELL_SECTIONS = [

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
@@ -3,13 +3,14 @@
 namespace Drupal\va_gov_post_api\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\post_api\Service\AddToQueue;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\NodeInterface;
+use Drupal\post_api\Service\AddToQueue;
+use Drupal\va_gov_lovell\LovellOps;
 
 /**
  * Class PostFacilityService posts specific service info to Lighthouse.
@@ -52,8 +53,6 @@ abstract class PostFacilityBase {
    * @var \Drupal\post_api\Service\AddToQueue
    */
   protected $postQueue;
-
-  const LOVELL_TRICARE = 1039;
 
   /**
    * Constructs a new PostFacilityBase object.
@@ -110,7 +109,7 @@ abstract class PostFacilityBase {
   protected function isLovellTricareSection(EntityInterface $entity) : bool {
     if (($entity instanceof NodeInterface) && ($entity->hasField('field_administration'))) {
       /** @var \Drupal\node\NodeInterface $entity*/
-      if ($entity->get('field_administration')->target_id == self::LOVELL_TRICARE) {
+      if ($entity->get('field_administration')->target_id == LovellOps::TRICARE_ID) {
         return TRUE;
       }
     }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -301,25 +301,14 @@ class PostFacilityStatus extends PostFacilityBase {
       $systemId = $this->facilityNode->get('field_region_page')->target_id;
       // System url overrides for Lovell VA.
       if (($systemId === LovellOps::LOVELL_FEDERAL_SYSTEM_ID) || ($systemId === LovellOps::VA_SYSTEM_ID)) {
-        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov';
-        $payload['system']['url'] = 'https://www.lovell.fhcc.va.gov';
-        $payload['system']['covid_url'] = 'https://www.lovell.fhcc.va.gov/services/covid-19-vaccines.asp';
+        $payload['core']['facility_url'] = 'https://www.va.gov/lovell-federal-health-care-va/';
+        $payload['system']['url'] = 'https://www.va.gov/lovell-federal-health-care-va/';
+        $payload['system']['covid_url'] = 'https://www.va.gov/lovell-federal-health-care-va/programs/covid-19-vaccines-and-testing/';
       }
       // Facility url overrides.
       $facility_id = $this->facilityNode->field_facility_locator_api_id->value;
-      // Evanston VA clinic - vha_556GA.
-      if ($facility_id === 'vha_556GA') {
-        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Evanston_Community_Based_Outpatient_Clinic.asp';
-      }
-      // Kenosha VA Clinic - vha_556GD.
-      if ($facility_id === 'vha_556GD') {
-        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Kenosha_Community_Based_Outpatient_Clinic.asp';
-      }
-      // McHenry VA Clinic - vha_556GC.
-      if ($facility_id === 'vha_556GC') {
-        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/McHenry_Community_Based_Outpatient_Clinic.asp';
-      }
-      // Manila VA Clinic - vha_358.
+
+      // Manila VA Clinic - vha_358.  Manila is a one facility system.
       if ($facility_id === 'vha_358') {
         $payload['core']['facility_url'] = 'https://www.visn21.va.gov/locations/manila.asp';
       }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -179,6 +179,7 @@ class PostFacilityStatus extends PostFacilityBase {
 
     if ($this->shouldPush($forcePush)) {
       $payload = [
+        'facility_url' => 'https://www.va.gov' . $this->facilityNode->toUrl()->toString(),
         'operating_status' => [
           'code' => strtoupper($this->statusToPush),
           'additional_info' => (strtoupper($this->statusToPush) != 'NORMAL') ? $this->additionalInfoToPush : NULL,
@@ -187,6 +188,7 @@ class PostFacilityStatus extends PostFacilityBase {
 
       $this->addSupplementalStatus($payload);
       $this->getRelatedSystemInfo($payload);
+      $this->getSystemOverrides($payload);
     }
 
     return $payload;
@@ -256,6 +258,43 @@ class PostFacilityStatus extends PostFacilityBase {
           'covid_url' => 'https://www.va.gov' . $systemUrl . '/programs/covid-19-vaccines',
           'va_health_connect_phone' => $systemNode->get('field_va_health_connect_phone')->value,
         ];
+      }
+    }
+  }
+
+  /**
+   * Update payload array with overrides for specific systems.
+   *
+   * @param array $payload
+   *   Payload array.
+   */
+  protected function getSystemOverrides(array &$payload) {
+    // If this facility references a system, include system information.
+    if ($this->facilityNode->hasField('field_region_page')) {
+      $systemId = $this->facilityNode->get('field_region_page')->target_id;
+      // System url overrides: Lovell VAMC System - 15007.
+      if ($systemId === '15007') {
+        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov';
+        $payload['system']['url'] = 'https://www.lovell.fhcc.va.gov';
+        $payload['system']['covid_url'] = 'https://www.lovell.fhcc.va.gov/services/covid-19-vaccines.asp';
+      }
+      // Facility url overrides.
+      $facility_id = $this->facilityNode->hasField('field_facility_locator_api_id') ? $this->facilityNode->get('field_facility_locator_api_id')->value : NULL;
+      // Evanston VA clinic - vha_556GA.
+      if ($facility_id === 'vha_556GA') {
+        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Evanston_Community_Based_Outpatient_Clinic.asp';
+      }
+      // Kenosha VA Clinic - vha_556GD.
+      if ($facility_id === 'vha_556GD') {
+        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Kenosha_Community_Based_Outpatient_Clinic.asp';
+      }
+      // McHenry VA Clinic - vha_556GC.
+      if ($facility_id === 'vha_556GC') {
+        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/McHenry_Community_Based_Outpatient_Clinic.asp';
+      }
+      // Manila VA Clinic - vha_358.
+      if ($facility_id === 'vha_358') {
+        $payload['facility_url'] = 'https://www.visn21.va.gov/locations/manila.asp';
       }
     }
   }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -4,6 +4,7 @@ namespace Drupal\va_gov_post_api\Service;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\NodeInterface;
+use Drupal\va_gov_lovell\LovellOps;
 
 /**
  * Class PostFacilityService posts facility status info to Lighthouse.
@@ -257,7 +258,7 @@ class PostFacilityStatus extends PostFacilityBase {
         $payload['system'] = [
           'name' => $systemNode->get('title')->value,
           'url' => 'https://www.va.gov' . $systemUrl,
-          'covid_url' => 'https://www.va.gov' . $systemUrl . '/programs/covid-19-vaccines',
+          'covid_url' => "https://www.va.gov{$systemUrl}/programs/covid-19-vaccines",
           'va_health_connect_phone' => $systemNode->get('field_va_health_connect_phone')->value,
         ];
       }
@@ -274,8 +275,8 @@ class PostFacilityStatus extends PostFacilityBase {
     // If this facility references a system, include system information.
     if ($this->facilityNode->hasField('field_region_page')) {
       $systemId = $this->facilityNode->get('field_region_page')->target_id;
-      // System url overrides: Lovell VAMC System - 15007.
-      if ($systemId === '15007') {
+      // System url overrides for Lovell VA.
+      if (($systemId === LovellOps::LOVELL_FEDERAL_SYSTEM_ID) || ($systemId === LovellOps::VA_SYSTEM_ID)) {
         $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov';
         $payload['system']['url'] = 'https://www.lovell.fhcc.va.gov';
         $payload['system']['covid_url'] = 'https://www.lovell.fhcc.va.gov/services/covid-19-vaccines.asp';

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -76,7 +76,7 @@ class PostFacilityStatus extends PostFacilityBase {
     if ($entity instanceof NodeInterface && $this->isFacilityWithStatus($entity)) {
       /** @var \Drupal\node\NodeInterface $entity*/
       $this->facilityNode = $entity;
-      $facility_id = $this->facilityNode->field_facility_locator_api_id->value;
+      $facility_id = $entity->hasField('field_facility_locator_api_id') ? $entity->get('field_facility_locator_api_id')->value : NULL;
       $data['nid'] = $entity->id();
       // Queue item's Unique ID.
       $data['uid'] = $facility_id ? "facility_status_{$facility_id}" : NULL;
@@ -213,7 +213,8 @@ class PostFacilityStatus extends PostFacilityBase {
     }
     else {
       // The page is not published, so send the Facility Locator Detail Page.
-      $facility_id = $this->facilityNode->field_facility_locator_api_id->value;
+      $facility_id = $this->facilityNode->hasField('field_facility_locator_api_id') ? $this->facilityNode->get('field_facility_locator_api_id')->value : NULL;
+
       if ($facility_id) {
         $facility_url = "https://www.va.gov/find-locations/facility/{$facility_id}";
       }
@@ -306,7 +307,7 @@ class PostFacilityStatus extends PostFacilityBase {
         $payload['system']['covid_url'] = 'https://www.va.gov/lovell-federal-health-care-va/programs/covid-19-vaccines-and-testing/';
       }
       // Facility url overrides.
-      $facility_id = $this->facilityNode->field_facility_locator_api_id->value;
+      $facility_id = $this->facilityNode->hasField('field_facility_locator_api_id') ? $this->facilityNode->get('field_facility_locator_api_id')->value : NULL;
 
       // Manila VA Clinic - vha_358.  Manila is a one facility system.
       if ($facility_id === 'vha_358') {

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -179,7 +179,9 @@ class PostFacilityStatus extends PostFacilityBase {
 
     if ($this->shouldPush($forcePush)) {
       $payload = [
-        'facility_url' => 'https://www.va.gov' . $this->facilityNode->toUrl()->toString(),
+        'core' => [
+          'facility_url' => 'https://www.va.gov' . $this->facilityNode->toUrl()->toString(),
+        ],
         'operating_status' => [
           'code' => strtoupper($this->statusToPush),
           'additional_info' => (strtoupper($this->statusToPush) != 'NORMAL') ? $this->additionalInfoToPush : NULL,
@@ -274,7 +276,7 @@ class PostFacilityStatus extends PostFacilityBase {
       $systemId = $this->facilityNode->get('field_region_page')->target_id;
       // System url overrides: Lovell VAMC System - 15007.
       if ($systemId === '15007') {
-        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov';
+        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov';
         $payload['system']['url'] = 'https://www.lovell.fhcc.va.gov';
         $payload['system']['covid_url'] = 'https://www.lovell.fhcc.va.gov/services/covid-19-vaccines.asp';
       }
@@ -282,19 +284,19 @@ class PostFacilityStatus extends PostFacilityBase {
       $facility_id = $this->facilityNode->hasField('field_facility_locator_api_id') ? $this->facilityNode->get('field_facility_locator_api_id')->value : NULL;
       // Evanston VA clinic - vha_556GA.
       if ($facility_id === 'vha_556GA') {
-        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Evanston_Community_Based_Outpatient_Clinic.asp';
+        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Evanston_Community_Based_Outpatient_Clinic.asp';
       }
       // Kenosha VA Clinic - vha_556GD.
       if ($facility_id === 'vha_556GD') {
-        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Kenosha_Community_Based_Outpatient_Clinic.asp';
+        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Kenosha_Community_Based_Outpatient_Clinic.asp';
       }
       // McHenry VA Clinic - vha_556GC.
       if ($facility_id === 'vha_556GC') {
-        $payload['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/McHenry_Community_Based_Outpatient_Clinic.asp';
+        $payload['core']['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/McHenry_Community_Based_Outpatient_Clinic.asp';
       }
       // Manila VA Clinic - vha_358.
       if ($facility_id === 'vha_358') {
-        $payload['facility_url'] = 'https://www.visn21.va.gov/locations/manila.asp';
+        $payload['core']['facility_url'] = 'https://www.visn21.va.gov/locations/manila.asp';
       }
     }
   }


### PR DESCRIPTION
## Description

Closes #7279 

## Testing done

Visual testing

## Screenshots

<img width="1698" alt="Screen Shot 2022-06-07 at 9 52 47 AM" src="https://user-images.githubusercontent.com/21045418/172397765-dac42257-5541-4497-b940-51845482a0dc.png">

## QA steps

As an admin user:

1. Visit /node/1481/edit
2. Modify the operating status to trigger a Facility status push
3. Save your changes
4. Visit /admin/config/post-api/queue
5. Verify the JSON object generated includes the following:

- [x] ['system']['url'] = 'https://www.lovell.fhcc.va.gov'
- [x] ['system']['covid_url'] = 'https://www.lovell.fhcc.va.gov/services/covid-19-vaccines.asp'
- [x] ['facility_url'] = 'https://www.lovell.fhcc.va.gov/locations/Evanston_Community_Based_Outpatient_Clinic.asp'

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

This PR cannot be merged until the Lighthouse team is ready to receive the new facility_url datapoint. Check with the Lighthouse team during their upcoming sprint (June 14 - June 28) to coordinate when this code can be merged and deployed.

https://dsva.slack.com/archives/C02BTJTDFTN/p1654549467258959