### PR TITLE
VAGOV-9295: [devops] Add slack_channel for CMS build job to notify of failures

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -1,5 +1,5 @@
-// This file is called from ansible/deployment/config/jenkins-vetsgov/seed_job.groovy
-// and is used in the http://jenkins.vfs.va.gov/job/testing/job/cms-test job that
+// This file is sourced from ansible/deployment/config/jenkins-vetsgov/seed_job.groovy
+// and is used in the http://jenkins.vfs.va.gov/job/testing/job/cms job that
 // auto-triggers deploys to DEV & STAGING on commit and which is triggered
 // by a webhook.
 
@@ -34,20 +34,20 @@ pipeline {
         build job: "builds/${params.app}", parameters: [
           booleanParam(name: 'release', value: false),
           booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'slack_channel', value: "${params.slack_channel}"),
           stringParam(name: 'ref', value: commit),
           booleanParam(name: 'force_rebuild', value: false)
         ], wait: true
       }
     }
 
-    stage('Deploy to dev') {
+    stage('Deploy to DEV') {
       when {
         expression {
           !shouldBail()
         }
       }
       steps {
-        sh 'echo SUCCESS, we are in DEV step'
         build job: "deploys/${params.app}-vagov-dev", parameters: [
           stringParam(name: 'app', value: params.app),
           booleanParam(name: 'notify_slack', value: true),
@@ -57,7 +57,7 @@ pipeline {
       }
     }
 
-    stage('Deploy to staging') {
+    stage('Deploy to STAGING') {
       when {
         expression {
           !shouldBail()


### PR DESCRIPTION
## Description
See #9295. This depends on a devops PR here https://github.com/department-of-veterans-affairs/devops/pull/11382. 

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
