### PR TITLE
VACMS-9360: Add hidden office hours field to billing.

### DIFF
--- a/config/sync/core.entity_form_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_system_billing_insurance.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.vamc_system_billing_insurance.field_hours_for_copay_inquiries_
     - field.field.node.vamc_system_billing_insurance.field_non_clinical_services
     - field.field.node.vamc_system_billing_insurance.field_office
+    - field.field.node.vamc_system_billing_insurance.field_office_hours
     - field.field.node.vamc_system_billing_insurance.field_phone_number
     - field.field.node.vamc_system_billing_insurance.field_service_name_and_descripti
     - node.type.vamc_system_billing_insurance
@@ -252,6 +253,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_office_hours: true
   field_service_name_and_descripti: true
   path: true
   promote: true

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.vamc_system_billing_insurance.field_hours_for_copay_inquiries_
     - field.field.node.vamc_system_billing_insurance.field_non_clinical_services
     - field.field.node.vamc_system_billing_insurance.field_office
+    - field.field.node.vamc_system_billing_insurance.field_office_hours
     - field.field.node.vamc_system_billing_insurance.field_phone_number
     - field.field.node.vamc_system_billing_insurance.field_service_name_and_descripti
     - node.type.vamc_system_billing_insurance
@@ -204,5 +205,6 @@ hidden:
   field_administration: true
   field_enforce_unique_combo: true
   field_office: true
+  field_office_hours: true
   field_service_name_and_descripti: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.teaser.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.vamc_system_billing_insurance.field_hours_for_copay_inquiries_
     - field.field.node.vamc_system_billing_insurance.field_non_clinical_services
     - field.field.node.vamc_system_billing_insurance.field_office
+    - field.field.node.vamc_system_billing_insurance.field_office_hours
     - field.field.node.vamc_system_billing_insurance.field_phone_number
     - field.field.node.vamc_system_billing_insurance.field_service_name_and_descripti
     - node.type.vamc_system_billing_insurance
@@ -55,6 +56,7 @@ hidden:
   field_hours_for_copay_inquiries_: true
   field_non_clinical_services: true
   field_office: true
+  field_office_hours: true
   field_phone_number: true
   field_service_name_and_descripti: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.vamc_system_billing_insurance.field_office_hours.yml
+++ b/config/sync/field.field.node.vamc_system_billing_insurance.field_office_hours.yml
@@ -1,0 +1,26 @@
+uuid: 2a5bef74-457f-4d22-8304-eb3c1465bef1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_office_hours
+    - node.type.vamc_system_billing_insurance
+  module:
+    - epp
+    - office_hours
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: node.vamc_system_billing_insurance.field_office_hours
+field_name: field_office_hours
+entity_type: node
+bundle: vamc_system_billing_insurance
+label: Hours
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: office_hours

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -182,6 +182,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Billing and Insurance | Enforce unique combo section | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | VAMC System Billing and Insurance | Enforce unique combo office | field_enforce_unique_combo_offic | Allow Only One |  | 1 | Allow Only One widget |  |
 | Content type | VAMC System Billing and Insurance | Hours | field_hours_for_copay_inquiries_ | Office hours |  | Unlimited | Office hours (week) |  |
+| Content type | VAMC System Billing and Insurance | Hours | field_office_hours | Office hours |  | Unlimited | -- Disabled -- | Translatable |
 | Content type | VAMC System Billing and Insurance | Non-clinical Services | field_non_clinical_services | Viewfield |  | 1 | Viewfield | Translatable |
 | Content type | VAMC System Billing and Insurance | VAMC System | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Billing and Insurance | Phone number | field_phone_number | Telephone number |  | 1 | Telephone number | Translatable |


### PR DESCRIPTION
## Description
closes #9360

## Testing done
Visual / behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/172668545-43cedc9f-8f0b-4097-8441-dddf210df929.png)

## QA steps
 - [ ] As an administrator, go to `/admin/structure/types/manage/vamc_system_billing_insurance/form-display` and visually verify `Hours` field appears in Disabled section

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
