### PR TITLE
VACMS-9410: Clear event registration info when toggling states.

### DIFF
--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -6,23 +6,37 @@
   const includeRegistrationsBool = document.getElementById(
     "edit-field-include-registration-info-value"
   );
-
+  const ctaSelect = document.getElementById("edit-field-event-cta");
+  const fieldLinkWrapper = document.getElementById("edit-field-link-wrapper");
+  const fieldLinkInput = document.getElementById("edit-field-link-0-uri");
+  const fieldLinkWrapperLabel = document.querySelector(
+    "#edit-field-link-wrapper label"
+  );
   const includeLocationItemsRadios = document.getElementById(
     "edit-field-location-type"
   );
+
+  const toggleCtaLinkRequired = (required = true) => {
+    const addRemove = required ? "add" : "remove";
+    fieldLinkWrapper.style.display = required ? "block" : "none";
+    fieldLinkInput.required = required ? "required" : "";
+    fieldLinkWrapperLabel.classList[addRemove](
+      "js-form-required",
+      "form-required"
+    );
+  };
 
   const toggleRegistrationElements = () => {
     const targetRegistrationElements = document.querySelectorAll(
       ".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper"
     );
-    const ctaUri = document.getElementById("edit-field-link-0-uri") || {};
-    const ctaSelect = document.getElementById("edit-field-event-cta") || {};
     const toggleVal = !!includeRegistrationsBool.checked;
-    let elementDisplayStyle = 'block';
+    let elementDisplayStyle = "block";
     if (!toggleVal) {
-      ctaUri.value = "";
+      fieldLinkInput.value = "";
       ctaSelect.value = "_none";
-      elementDisplayStyle = 'none';
+      elementDisplayStyle = "none";
+      toggleCtaLinkRequired(false);
     }
     targetRegistrationElements.forEach((element) => {
       element.style.display = elementDisplayStyle;
@@ -30,20 +44,12 @@
   };
 
   const requireCTA = () => {
-    const ctaSelect = document.getElementById("edit-field-event-cta");
-    const fieldLinkWrapper = document.getElementById("edit-field-link-wrapper");
-    const fieldLinkInput = document.getElementById("edit-field-link-0-uri");
-    const fieldLinkWrapperLabel = document.querySelector(
-      "#edit-field-link-wrapper label"
-    );
     // Default should be hidden.
     fieldLinkWrapper.style.display = "none";
 
     // If there is a cta on page load, require an input.
     if (ctaSelect.value !== "_none") {
-      fieldLinkWrapper.style.display = "block";
-      fieldLinkInput.required = "required";
-      fieldLinkWrapperLabel.classList.add("js-form-required", "form-required");
+      toggleCtaLinkRequired();
     }
 
     // Check on change if cta value, and require input if so.

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -15,12 +15,16 @@
     const targetRegistrationElements = document.querySelectorAll(
       ".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper"
     );
+    const ctaUri = document.getElementById("edit-field-link-0-uri") || {};
+    const ctaSelect = document.getElementById("edit-field-event-cta") || {};
     const toggleVal = !!includeRegistrationsBool.checked;
     targetRegistrationElements.forEach((element) => {
       if (toggleVal) {
         element.style.display = "block";
       } else {
         element.style.display = "none";
+        ctaUri.value = "";
+        ctaSelect.value = "_none";
       }
     });
   };
@@ -57,6 +61,8 @@
           "form-required"
         );
         fieldLinkWrapper.style.display = "block";
+      } else {
+        fieldLinkInput.value = "";
       }
     });
   };

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -18,14 +18,14 @@
     const ctaUri = document.getElementById("edit-field-link-0-uri") || {};
     const ctaSelect = document.getElementById("edit-field-event-cta") || {};
     const toggleVal = !!includeRegistrationsBool.checked;
