### PR TITLE
VACMS-9948 Lovell Tricare menu

### DIFF
--- a/config/sync/menu_breadcrumb.settings.yml
+++ b/config/sync/menu_breadcrumb.settings.yml
@@ -74,22 +74,17 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
+  va-indiana-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
   va-greater-los-angeles-health-ca:
     enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-northern-indiana-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
   va-hines-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-indiana-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -104,7 +99,7 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-dublin-health-care:
+  va-detroit-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -124,12 +119,12 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-leavenworth-health-care:
+  va-dublin-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-detroit-health-care:
+  va-leavenworth-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -140,6 +135,11 @@ menu_breadcrumb_menus:
     taxattach: 0
     langhandle: 0
   va-columbia-south-carolina-healt:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-columbia-missouri-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -159,12 +159,17 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
+  va-louisville-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
   va-puget-sound-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-miami-health-care:
+  va-milwaukee-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -204,17 +209,17 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-milwaukee-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-memphis-health-care:
+  va-miami-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
   va-lexington-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-memphis-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -244,11 +249,6 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-louisville-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
   va-long-beach-health-care:
     enabled: 1
     weight: 0
@@ -264,27 +264,7 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-columbia-missouri-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-bay-pines-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-atlanta-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-battle-creek-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-tennessee-valley-health-care:
+  va-northern-indiana-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -294,7 +274,7 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-tampa-health-care:
+  va-boise-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -304,12 +284,7 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-birmingham-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-st-louis-health-care:
+  va-augusta-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -319,12 +294,22 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-texas-valley-health-care:
+  va-battle-creek-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-boise-health-care:
+  va-bay-pines-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-tampa-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-texas-valley-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -339,12 +324,17 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-spokane-health-care:
+  va-alaska-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-alaska-health-care:
+  va-birmingham-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-st-louis-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -354,17 +344,27 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-southern-oregon-health-care:
+  va-tennessee-valley-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-walla-walla-health-care:
+    enabled: 0
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  pension-benefits-hub:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  lovell-federal-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
   va-south-texas-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-wichita-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -379,22 +379,7 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  lovell-federal-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-augusta-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-west-texas-health-care:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
-  va-southern-arizona-health-care:
+  va-wichita-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -404,7 +389,12 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  pension-benefits-hub:
+  va-southern-arizona-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  lovell-tricare-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -419,8 +409,23 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  va-walla-walla-health-care:
-    enabled: 0
+  va-southern-oregon-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-west-texas-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-spokane-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-atlanta-health-care:
+    enabled: 1
     weight: 0
     taxattach: 0
     langhandle: 0
@@ -469,7 +474,7 @@ menu_breadcrumb_menus:
     weight: 9
     taxattach: 0
     langhandle: 0
-  va-sheridan-health-care:
+  va-southern-nevada-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -509,7 +514,7 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-shreveport-health-care:
+  va-southeast-louisiana-health-ca:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -519,12 +524,12 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-southern-nevada-health-care:
+  va-san-francisco-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-southeast-louisiana-health-ca:
+  va-sheridan-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -534,22 +539,22 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-syracuse-health-care:
+  va-sioux-falls-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-san-francisco-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  va-washington-dc-health-care:
+  va-st-cloud-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
   va-salt-lake-city-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-washington-dc-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
@@ -569,17 +574,17 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-st-cloud-health-care:
-    enabled: 1
-    weight: 10
-    taxattach: 0
-    langhandle: 0
   va-richmond-health-care:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  va-sioux-falls-health-care:
+  va-syracuse-health-care:
+    enabled: 1
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  va-shreveport-health-care:
     enabled: 1
     weight: 10
     taxattach: 0

--- a/config/sync/system.menu.lovell-tricare-health-care.yml
+++ b/config/sync/system.menu.lovell-tricare-health-care.yml
@@ -1,0 +1,16 @@
+uuid: 9bdb2003-8327-48e3-babf-92dab875b7ed
+langcode: en
+status: true
+dependencies:
+  module:
+    - workbench_menu_access
+third_party_settings:
+  workbench_menu_access:
+    access_scheme:
+      347: '347'
+      1039: '1039'
+      1040: '1040'
+id: lovell-tricare-health-care
+label: 'Lovell Tricare health care'
+description: 'VISN 12 | va.gov/lovell-tricare-health-care'
+locked: false

--- a/tests/behat/drupal-spec-tool/menus.feature
+++ b/tests/behat/drupal-spec-tool/menus.feature
@@ -23,6 +23,7 @@ Feature: Menus
 | Housing Assistance benefits hub | housing-assistance-benefits | va.gov/housing-assistance |
 | Life insurance benefits hub | life-insurance-benefits-hub | va.gov/life-insurance |
 | Lovell Federal health care | lovell-federal-health-care | VISN 12 \| va.gov/lovell-federal-health-care |
+| Lovell Tricare health care | lovell-tricare-health-care | VISN 12 \| va.gov/lovell-tricare-health-care |
 | Main navigation | main | Site section links |
 | Outreach and events | outreach-and-events |  |
 | Pension benefits hub | pension-benefits-hub | va.gov/pension |


### PR DESCRIPTION
## Description

Closes #9948 

## Testing done
Manually

## Screenshots
### Menu
![Screen Shot 2022-08-02 at 7 16 43 AM](https://user-images.githubusercontent.com/766573/182372737-53ce37dd-770d-4faf-b834-0f4f636b7953.png)
### Workbench menu access
![Screen Shot 2022-08-02 at 7 16 56 AM](https://user-images.githubusercontent.com/766573/182372772-0e7712ed-68f3-4fe0-93ac-293e443995ac.png)
### Menu Breadcrumb config
![Screen Shot 2022-08-02 at 7 17 58 AM](https://user-images.githubusercontent.com/766573/182372799-3d158511-59db-446a-92e3-922677bb4750.png)


## QA steps
As an admin 
1. Go to admin/structure/menu
   - [x] Validate that "Lovell Tricare health care"	exists
2. Then click "Edit menu"
   - [x] Validate that the Administrative summary matches the Acceptance Criteria (AC)
   - [x] Validate that the machine name matches the AC
   - [x] Validate that the Workbench menu access matches the AC
3. Edit a facility and in field administration, 
    - [x] validate that both Lovell menu options exist.  
4. Then go to /admin/config/user-interface/menu-breadcrumb
   - [x] Validate that the Lovell Tricare health care menu is enabled


### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ x ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
