### PR TITLE
VACMS-9637: add geocoder (lat/long) field to facilities

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_description
     - field.field.node.health_care_local_facility.field_facility_classification
     - field.field.node.health_care_local_facility.field_facility_locator_api_id
+    - field.field.node.health_care_local_facility.field_geolocation
     - field.field.node.health_care_local_facility.field_intro_text
     - field.field.node.health_care_local_facility.field_local_health_care_service_
     - field.field.node.health_care_local_facility.field_location_services
@@ -28,6 +29,7 @@ dependencies:
     - address
     - content_moderation
     - field_group
+    - geofield
     - media_library
     - office_hours
     - paragraphs
@@ -71,7 +73,7 @@ third_party_settings:
       label: '"Prepare for your visit"'
       region: content
       parent_name: ''
-      weight: 7
+      weight: 8
       format_type: details
       format_settings:
         classes: ''
@@ -86,7 +88,7 @@ third_party_settings:
       label: 'VAMC system'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -100,7 +102,7 @@ third_party_settings:
       label: 'Title and summary'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -112,7 +114,7 @@ third_party_settings:
       label: 'Social Media'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         classes: ''
@@ -126,7 +128,7 @@ third_party_settings:
       label: 'Operating status'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -140,7 +142,7 @@ third_party_settings:
       label: 'Meta Tags'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         classes: ''
@@ -167,6 +169,7 @@ third_party_settings:
         - field_facility_locator_api_id
         - field_facility_classification
         - field_address
+        - field_geolocation
         - field_mobile
         - field_phone_number
         - field_mental_health_phone
@@ -194,7 +197,7 @@ third_party_settings:
       label: 'COVID-19 health protection guidelines'
       region: content
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
@@ -265,9 +268,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_geolocation:
+    type: geofield_latlon
+    weight: 25
+    region: content
+    settings:
+      html5_geolocation: false
+    third_party_settings: {  }
   field_intro_text:
     type: string_textarea_with_counter
-    weight: 6
+    weight: 9
     region: content
     settings:
       rows: 5
@@ -299,28 +309,28 @@ content:
     third_party_settings: {  }
   field_media:
     type: media_library_widget
-    weight: 8
+    weight: 10
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_mental_health_phone:
     type: telephone_default
-    weight: 27
+    weight: 28
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_mobile:
     type: boolean_checkbox
-    weight: 25
+    weight: 26
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_office_hours:
     type: office_hours_default
-    weight: 28
+    weight: 29
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -345,7 +355,7 @@ content:
     third_party_settings: {  }
   field_phone_number:
     type: telephone_default
-    weight: 26
+    weight: 27
     region: content
     settings:
       placeholder: ''
@@ -375,7 +385,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_description
     - field.field.node.health_care_local_facility.field_facility_classification
     - field.field.node.health_care_local_facility.field_facility_locator_api_id
+    - field.field.node.health_care_local_facility.field_geolocation
     - field.field.node.health_care_local_facility.field_intro_text
     - field.field.node.health_care_local_facility.field_local_health_care_service_
     - field.field.node.health_care_local_facility.field_location_services
@@ -139,6 +140,7 @@ hidden:
   field_description: true
   field_facility_classification: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_intro_text: true
   field_local_health_care_service_: true
   field_location_services: true

--- a/config/sync/core.entity_form_display.node.nca_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.nca_facility.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.nca_facility.field_administration
     - field.field.node.nca_facility.field_facility_locator_api_id
+    - field.field.node.nca_facility.field_geolocation
     - field.field.node.nca_facility.field_operating_status_facility
     - field.field.node.nca_facility.field_operating_status_more_info
     - node.type.nca_facility
@@ -12,6 +13,7 @@ dependencies:
   module:
     - content_moderation
     - field_group
+    - geofield
     - textfield_counter
 third_party_settings:
   field_group:
@@ -19,6 +21,7 @@ third_party_settings:
       children:
         - title
         - field_facility_locator_api_id
+        - field_geolocation
       label: 'Facility API'
       region: content
       parent_name: ''
@@ -92,6 +95,13 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_geolocation:
+    type: geofield_latlon
+    weight: 3
+    region: content
+    settings:
+      html5_geolocation: false
     third_party_settings: {  }
   field_operating_status_facility:
     type: options_select

--- a/config/sync/core.entity_form_display.node.vba_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.vba_facility.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.vba_facility.field_administration
     - field.field.node.vba_facility.field_facility_locator_api_id
