### PR TITLE
[ DO-NOT-RELEASE-BEFORE 9361] VACMS-9363: Switch old copay hours field for office hours field on form and view

### DIFF
--- a/config/sync/core.entity_form_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_system_billing_insurance.default.yml
@@ -104,7 +104,7 @@ third_party_settings:
     group_inquiries_about_copay:
       children:
         - field_phone_number
-        - field_hours_for_copay_inquiries_
+        - field_office_hours
       label: 'For inquiries by phone about copay balance'
       region: content
       parent_name: ''
@@ -173,7 +173,7 @@ content:
     third_party_settings: {  }
   field_cc_bottom_of_page_content:
     type: entity_field_fetch_widget
-    weight: 11
+    weight: 14
     region: content
     settings:
       show_field_label: 0
@@ -182,7 +182,7 @@ content:
     third_party_settings: {  }
   field_cc_related_links:
     type: entity_field_fetch_widget
-    weight: 13
+    weight: 15
     region: content
     settings:
       show_field_label: '1'
@@ -212,12 +212,6 @@ content:
     settings:
       size: 1
     third_party_settings: {  }
-  field_hours_for_copay_inquiries_:
-    type: office_hours_default
-    weight: 9
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_non_clinical_services:
     type: viewfield_select
     weight: 8
@@ -227,6 +221,12 @@ content:
   field_office:
     type: options_select
     weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_office_hours:
+    type: office_hours_default
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -243,6 +243,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 1
@@ -253,11 +260,10 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_office_hours: true
+  field_hours_for_copay_inquiries_: true
   field_service_name_and_descripti: true
   path: true
   promote: true
-  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
@@ -69,7 +69,7 @@ third_party_settings:
     group_inquiries_about_copay:
       children:
         - field_phone_number
-        - field_hours_for_copay_inquiries_
+        - field_office_hours
       label: 'For inquiries by phone about copay balance'
       parent_name: ''
       region: content
@@ -140,7 +140,17 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-  field_hours_for_copay_inquiries_:
+  field_non_clinical_services:
+    type: viewfield_default
+    label: hidden
+    settings:
+      view_title: above
+      always_build_output: true
+      empty_view_title: above
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_office_hours:
     type: office_hours
     label: above
     settings:
@@ -166,16 +176,6 @@ content:
         enabled: false
     third_party_settings: {  }
     weight: 9
-    region: content
-  field_non_clinical_services:
-    type: viewfield_default
-    label: hidden
-    settings:
-      view_title: above
-      always_build_output: true
-      empty_view_title: above
-    third_party_settings: {  }
-    weight: 5
     region: content
   field_phone_number:
     type: telephone_link
@@ -204,7 +204,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_enforce_unique_combo: true
+  field_hours_for_copay_inquiries_: true
   field_office: true
-  field_office_hours: true
   field_service_name_and_descripti: true
   search_api_excerpt: true

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -181,8 +181,8 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Billing and Insurance | National top of page content | field_cc_top_of_page_content | Entity Field Fetch field |  | 1 | Entity Field Fetch widget | Translatable |
 | Content type | VAMC System Billing and Insurance | Enforce unique combo section | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | VAMC System Billing and Insurance | Enforce unique combo office | field_enforce_unique_combo_offic | Allow Only One |  | 1 | Allow Only One widget |  |
-| Content type | VAMC System Billing and Insurance | Hours | field_hours_for_copay_inquiries_ | Office hours |  | Unlimited | Office hours (week) |  |
-| Content type | VAMC System Billing and Insurance | Hours | field_office_hours | Office hours |  | Unlimited | -- Disabled -- | Translatable |
+| Content type | VAMC System Billing and Insurance | Hours | field_hours_for_copay_inquiries_ | Office hours |  | Unlimited | -- Disabled -- | |
+| Content type | VAMC System Billing and Insurance | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) | Translatable |
 | Content type | VAMC System Billing and Insurance | Non-clinical Services | field_non_clinical_services | Viewfield |  | 1 | Viewfield | Translatable |
 | Content type | VAMC System Billing and Insurance | VAMC System | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Billing and Insurance | Phone number | field_phone_number | Telephone number |  | 1 | Telephone number | Translatable |


### PR DESCRIPTION
## Description
closes #9363

## Testing done
Visual / behat

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/172715570-5163e238-d984-4771-ad07-31169463228b.png)

## QA steps
 - [ ] As an administrator, go to `/boston-health-care/billing-and-insurance` in cms, hover over hours field in inspector, and visually verify the field name is `field_office_hours`

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
