### PR TITLE
VACMS-9737: Implements Q&A reusability for Resource & Support

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
@@ -6,10 +6,13 @@ dependencies:
     - entity_browser.browser.q_a_browser
     - field.field.paragraph.q_a_group.field_accordion_display
     - field.field.paragraph.q_a_group.field_q_as
+    - field.field.paragraph.q_a_group.field_rich_wysiwyg
     - field.field.paragraph.q_a_group.field_section_header
     - paragraphs.paragraphs_type.q_a_group
   module:
     - entity_browser_table
+    - limited_field_widgets
+    - text
     - textfield_counter
 id: paragraph.q_a_group.default
 targetEntityType: paragraph
@@ -18,24 +21,34 @@ mode: default
 content:
   field_accordion_display:
     type: boolean_checkbox
-    weight: 1
+    weight: 2
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_q_as:
     type: entity_reference_browser_table_widget
-    weight: 2
+    weight: 3
     region: content
     settings:
       entity_browser: q_a_browser
       field_widget_display: label
+      field_widget_edit: '1'
       field_widget_remove: '1'
       selection_mode: selection_append
-      field_widget_edit: 0
       field_widget_replace: 0
       open: 0
       field_widget_display_settings: {  }
+    third_party_settings:
+      limited_field_widgets:
+        limit_values: '0'
+  field_rich_wysiwyg:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   field_section_header:
     type: string_textfield_with_counter

--- a/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
@@ -12,7 +12,6 @@ dependencies:
   module:
     - entity_browser_table
     - limited_field_widgets
-    - text
     - textfield_counter
 id: paragraph.q_a_group.default
 targetEntityType: paragraph
@@ -21,14 +20,14 @@ mode: default
 content:
   field_accordion_display:
     type: boolean_checkbox
-    weight: 2
+    weight: 1
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_q_as:
     type: entity_reference_browser_table_widget
-    weight: 3
+    weight: 2
     region: content
     settings:
       entity_browser: q_a_browser
@@ -42,14 +41,6 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-  field_rich_wysiwyg:
-    type: text_textarea
-    weight: 1
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
   field_section_header:
     type: string_textfield_with_counter
     weight: 0
@@ -66,4 +57,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_rich_wysiwyg: true
   status: true

--- a/config/sync/core.entity_view_display.paragraph.q_a_group.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.q_a_group.default.yml
@@ -5,8 +5,11 @@ dependencies:
   config:
     - field.field.paragraph.q_a_group.field_accordion_display
     - field.field.paragraph.q_a_group.field_q_as
+    - field.field.paragraph.q_a_group.field_rich_wysiwyg
     - field.field.paragraph.q_a_group.field_section_header
     - paragraphs.paragraphs_type.q_a_group
+  module:
+    - text
 id: paragraph.q_a_group.default
 targetEntityType: paragraph
 bundle: q_a_group
@@ -20,7 +23,7 @@ content:
       format_custom_false: ''
       format_custom_true: 'Q&A''s in this section will display as accordions'
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_q_as:
     type: entity_reference_label
@@ -28,7 +31,14 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_rich_wysiwyg:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
   field_section_header:
     type: string

--- a/config/sync/core.entity_view_display.paragraph.q_a_group.user_guides.yml
+++ b/config/sync/core.entity_view_display.paragraph.q_a_group.user_guides.yml
@@ -6,10 +6,12 @@ dependencies:
     - core.entity_view_mode.paragraph.user_guides
     - field.field.paragraph.q_a_group.field_accordion_display
     - field.field.paragraph.q_a_group.field_q_as
+    - field.field.paragraph.q_a_group.field_rich_wysiwyg
     - field.field.paragraph.q_a_group.field_section_header
     - paragraphs.paragraphs_type.q_a_group
   module:
     - layout_builder
+    - text
 third_party_settings:
   layout_builder:
     enabled: false
@@ -27,7 +29,7 @@ content:
       format_custom_false: ''
       format_custom_true: 'Q&A''s in this section will display as accordions'
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_q_as:
     type: entity_reference_label
@@ -35,7 +37,14 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_rich_wysiwyg:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
   field_section_header:
     type: string

--- a/config/sync/field.field.node.support_resources_detail_page.field_content_block.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_content_block.yml
@@ -6,11 +6,17 @@ dependencies:
     - field.storage.node.field_content_block
     - node.type.support_resources_detail_page
     - paragraphs.paragraphs_type.collapsible_panel