+    - field.field.node.vba_facility.field_geolocation
     - field.field.node.vba_facility.field_operating_status_facility
     - field.field.node.vba_facility.field_operating_status_more_info
     - node.type.vba_facility
@@ -12,6 +13,7 @@ dependencies:
   module:
     - content_moderation
     - field_group
+    - geofield
     - textfield_counter
 third_party_settings:
   field_group:
@@ -19,6 +21,7 @@ third_party_settings:
       children:
         - title
         - field_facility_locator_api_id
+        - field_geolocation
       label: 'Facility API'
       region: content
       parent_name: ''
@@ -50,7 +53,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -67,7 +70,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -92,6 +95,13 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_geolocation:
+    type: geofield_latlon
+    weight: 3
+    region: content
+    settings:
+      html5_geolocation: false
     third_party_settings: {  }
   field_operating_status_facility:
     type: options_select

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.vet_center.field_cc_vet_center_faqs
     - field.field.node.vet_center.field_cc_vet_center_featured_con
     - field.field.node.vet_center.field_facility_locator_api_id
+    - field.field.node.vet_center.field_geolocation
     - field.field.node.vet_center.field_health_services
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_media
@@ -30,6 +31,7 @@ dependencies:
     - entity_browser_entity_form
     - entity_field_fetch
     - field_group
+    - geofield
     - ief_table_view_mode
     - limited_field_widgets
     - markup
@@ -61,7 +63,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -78,7 +80,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: fieldset
       format_settings:
         classes: ''
@@ -90,7 +92,7 @@ third_party_settings:
       label: 'Direct line'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         classes: ''
@@ -155,7 +157,7 @@ third_party_settings:
       label: 'Prepare for your visit'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -169,7 +171,7 @@ third_party_settings:
       label: 'Featured content'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         classes: ''
@@ -182,7 +184,7 @@ third_party_settings:
       label: 'How we''re different than a clinic (FAQs)'
       region: content
       parent_name: ''
-      weight: 8
+      weight: 9
       format_type: tooltip
       format_settings:
         show_label: '0'
@@ -199,6 +201,7 @@ third_party_settings:
       children:
         - field_facility_locator_api_id
         - field_address
+        - field_geolocation
         - field_phone_number
         - field_office_hours
       label: 'Facility data'
@@ -298,9 +301,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_geolocation:
+    type: geofield_latlon
+    weight: 9
+    region: content
+    settings:
+      html5_geolocation: false
+    third_party_settings: {  }
   field_health_services:
     type: inline_entity_form_complex_table_view_mode
-    weight: 7
+    weight: 8
     region: content
     settings:
       form_mode: inline_entity_form
@@ -373,7 +383,7 @@ content:
     third_party_settings: {  }
   field_phone_number:
     type: telephone_default
-    weight: 9
+    weight: 10
     region: content
     settings:
       placeholder: ''

--- a/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center_outstation.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.vet_center_outstation.field_address
     - field.field.node.vet_center_outstation.field_administration
     - field.field.node.vet_center_outstation.field_facility_locator_api_id
+    - field.field.node.vet_center_outstation.field_geolocation
     - field.field.node.vet_center_outstation.field_media
     - field.field.node.vet_center_outstation.field_office
     - field.field.node.vet_center_outstation.field_office_hours
@@ -19,6 +20,7 @@ dependencies:
     - address
     - content_moderation
     - field_group
+    - geofield
     - markup
     - media_library
     - office_hours
@@ -122,6 +124,7 @@ third_party_settings:
       children:
         - field_facility_locator_api_id
         - field_address
+        - field_geolocation
         - field_phone_number
         - field_office_hours
       label: 'Facility data'
@@ -165,6 +168,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_geolocation:
+    type: geofield_latlon
+    weight: 23
+    region: content
+    settings:
+      html5_geolocation: false
+    third_party_settings: {  }
   field_media:
     type: media_library_widget
     weight: 5
@@ -180,7 +190,7 @@ content:
     third_party_settings: {  }
   field_office_hours:
     type: office_hours_default
-    weight: 24
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -205,7 +215,7 @@ content:
     third_party_settings: {  }
   field_phone_number:
     type: telephone_default
-    weight: 23
+    weight: 24
     region: content
     settings:
       placeholder: ''

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_description
     - field.field.node.health_care_local_facility.field_facility_classification
     - field.field.node.health_care_local_facility.field_facility_locator_api_id
