### PR TITLE
VACMS-9510 add drush command patch, export config for sitewide alerts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,6 +144,7 @@
         "drupal/seckit": "^2.0",
         "drupal/simplesamlphp_auth": "^3.2",
         "drupal/site_alert": "1.2",
+        "drupal/sitewide_alert": "^2.0",
         "drupal/slack": "^1.3",
         "drupal/smart_date": "^3.5",
         "drupal/social_media_links": "^2.8",
@@ -535,6 +536,9 @@
             },
             "drupal/dropzonejs": {
                 "Select files button and Add media window text should respect field cardinality": "https://www.drupal.org/files/issues/2022-03-29/3174484-add-media-window-and-select-button-text-should-respect-field-cardinality-4.patch"
+            },
+            "drupal/sitewide_alert": {
+                "3290964 - Add drush commands for sitewide alerts": "https://www.drupal.org/files/issues/2022-06-24/3290964-add-drush-commands.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37abcb5c96d14b20e1f0dc8a82d0f012",
+    "content-hash": "366eab04aabf80aec9403558df3bba30",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -10919,6 +10919,57 @@
             "homepage": "https://www.drupal.org/project/site_alert",
             "support": {
                 "source": "https://git.drupalcode.org/project/site_alert"
+            }
+        },
+        {
+            "name": "drupal/sitewide_alert",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/sitewide_alert.git",
+                "reference": "2.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/sitewide_alert-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "3cf4c5f440660208155b6ea97b17993fe42aa8dc"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10",
+                "php": ">=7.4"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.2",
+                    "datestamp": "1655433471",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Snyder",
+                    "homepage": "https://www.drupal.org/user/1988434",
+                    "email": "chris@chrissnyder.org",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Provides ability to display an alert message at the top of all pages.",
+            "homepage": "https://www.drupal.org/project/sitewide_alert",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/sitewide_alert",
+                "issues": "https://www.drupal.org/project/issues/sitewide_alert"
             }
         },
         {

--- a/config/sync/core.entity_form_display.sitewide_alert.sitewide_alert.default.yml
+++ b/config/sync/core.entity_form_display.sitewide_alert.sitewide_alert.default.yml
@@ -1,0 +1,33 @@
+uuid: 5e1aa894-5f55-471c-a29b-5de9c21a2185
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sitewide_alert.sitewide_alert.field_alert_title
+  module:
+    - datetime_range
+    - sitewide_alert
+    - text
+id: sitewide_alert.sitewide_alert.default
+targetEntityType: sitewide_alert
+bundle: sitewide_alert
+mode: default
+content:
+  field_alert_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  message:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 4
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  user_id: true

--- a/config/sync/core.entity_view_display.sitewide_alert.sitewide_alert.default.yml
+++ b/config/sync/core.entity_view_display.sitewide_alert.sitewide_alert.default.yml
@@ -1,0 +1,31 @@
+uuid: d97d2dfe-03b2-4f05-9146-b2d36077aa62
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sitewide_alert.sitewide_alert.field_alert_title
+  module:
+    - sitewide_alert
+    - text
+id: sitewide_alert.sitewide_alert.default
+targetEntityType: sitewide_alert
+bundle: sitewide_alert
+mode: default
+content:
+  field_alert_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  message:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -178,6 +178,7 @@ module:
   simple_oauth: 0
   simplesamlphp_auth: 0
   site_alert: 0
+  sitewide_alert: 0
   slack: 0
   smart_date: 0
   smart_date_recur: 0
@@ -210,8 +211,8 @@ module:
   va_gov_consumers: 0
   va_gov_dashboards: 0
   va_gov_db: 0
-  va_gov_facilities: 0
   va_gov_events: 0
+  va_gov_facilities: 0
   va_gov_flags: 0
   va_gov_govdelivery: 0
   va_gov_graphql: 0

--- a/config/sync/field.field.sitewide_alert.sitewide_alert.field_alert_title.yml
+++ b/config/sync/field.field.sitewide_alert.sitewide_alert.field_alert_title.yml
@@ -1,0 +1,25 @@
+uuid: d3ed5d80-bd3d-46ae-bfba-264f63eaa39f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sitewide_alert.field_alert_title
+  module:
+    - epp
+    - sitewide_alert
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: sitewide_alert.sitewide_alert.field_alert_title
+field_name: field_alert_title
+entity_type: sitewide_alert
+bundle: sitewide_alert
+label: 'Alert Title'
+description: 'The visible title of the alert message.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.sitewide_alert.field_alert_title.yml
+++ b/config/sync/field.storage.sitewide_alert.field_alert_title.yml
@@ -1,0 +1,21 @@
+uuid: 8bc18b97-55f0-4cc4-a57d-4be8a791a0cd
+langcode: en
+status: true
+dependencies:
+  module:
+    - sitewide_alert
+id: sitewide_alert.field_alert_title
+field_name: field_alert_title
+entity_type: sitewide_alert
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/sitewide_alert.settings.yml
+++ b/config/sync/sitewide_alert.settings.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: GnciVSpJGwXtuBeAb60PIb2f1e3gGcwKpoyRpxgQ3gM
+show_on_admin: 1
+alert_styles: "primary|Informational\r\nwarning|Warning\r\nshield|Site Shield"
+refresh_interval: 15
+automatic_refresh: 1


### PR DESCRIPTION
## Description
Closes #9510. Adds drush commands for ability to create / enable / disable / delete sitewide alerts. 

TODO: clean up menu placement for sitewide alert... right now it places itself in the tab list on `/admin/content` in the second spot and throws everything off. gross.

## Testing done

Same syntax as site alert drush commands: `"label"`, `"message"`, `--option` flags. Adjust quotes as needed for passing into ddev properly, see below:

**create alert:**
`ddev drush sitewide-alert:create "'test-alert 7' 'testing my new alert' --style=warning --dismissible"`

`ddev drush sitewide-alert:create "'schedule-end' 'a brand new world' --style=shield --end='20 minutes'"`
 
`ddev drush sitewide-alert:create "'test-alert 4' 'testing my new alert' --style=warning --status=0 --dismissible=0"`

**enable alert:**
`ddev drush sitewide-alert:enable "'test-alert 4'" -y`

**delete alert:**
`ddev drush sitewide-alert:delete "'test-alert 4'" -y`

**disable alert:**
`ddev drush sitewide-alert:disable "'test-alert 7'" -y`

## Screenshots
<img width="1517" alt="Screen Shot 2022-06-24 at 1 04 15 PM" src="https://user-images.githubusercontent.com/11279744/175659729-b0a74a3d-c823-42fa-ae8e-f72b6b77a5d5.png">

## QA steps

pull branch locally, verify that the above drush commands return successfully for you. malformed commands should throw proper error messages or normalize to allowed values (in the case of the `--style` option)

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`
