### PR TITLE
VACMS-9591: Augment html_tag_usage filtering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -436,7 +436,7 @@
                 "3145496 - Make d9 compatible": "https://www.drupal.org/files/issues/2020-06-05/3145496-6.patch"
             },
             "drupal/html_tag_usage": {
-                "3270450 - Add csv generator and filters": "https://www.drupal.org/files/issues/2022-03-21/add-filters-and-csv-5.patch"
+                "3270450 - Add csv generator and filters": "https://www.drupal.org/files/issues/2022-06-30/add-filters-and-csv-20.patch"
             },
             "drupal/ics_field": {
                 "Include end date / time in ICS file.": "https://www.drupal.org/files/issues/2018-10-06/ics_field-2852239-11.patch"


### PR DESCRIPTION
## Description
closes #9591

## Testing done
Visual / filtering

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/176237819-9319f609-3a88-407b-ad4f-b6ebe74efe32.png)

![image](https://user-images.githubusercontent.com/2404547/176237867-956a5266-b573-44b7-9f72-fa7459117599.png)


## QA steps
 - [x] Go to `admin/reports/html_tag_usage` and select one of the count items (e.g.: `Rich text -> a -> href: count`)
 - [x] On subsequent page, select `node` entity and visually verify bundle and search string filters appear
 - [x] Visit an entity listed in the table, and copy a snippet of text from the field that is highlighted as a match in the table
 - [x] Return to the filter form, enter the name of the field in the `Name of the field to filter` filter, choose `node` for entity type, enter the node bundle in the bundle filter, and paste the snippet in the `Search by string` filter
 - [x] Click `Apply filters` and verify your node is returned (may be more than one result if item appears on other pages)
 - [x] Choose `paragraph` for the entity type filter
 - [x] Visually verify 4 filters appear
 - [x] Choose an entity type that is not `node` or `paragraph` and visually verify only two filters appear
 - [x] If QA meets use case, please mark https://www.drupal.org/project/html_tag_usage/issues/3270450 as `Reviewed and tested by the community`


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