+    - field.field.node.health_care_local_facility.field_geolocation
     - field.field.node.health_care_local_facility.field_intro_text
     - field.field.node.health_care_local_facility.field_local_health_care_service_
     - field.field.node.health_care_local_facility.field_location_services
@@ -281,6 +282,7 @@ hidden:
   content_moderation_control: true
   field_administration: true
   field_facility_classification: true
+  field_geolocation: true
   field_local_health_care_service_: true
   field_main_location: true
   field_meta_tags: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_description
     - field.field.node.health_care_local_facility.field_facility_classification
     - field.field.node.health_care_local_facility.field_facility_locator_api_id
+    - field.field.node.health_care_local_facility.field_geolocation
     - field.field.node.health_care_local_facility.field_intro_text
     - field.field.node.health_care_local_facility.field_local_health_care_service_
     - field.field.node.health_care_local_facility.field_location_services
@@ -255,6 +256,7 @@ hidden:
   field_administration: true
   field_description: true
   field_facility_classification: true
+  field_geolocation: true
   field_intro_text: true
   field_local_health_care_service_: true
   field_location_services: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_description
     - field.field.node.health_care_local_facility.field_facility_classification
     - field.field.node.health_care_local_facility.field_facility_locator_api_id
+    - field.field.node.health_care_local_facility.field_geolocation
     - field.field.node.health_care_local_facility.field_intro_text
     - field.field.node.health_care_local_facility.field_local_health_care_service_
     - field.field.node.health_care_local_facility.field_location_services
@@ -108,6 +109,7 @@ hidden:
   field_description: true
   field_facility_classification: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_intro_text: true
   field_local_health_care_service_: true
   field_location_services: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_description
     - field.field.node.health_care_local_facility.field_facility_classification
     - field.field.node.health_care_local_facility.field_facility_locator_api_id
+    - field.field.node.health_care_local_facility.field_geolocation
     - field.field.node.health_care_local_facility.field_intro_text
     - field.field.node.health_care_local_facility.field_local_health_care_service_
     - field.field.node.health_care_local_facility.field_location_services
@@ -68,6 +69,7 @@ hidden:
   field_description: true
   field_facility_classification: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_intro_text: true
   field_local_health_care_service_: true
   field_location_services: true

--- a/config/sync/core.entity_view_display.node.nca_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.nca_facility.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.nca_facility.field_administration
     - field.field.node.nca_facility.field_facility_locator_api_id
+    - field.field.node.nca_facility.field_geolocation
     - field.field.node.nca_facility.field_operating_status_facility
     - field.field.node.nca_facility.field_operating_status_more_info
     - node.type.nca_facility
@@ -53,7 +54,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
-  field_administration: true
+  field_geolocation: true
   flag_changed_name: true
   flag_changed_title: true
   flag_new: true

--- a/config/sync/core.entity_view_display.node.nca_facility.teaser.yml
+++ b/config/sync/core.entity_view_display.node.nca_facility.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.nca_facility.field_administration
     - field.field.node.nca_facility.field_facility_locator_api_id
+    - field.field.node.nca_facility.field_geolocation
     - field.field.node.nca_facility.field_operating_status_facility
     - field.field.node.nca_facility.field_operating_status_more_info
     - node.type.nca_facility
@@ -29,6 +30,7 @@ content:
 hidden:
   field_administration: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_operating_status_facility: true
   field_operating_status_more_info: true
   flag_changed_name: true

--- a/config/sync/core.entity_view_display.node.vba_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.vba_facility.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.vba_facility.field_administration
     - field.field.node.vba_facility.field_facility_locator_api_id
+    - field.field.node.vba_facility.field_geolocation
     - field.field.node.vba_facility.field_operating_status_facility
     - field.field.node.vba_facility.field_operating_status_more_info
     - node.type.vba_facility
@@ -53,7 +54,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
-  field_administration: true
+  field_geolocation: true
   flag_changed_name: true
   flag_changed_title: true
   flag_new: true

--- a/config/sync/core.entity_view_display.node.vba_facility.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vba_facility.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.vba_facility.field_administration
     - field.field.node.vba_facility.field_facility_locator_api_id
+    - field.field.node.vba_facility.field_geolocation
     - field.field.node.vba_facility.field_operating_status_facility
     - field.field.node.vba_facility.field_operating_status_more_info
     - node.type.vba_facility
