### PR TITLE
VACMS-9714: add scripts to update crisis number to 988

### DIFF
--- a/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
@@ -115,6 +115,8 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
  *
  * @param string $input
  *   The string to normalize.
+ * @param bool $plain
+ *   True if the result should be a plain string, false for html.
  *
  * @return string
  *   The value of $input with all crisis numbers updated.

--- a/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
@@ -74,13 +74,15 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
     $new_value = normalize_crisis_number($old_value);
 
     // If the value was altered then update the node.
-    if ($new_value !== $old_value) {
+    if ($new_value !== $old_value && !empty($new_value)) {
       $paragraph->field_wysiwyg->setValue(
         [
           'value' => $new_value,
           'format' => 'rich_text',
         ]
       );
+      $paragraph->setSyncing(TRUE);
+      $paragraph->setValidationRequired(FALSE);
       $paragraph->save();
       $sandbox['updated']++;
       $pids[] = $paragraph->id();
@@ -91,11 +93,13 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
   }
 
   // Log the processed nodes.
-  Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, '%current paragraphs progress. Paragraphs updated: %pids', [
-      '%current' => $sandbox['current'],
-      '%pids' => empty($pids) ? 'None' : implode(', ', $pids),
-    ]);
+  if (!empty($pids)) {
+    Drupal::logger('va_gov_db')
+      ->log(LogLevel::INFO, '%current paragraphs progress. Paragraphs updated: %pids', [
+        '%current' => $sandbox['current'],
+        '%pids' => empty($pids) ? 'None' : implode(', ', $pids),
+      ]);
+  }
 
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
 

--- a/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * @file
+ * Replace 800-273-8255 with 988 for paragraphs.
+ *
+ * VACMS-9714-paragraphs-crisis-to-988.php.
+ */
+
+require_once __DIR__ . '/script-library.php';
+
+use Psr\Log\LogLevel;
+
+$revision_message = 'Updated Crisis number from 800-273-8255 to 988';
+$sandbox = ['#finished' => 0];
+do {
+  print(va_gov_change_crisis_hotline_to_988_nodes($sandbox, $revision_message));
+} while ($sandbox['#finished'] < 1);
+// Paragraph processing complete.  Call this done.
+return;
+
+/**
+ * Replace 800-273-8255 with 988.
+ *
+ * @param array $sandbox
+ *   Modeling the structure of hook_update_n sandbox.
+ * @param string $revision_message
+ *   Text to be used in revision log message.
+ *
+ * @return string
+ *   Status message.
+ */
+function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_message) {
+  $paragraph_storage = \Drupal::entityTypeManager()->getStorage('paragraph');
+
+  // Get the count for paragraphs.
+  // This runs only once.
+  if (!isset($sandbox['total'])) {
+    $paragraph_types = [
+      'collapsible_panel_item',
+      'health_care_local_facility_servi',
+      'wysiwyg',
+    ];
+
+    $query = $paragraph_storage->getQuery();
+    $query->condition('type', $paragraph_types, 'IN');
+    $pids_to_update = $query->execute();
+    $result_count = count($pids_to_update);
+    $sandbox['total'] = $result_count;
+    $sandbox['current'] = 0;
+    $sandbox['updated'] = 0;
+
+    // Create non-numeric keys to accurately remove each nid when processed.
+    $sandbox['pids_to_update'] = array_combine(
+      array_map('_va_gov_stringifypid', array_values($pids_to_update)),
+      array_values($pids_to_update)
+    );
+  }
+
+  // Do not continue if no nodes are found.
+  if (empty($sandbox['total'])) {
+    $sandbox['#finished'] = 1;
+    return "No paragraphs found for processing.\n";
+  }
+
+  $limit = 25;
+
+  // Load entities.
+  $paragraph_ids = array_slice($sandbox['pids_to_update'], 0, $limit, TRUE);
+  $paragraphs = $paragraph_storage->loadMultiple($paragraph_ids);
+  foreach ($paragraphs as $paragraph) {
+    /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
+    $old_value = $paragraph->get('field_wysiwyg')->value;
+    $new_value = normalize_crisis_number($old_value);
+
+    // If the value was altered then update the node.
+    if ($new_value !== $old_value) {
+      $paragraph->field_wysiwyg->setValue(
+        [
+          'value' => $new_value,
+          'format' => 'rich_text',
+        ]
+      );
+      $paragraph->save();
+      $sandbox['updated']++;
+    }
+
+    unset($sandbox['pids_to_update']["paragraph_{$paragraph->id()}"]);
+    $pids[] = $paragraph->id();
+    $sandbox['current'] = $sandbox['total'] - count($sandbox['pids_to_update']);
+  }
+
+  // Log the processed nodes.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, '%current paragraphs progress. Paragraphs processed: %pids', [
+      '%current' => $sandbox['current'],
+      '%pids' => implode(', ', $pids),
+    ]);
+
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+  // Log the all-finished notice.
+  if ($sandbox['#finished'] == 1) {
+    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'Processing all %count paragraphs completed', [
+      '%count' => $sandbox['total'],
+    ]);
+    return "Paragraph updates complete. {$sandbox['current']} / {$sandbox['total']} - Total updated: {$sandbox['updated']}\n";
+  }
+
+  return "Processed paragraphs... {$sandbox['current']} / {$sandbox['total']}.\n";
+}
+
+/**
+ * Normalize all crisis hotline instances in a provided string.
+ *
+ * @param string $input
+ *   The string to normalize.
+ *
+ * @return string
+ *   The value of $input with all crisis numbers updated.
+ */
+function normalize_crisis_number($input, $plain = FALSE): string {
+  $replacement_string = '988';
+  $replacement_html = '<a aria-label="9 8 8" href="tel:988">988</a>';
+  // Remove telephone "link" from number.
+  $first_pattern = "/\<a[^>]*\>(?:1-)?800[\-\.]273[\-\.]8255\<\/a\>/i";
+  $output = preg_replace($first_pattern, '800-273-8255', $input);
+  // Remove area code prefixes.
+  $output = str_replace('1-800-273-8255', '800-273-8255', $output);
+  // All instances should now be 800-273-8255 and can be replaced.
+  if ($plain) {
+    $output = str_replace('800-273-8255', $replacement_string, $output);
+  }
+  else {
+    $output = str_replace('800-273-8255', $replacement_html, $output);
+  }
+  return $output;
+}