+    - paragraphs.paragraphs_type.q_a_group
     - paragraphs.paragraphs_type.react_widget
     - paragraphs.paragraphs_type.table
     - paragraphs.paragraphs_type.wysiwyg
   module:
     - entity_reference_revisions
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: node.support_resources_detail_page.field_content_block
 field_name: field_content_block
 entity_type: node
@@ -29,6 +35,7 @@ settings:
       table: table
       collapsible_panel: collapsible_panel
       react_widget: react_widget
+      q_a_group: q_a_group
     negate: 0
     target_bundles_drag_drop:
       address:
@@ -40,8 +47,17 @@ settings:
       alert_single:
         weight: -69
         enabled: false
+      audience_topics:
+        weight: 48
+        enabled: false
+      basic_accordion:
+        weight: 49
+        enabled: false
       button:
         weight: -68
+        enabled: false
+      centralized_content_descriptor:
+        weight: 51
         enabled: false
       checklist:
         weight: -67
@@ -55,20 +71,32 @@ settings:
       collapsible_panel_item:
         weight: -65
         enabled: false
+      contact_information:
+        weight: 56
+        enabled: false
       downloadable_file:
         weight: -64
         enabled: false
       email_contact:
         weight: -63
         enabled: false
+      embedded_video:
+        weight: 59
+        enabled: false
       expandable_text:
         weight: -62
+        enabled: false
+      featured_content:
+        weight: 61
         enabled: false
       health_care_local_facility_servi:
         weight: -61
         enabled: false
       link_teaser:
         weight: -60
+        enabled: false
+      link_teaser_with_image:
+        weight: 64
         enabled: false
       list_of_link_teasers:
         weight: -59
@@ -105,13 +133,16 @@ settings:
         enabled: false
       q_a_group:
         weight: -48
-        enabled: false
+        enabled: true
       q_a_section:
         weight: -47
         enabled: false
       react_widget:
         weight: -72
         enabled: true
+      rich_text_char_limit_1000:
+        weight: 79
+        enabled: false
       service_location:
         weight: -46
         enabled: false
@@ -126,9 +157,6 @@ settings:
         enabled: false
       staff_profile:
         weight: -42
-        enabled: false
-      starred_horizontal_rule:
-        weight: -41
         enabled: false
       step:
         weight: -40

--- a/config/sync/field.field.paragraph.q_a_group.field_rich_wysiwyg.yml
+++ b/config/sync/field.field.paragraph.q_a_group.field_rich_wysiwyg.yml
@@ -1,0 +1,30 @@
+uuid: 042fa7d2-e282-4014-8de8-c95240df360d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_rich_wysiwyg
+    - paragraphs.paragraphs_type.q_a_group
+  module:
+    - allowed_formats
+    - epp
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - rich_text_limited
+  epp:
+    value: ''
+    on_update: 0
+id: paragraph.q_a_group.field_rich_wysiwyg
+field_name: field_rich_wysiwyg
+entity_type: paragraph
+bundle: q_a_group
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/node.type.support_resources_detail_page.yml
+++ b/config/sync/node.type.support_resources_detail_page.yml
@@ -20,7 +20,7 @@ third_party_settings:
   menu_force:
     menu_force: 0
     menu_force_parent: 0
-name: 'Resources and support Detail Page'
+name: 'Resources and Support Detail Page'
 type: support_resources_detail_page
 description: 'A page that contains in-depth information about a single resource available to Veterans or other beneficiaries.'
 help: ''

--- a/config/sync/views.view.content_entity_browsers.yml
+++ b/config/sync/views.view.content_entity_browsers.yml
@@ -4,14 +4,17 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_administration
+    - field.storage.node.field_answer
     - field.storage.node.field_datetime_range_timezone
     - node.type.event
     - node.type.q_a
     - taxonomy.vocabulary.administration
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - entity_browser
     - node
+    - paragraphs
     - smart_date
     - taxonomy
 id: content_entity_browsers
@@ -850,6 +853,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_answer:
+          id: field_answer
+          table: node__field_answer
+          field: field_answer
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Answer
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: paragraph_summary
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       filters:
         field_administration_target_id:
           id: field_administration_target_id
@@ -950,6 +1015,102 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: 'Keyword or Title'
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: 'not in'
+          value:
+            editorial-archived: editorial-archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -971,6 +1132,8 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_administration'
+        - 'config:field.storage.node.field_answer'
+        - 'config:workflow_list'
   event_entity_browser:
     id: event_entity_browser
     display_title: 'Event entity browser'

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -42,7 +42,7 @@ Feature: Content model bundles
 | VAMC System Health Service | regional_health_care_service_des | Content type | A description of a health service specific to a VAMC system, which appears on a VAMC's health services page and on facility pages, within accordions. |
 | Step-by-Step | step_by_step | Content type | A page that includes numbered steps a Veteran can take to complete an action. Use for instructions that must be completed in order. |
 | Stories List | story_listing | Content type | A listing of stories. |