@@ -29,6 +30,7 @@ content:
 hidden:
   field_administration: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_operating_status_facility: true
   field_operating_status_more_info: true
   flag_changed_name: true

--- a/config/sync/core.entity_view_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.vet_center.field_cc_vet_center_faqs
     - field.field.node.vet_center.field_cc_vet_center_featured_con
     - field.field.node.vet_center.field_facility_locator_api_id
+    - field.field.node.vet_center.field_geolocation
     - field.field.node.vet_center.field_health_services
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_media
@@ -341,6 +342,7 @@ content:
 hidden:
   content_moderation_control: true
   field_administration: true
+  field_geolocation: true
   field_table_of_contents: true
   flag_changed_name: true
   flag_changed_title: true

--- a/config/sync/core.entity_view_display.node.vet_center.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.external_content.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.vet_center.field_cc_vet_center_faqs
     - field.field.node.vet_center.field_cc_vet_center_featured_con
     - field.field.node.vet_center.field_facility_locator_api_id
+    - field.field.node.vet_center.field_geolocation
     - field.field.node.vet_center.field_health_services
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_media
@@ -113,6 +114,7 @@ hidden:
   field_cc_vet_center_call_center: true
   field_cc_vet_center_faqs: true
   field_cc_vet_center_featured_con: true
+  field_geolocation: true
   field_health_services: true
   field_intro_text: true
   field_media: true

--- a/config/sync/core.entity_view_display.node.vet_center.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.ief_table.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.vet_center.field_cc_vet_center_faqs
     - field.field.node.vet_center.field_cc_vet_center_featured_con
     - field.field.node.vet_center.field_facility_locator_api_id
+    - field.field.node.vet_center.field_geolocation
     - field.field.node.vet_center.field_health_services
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_media
@@ -63,6 +64,7 @@ hidden:
   field_cc_vet_center_faqs: true
   field_cc_vet_center_featured_con: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_intro_text: true
   field_media: true
   field_office_hours: true

--- a/config/sync/core.entity_view_display.node.vet_center.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.vet_center.field_cc_vet_center_faqs
     - field.field.node.vet_center.field_cc_vet_center_featured_con
     - field.field.node.vet_center.field_facility_locator_api_id
+    - field.field.node.vet_center.field_geolocation
     - field.field.node.vet_center.field_health_services
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_media
@@ -44,6 +45,7 @@ hidden:
   field_cc_vet_center_faqs: true
   field_cc_vet_center_featured_con: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_health_services: true
   field_intro_text: true
   field_media: true

--- a/config/sync/core.entity_view_display.node.vet_center_outstation.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_outstation.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.vet_center_outstation.field_address
     - field.field.node.vet_center_outstation.field_administration
     - field.field.node.vet_center_outstation.field_facility_locator_api_id
+    - field.field.node.vet_center_outstation.field_geolocation
     - field.field.node.vet_center_outstation.field_media
     - field.field.node.vet_center_outstation.field_office
     - field.field.node.vet_center_outstation.field_office_hours
@@ -174,6 +175,7 @@ content:
 hidden:
   content_moderation_control: true
   field_administration: true
+  field_geolocation: true
   field_table_of_contents: true
   flag_changed_name: true
   flag_changed_title: true

--- a/config/sync/core.entity_view_display.node.vet_center_outstation.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_outstation.external_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.vet_center_outstation.field_address
     - field.field.node.vet_center_outstation.field_administration
     - field.field.node.vet_center_outstation.field_facility_locator_api_id
+    - field.field.node.vet_center_outstation.field_geolocation
     - field.field.node.vet_center_outstation.field_media
     - field.field.node.vet_center_outstation.field_office
     - field.field.node.vet_center_outstation.field_office_hours
@@ -102,6 +103,7 @@ content:
 hidden:
   content_moderation_control: true
   field_administration: true
+  field_geolocation: true
   field_media: true
   field_office: true
   field_operating_status_facility: true

--- a/config/sync/core.entity_view_display.node.vet_center_outstation.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_outstation.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.vet_center_outstation.field_address
     - field.field.node.vet_center_outstation.field_administration
     - field.field.node.vet_center_outstation.field_facility_locator_api_id