--- a/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
@@ -94,7 +94,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
   Drupal::logger('va_gov_db')
     ->log(LogLevel::INFO, '%current paragraphs progress. Paragraphs updated: %pids', [
       '%current' => $sandbox['current'],
-      '%pids' => implode(', ', $pids),
+      '%pids' => empty($pids) ? 'None' : implode(', ', $pids),
     ]);
 
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);

--- a/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
@@ -83,16 +83,16 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
       );
       $paragraph->save();
       $sandbox['updated']++;
+      $pids[] = $paragraph->id();
     }
 
     unset($sandbox['pids_to_update']["paragraph_{$paragraph->id()}"]);
-    $pids[] = $paragraph->id();
     $sandbox['current'] = $sandbox['total'] - count($sandbox['pids_to_update']);
   }
 
   // Log the processed nodes.
   Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, '%current paragraphs progress. Paragraphs processed: %pids', [
+    ->log(LogLevel::INFO, '%current paragraphs progress. Paragraphs updated: %pids', [
       '%current' => $sandbox['current'],
       '%pids' => implode(', ', $pids),
     ]);

--- a/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-paragraphs-crisis-to-988.php
@@ -78,7 +78,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
       $paragraph->field_wysiwyg->setValue(
         [
           'value' => $new_value,
-          'format' => 'rich_text',
+          'format' => $paragraph->field_wysiwyg->format,
         ]
       );
       $paragraph->setSyncing(TRUE);
@@ -112,33 +112,4 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
   }
 
   return "Processed paragraphs... {$sandbox['current']} / {$sandbox['total']}.\n";
-}
-
-/**
- * Normalize all crisis hotline instances in a provided string.
- *
- * @param string $input
- *   The string to normalize.
- * @param bool $plain
- *   True if the result should be a plain string, false for html.
- *
- * @return string
- *   The value of $input with all crisis numbers updated.
- */
-function normalize_crisis_number($input, $plain = FALSE): string {
-  $replacement_string = '988';
-  $replacement_html = '<a aria-label="9 8 8" href="tel:988">988</a>';
-  // Remove telephone "link" from number.
-  $first_pattern = "/\<a[^>]*\>(?:1-)?800[\-\.]273[\-\.]8255\<\/a\>/i";
-  $output = preg_replace($first_pattern, '800-273-8255', $input);
-  // Remove area code prefixes.
-  $output = str_replace('1-800-273-8255', '800-273-8255', $output);
-  // All instances should now be 800-273-8255 and can be replaced.
-  if ($plain) {
-    $output = str_replace('800-273-8255', $replacement_string, $output);
-  }
-  else {
-    $output = str_replace('800-273-8255', $replacement_html, $output);
-  }
-  return $output;
 }

--- a/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
@@ -102,7 +102,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
   Drupal::logger('va_gov_db')
     ->log(LogLevel::INFO, 'VAMC Detail Page nodes: %current nodes phone numbers updated. Nodes updated: %nids', [
       '%current' => $sandbox['current'],
-      '%nids' => implode(', ', $nids),
+      '%nids' => empty($nids) ? 'None' : implode(', ', $nids),
     ]);
 
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);

