### PR TITLE
VACMS-0000 update site alert to not print empty h2, fix static shield transparency

### DIFF
--- a/docroot/sites/default/maintenance.html
+++ b/docroot/sites/default/maintenance.html
@@ -5,7 +5,7 @@
 <style>
     body {
         font-family: "Lucida Grande", "Lucida Sans Unicode", "DejaVu Sans", "Lucida Sans", sans-serif;
-        background-color: rgb(255, 241, 210);
+        background-color: rgba(255, 241, 210, 0.9); /* va-gold-lightest 90% */
         border-top: 16px solid #fdb81e; /* var(--va-gold-med) */
         margin: 0;
     }

--- a/docroot/themes/custom/vagovclaro/templates/misc/sitewide-alert.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/misc/sitewide-alert.html.twig
@@ -1,6 +1,6 @@
 {% include '@cmsds/sitewide-alert.twig' with {
   attributes,
-  title: content.field_alert_title,
+  title: content.field_alert_title.value,
   message: content.message,
   uuid,
   style,


### PR DESCRIPTION
## Description

This slack thread: https://dsva.slack.com/archives/C03LFSPGV16/p1658864433963339 raised some issues with sitewide alert appearances. This PR contains 2 of the 3 fixes:
- empty `<h2>` tag does not print if title field is empty
- maintenance page site shield has added transparency

I attempted to use the `|raw` filter to escape the message content to actually render the html entities... but it appears the escaping is done before the twig render happens in the module somewhere, as I'm still getting html entities in plaintext. 

I don't have the bandwidth today to dig on this further unfortunately

## Testing done
- created a new site alert with `ddev drush sitewide-alert:create "'test-alert 9' 'testing my new alert' --style='warning' --dismissible"` and saw that the empty title tag no longer printed.
- edited that site alert to add `<strong>` and `<i>` tags to the message... these still rendered in plaintext even with the `|raw` filter.

## Screenshots
![Screen Shot 2022-07-28 at 7 43 42 AM](https://user-images.githubusercontent.com/11279744/181564348-068bccde-39b9-457c-9d6f-9d3ed818a295.png)


## QA steps

- create a new sitewide alert without a title field, see that no empty `<h2>` prints and the icons + message are aligned

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`