+    - field.field.node.vet_center_outstation.field_geolocation
     - field.field.node.vet_center_outstation.field_media
     - field.field.node.vet_center_outstation.field_office
     - field.field.node.vet_center_outstation.field_office_hours
@@ -27,6 +28,21 @@ content:
     third_party_settings: {  }
     weight: -20
     region: content
+  flag_changed_name:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  flag_new:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  flag_removed_from_source:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -36,6 +52,7 @@ hidden:
   field_address: true
   field_administration: true
   field_facility_locator_api_id: true
+  field_geolocation: true
   field_media: true
   field_office: true
   field_office_hours: true

--- a/config/sync/field.field.node.health_care_local_facility.field_geolocation.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_geolocation.yml
@@ -1,0 +1,26 @@
+uuid: df8be1c4-9dba-4223-9463-99503be96e8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation
+    - node.type.health_care_local_facility
+  module:
+    - epp
+    - geofield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: node.health_care_local_facility.field_geolocation
+field_name: field_geolocation
+entity_type: node
+bundle: health_care_local_facility
+label: Geolocation
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/field.field.node.nca_facility.field_geolocation.yml
+++ b/config/sync/field.field.node.nca_facility.field_geolocation.yml
@@ -1,0 +1,26 @@
+uuid: b272a878-f320-43bb-8675-fb607e16d4d2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation
+    - node.type.nca_facility
+  module:
+    - epp
+    - geofield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: node.nca_facility.field_geolocation
+field_name: field_geolocation
+entity_type: node
+bundle: nca_facility
+label: Geolocation
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/field.field.node.vba_facility.field_geolocation.yml
+++ b/config/sync/field.field.node.vba_facility.field_geolocation.yml
@@ -1,0 +1,26 @@
+uuid: aef60ac8-08a9-4dac-bcc2-fabde7ed42aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation
+    - node.type.vba_facility
+  module:
+    - epp
+    - geofield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: node.vba_facility.field_geolocation
+field_name: field_geolocation
+entity_type: node
+bundle: vba_facility
+label: Geolocation
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/field.field.node.vet_center.field_geolocation.yml
+++ b/config/sync/field.field.node.vet_center.field_geolocation.yml
@@ -1,0 +1,26 @@
+uuid: 71ba88d7-7bdf-4068-9149-501f2673d29c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation
+    - node.type.vet_center
+  module:
+    - epp
+    - geofield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: node.vet_center.field_geolocation
+field_name: field_geolocation
+entity_type: node
+bundle: vet_center
+label: Geolocation
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/field.field.node.vet_center_outstation.field_geolocation.yml
+++ b/config/sync/field.field.node.vet_center_outstation.field_geolocation.yml
@@ -1,0 +1,26 @@
+uuid: 54025fb0-1180-4e3c-b179-925a5b43c57a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation
+    - node.type.vet_center_outstation
+  module:
+    - epp
+    - geofield
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: node.vet_center_outstation.field_geolocation
+field_name: field_geolocation
+entity_type: node
+bundle: vet_center_outstation
+label: Geolocation
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/geocoder.geocoder_provider.mapbox.yml
+++ b/config/sync/geocoder.geocoder_provider.mapbox.yml
@@ -11,3 +11,5 @@ configuration:
     limit: null
   accessToken: 'set with environment variable'
   country: ''
+  location_type: address
+  fuzzy_match: false

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_fields.scss
@@ -209,4 +209,8 @@ body:not(.role-admin) {
       display: none;
     }
   }
+
+  .field--widget-geofield-latlon {
+    display: none;
+  }
 }

--- a/tests/behat/drupal-spec-tool/content_model_nca_facility_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_nca_facility_content_type_fields.feature
@@ -10,5 +10,6 @@ Feature: Content model: NCA facility Content Type fields
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Content type | NCA Facility | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | NCA Facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | NCA Facility | Geolocation | field_geolocation | Geofield |  | 1 | Latitude/Longitude | Translatable |
 | Content type | NCA Facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
 | Content type | NCA Facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vamc_content_type_fields.feature
@@ -110,6 +110,7 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC Facility | Meta description | field_description | Text (plain) | Required | 1 | Textfield with counter | Translatable |
 | Content type | VAMC Facility | Classification | field_facility_classification | List (text) |  | 1 | Select list |  |
 | Content type | VAMC Facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield |  |
