### PR TITLE
VACMS-6528: archive related services/events when a facility is archived

### DIFF
--- a/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
@@ -28,6 +28,7 @@ assignees: ''
 - [ ] Becomes aware that the facility is no longer on the Facility API, via the "Facility closed" flag, and create github issue  (Future state: Flag autogenerates github issue)
 - [ ] Fill out the stakeholders in github issue.
 - [ ] If we don't already have context (say, via a HD ticket submitted by an editor), check with editor to find out more about the status of the facility
+- [ ] Find out if there are any services or events tied to the facility to be archived that should be moved to a new facility or otherwise preserved and updated
 
 <details><summary>Email template </summary>
 
@@ -61,18 +62,19 @@ If this facility has been removed from VAST in error, please notify our Support 
 </details>
 
 #### 2a. If facility has moved to a new system or merged
-- [ ] Can any of the associated content  (eg services, facility map?) be reused? If so
+- [ ] Can any of the associated content (eg services, facility map, future events?) be reused? If so
   - [ ] is there a new facility in VAST/Facility API that content should be moved to?
 - [ ] Create [redirect request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&labels=Redirect+request&template=redirect-request-facility-url.md&title=Redirect+Request+for%3A+%3Cinsert+facility+name%3E) to point to URL of new facility.
 - [ ] When redirect is ready to go out, plan to make these changes immediately after redirect is released. Practice first on staging or a demo environment.
   - [ ] In certain, rare situations: CMS engineer bulk moves any content to new facility.
   - [ ] CMS engineer finds the menu for the system https://prod.cms.va.gov/admin/structure/menu and deletes the menu item for the merged facility.
 
-#### 2b. If not
+#### 2b. If facility has NOT moved to a new system or merged
 - [ ] Determine where should redirect go? to the system? or to the nearest clinic?
 - [ ] Create [redirect request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&labels=Redirect+request&template=redirect-request-facility-url.md&title=Redirect+Request+for%3A+%3Cinsert+facility+name%3E) accordingly.
 - [ ] When redirect is ready to go out, plan to make these changes immediately after redirect is released. Practice first on staging or a demo environment.
-  - [ ] CMS engineer edits the facility node, removes  flag `Removed from source`, add a revision log that explains the change, with a link to github issue, and change moderation state to archive. (Note: any related health services, non-clinical services and events for the given facility will be archived automatically when these changes are saved.)
+  - [ ] Are there any events tied to this facility that have yet to occur and if so should any of them be updated to a new location? If yes, update these events accordingly.
+  - [ ] CMS engineer edits the facility node, removes flag `Removed from source`, add a revision log that explains the change, with a link to github issue, and change moderation state to archive. (Note: any related health services, non-clinical services and events for the given facility will be archived automatically when these changes are saved.)
   - [ ] CMS engineer finds the menu for the system https://prod.cms.va.gov/admin/structure/menu and deletes the menu item for the closed facility.
 - [ ] Let HD know this is complete.
 

--- a/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
@@ -72,10 +72,7 @@ If this facility has been removed from VAST in error, please notify our Support 
 - [ ] Determine where should redirect go? to the system? or to the nearest clinic?
 - [ ] Create [redirect request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&labels=Redirect+request&template=redirect-request-facility-url.md&title=Redirect+Request+for%3A+%3Cinsert+facility+name%3E) accordingly.
 - [ ] When redirect is ready to go out, plan to make these changes immediately after redirect is released. Practice first on staging or a demo environment.