--- a/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * @file
+ * Replace 800-273-8255 with 988 for VAMC System Operating Status.
+ *
+ * VACMS-9714-vamc-detail-page-crisis-to-988.php.
+ */
+
+require_once __DIR__ . '/script-library.php';
+
+use Psr\Log\LogLevel;
+
+$revision_message = 'Updated Crisis number from 800-273-8255 to 988';
+$sandbox = ['#finished' => 0];
+do {
+  print(va_gov_change_crisis_hotline_to_988_nodes($sandbox, $revision_message));
+} while ($sandbox['#finished'] < 1);
+// Node processing complete.  Call this done.
+return;
+
+/**
+ * Replace 800-273-8255 with 988.
+ *
+ * @param array $sandbox
+ *   Modeling the structure of hook_update_n sandbox.
+ * @param string $revision_message
+ *   Text to be used in revision log message.
+ *
+ * @return string
+ *   Status message.
+ */
+function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_message) {
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  // Get the node count for VAMC Detail Page nodes that are not archived.
+  // This runs only once.
+  if (!isset($sandbox['total'])) {
+    $query = $node_storage->getQuery();
+    $query->condition('type', 'health_care_region_detail_page');
+    $query->condition('moderation_state', 'archived', '!=');
+    $nids_to_update = $query->execute();
+    $result_count = count($nids_to_update);
+    $sandbox['total'] = $result_count;
+    $sandbox['current'] = 0;
+    $sandbox['updated'] = 0;
+
+    // Create non-numeric keys to accurately remove each nid when processed.
+    $sandbox['nids_to_update'] = array_combine(
+      array_map('_va_gov_stringifynid', array_values($nids_to_update)),
+      array_values($nids_to_update)
+    );
+  }
+
+  // Do not continue if no nodes are found.
+  if (empty($sandbox['total'])) {
+    $sandbox['#finished'] = 1;
+    return "No VAMC Detail Page nodes found for processing.\n";
+  }
+
+  $limit = 25;
+
+  // Load entities.
+  $node_ids = array_slice($sandbox['nids_to_update'], 0, $limit, TRUE);
+  $nodes = $node_storage->loadMultiple($node_ids);
+  foreach ($nodes as $node) {
+    /** @var \Drupal\node\NodeInterface $node */
+    $nid = $node->id();
+    $nvid = $node->getRevisionId();
+    $old_value = $node->get('field_description')->value;
+    $new_value = normalize_crisis_number($old_value, TRUE);
+
+    // If the value was altered then update the node.
+    if ($new_value !== $old_value) {
+      $node->field_description->setValue($new_value);
+
+      // Grab the latest revision before we save this one.
+      $latest_revision = get_node_at_latest_revision($nid);
+      save_node_revision($node, $revision_message);
+
+      // If a revision (draft) newer than the default exists, update it as well.
+      if ($nvid !== $latest_revision->getRevisionId()) {
+        $old_revision_value = $latest_revision->get('field_description')->value;
+        $new_revision_value = normalize_crisis_number($old_revision_value, TRUE);
+
+        if ($new_revision_value !== $old_revision_value) {
+          $latest_revision->field_description->setValue($new_revision_value);
+          save_node_revision($latest_revision, $revision_message);
+          unset($latest_revision);
+        }
+      }
+
+      $sandbox['updated']++;
+    }
+
+    unset($sandbox['nids_to_update']["node_{$nid}"]);
+    $nids[] = $nid;
+    $sandbox['current'] = $sandbox['total'] - count($sandbox['nids_to_update']);
+  }
+
+  // Log the processed nodes.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'VAMC Detail Page nodes: %current nodes phone numbers updated. Nodes processed: %nids', [
+      '%current' => $sandbox['current'],
+      '%nids' => implode(', ', $nids),
+    ]);
+
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+  // Log the all-finished notice.
+  if ($sandbox['#finished'] == 1) {
+    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'Processing all %count VAMC Detail Page nodes completed', [
+      '%count' => $sandbox['total'],
+    ]);
+    return "VAMC Detail Page node updates complete. {$sandbox['current']} / {$sandbox['total']} - Total updated: {$sandbox['updated']}\n";
+  }
+
+  return "Processed nodes... {$sandbox['current']} / {$sandbox['total']}.\n";
+}
+
+/**
+ * Normalize all crisis hotline instances in a provided string.
+ *
+ * @param string $input
+ *   The string to normalize.
+ *
+ * @return string
+ *   The value of $input with all crisis numbers updated.
+ */
+function normalize_crisis_number($input, $plain = FALSE): string {
+  $replacement_string = '988';
+  $replacement_html = '<a aria-label="9 8 8" href="tel:988">988</a>';
+  // Remove telephone "link" from number.
+  $first_pattern = "/\<a[^>]*\>(?:1-)?800[\-\.]273[\-\.]8255\<\/a\>/i";
+  $output = preg_replace($first_pattern, '800-273-8255', $input);
+  // Remove area code prefixes.
+  $output = str_replace('1-800-273-8255', '800-273-8255', $output);
+  // All instances should now be 800-273-8255 and can be replaced.
+  if ($plain) {
+    $output = str_replace('800-273-8255', $replacement_string, $output);
+  }
+  else {
+    $output = str_replace('800-273-8255', $replacement_html, $output);
+  }
+  return $output;
+}