+    let elementDisplayStyle = 'block';
+    if (!toggleVal) {
+      ctaUri.value = "";
+      ctaSelect.value = "_none";
+      elementDisplayStyle = 'none';
+    }
     targetRegistrationElements.forEach((element) => {
-      if (toggleVal) {
-        element.style.display = "block";
-      } else {
-        element.style.display = "none";
-        ctaUri.value = "";
-        ctaSelect.value = "_none";
-      }
+      element.style.display = elementDisplayStyle;
     });
   };
 

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -3,6 +3,9 @@
  */
 
 ((Drupal) => {
+  const registrationRequiredBool = document.getElementById(
+    "edit-field-event-registrationrequired-value"
+  );
   const includeRegistrationsBool = document.getElementById(
     "edit-field-include-registration-info-value"
   );
@@ -36,6 +39,7 @@
       fieldLinkInput.value = "";
       ctaSelect.value = "_none";
       elementDisplayStyle = "none";
+      registrationRequiredBool.checked = false;
       toggleCtaLinkRequired(false);
     }
     targetRegistrationElements.forEach((element) => {
@@ -54,19 +58,9 @@
 
     // Check on change if cta value, and require input if so.
     ctaSelect.addEventListener("change", (e) => {
-      fieldLinkInput.required = "";
-      fieldLinkWrapper.style.display = "none";
-      fieldLinkWrapperLabel.classList.remove(
-        "js-form-required",
-        "form-required"
-      );
+      toggleCtaLinkRequired(false);
       if (e.target.value !== "_none") {
-        fieldLinkInput.attributes.required = "required";
-        fieldLinkWrapperLabel.classList.add(
-          "js-form-required",
-          "form-required"
-        );
-        fieldLinkWrapper.style.display = "block";
+        toggleCtaLinkRequired();
       } else {
         fieldLinkInput.value = "";
       }

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -12,12 +12,16 @@
 
   var toggleRegistrationElements = function toggleRegistrationElements() {
     var targetRegistrationElements = document.querySelectorAll(".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper");
+    var ctaUri = document.getElementById("edit-field-link-0-uri") || {};
+    var ctaSelect = document.getElementById("edit-field-event-cta") || {};
     var toggleVal = !!includeRegistrationsBool.checked;
     targetRegistrationElements.forEach(function (element) {
       if (toggleVal) {
         element.style.display = "block";
       } else {
         element.style.display = "none";
+        ctaUri.value = "";
+        ctaSelect.value = "_none";
       }
     });
   };
@@ -44,6 +48,8 @@
         fieldLinkInput.attributes.required = "required";
         fieldLinkWrapperLabel.classList.add("js-form-required", "form-required");
         fieldLinkWrapper.style.display = "block";
+      } else {
+        fieldLinkInput.value = "";
       }
     });
   };

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -15,14 +15,14 @@
     var ctaUri = document.getElementById("edit-field-link-0-uri") || {};
     var ctaSelect = document.getElementById("edit-field-event-cta") || {};
     var toggleVal = !!includeRegistrationsBool.checked;
+    var elementDisplayStyle = 'block';
+    if (!toggleVal) {
+      ctaUri.value = "";
+      ctaSelect.value = "_none";
+      elementDisplayStyle = 'none';
+    }
     targetRegistrationElements.forEach(function (element) {
-      if (toggleVal) {
-        element.style.display = "block";
-      } else {
-        element.style.display = "none";
-        ctaUri.value = "";
-        ctaSelect.value = "_none";
-      }
+      element.style.display = elementDisplayStyle;
     });
   };
 

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -6,6 +6,7 @@
 **/
 
 (function (Drupal) {
+  var registrationRequiredBool = document.getElementById("edit-field-event-registrationrequired-value");
   var includeRegistrationsBool = document.getElementById("edit-field-include-registration-info-value");
   var ctaSelect = document.getElementById("edit-field-event-cta");
   var fieldLinkWrapper = document.getElementById("edit-field-link-wrapper");
@@ -30,6 +31,7 @@
       fieldLinkInput.value = "";
       ctaSelect.value = "_none";
       elementDisplayStyle = "none";
+      registrationRequiredBool.checked = false;
       toggleCtaLinkRequired(false);
     }
     targetRegistrationElements.forEach(function (element) {
@@ -45,13 +47,9 @@
     }
 
     ctaSelect.addEventListener("change", function (e) {
-      fieldLinkInput.required = "";
-      fieldLinkWrapper.style.display = "none";
-      fieldLinkWrapperLabel.classList.remove("js-form-required", "form-required");
+      toggleCtaLinkRequired(false);
       if (e.target.value !== "_none") {
-        fieldLinkInput.attributes.required = "required";
-        fieldLinkWrapperLabel.classList.add("js-form-required", "form-required");
-        fieldLinkWrapper.style.display = "block";
+        toggleCtaLinkRequired();
       } else {
         fieldLinkInput.value = "";
       }

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -7,19 +7,30 @@
 
 (function (Drupal) {
   var includeRegistrationsBool = document.getElementById("edit-field-include-registration-info-value");
-
+  var ctaSelect = document.getElementById("edit-field-event-cta");
+  var fieldLinkWrapper = document.getElementById("edit-field-link-wrapper");
+  var fieldLinkInput = document.getElementById("edit-field-link-0-uri");
+  var fieldLinkWrapperLabel = document.querySelector("#edit-field-link-wrapper label");
   var includeLocationItemsRadios = document.getElementById("edit-field-location-type");
+
+  var toggleCtaLinkRequired = function toggleCtaLinkRequired() {
+    var required = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
+
+    var addRemove = required ? "add" : "remove";
+    fieldLinkWrapper.style.display = required ? "block" : "none";
+    fieldLinkInput.required = required ? "required" : "";
+    fieldLinkWrapperLabel.classList[addRemove]("js-form-required", "form-required");
+  };
 
   var toggleRegistrationElements = function toggleRegistrationElements() {
     var targetRegistrationElements = document.querySelectorAll(".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper");
-    var ctaUri = document.getElementById("edit-field-link-0-uri") || {};
-    var ctaSelect = document.getElementById("edit-field-event-cta") || {};
     var toggleVal = !!includeRegistrationsBool.checked;
-    var elementDisplayStyle = 'block';
+    var elementDisplayStyle = "block";
     if (!toggleVal) {
-      ctaUri.value = "";
+      fieldLinkInput.value = "";
       ctaSelect.value = "_none";
-      elementDisplayStyle = 'none';
+      elementDisplayStyle = "none";
+      toggleCtaLinkRequired(false);
     }
     targetRegistrationElements.forEach(function (element) {
       element.style.display = elementDisplayStyle;
@@ -27,17 +38,10 @@
   };
 
   var requireCTA = function requireCTA() {
-    var ctaSelect = document.getElementById("edit-field-event-cta");
-    var fieldLinkWrapper = document.getElementById("edit-field-link-wrapper");
-    var fieldLinkInput = document.getElementById("edit-field-link-0-uri");
-    var fieldLinkWrapperLabel = document.querySelector("#edit-field-link-wrapper label");
-
     fieldLinkWrapper.style.display = "none";
 
     if (ctaSelect.value !== "_none") {
-      fieldLinkWrapper.style.display = "block";
-      fieldLinkInput.required = "required";
-      fieldLinkWrapperLabel.classList.add("js-form-required", "form-required");
+      toggleCtaLinkRequired();
     }
 
     ctaSelect.addEventListener("change", function (e) {


### PR DESCRIPTION
## Description

Relates to #9410

## QA steps
1) Go to https://pr9593-z2tm41jng73mcitwl40kpzruinndwc2h.ci.cms.va.gov/node/add/event
2) Fill out all required fields
3) Click the box for "Include registration information"
4) Select an option other than "none" for Call to action.
5) Put in a URL
6) Change the Call to Action select to "- None -"
7. +Save the node.
- [x] +Validate that no url is showing on node view. 
8. +Edit the node. and change the CTA to an option other than -none-.
- [x] 7) Confirm that the URL is now blank
8) Select an option other than "none" for Call to action.
9) Put in a URL
10) Uncheck the "Include registration information" checkbox
11) Check the "Include registration information" checkbox
- [x] 12) Confirm that the Call to Action is now set to "- None -" and the URL is empty.

13) +Edit the node.
14) +Set the call to action to "Apply".
15) +Enter a url.
16) +save the node
17) +Edit the node
18) +Uncheck the "Include registration information"
19) +save the node
- [ ]  20) +Validate that the node saves with no values for the url or its type. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`
