### PR TITLE
Fix content build request permissions

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/RouteProvider.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/RouteProvider.php
@@ -74,7 +74,8 @@ class RouteProvider {
       // Options.
       [
         'no_cache' => TRUE,
-      ],
+        '_auth' => ['basic_auth', 'cookie'],
+      ]
     );
 
     $routes->add('va_gov_build_trigger.content_release_request_build', $route);


### PR DESCRIPTION
## Description

The "Request Content Build" workflow is failing. The user likely doesn't have the permission that was specified in the route. This PR fixes that.

Also, we need to allow HTTP auth on that route.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