--- a/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
@@ -123,6 +123,8 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
  *
  * @param string $input
  *   The string to normalize.
+ * @param bool $plain
+ *   True if the result should be a plain string, false for html.
  *
  * @return string
  *   The value of $input with all crisis numbers updated.

--- a/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
@@ -91,16 +91,16 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
       }
 
       $sandbox['updated']++;
+      $nids[] = $nid;
     }
 
     unset($sandbox['nids_to_update']["node_{$nid}"]);
-    $nids[] = $nid;
     $sandbox['current'] = $sandbox['total'] - count($sandbox['nids_to_update']);
   }
 
   // Log the processed nodes.
   Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, 'VAMC Detail Page nodes: %current nodes phone numbers updated. Nodes processed: %nids', [
+    ->log(LogLevel::INFO, 'VAMC Detail Page nodes: %current nodes phone numbers updated. Nodes updated: %nids', [
       '%current' => $sandbox['current'],
       '%nids' => implode(', ', $nids),
     ]);

--- a/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
@@ -71,7 +71,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
     $new_value = normalize_crisis_number($old_value, TRUE);
 
     // If the value was altered then update the node.
-    if ($new_value !== $old_value) {
+    if ($new_value !== $old_value && !empty($new_value)) {
       $node->field_description->setValue($new_value);
 
       // Grab the latest revision before we save this one.
@@ -83,7 +83,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
         $old_revision_value = $latest_revision->get('field_description')->value;
         $new_revision_value = normalize_crisis_number($old_revision_value, TRUE);
 
-        if ($new_revision_value !== $old_revision_value) {
+        if ($new_revision_value !== $old_revision_value && !empty($new_revision_value)) {
           $latest_revision->field_description->setValue($new_revision_value);
           save_node_revision($latest_revision, $revision_message);
           unset($latest_revision);
@@ -99,11 +99,13 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
   }
 
   // Log the processed nodes.
-  Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, 'VAMC Detail Page nodes: %current nodes phone numbers updated. Nodes updated: %nids', [
-      '%current' => $sandbox['current'],
-      '%nids' => empty($nids) ? 'None' : implode(', ', $nids),
-    ]);
+  if (!empty($nids)) {
+    Drupal::logger('va_gov_db')
+      ->log(LogLevel::INFO, 'VAMC Detail Page nodes: %current nodes phone numbers updated. Nodes updated: %nids', [
+        '%current' => $sandbox['current'],
+        '%nids' => empty($nids) ? 'None' : implode(', ', $nids),
+      ]);
+  }
 
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
 

--- a/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php
@@ -119,32 +119,3 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
 
   return "Processed nodes... {$sandbox['current']} / {$sandbox['total']}.\n";
 }
-
-/**
- * Normalize all crisis hotline instances in a provided string.
- *
- * @param string $input
- *   The string to normalize.
- * @param bool $plain
- *   True if the result should be a plain string, false for html.
- *
- * @return string
- *   The value of $input with all crisis numbers updated.
- */
-function normalize_crisis_number($input, $plain = FALSE): string {
-  $replacement_string = '988';
-  $replacement_html = '<a aria-label="9 8 8" href="tel:988">988</a>';
-  // Remove telephone "link" from number.
-  $first_pattern = "/\<a[^>]*\>(?:1-)?800[\-\.]273[\-\.]8255\<\/a\>/i";
-  $output = preg_replace($first_pattern, '800-273-8255', $input);
-  // Remove area code prefixes.
-  $output = str_replace('1-800-273-8255', '800-273-8255', $output);
-  // All instances should now be 800-273-8255 and can be replaced.
-  if ($plain) {
-    $output = str_replace('800-273-8255', $replacement_string, $output);
-  }
-  else {
-    $output = str_replace('800-273-8255', $replacement_html, $output);
-  }
-  return $output;
-}

--- a/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
@@ -101,16 +101,16 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
       }
 
       $sandbox['updated']++;
+      $nids[] = $nid;
     }
 
     unset($sandbox['nids_to_update']["node_{$nid}"]);
