### PR TITLE
VACMS-6759: Rearrange content views tabs.

### DIFF
--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -263,6 +263,16 @@ content:
     third_party_settings: {  }
     weight: 26
     region: content
+  flag_email_node:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  flag_subscribe_node:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
 hidden:
   content_moderation_control: true
   field_administration: true

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -3171,7 +3171,9 @@ display:
           plugin_id: result
           empty: false
           content: "<p>This view is only available to admins.</p>\r\n<hr />\r\nDisplaying @start - @end of @total"
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/events
       menu:
         type: tab
@@ -3182,6 +3184,11 @@ display:
         menu_name: admin
         parent: system.admin_content
         context: '0'
+        as_local_task: true
+        local_task_link_title: Events
+        local_task_parent: _custom
+        local_task_weight: 2
+        local_task_custom_parent_route: system.admin_content
       tab_options:
         type: normal
         title: Content
@@ -4646,7 +4653,9 @@ display:
           plugin_id: result
           empty: false
           content: "<p>This view is only available to content admins.</p>\r\n\r\n\r\n<p>Displaying @start - @end of @total</p>"
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/bulk
       menu:
         type: tab
@@ -4657,6 +4666,11 @@ display:
         menu_name: admin
         parent: system.admin_content
         context: '0'
+        as_local_task: true
+        local_task_link_title: 'Bulk Edit'
+        local_task_parent: 'views_view:view.content.content_audit_page'
+        local_task_weight: 0
+        local_task_custom_parent_route: ''
       tab_options:
         type: normal
         title: Content
@@ -5895,17 +5909,24 @@ display:
           content: "<br><h4><b>Resources and support content</b></h4>\r\nDisplaying @start - @end of @total"
       footer: {  }
       exposed_block: false
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/resources-and-support
       menu:
         type: tab
         title: 'Resources and support'
         description: ''
-        weight: 0
+        weight: 5
         expanded: false
         menu_name: admin
         parent: system.admin_content
         context: '0'
+        as_local_task: false
+        local_task_link_title: ''
+        local_task_parent: 'views_view:view.centralized_content_paragraphs.centralized_content_paragraphs'
+        local_task_weight: 5
+        local_task_custom_parent_route: ''
       tab_options:
         type: normal
         title: Content

--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -3504,13 +3504,15 @@ display:
           plugin_id: standard
           required: false
       display_description: ''
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/facilities
       menu:
         type: tab
         title: Facilities
         description: ''
-        weight: 0
+        weight: 3
         expanded: true
         menu_name: admin
         parent: system.admin_content

--- a/config/sync/views.view.feedback.yml
+++ b/config/sync/views.view.feedback.yml
@@ -959,7 +959,9 @@ display:
             value: "There is one line <strong>per translation</strong> below and the overall score is for each translation!\r\nSo, a node's feedback can be different between every language."
             format: rich_text_limited
           tokenize: false
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/feedback
       menu:
         type: tab
@@ -970,6 +972,11 @@ display:
         menu_name: main
         parent: ''
         context: '0'
+        as_local_task: true
+        local_task_link_title: Feedback
+        local_task_parent: 'views_view:view.content.content_audit_page'
+        local_task_weight: 3
+        local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.flagged_content.yml
+++ b/config/sync/views.view.flagged_content.yml
@@ -2069,7 +2069,9 @@ display:
     display_options:
       display_description: ''
       display_comment: 'A view of flagged content.'
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/flagged
       menu:
         type: tab
@@ -2080,6 +2082,11 @@ display:
         menu_name: admin
         parent: system.admin_content
         context: '0'
+        as_local_task: true
+        local_task_link_title: Flagged
+        local_task_parent: 'views_view:view.content.content_audit_page'
+        local_task_weight: 4
+        local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -4356,17 +4356,19 @@ display:
           empty: false
           content: '<div>This page shows all media files (documents, images, videos) across the VA.gov CMS. Media can be edited by members of the <a href="/sections">section</a> to which it was posted (or members of any "parent" section).  Media can be reused by CMS editors outside that section, as long as the media item is set to be shown in the media library. You can filter by section or by whether or not the media is reusable (shown in library). When adding media to a piece of content, you will only be able to see media that has the "Show in library" checked.  </div>'
           tokenize: false
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/media
       menu:
         type: tab
         title: 'Media library'
         description: ''
-        weight: 3
+        weight: 2
         expanded: false
         menu_name: admin
         parent: system.admin_content
