### PR TITLE
VACMS-9496: patch field_group to always supply #description_display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -423,7 +423,8 @@
             },
             "drupal/field_group": {
                 "2787179 Visibility of invalid fields": "https://www.drupal.org/files/issues/2021-01-05/2787179-highlight-html5-validation-59.patch",
-                "1482958-47 Allow field_group with empty fields to be displayed via setting": "https://www.drupal.org/files/issues/2020-06-24/field_group-empty-config-1482958-47.patch"
+                "1482958-47 Allow field_group with empty fields to be displayed via setting": "https://www.drupal.org/files/issues/2020-06-24/field_group-empty-config-1482958-47.patch",
+                "Undefined index #description_display when adding a description to fieldset group type": "https://www.drupal.org/files/issues/2022-07-04/field_group-undefined-index-description-display-3053242-11.patch"
             },
             "drupal/graphql": {
                 "Fix Explorer with Layout Builder enabled - https://github.com/drupal-graphql/graphql/pull/1144": "patches/graphql_8x3x_layout_builder_incompat.patch",


### PR DESCRIPTION
## Description

Closes #9496 

## Testing done

Manual/visual testing

## Screenshots

![Screen Shot 2022-07-04 at 4 50 36 PM](https://user-images.githubusercontent.com/21045418/177215296-6a784d27-db46-4957-9779-af690f2705a4.png)

## QA steps

1. Go to '[/northern-maine-vet-center](https://dev.cms.va.gov/node/3615)` on local, tugboat or dev (notices are not displayed visibly on staging or prod)
2. Click on on the edit tab.
3. Save the node
4. You should not see any notices with the following text anymore:

```
Notice: Undefined index: #description_display in template_preprocess_fieldset() (line 219 of core/includes/form.inc).
Notice: Undefined index: #description_display in template_preprocess_fieldset() (line 220 of core/includes/form.inc).
```

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