-  - [ ] CMS engineer bulk archives the facility service nodes. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service).
-  - [ ] CMS engineer bulk archives the facility non-clinical service nodes. (https://prod.cms.va.gov/admin/content/bulk?type=vha_facility_nonclinical_service).
-  - [ ] CMS engineer filters content by the health care system and scans for any events that might be taking place at that facility. Archive if any are found.
-  - [ ] CMS engineer edits the facility node, removes  flag `Removed from source`, add a revision log that explains the change, with a link to github issue, and change moderation state to archive.
+  - [ ] CMS engineer edits the facility node, removes  flag `Removed from source`, add a revision log that explains the change, with a link to github issue, and change moderation state to archive. (Note: any related health services, non-clinical services and events for the given facility will be archived automatically when these changes are saved.)
   - [ ] CMS engineer finds the menu for the system https://prod.cms.va.gov/admin/structure/menu and deletes the menu item for the closed facility.
 - [ ] Let HD know this is complete.
 

--- a/docroot/modules/custom/va_gov_facilities/src/EventSubscriber/FacilitiesSubscriber.php
+++ b/docroot/modules/custom/va_gov_facilities/src/EventSubscriber/FacilitiesSubscriber.php
@@ -45,20 +45,20 @@ class FacilitiesSubscriber implements EventSubscriberInterface {
   /**
    * Constructs the EventSubscriber object.
    *
-   * @param \Drupal\Core\Session\AccountInterface $current_user
+   * @param \Drupal\Core\Session\AccountInterface $currentUser
    *   The current user.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
    *   The string entity type service.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    */
   public function __construct(
-    AccountInterface $current_user,
-    EntityTypeManager $entity_type_manager,
+    AccountInterface $currentUser,
+    EntityTypeManager $entityTypeManager,
     MessengerInterface $messenger
   ) {
-    $this->currentUser = $current_user;
-    $this->entityTypeManager = $entity_type_manager;
+    $this->currentUser = $currentUser;
+    $this->entityTypeManager = $entityTypeManager;
     $this->messenger = $messenger;
   }
 
@@ -107,14 +107,15 @@ class FacilitiesSubscriber implements EventSubscriberInterface {
         ];
 
         // Find all related published services and events.
-        $query = \Drupal::entityQuery('node');
+        $nodeStorage = $this->entityTypeManager->getStorage('node');
+        $query = $nodeStorage->getQuery();
         $query->condition('type', $relatedTypes, 'IN')
           ->condition('field_facility_location', $facilityID)
           ->condition('moderation_state', 'published');
         $nids = $query->execute();
 
         if (count($nids)) {
-          $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+          $nodes = $nodeStorage->loadMultiple($nids);
           $updated = [
             'event' => 0,
             'health_care_local_health_service' => 0,
@@ -136,7 +137,7 @@ class FacilitiesSubscriber implements EventSubscriberInterface {
               $node->setRevisionLogMessage('Automatically archived when parent facility was archived.');
               $node->save();
               // Increment updated count.
-              $updated[$node->bundle()] += 1;
+              $updated[$node->bundle()]++;
             }
           }
 

--- a/docroot/modules/custom/va_gov_facilities/src/EventSubscriber/FacilitiesSubscriber.php
+++ b/docroot/modules/custom/va_gov_facilities/src/EventSubscriber/FacilitiesSubscriber.php
@@ -176,17 +176,17 @@ class FacilitiesSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Check to see if a supplied $entity is being archived.
+   * Check to see if a supplied node is being archived.
    *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   Entity.
+   * @param \Drupal\node\NodeInterface $node
+   *   Node.
    *
    * @return bool
-   *   Is this entity being archived?
+   *   Is this node being archived?
    */
-  protected function isBeingArchived(EntityInterface $entity): bool {
-    $currentState = $entity->get('moderation_state')->value;
-    $oldState = $entity->original->get('moderation_state')->value;
+  protected function isBeingArchived(NodeInterface $node): bool {
+    $currentState = $node->get('moderation_state')->value;
+    $oldState = $node->original->get('moderation_state')->value;
     if ($oldState === 'archived' || $currentState !== 'archived') {
       return FALSE;
     }

--- a/docroot/modules/custom/va_gov_facilities/src/EventSubscriber/FacilitiesSubscriber.php
+++ b/docroot/modules/custom/va_gov_facilities/src/EventSubscriber/FacilitiesSubscriber.php
@@ -2,9 +2,14 @@
 
 namespace Drupal\va_gov_facilities\EventSubscriber;
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent;
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
 use Drupal\node\NodeInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -12,6 +17,50 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * VA.gov VA Facilities Entity Event Subscriber.
  */
 class FacilitiesSubscriber implements EventSubscriberInterface {
+  use StringTranslationTrait;
+
+  /**
+   * The active user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   *  The user object.
+   */
+  private $currentUser;
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   *  The entity manager.
+   */
+  private $entityTypeManager;
+
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs the EventSubscriber object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   The string entity type service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(
+    AccountInterface $current_user,
+    EntityTypeManager $entity_type_manager,
+    MessengerInterface $messenger
+  ) {
+    $this->currentUser = $current_user;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->messenger = $messenger;
+  }
 
   /**
    * {@inheritdoc}
@@ -19,6 +68,7 @@ class FacilitiesSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents(): array {
     return [
       EntityHookEvents::ENTITY_PRE_SAVE => 'entityPresave',
+      EntityHookEvents::ENTITY_UPDATE => 'entityUpdate',
     ];
   }
 
@@ -31,6 +81,76 @@ class FacilitiesSubscriber implements EventSubscriberInterface {
   public function entityPresave(EntityPresaveEvent $event): void {
     $entity = $event->getEntity();
     $this->clearNormalStatusDetails($entity);
+  }
+
+  /**
+   * Entity update Event call.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent $event
+   *   The event.
+   */
+  public function entityUpdate(EntityUpdateEvent $event): void {
+    $entity = $event->getEntity();
+    if ($entity instanceof NodeInterface && $entity->bundle() === 'health_care_local_facility') {
+      // When a facility is archived auto archive related services and events.
+      if (isset($entity->original) && ($entity->original instanceof NodeInterface)) {
+        $currentState = $entity->get('moderation_state')->value;
+        $oldState = $entity->original->get('moderation_state')->value;
+        if ($oldState === 'archived' || $currentState !== 'archived') {
+          return;
+        }
+        $facilityID = $entity->id();
+        $relatedTypes = [
+          'event',
+          'health_care_local_health_service',
+          'vha_facility_nonclinical_service',
+        ];
+
+        // Find all related published services and events.
+        $query = \Drupal::entityQuery('node');
+        $query->condition('type', $relatedTypes, 'IN')
+          ->condition('field_facility_location', $facilityID)
+          ->condition('moderation_state', 'published');
+        $nids = $query->execute();
+
+        if (count($nids)) {
+          $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+          $updated = [
+            'event' => 0,
+            'health_care_local_health_service' => 0,
+            'vha_facility_nonclinical_service' => 0,
+          ];
+          foreach ($nodes as $node) {
+            if ($node instanceof NodeInterface) {
+              // Make this change a new revision.
+              $node->setNewRevision(TRUE);
+              // Set as archived and unpublished.
+              $node->set('moderation_state', 'archived');
+              $node->setUnpublished();
+              // Set revision author to current user.
+              $node->setRevisionUserId($this->currentUser->id());
+              $node->setChangedTime(time());
+              $node->isDefaultRevision(TRUE);
+              $node->setRevisionCreationTime(time());
+              // Set revision log message.
+              $node->setRevisionLogMessage('Automatically archived when parent facility was archived.');
+              $node->save();
+              // Increment updated count.
+              $updated[$node->bundle()] += 1;
+            }
+          }
+
+          // Status message so editor knows the extent of the changes.
+          $message = $this->t('%services health services, %nonclinicals non-clinical services, and %events events were also archived.', [
+            '%services' => $updated['health_care_local_health_service'],
+            '%nonclinicals' => $updated['vha_facility_nonclinical_service'],
+            '%events' => $updated['event'],
+          ]);
+          $this->messenger->addStatus($message);
+        }
+
+      }
+    }
   }
 
   /**

--- a/docroot/modules/custom/va_gov_facilities/va_gov_facilities.services.yml
+++ b/docroot/modules/custom/va_gov_facilities/va_gov_facilities.services.yml
@@ -1,7 +1,6 @@
 services:
   va_gov_facilities.entity_event_subscriber:
     class: Drupal\va_gov_facilities\EventSubscriber\FacilitiesSubscriber
-    arguments:
-      - '@entity_type.manager'
+    arguments: ['@current_user', '@entity_type.manager', '@messenger']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
## Description

Closes #6528

## Testing done

Manual / visual testing

## Screenshots

![Screen Shot 2022-06-27 at 4 39 27 PM](https://user-images.githubusercontent.com/21045418/176033397-1a8aaa1e-c4b4-4feb-a98f-3f980140118d.png)

![Screen Shot 2022-06-27 at 4 51 38 PM](https://user-images.githubusercontent.com/21045418/176033546-176d0c36-0e47-4fae-b630-39716d2c0859.png)

![Screen Shot 2022-06-27 at 4 51 47 PM](https://user-images.githubusercontent.com/21045418/176033635-7fcb376c-e6cc-4096-b32f-047749b0717a.png)

![Screen Shot 2022-06-27 at 4 52 05 PM](https://user-images.githubusercontent.com/21045418/176033651-c029512f-1b34-477b-aaf4-5f58f6efdd8d.png)

## QA steps

As an admin user
1. Load the Events view /admin/content/events and filter by: Facility title contains = **Rocky Mountain** (note the total number of items)
2. Load the Bulk edit view /admin/content/bulk and filter by: Title = **Rocky Mountain** and Content type = **VAMC Facility Health Service** (note the total number of items)
3. Load the Bulk edit view /admin/content/bulk and filter by: Title = **Rocky Mountain** and Content type = **VAMC Facility Non-clinical Service** (note the total number of items)
4. Load the following VAMC Facility Node page: /eastern-colorado-health-care/locations/rocky-mountain-regional-va-medical-center
5. Edit the Facility node, change the moderation state to Archived

- [ ] Verify the facility is unpublished
- [ ] Verify the status message shows a number of additional items that were archived
- [ ] Refresh the view pages listed above and verify the items are all archived
- [ ] Open one item of each type and ensure there is a revision log message stating that the item was automatically archived when the parent facility was archived.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
