### PR TITLE
VACMS-9829: add patch to handle edge cases where menu references trigger early rendering.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -521,7 +521,8 @@
                 "Add option to display default view on node edit when always use default value selected": "https://www.drupal.org/files/issues/2021-12-15/viewfield-option-display-default-view-on-node-edit-3252356-4.patch"
             },
             "drupal/workbench_access": {
-                "3118596 - Cache isn't invalidated after user is removed from section/added to section.": "https://www.drupal.org/files/issues/2020-06-30/3118596_workbench_access-user-cache-18.patch"
+                "3118596 - Cache isn't invalidated after user is removed from section/added to section.": "https://www.drupal.org/files/issues/2020-06-30/3118596_workbench_access-user-cache-18.patch",
+                "3298498 - workbench_access AccessControlHierarchy implementations leak cacheability metadata": "https://www.drupal.org/files/issues/2022-07-19/3298498-capture_bubbleable_metadata.patch"
             },
             "drupal/workflow_participants": {
                 "Fix revision uncaught type error by extending class.": "https://www.drupal.org/files/issues/2019-08-16/workflow_participants-revision-error-3075426-1.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a159ba125887e7967e265ddf40d669cd",
+    "content-hash": "35882afd39a99a39d0c1dd85cb91f521",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",


### PR DESCRIPTION
## Description

Relates to #9829 

workbench_access and menu reference fields interact in unexpected ways when queried via JSON:API. More full explanation here, where I also attached the patch: https://www.drupal.org/project/workbench_access/issues/3298498#comment-14616033

