### PR TITLE
VACMS-9468: Remove stuation updates and operating statuses from conte…

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -2225,7 +2225,7 @@ display:
               redirect_administrator: '0'
               admnistrator_users: '0'
               administrator: '0'
-            reduce: false
+            reduce: true
           is_grouped: false
           group_info:
             label: ''

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -8,15 +8,54 @@ dependencies:
     - field.storage.node.field_other_categories
     - field.storage.node.field_primary_category
     - field.storage.paragraph.field_topics
+    - node.type.banner
     - node.type.basic_landing_page
+    - node.type.campaign_landing_page
+    - node.type.centralized_content
     - node.type.checklist
+    - node.type.documentation_page
     - node.type.event
+    - node.type.event_listing
     - node.type.faq_multiple_q_a
+    - node.type.health_care_local_facility
+    - node.type.health_care_local_health_service
+    - node.type.health_care_region_detail_page
+    - node.type.health_care_region_page
+    - node.type.health_services_listing
+    - node.type.landing_page
+    - node.type.leadership_listing
+    - node.type.locations_listing
     - node.type.media_list_images
     - node.type.media_list_videos
+    - node.type.nca_facility
+    - node.type.news_story
+    - node.type.office
+    - node.type.outreach_asset
+    - node.type.page
+    - node.type.person_profile
+    - node.type.press_release
+    - node.type.press_releases_listing
+    - node.type.promo_banner
+    - node.type.publication_listing
     - node.type.q_a
+    - node.type.regional_health_care_service_des
     - node.type.step_by_step
+    - node.type.story_listing
     - node.type.support_resources_detail_page
+    - node.type.support_service
+    - node.type.va_form
+    - node.type.vamc_system_billing_insurance
+    - node.type.vamc_system_medical_records_offi
+    - node.type.vamc_system_policies_page
+    - node.type.vamc_system_register_for_care
+    - node.type.vba_facility
+    - node.type.vet_center
+    - node.type.vet_center_cap
+    - node.type.vet_center_facility_health_servi
+    - node.type.vet_center_locations_list
+    - node.type.vet_center_mobile_vet_center
+    - node.type.vet_center_outstation
+    - node.type.vha_facility_nonclinical_service
     - taxonomy.vocabulary.administration
     - taxonomy.vocabulary.lc_categories
     - taxonomy.vocabulary.topics
@@ -2107,7 +2146,55 @@ display:
           entity_field: type
           plugin_id: bundle
           operator: in
-          value: {  }
+          value:
+            page: page
+            landing_page: landing_page
+            documentation_page: documentation_page
+            campaign_landing_page: campaign_landing_page
+            centralized_content: centralized_content
+            checklist: checklist
+            event: event
+            event_listing: event_listing
+            faq_multiple_q_a: faq_multiple_q_a
+            banner: banner
+            health_services_listing: health_services_listing
+            media_list_images: media_list_images
+            basic_landing_page: basic_landing_page
+            leadership_listing: leadership_listing
+            nca_facility: nca_facility
+            press_release: press_release
+            press_releases_listing: press_releases_listing
+            office: office
+            promo_banner: promo_banner
+            outreach_asset: outreach_asset
+            publication_listing: publication_listing
+            q_a: q_a
+            support_resources_detail_page: support_resources_detail_page
+            person_profile: person_profile
+            step_by_step: step_by_step
+            story_listing: story_listing
+            news_story: news_story
+            support_service: support_service
+            va_form: va_form
+            health_care_region_detail_page: health_care_region_detail_page
+            health_care_local_facility: health_care_local_facility
+            health_care_local_health_service: health_care_local_health_service
+            vha_facility_nonclinical_service: vha_facility_nonclinical_service
+            health_care_region_page: health_care_region_page
+            vamc_system_billing_insurance: vamc_system_billing_insurance
+            regional_health_care_service_des: regional_health_care_service_des
+            locations_listing: locations_listing
+            vamc_system_medical_records_offi: vamc_system_medical_records_offi
+            vamc_system_policies_page: vamc_system_policies_page
+            vamc_system_register_for_care: vamc_system_register_for_care
+            vba_facility: vba_facility
+            vet_center: vet_center
+            vet_center_cap: vet_center_cap
+            vet_center_facility_health_servi: vet_center_facility_health_servi
+            vet_center_locations_list: vet_center_locations_list
+            vet_center_mobile_vet_center: vet_center_mobile_vet_center
+            vet_center_outstation: vet_center_outstation
+            media_list_videos: media_list_videos
           group: 1
           exposed: true
           expose:


### PR DESCRIPTION
…nt audit.

## Description

Closes #9468 . 

## Testing done
manual, automatic

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/173896656-e447dc8a-48ac-4ec4-a1e8-fb0b4eb3516c.png)


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Go to `/admin/content/audit`
   - [ ] Validate that `VAMC System Banner Alert with Situation Updates` and `VAMC Operating status` are not in present in the Content type filter


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