-    $nids[] = $nid;
     $sandbox['current'] = $sandbox['total'] - count($sandbox['nids_to_update']);
   }
 
   // Log the processed nodes.
   Drupal::logger('va_gov_db')
-    ->log(LogLevel::INFO, 'VAMC System Operating Status nodes: %current nodes phone numbers updated. Nodes processed: %nids', [
+    ->log(LogLevel::INFO, 'VAMC System Operating Status nodes: %current nodes phone numbers updated. Nodes updated: %nids', [
       '%current' => $sandbox['current'],
       '%nids' => implode(', ', $nids),
     ]);

--- a/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
@@ -133,6 +133,8 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
  *
  * @param string $input
  *   The string to normalize.
+ * @param bool $plain
+ *   True if the result should be a plain string, false for html.
  *
  * @return string
  *   The value of $input with all crisis numbers updated.

--- a/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
@@ -75,7 +75,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
       $node->field_operating_status_emerg_inf->setValue(
         [
           'value' => $new_value,
-          'format' => 'rich_text',
+          'format' => $node->field_operating_status_emerg_inf->format,
         ]
       );
 
@@ -92,7 +92,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
           $latest_revision->field_operating_status_emerg_inf->setValue(
             [
               'value' => $new_revision_value,
-              'format' => 'rich_text',
+              'format' => $latest_revision->field_operating_status_emerg_inf->format,
             ]
           );
           save_node_revision($latest_revision, $revision_message);
@@ -126,33 +126,4 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
   }
 
   return "Processed nodes... {$sandbox['current']} / {$sandbox['total']}.\n";
-}
-
-/**
- * Normalize all crisis hotline instances in a provided string.
- *
- * @param string $input
- *   The string to normalize.
- * @param bool $plain
- *   True if the result should be a plain string, false for html.
- *
- * @return string
- *   The value of $input with all crisis numbers updated.
- */
-function normalize_crisis_number($input, $plain = FALSE): string {
-  $replacement_string = '988';
-  $replacement_html = '<a aria-label="9 8 8" href="tel:988">988</a>';
-  // Remove telephone "link" from number.
-  $first_pattern = "/\<a[^>]*\>(?:1-)?800[\-\.]273[\-\.]8255\<\/a\>/i";
-  $output = preg_replace($first_pattern, '800-273-8255', $input);
-  // Remove area code prefixes.
-  $output = str_replace('1-800-273-8255', '800-273-8255', $output);
-  // All instances should now be 800-273-8255 and can be replaced.
-  if ($plain) {
-    $output = str_replace('800-273-8255', $replacement_string, $output);
-  }
-  else {
-    $output = str_replace('800-273-8255', $replacement_html, $output);
-  }
-  return $output;
 }

--- a/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
@@ -112,7 +112,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
   Drupal::logger('va_gov_db')
     ->log(LogLevel::INFO, 'VAMC System Operating Status nodes: %current nodes phone numbers updated. Nodes updated: %nids', [
       '%current' => $sandbox['current'],
-      '%nids' => implode(', ', $nids),
+      '%nids' => empty($nids) ? 'None' : implode(', ', $nids),
     ]);
 
   $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);