+| Content type | VAMC Facility | Geolocation | field_geolocation | Geofield |  | 1 | Latitude/Longitude | Translatable |
 | Content type | VAMC Facility | Page introduction | field_intro_text | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |
 | Content type | VAMC Facility | Health services | field_local_health_care_service_ | Entity reference |  | Unlimited | -- Disabled -- | Translatable |
 | Content type | VAMC Facility | Location services | field_location_services | Entity reference revisions |  | Unlimited | Paragraphs Legacy |  |
@@ -242,4 +243,3 @@ Feature: Content model: VAMC Content Type fields
 | Content type | VAMC System Register for Care | Non-clinical Services | field_non_clinical_services | Viewfield |  | 1 | Viewfield |  |
 | Content type | VAMC System Register for Care | VAMC System | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VAMC System Register for Care | Service | field_service_name_and_descripti | Entity reference |  | 1 | -- Disabled -- | Translatable |
- 

--- a/tests/behat/drupal-spec-tool/content_model_vba_facility_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vba_facility_content_type_fields.feature
@@ -10,5 +10,6 @@ Feature: Content model: VBA facility Content Type fields
        | Type | Bundle | Field label | Machine name | Field type | Required | Cardinality | Form widget | Translatable |
 | Content type | VBA Facility | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | VBA Facility | Facility Locator API ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | VBA Facility | Geolocation | field_geolocation | Geofield |  | 1 | Latitude/Longitude | Translatable |
 | Content type | VBA Facility | Operating status | field_operating_status_facility | List (text) | Required | 1 | Select list | Translatable |
 | Content type | VBA Facility | Operating status - more info | field_operating_status_more_info | Text (plain, long) |  | 1 | Textarea (multiple rows) with counter | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vet_center_content_type_fields.feature
@@ -15,6 +15,7 @@ Feature: Content model: Vet Center Content Type fields
 | Content type | Vet Center | Vet Center faqs | field_cc_vet_center_faqs | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
 | Content type | Vet Center | Nationally featured Vet Center content | field_cc_vet_center_featured_con | Entity Field Fetch field |  | 1 | Entity Field Fetch widget |  |
 | Content type | Vet Center | Facility ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | Vet Center | Geolocation | field_geolocation | Geofield |  | 1 | Latitude/Longitude | Translatable |
 | Content type | Vet Center | Services | field_health_services | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
 | Content type | Vet Center | Page introduction | field_intro_text | Text (plain, long) | Required | 1 | Text area (multiple rows) | Translatable |
 | Content type | Vet Center | Facility photo | field_media | Entity reference |  | 1 | Media library | Translatable |
@@ -59,6 +60,7 @@ Feature: Content model: Vet Center Content Type fields
 | Content type | Vet Center - Outstation | Location address | field_address | Address |  | 1 | Address | Translatable |
 | Content type | Vet Center - Outstation | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Outstation | Facility ID | field_facility_locator_api_id | Text (plain) |  | 1 | Textfield | Translatable |
+| Content type | Vet Center - Outstation | Geolocation | field_geolocation | Geofield |  | 1 | Latitude/Longitude | Translatable |
 | Content type | Vet Center - Outstation | Facility photo | field_media | Entity reference |  | 1 | Media library | Translatable |
 | Content type | Vet Center - Outstation | Main Vet Center location | field_office | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Vet Center - Outstation | Hours | field_office_hours | Office hours |  | Unlimited | Office hours (week) | Translatable |


### PR DESCRIPTION
## Description

Closes #9637 

## Testing done

Visual testing

## Screenshots

Admin editing experience on the left - non-admin editor on the right:

![Screen Shot 2022-07-07 at 4 02 22 PM](https://user-images.githubusercontent.com/21045418/177874139-14855c41-47b5-41ef-9e00-7c6eca371af0.png)

## QA steps

**As an admin:**

1. [x] visit /admin/content and filter the results for each of the content types listed below (one at a time). Open one of each of these types in their own tab in edit mode (Note the last non-admin editor who made modifications to the node)
VAMC Facility
VBA Facility
NCA Facility
Vet Center
Vet Center Outstation
2. [x] Verify the appearance of the lat/long fields in the edit form
3. [x] Click node view and verify the lat/long fields are not displayed

**As the non-admin editor noted in step 1 above:**

1. [ ] Using an incognito window or a secondary browser, log in as a non-admin editor you noted above and copy/paste the edit link above so you can view the edit form as that user. Verify that the lat/long fields are not visible or at least disabled.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
