### PR TITLE
VACMS-9309 update block placement config for recurring events block

### DIFF
--- a/config/sync/block.block.recurringeventsannouncement.yml
+++ b/config/sync/block.block.recurringeventsannouncement.yml
@@ -1,24 +1,24 @@
-uuid: fbb6b721-d673-4b9b-88ad-cc7fefea9c97
+uuid: 7649e6ad-0318-4a1b-bec5-65f39429799c
 langcode: en
 status: true
 dependencies:
   content:
-    - 'block_content:cms_announcement:03be10fc-8d69-4dd8-a0aa-e4df46dd1697'
+    - 'block_content:cms_announcement:96d388d3-e2c5-4aa9-b1a4-b9bb91502957'
   module:
     - block_content
     - node
   theme:
     - vagovclaro
-id: recurringevents
+id: recurringeventsannouncement
 theme: vagovclaro
 region: content
 weight: -15
 provider: null
-plugin: 'block_content:03be10fc-8d69-4dd8-a0aa-e4df46dd1697'
+plugin: 'block_content:96d388d3-e2c5-4aa9-b1a4-b9bb91502957'
 settings:
-  id: 'block_content:03be10fc-8d69-4dd8-a0aa-e4df46dd1697'
-  label: 'Recurring Events'
-  label_display: '0'
+  id: 'block_content:96d388d3-e2c5-4aa9-b1a4-b9bb91502957'
+  label: 'Recurring events announcement'
+  label_display: visible
   provider: block_content
   status: true
   info: ''


### PR DESCRIPTION
## Description

Closes #9309. Updates config for the recurring events block so that it is aligned with content.

## Testing done
- Removed outdated events block that was placing the "This block is broken or missing" message on the screen.
- Replaced updated CMS Announcement block for recurring events in the same place.
- Exported config

## Screenshots
<img width="960" alt="Screen Shot 2022-06-08 at 12 43 08 PM" src="https://user-images.githubusercontent.com/11279744/172703827-b743f4d4-b17a-4474-8ec2-2125410d2a54.png">


## QA steps

As a user, create a new event node or edit an existing one. The block should appear at the top of the page below the breadcrumbs.

There should be no message about a block with missing or broken content.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`