--- a/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * @file
+ * Replace 800-273-8255 with 988 for VAMC System Operating Status.
+ *
+ * VACMS-9714-vamc-system-operating-status-crisis-to-988.php.
+ */
+
+require_once __DIR__ . '/script-library.php';
+
+use Psr\Log\LogLevel;
+
+$revision_message = 'Updated Crisis number from 800-273-8255 to 988';
+$sandbox = ['#finished' => 0];
+do {
+  print(va_gov_change_crisis_hotline_to_988_nodes($sandbox, $revision_message));
+} while ($sandbox['#finished'] < 1);
+// Node processing complete.  Call this done.
+return;
+
+/**
+ * Replace 800-273-8255 with 988.
+ *
+ * @param array $sandbox
+ *   Modeling the structure of hook_update_n sandbox.
+ * @param string $revision_message
+ *   Text to be used in revision log message.
+ *
+ * @return string
+ *   Status message.
+ */
+function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_message) {
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  // Get the count for VAMC System Operating Status nodes that are not archived.
+  // This runs only once.
+  if (!isset($sandbox['total'])) {
+    $query = $node_storage->getQuery();
+    $query->condition('type', 'vamc_operating_status_and_alerts');
+    $query->condition('moderation_state', 'archived', '!=');
+    $nids_to_update = $query->execute();
+    $result_count = count($nids_to_update);
+    $sandbox['total'] = $result_count;
+    $sandbox['current'] = 0;
+    $sandbox['updated'] = 0;
+
+    // Create non-numeric keys to accurately remove each nid when processed.
+    $sandbox['nids_to_update'] = array_combine(
+      array_map('_va_gov_stringifynid', array_values($nids_to_update)),
+      array_values($nids_to_update)
+    );
+  }
+
+  // Do not continue if no nodes are found.
+  if (empty($sandbox['total'])) {
+    $sandbox['#finished'] = 1;
+    return "No VAMC System Operating Status nodes found for processing.\n";
+  }
+
+  $limit = 25;
+
+  // Load entities.
+  $node_ids = array_slice($sandbox['nids_to_update'], 0, $limit, TRUE);
+  $nodes = $node_storage->loadMultiple($node_ids);
+  foreach ($nodes as $node) {
+    /** @var \Drupal\node\NodeInterface $node */
+    $nid = $node->id();
+    $nvid = $node->getRevisionId();
+    $old_value = $node->get('field_operating_status_emerg_inf')->value;
+    $new_value = normalize_crisis_number($old_value);
+
+    // If the value was altered then update the node.
+    if ($new_value !== $old_value) {
+      $node->field_operating_status_emerg_inf->setValue(
+        [
+          'value' => $new_value,
+          'format' => 'rich_text',
+        ]
+      );
+
+      // Grab the latest revision before we save this one.
+      $latest_revision = get_node_at_latest_revision($nid);
+      save_node_revision($node, $revision_message);
+
+      // If a revision (draft) newer than the default exists, update it as well.
+      if ($nvid !== $latest_revision->getRevisionId()) {
+        $old_revision_value = $latest_revision->get('field_operating_status_emerg_inf')->value;
+        $new_revision_value = normalize_crisis_number($old_revision_value);
+
+        if ($new_revision_value !== $old_revision_value) {
+          $latest_revision->field_operating_status_emerg_inf->setValue(
+            [
+              'value' => $new_revision_value,
+              'format' => 'rich_text',
+            ]
+          );
+          save_node_revision($latest_revision, $revision_message);
+          unset($latest_revision);
+        }
+      }
+
+      $sandbox['updated']++;
+    }
+
+    unset($sandbox['nids_to_update']["node_{$nid}"]);
+    $nids[] = $nid;
+    $sandbox['current'] = $sandbox['total'] - count($sandbox['nids_to_update']);
+  }
+
+  // Log the processed nodes.
+  Drupal::logger('va_gov_db')
+    ->log(LogLevel::INFO, 'VAMC System Operating Status nodes: %current nodes phone numbers updated. Nodes processed: %nids', [
+      '%current' => $sandbox['current'],
+      '%nids' => implode(', ', $nids),
+    ]);
+
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+  // Log the all-finished notice.
+  if ($sandbox['#finished'] == 1) {
+    Drupal::logger('va_gov_db')->log(LogLevel::INFO, 'Processing all %count VAMC System Operating Status nodes completed', [
+      '%count' => $sandbox['total'],
+    ]);
+    return "VAMC System Operating Status node updates complete. {$sandbox['current']} / {$sandbox['total']} - Total updated: {$sandbox['updated']}\n";
+  }
+
+  return "Processed nodes... {$sandbox['current']} / {$sandbox['total']}.\n";
+}
+
+/**
+ * Normalize all crisis hotline instances in a provided string.
+ *
+ * @param string $input
+ *   The string to normalize.
+ *
+ * @return string
+ *   The value of $input with all crisis numbers updated.
+ */
+function normalize_crisis_number($input, $plain = FALSE): string {
+  $replacement_string = '988';
+  $replacement_html = '<a aria-label="9 8 8" href="tel:988">988</a>';
+  // Remove telephone "link" from number.
+  $first_pattern = "/\<a[^>]*\>(?:1-)?800[\-\.]273[\-\.]8255\<\/a\>/i";
+  $output = preg_replace($first_pattern, '800-273-8255', $input);
+  // Remove area code prefixes.
+  $output = str_replace('1-800-273-8255', '800-273-8255', $output);
+  // All instances should now be 800-273-8255 and can be replaced.
+  if ($plain) {
+    $output = str_replace('800-273-8255', $replacement_string, $output);
+  }
+  else {
+    $output = str_replace('800-273-8255', $replacement_html, $output);
+  }
+  return $output;
+}

--- a/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
+++ b/scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php
@@ -71,7 +71,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
     $new_value = normalize_crisis_number($old_value);
 
     // If the value was altered then update the node.