-| Resources and support Detail Page | support_resources_detail_page | Content type | A page that contains in-depth information about a single resource available to Veterans or other beneficiaries.  |
+| Resources and Support Detail Page | support_resources_detail_page | Content type | A page that contains in-depth information about a single resource available to Veterans or other beneficiaries.  |
 | Support Service | support_service | Content type | Help desks, hotlines, etc, to be contextually placed alongside relevant content. |
 | VA Form | va_form | Content type | VA forms available for download. Used to populate search results and also generate form landing pages |
 | VAMC System Operating Status | vamc_operating_status_and_alerts | Content type | Create one of these pages for each VAMC system. Then you can add banner alerts and update facilities' operating status, all from one place. |

--- a/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_lc_content_type_fields.feature
@@ -58,19 +58,19 @@ Feature: Content model: LC Content Type fields
 | Content type | Q&A - single | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs (stable) | Translatable |
 | Content type | Q&A - single | Enable standalone Resources and support page for this Q&A. | field_standalone_page | Boolean |  | 1 | Single on/off checkbox |  |
 | Content type | Q&A - single | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Legacy |  |
-| Content type | Resources and support Detail Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Resources and support Detail Page | Alert | field_alert_single | Entity reference revisions | Required | 1 | Paragraphs Legacy | Translatable |
-| Content type | Resources and support Detail Page | Calls to action | field_buttons | Entity reference revisions |  | 2 | Paragraphs (stable) | Translatable |
-| Content type | Resources and support Detail Page | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | Resources and support Detail Page | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Legacy | Translatable |
-| Content type | Resources and support Detail Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
-| Content type | Resources and support Detail Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
-| Content type | Resources and support Detail Page | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
-| Content type | Resources and support Detail Page | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | Resources and support Detail Page | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table |  |
-| Content type | Resources and support Detail Page | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs (stable) |  |
-| Content type | Resources and support Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
-| Content type | Resources and support Detail Page | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Legacy |  |
+| Content type | Resources and Support Detail Page | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Resources and Support Detail Page | Alert | field_alert_single | Entity reference revisions | Required | 1 | Paragraphs Legacy | Translatable |
+| Content type | Resources and Support Detail Page | Calls to action | field_buttons | Entity reference revisions |  | 2 | Paragraphs (stable) | Translatable |
+| Content type | Resources and Support Detail Page | Repeat CTA buttons | field_buttons_repeat | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Resources and Support Detail Page | Need more help? | field_contact_information | Entity reference revisions |  | 1 | Paragraphs Legacy | Translatable |
+| Content type | Resources and Support Detail Page | Main content | field_content_block | Entity reference revisions | Required | Unlimited | Paragraphs Browser EXPERIMENTAL | Translatable |
+| Content type | Resources and Support Detail Page | Page introduction | field_intro_text_limited_html  | Text (formatted, long) | Required | 1 | Textarea (multiple rows) with counter | Translatable |
+| Content type | Resources and Support Detail Page | Additional categories (optional) | field_other_categories | Entity reference |  | 6 | Check boxes/radio buttons | Translatable |
+| Content type | Resources and Support Detail Page | Primary category | field_primary_category | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | Resources and Support Detail Page | VA Benefit Hubs | field_related_benefit_hubs | Entity reference | Required | 3 | Entity Browser - Table |  |
+| Content type | Resources and Support Detail Page | Related Information | field_related_information | Entity reference revisions |  | 5 | Paragraphs (stable) |  |
+| Content type | Resources and Support Detail Page | Generate a table of contents from major headings | field_table_of_contents_boolean | Boolean |  | 1 | Single on/off checkbox | Translatable |
+| Content type | Resources and Support Detail Page | Tags | field_tags | Entity reference revisions |  | 1 | Paragraphs Legacy |  |
 | Content type | Step-by-Step | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
 | Content type | Step-by-Step | Alert | field_alert_single | Entity reference revisions | Required | 1 | Paragraphs Legacy | Translatable |
 | Content type | Step-by-Step | Calls to action | field_buttons | Entity reference revisions |  | 2 | Paragraphs Legacy |  |

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -89,7 +89,7 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  |
 | Paragraph type | Q&A group | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Paragraph type | Q&A group | Q&As | field_q_as | Entity reference | Required | Unlimited | Entity Browser - Table |  |