-        context: '1'
+        context: '0'
         as_local_task: true
         local_task_link_title: Media
         local_task_parent: _custom

--- a/config/sync/views.view.message.yml
+++ b/config/sync/views.view.message.yml
@@ -576,16 +576,24 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/messages
       menu:
         type: tab
         title: Message
         description: ''
         weight: 0
+        expanded: false
         menu_name: admin
         parent: system.admin_content
         context: '0'
+        as_local_task: true
+        local_task_link_title: Messages
+        local_task_parent: 'views_view:view.content.content_audit_page'
+        local_task_weight: 5
+        local_task_custom_parent_route: ''
       tab_options:
         type: none
         title: ''

--- a/config/sync/views.view.rich_text_field_audit.yml
+++ b/config/sync/views.view.rich_text_field_audit.yml
@@ -3398,7 +3398,9 @@ display:
           plugin_id: result
           empty: false
           content: "<p>Displaying @start - @end of @total</p>\r\n<p>This audit searches through all field_wysiwyg to find instances of 'usa-button' within the content which is used to create buttons. </p>"
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/audit/buttons
       menu:
         type: tab
@@ -4655,7 +4657,9 @@ display:
         filters: false
         filter_groups: false
       display_description: ''
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/audit/rich-text-field-audit
       menu:
         type: tab
@@ -4669,7 +4673,7 @@ display:
         as_local_task: true
         local_task_link_title: 'Rich Text'
         local_task_parent: 'views_view:view.content.content_audit_page'
-        local_task_weight: 0
+        local_task_weight: 6
         local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1

--- a/config/sync/views.view.va_blocks_admin.yml
+++ b/config/sync/views.view.va_blocks_admin.yml
@@ -1306,7 +1306,9 @@ display:
       defaults:
         fields: false
       display_description: ''
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/promos
       menu:
         type: tab
@@ -1317,6 +1319,11 @@ display:
         menu_name: admin
         parent: ''
         context: '0'
+        as_local_task: true
+        local_task_link_title: Promos
+        local_task_parent: _custom
+        local_task_weight: 4
+        local_task_custom_parent_route: system.admin_content
     cache_metadata:
       max-age: -1
       contexts:
@@ -1854,6 +1861,8 @@ display:
           content: '<p>You can <a href="/block/add/alert?destination=/admin/content/alerts">create an alert</a> to highlight time-sensitive content, usually at the top of a page.  Alerts can be created and then added to an existing page, or can be added directly from certain types of content.</p>'
           tokenize: false
       display_extenders:
+        jsonapi_views:
+          enabled: true
         views_merge_rows: {  }
       path: admin/content/alerts
       menu:
@@ -1865,6 +1874,11 @@ display:
         menu_name: admin
         parent: ''
         context: '0'
+        as_local_task: true
+        local_task_link_title: Alerts
+        local_task_parent: _custom
+        local_task_weight: 1
+        local_task_custom_parent_route: system.admin_content
       merge_rows: 1
       use_grouping: 0
       field_config:

--- a/config/sync/views.view.va_forms.yml
+++ b/config/sync/views.view.va_forms.yml
@@ -1270,17 +1270,24 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/va-forms
       menu:
         type: tab
         title: 'VA Forms'
         description: ''
-        weight: 0
+        weight: 6
         expanded: false
         menu_name: admin
         parent: system.admin_content
         context: '0'
+        as_local_task: false
+        local_task_link_title: ''
+        local_task_parent: 'views_view:view.centralized_content_paragraphs.centralized_content_paragraphs'
+        local_task_weight: 0
+        local_task_custom_parent_route: ''
     cache_metadata:
       max-age: 0
       contexts:


### PR DESCRIPTION
## Description

Closes #6759 

## Testing done
manual, automatic

## Screenshots
![image](https://user-images.githubusercontent.com/8375335/174108172-02a100e1-5e61-4807-9fd8-bf69fe15c7cf.png)


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As content editor
1. Visit `admin/content`
2. Then validate Acceptance Criteria from issue
   - [x] Menus for audit tool Views appear on the admin/content menu When the audit tools tab is selected.
   - [ ] Content menu IA is as follows
     - Content
       - Overview
       - Moderated content
       - Alerts
       - Events
       - Promos
     - Content audit tools
       - Bulk edit
       - Button Audit
       - Feedback
       - Flagged
       - Messages
       - Rich Text
     - Facilities
     - Resources and support
     - VA Forms
     - Media



### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