-    if ($new_value !== $old_value) {
+    if ($new_value !== $old_value && !empty($new_value)) {
       $node->field_operating_status_emerg_inf->setValue(
         [
           'value' => $new_value,
@@ -88,7 +88,7 @@ function va_gov_change_crisis_hotline_to_988_nodes(array &$sandbox, $revision_me
         $old_revision_value = $latest_revision->get('field_operating_status_emerg_inf')->value;
         $new_revision_value = normalize_crisis_number($old_revision_value);
 
-        if ($new_revision_value !== $old_revision_value) {
+        if ($new_revision_value !== $old_revision_value && !empty($new_revision_value)) {
           $latest_revision->field_operating_status_emerg_inf->setValue(
             [
               'value' => $new_revision_value,

--- a/scripts/content/script-library.php
+++ b/scripts/content/script-library.php
@@ -26,7 +26,7 @@ function get_node_at_latest_revision(int $nid): NodeInterface {
 }
 
 /**
- * Returns a serialized form of the node as JSON.
+ * Saves a node revision with log messaging.
  *
  * @param \Drupal\node\NodeInterface $node
  *   The node to serialize.

--- a/scripts/content/script-library.php
+++ b/scripts/content/script-library.php
@@ -26,6 +26,36 @@ function get_node_at_latest_revision(int $nid): NodeInterface {
 }
 
 /**
+ * Normalize all crisis hotline instances in a provided string.
+ *
+ * @param string $input
+ *   The string to normalize.
+ * @param bool $plain
+ *   True if the result should be a plain string, false for html.
+ *
+ * @return string
+ *   The value of $input with all crisis numbers updated.
+ */
+function normalize_crisis_number($input, $plain = FALSE): string {
+  // @todo refactor/rename to search and replacement strings.
+  $replacement_string = '988';
+  $replacement_html = '<a aria-label="9 8 8" href="tel:988">988</a>';
+  // Remove telephone "link" from number.
+  $first_pattern = "/\<a[^>]*\>(?:1-)?800[\-\.]273[\-\.]8255\<\/a\>/i";
+  $output = preg_replace($first_pattern, '800-273-8255', $input);
+  // Remove area code prefixes.
+  $output = str_replace('1-800-273-8255', '800-273-8255', $output);
+  // All instances should now be 800-273-8255 and can be replaced.
+  if ($plain) {
+    $output = str_replace('800-273-8255', $replacement_string, $output);
+  }
+  else {
+    $output = str_replace('800-273-8255', $replacement_html, $output);
+  }
+  return $output;
+}
+
+/**
  * Saves a node revision with log messaging.
  *
  * @param \Drupal\node\NodeInterface $node

--- a/scripts/content/script-library.php
+++ b/scripts/content/script-library.php
@@ -7,8 +7,7 @@
 
 use Drupal\node\NodeInterface;
 
-// User ID for CMS Migrator.
-const USER_ID = 1317;
+const CMS_MIGRATOR_ID = 1317;
 
 /**
  * Load the latest revision of a node.
@@ -42,7 +41,7 @@ function save_node_revision(NodeInterface $node, $message): void {
   $moderation_state = $node->get('moderation_state')->value;
   $node->setNewRevision(TRUE);
   // If draft or review preserve the user from revision, otherwise CMS Migrator.
-  $uid = (in_array($moderation_state, $states)) ? $node->getRevisionUserId() : USER_ID;
+  $uid = (in_array($moderation_state, $states)) ? $node->getRevisionUserId() : CMS_MIGRATOR_ID;
   $node->setRevisionUserId($uid);
   $node->setChangedTime(time());
   $node->setRevisionCreationTime(time());

--- a/scripts/content/script-library.php
+++ b/scripts/content/script-library.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @file
+ * Common code related to drupal content scripts.
+ */
+
+use Drupal\node\NodeInterface;
+
+// User ID for CMS Migrator.
+const USER_ID = 1317;
+
+/**
+ * Load the latest revision of a node.
+ *
+ * @param int $nid
+ *   The node ID.
+ *
+ * @return \Drupal\node\NodeInterface
+ *   The latest revision of that node.
+ */
+function get_node_at_latest_revision(int $nid): NodeInterface {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $node_storage = $entity_type_manager->getStorage('node');
+  $result = $node_storage->loadRevision($node_storage->getLatestRevisionId($nid));
+  return $result;
+}
+
+/**
+ * Returns a serialized form of the node as JSON.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node to serialize.
+ * @param string $message
+ *   The log message for the new revision.
+ */
+function save_node_revision(NodeInterface $node, $message): void {
+  $states = [
+    'draft',
+    'review',
+  ];
+  $moderation_state = $node->get('moderation_state')->value;
+  $node->setNewRevision(TRUE);
+  // If draft or review preserve the user from revision, otherwise CMS Migrator.
+  $uid = (in_array($moderation_state, $states)) ? $node->getRevisionUserId() : USER_ID;
+  $node->setRevisionUserId($uid);
+  $node->setChangedTime(time());
+  $node->setRevisionCreationTime(time());
+  // If draft or review append new log message to previous log message.
+  $prefix = (in_array($moderation_state, $states)) ? $node->getRevisionLogMessage() . ' - ' : '';
+  $node->setRevisionLogMessage($prefix . $message);
+  $node->set('moderation_state', $moderation_state);
+  $node->save();
+}
+
+/**
+ * Callback function to concat node ids with string.
+ *
+ * @param int $nid
+ *   The node id.
+ *
+ * @return string
+ *   The node id concatenated to the end of node_
+ */
+function _va_gov_stringifynid($nid) {
+  return "node_$nid";
+}
+
+/**
+ * Callback function to concat paragraph ids with string.
+ *
+ * @param int $pid
+ *   The paragraph id.
+ *
+ * @return string
+ *   The paragraph id appended to the end of paragraph_.
+ */
+function _va_gov_stringifypid($pid) {
+  return "paragraph_$pid";
+}

--- a/scripts/content/vacms-5744/library.php
+++ b/scripts/content/vacms-5744/library.php
@@ -22,6 +22,9 @@ const SITE_ALERT_MESSAGE = <<<EOF
   🚧 We are cleaning up some old data; while this alert is in place, some content may be locked and not editable. 🚧
 EOF;
 
+// User ID used to make these changes.
+const USER_ID = 1317;
+
 // Exception codes.
 const EXCEPTION_COULD_NOT_LOCK = 1;
 const EXCEPTION_UNEXPECTED_DIFFERENCES = 2;

--- a/scripts/content/vacms-5744/library.php
+++ b/scripts/content/vacms-5744/library.php
@@ -5,9 +5,10 @@
  * Common code related to VACMS #5744 useful across multiple scripts.
  */
 
+require_once __DIR__ . '/../script-library.php';
+
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\entity_clone\EntityClone\Content\ContentEntityCloneBase;
-use Drupal\node\NodeInterface;
 use Drupal\user\Entity\User;
 
 // Notices might mean my world is getting rocked.
@@ -20,9 +21,6 @@ const SITE_ALERT_LABEL = 'VACMS-5744: Clone and Repair Paragraphs';
 const SITE_ALERT_MESSAGE = <<<EOF
   🚧 We are cleaning up some old data; while this alert is in place, some content may be locked and not editable. 🚧
 EOF;
-
-// User ID used to make these changes.
-const USER_ID = 1317;
 
 // Exception codes.
 const EXCEPTION_COULD_NOT_LOCK = 1;
@@ -519,22 +517,6 @@ function get_node_serialization(NodeInterface $node): string {
     }, $paragraphs);
   }
   $result = json_encode($object, JSON_PRETTY_PRINT);
-  return $result;
-}
-
-/**
- * Load the latest revision of a node.
- *
- * @param int $nid
- *   The node ID.
- *
- * @return \Drupal\node\NodeInterface
- *   The latest revision of that node.
- */
-function get_node_at_latest_revision(int $nid): NodeInterface {
-  $entity_type_manager = \Drupal::entityTypeManager();
-  $node_storage = $entity_type_manager->getStorage('node');
-  $result = $node_storage->loadRevision($node_storage->getLatestRevisionId($nid));
   return $result;
 }
 


### PR DESCRIPTION
## Description

Using the CMS Content Audits as a reference: https://airtable.com/shrngt7aaXoIwAenS/tblO7nwMBRn1jWpcJ/viwUPS9GYFKTkAK5j?blocks=hide

This PR provides scripts to update the crisis hotline to 988 for the following airtable (above) sections:
- VAMC Facility
- VAMC System Operating Status
- VAMC Detail Page

Post release note: once these scripts have been run the remaining items not explicitly skipped in the issue description need to be manually checked/fixed. Some of these may have already been fixed.
- Alerts
- Resources and Support
- VAMC System Banner
- Benefits Detail Page

Closes #9714 

## Testing done

Manual testing. 

## QA steps

With terminal access, run the following commands:
- [x] `drush scr ./scripts/content/VACMS-9714-paragraphs-crisis-to-988.php`
- [x] `drush scr ./scripts/content/VACMS-9714-vamc-detail-page-crisis-to-988.php`
- [ ] `drush scr ./scripts/content/VACMS-9714-vamc-system-operating-status-crisis-to-988.php`
- [ ] Using the airtable link above, check content to be sure instances of 800-273-8255 were replaced with 988

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