-| Paragraph type | Q&A group | Description | field_rich_wysiwyg | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
+| Paragraph type | Q&A group | Description | field_rich_wysiwyg | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Paragraph type | Q&A group | Section Header | field_section_header | Text (plain) |  | 1 | Textfield with counter | Translatable |
 | Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs (stable) |  |

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -89,7 +89,7 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  |
 | Paragraph type | Q&A group | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Paragraph type | Q&A group | Q&As | field_q_as | Entity reference | Required | Unlimited | Entity Browser - Table |  |
-| Paragraph type | Q&A group | Description | field_rich_wysiwyg | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Paragraph type | Q&A group | Description | field_rich_wysiwyg | Text (formatted, long) |  | 1 | -- Disabled -- | Translatable |
 | Paragraph type | Q&A group | Section Header | field_section_header | Text (plain) |  | 1 | Textfield with counter | Translatable |
 | Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs (stable) |  |

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -89,6 +89,7 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  |
 | Paragraph type | Q&A group | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Paragraph type | Q&A group | Q&As | field_q_as | Entity reference | Required | Unlimited | Entity Browser - Table |  |
+| Paragraph type | Q&A group | Description | field_rich_wysiwyg | Text (formatted, long) |  | 1 | Text area (multiple rows) |  |
 | Paragraph type | Q&A group | Section Header | field_section_header | Text (plain) |  | 1 | Textfield with counter | Translatable |
 | Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs (stable) |  |


### PR DESCRIPTION
Including added features.

* Added a limited rich text description field to Q&A Groups paragraph type

* Added Q&A Groups paragraph type to Resource and Support content type

* Edited Q&A Entity Browser view to include title/keyword filter,
  remove archived Q&A from populating and show answer preview

## Description
closes #9737
Relates to #9579, #8630

## Testing done
Hand-tested backend content add form.

## Screenshots

![Screen Shot 2022-07-07 at 3 01 23 AM](https://user-images.githubusercontent.com/22764938/177945940-bd92edc5-0eb8-4800-a967-7fa4f80f50ef.png)

![Screen Shot 2022-07-07 at 6 07 59 PM](https://user-images.githubusercontent.com/22764938/177945574-2dffba20-2324-4686-9c9f-60927136e53c.png)

![Screen Shot 2022-07-07 at 5 41 30 PM](https://user-images.githubusercontent.com/22764938/177945626-e5cd4af5-e224-43f5-a84b-003c8ca9d5f3.png)

![Screen Shot 2022-07-07 at 1 04 49 AM](https://user-images.githubusercontent.com/22764938/177946207-961f4727-cf83-427c-931d-838e5105a633.png)

## QA steps

What needs to be checked to prove this works?  

- Editor can add or edit Resources and Support content, add main content block and choose Q&A Group for a modal to pop up (see above screenshots). Please edit node 47411 so you can run the GraphQL query I provided in t[his comment](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/9746#issuecomment-1196292977) below.
   - go to https://pr9746-zqis1amj7i3jmmqvydvdxfmptbsn7zzf.ci.cms.va.gov/node/47411/edit 
   - add a QA group to main content
   - [x] validate that it appears and can be added. 
- [x] Content shown in modal should not include archived
- [x] Modal should have keyword/title filter option
- [x]  description field is not visible on node edit form
- [ ] ~Pattern change and new fields should be able to be pulled into frontend~ Covered by FE ticket https://github.com/department-of-veterans-affairs/content-build/pull/1253
- [ ] Accordion display works when chosen (not sure how to see this in action, only showed the questions before and after I made changes)

What needs to be checked to prove it didn't break any related things?  

- [x] Edit existing Resource and Support to include new Q&A Group content block
- [x] Edit or create FAQ content type and check that new Description field doesn't cause issues if it's not populated (it is not required)
- [x] Access for non-editors and editors should not have changed and should still be appropriate

What variations of circumstances (users, actions, values) need to be checked?  

- [ ] Non-editors can't edit
- [ ] Accordion type vs. non-accordion type should work the same way as it did before
- [ ] Q&A Group can be moved/rearranged on the page with respect to other main content blocks; old way of putting in Q&A content on a particular node can be edited/removed

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] Design approval
- [ ] FE isn't blocked by an issue/needed change

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`
- [ ]  Wait for FE related ticket to be good to go

### Does this PR need review from a Product Owner

- [ ] `Needs PO review` TBD

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping @ rachel-kauff so she's ready to publish after deployment
- [x] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping @ rachel-kauff to prompt her to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
