### PR TITLE
VACMS-9943: block lighthouse updates for Lovell Tricare section

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
@@ -8,6 +8,8 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\post_api\Service\AddToQueue;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Class PostFacilityService posts specific service info to Lighthouse.
@@ -51,6 +53,8 @@ abstract class PostFacilityBase {
    */
   protected $postQueue;
 
+  const LOVELL_TRICARE = 1039;
+
   /**
    * Constructs a new PostFacilityBase object.
    *
@@ -92,6 +96,25 @@ abstract class PostFacilityBase {
   protected function shouldDedupe() : bool {
     // If bypass_data_check setting is enabled, do not dedupe..
     return !$this->shouldBypass();
+  }
+
+  /**
+   * Checks if the entity is within the Lovell Tricare section.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   *
+   * @return bool
+   *   TRUE if entity is within Lovell Tricare section. FALSE otherwise.
+   */
+  protected function isLovellTricareSection(EntityInterface $entity) : bool {
+    if (($entity instanceof NodeInterface) && ($entity->hasField('field_administration'))) {
+      /** @var \Drupal\node\NodeInterface $entity*/
+      if ($entity->get('field_administration')->target_id == self::LOVELL_TRICARE) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -3,7 +3,6 @@
 namespace Drupal\va_gov_post_api\Service;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * Class PostFacilityService posts specific service info to Lighthouse.
@@ -16,8 +15,6 @@ class PostFacilityService extends PostFacilityBase {
    * @var array
    */
   protected $errors = [];
-
-  const LOVELL_TRICARE = 1039;
 
   /**
    * The facility service node.
@@ -326,25 +323,6 @@ class PostFacilityService extends PostFacilityBase {
     ];
 
     return $map[$raw] ?? NULL;
-  }
-
-  /**
-   * Checks if the entity is within the Lovell Tricare section.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   Entity.
-   *
-   * @return bool
-   *   TRUE if entity is within Lovell Tricare section. FALSE otherwise.
-   */
-  protected function isLovellTricareSection(EntityInterface $entity) : bool {
-    if (($entity instanceof NodeInterface) && ($entity->hasField('field_administration'))) {
-      /** @var \Drupal\node\NodeInterface $entity*/
-      if ($entity->get('field_administration')->target_id == self::LOVELL_TRICARE) {
-        return TRUE;
-      }
-    }
-    return FALSE;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -16,6 +16,8 @@ class PostFacilityService extends PostFacilityBase {
    */
   protected $errors = [];
 
+  const LOVELL_TRICARE = 1039;
+
   /**
    * The facility service node.
    *
@@ -63,7 +65,9 @@ class PostFacilityService extends PostFacilityBase {
    */
   public function queueFacilityService(EntityInterface $entity, bool $forcePush = FALSE) {
     $this->errors = [];
-    if (($entity->getEntityTypeId() === 'node') && ($entity->bundle() === 'health_care_local_health_service')) {
+    if (($entity->getEntityTypeId() === 'node')
+    && ($entity->bundle() === 'health_care_local_health_service')
+    && !$this->isLovellTricareSection($entity)) {
       // This is an appropriate service so begin gathering data to process.
       $this->facilityService = $entity;
 
@@ -323,6 +327,24 @@ class PostFacilityService extends PostFacilityBase {
     ];
 
     return $map[$raw] ?? NULL;
+  }
+
+  /**
+   * Checks if the entity is within the Lovell Tricare section.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The node to evaluate.
+   *
+   * @return bool
+   *   TRUE if entity is within Lovell Tricare section. FALSE otherwise.
+   */
+  protected function isLovellTricareSection(NodeInterface $entity) : bool {
+    if ($entity->hasField('field_administration')) {
+      if ($entity->get('field_administration')->target_id == self::LOVELL_TRICARE) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -3,7 +3,6 @@
 namespace Drupal\va_gov_post_api\Service;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * Class PostFacilityService posts specific service info to Lighthouse.
@@ -331,14 +330,15 @@ class PostFacilityService extends PostFacilityBase {
   /**
    * Checks if the entity is within the Lovell Tricare section.
    *
-   * @param \Drupal\node\NodeInterface $entity
-   *   The node to evaluate.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
    *
    * @return bool
    *   TRUE if entity is within Lovell Tricare section. FALSE otherwise.
    */
-  protected function isLovellTricareSection(NodeInterface $entity) : bool {
-    if ($entity->hasField('field_administration')) {
+  protected function isLovellTricareSection(EntityInterface $entity) : bool {
+    if (($entity instanceof NodeInterface) && ($entity->hasField('field_administration'))) {
+      /** @var \Drupal\node\NodeInterface $entity*/
       if ($entity->get('field_administration')->target_id == self::LOVELL_TRICARE) {
         return TRUE;
       }
@@ -367,7 +367,7 @@ class PostFacilityService extends PostFacilityBase {
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
-      case $this->isLovellTricareSection($this->facilityService):
+      case $this->isLovellTricareSection($entity):
         // Node is part of the Lovell-Tricare section, do not push.
         $push = FALSE;
         break;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -364,11 +364,10 @@ class PostFacilityService extends PostFacilityBase {
     $thisRevisionIsPublished = $entity->isPublished();
     $defaultRevisionIsPublished = (isset($entity->original) && ($entity->original instanceof EntityInterface)) ? (bool) $entity->original->status->value : (bool) $entity->status->value;
     $isNew = $entity->isNew();
-    $isLovellTricare = $this->isLovellTricareSection($this->facilityService);
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
-      case $isLovellTricare:
+      case $this->isLovellTricareSection($this->facilityService):
         // Node is part of the Lovell-Tricare section, do not push.
         $push = FALSE;
         break;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_post_api\Service;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Class PostFacilityService posts specific service info to Lighthouse.

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -66,9 +66,7 @@ class PostFacilityService extends PostFacilityBase {
    */
   public function queueFacilityService(EntityInterface $entity, bool $forcePush = FALSE) {
     $this->errors = [];
-    if (($entity->getEntityTypeId() === 'node')
-    && ($entity->bundle() === 'health_care_local_health_service')
-    && !$this->isLovellTricareSection($entity)) {
+    if (($entity->getEntityTypeId() === 'node') && ($entity->bundle() === 'health_care_local_health_service')) {
       // This is an appropriate service so begin gathering data to process.
       $this->facilityService = $entity;
 
@@ -366,9 +364,15 @@ class PostFacilityService extends PostFacilityBase {
     $thisRevisionIsPublished = $entity->isPublished();
     $defaultRevisionIsPublished = (isset($entity->original) && ($entity->original instanceof EntityInterface)) ? (bool) $entity->original->status->value : (bool) $entity->status->value;
     $isNew = $entity->isNew();
+    $isLovellTricare = $this->isLovellTricareSection($this->facilityService);
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
+      case $isLovellTricare:
+        // Node is part of the Lovell-Tricare section, do not push.
+        $push = FALSE;
+        break;
+
       case $forcePush && $thisRevisionIsPublished:
         // Forced push from updates to referenced entity.
       case $isNew:

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -293,11 +293,10 @@ class PostFacilityStatus extends PostFacilityBase {
     $statusInfoChanged = $this->changedValue($this->facilityNode, $defaultRevision, 'field_operating_status_more_info');
     $supStatusChanged = $this->changedTarget($this->facilityNode, $defaultRevision, 'field_supplemental_status');
     $somethingChanged = $statusChanged || $statusInfoChanged || $supStatusChanged;
-    $isLovellTricare = $this->isLovellTricareSection($this->facilityNode);
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
-      case $isLovellTricare:
+      case $this->isLovellTricareSection($this->facilityNode):
         // Node is part of the Lovell-Tricare section, do not push.
         $push = FALSE;
         break;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -20,7 +20,6 @@ class PostFacilityStatus extends PostFacilityBase {
   const STATE_ARCHIVED = 'archived';
   const STATE_DRAFT = 'draft';
   const STATE_PUBLISHED = 'published';
-  const LOVELL_TRICARE = 1039;
 
   /**
    * The facility node.
@@ -249,24 +248,6 @@ class PostFacilityStatus extends PostFacilityBase {
    */
   protected function isFacilityWithStatus(NodeInterface $entity) : bool {
     return in_array($entity->bundle(), $this->facilitiesWithServices);
-  }
-
-  /**
-   * Checks if the entity is within the Lovell Tricare section.
-   *
-   * @param \Drupal\node\NodeInterface $entity
-   *   The node to evaluate.
-   *
-   * @return bool
-   *   TRUE if entity is within Lovell Tricare section. FALSE otherwise.
-   */
-  protected function isLovellTricareSection(NodeInterface $entity) : bool {
-    if ($entity->hasField('field_administration')) {
-      if ($entity->get('field_administration')->target_id == self::LOVELL_TRICARE) {
-        return TRUE;
-      }
-    }
-    return FALSE;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -23,7 +23,7 @@ class PostFacilityStatus extends PostFacilityBase {
   const LOVELL_TRICARE = 1039;
 
   /**
-   * The facility service node.
+   * The facility node.
    *
    * @var \Drupal\node\NodeInterface
    */

--- a/tests/phpunit/Content/FacilityStatusQueueTest.php
+++ b/tests/phpunit/Content/FacilityStatusQueueTest.php
@@ -112,7 +112,7 @@ class FacilityStatusQueueTest extends ExistingSiteBase {
       $nodeProphecy->hasField(self::STATUS_FIELD_MORE_INFO_NAME)->willReturn(TRUE);
       $nodeProphecy->get(self::STATUS_FIELD_MORE_INFO_NAME)->willReturn((object) ['value' => 'a']);
       $nodeProphecy->hasField(self::SECTION_FIELD_NAME)->willReturn(TRUE);
-      $nodeProphecy->get(self::SECTION_FIELD_NAME)->willReturn((object) ['value' => 'a']);
+      $nodeProphecy->get(self::SECTION_FIELD_NAME)->willReturn((object) ['target_id' => '1']);
       if ($contentType === 'health_care_local_facility') {
         if (!is_null($supplementalStatusChanged)) {
           $nodeProphecy->hasField(self::SUPPLEMENTAL_STATUS_FIELD_NAME)->willReturn(TRUE);

--- a/tests/phpunit/Content/FacilityStatusQueueTest.php
+++ b/tests/phpunit/Content/FacilityStatusQueueTest.php
@@ -46,6 +46,7 @@ class FacilityStatusQueueTest extends ExistingSiteBase {
   const STATUS_SAME = 'status_same';
   const SUP_STATUS_ONE = 'sup_status_one';
   const SUP_STATUS_TWO = 'sup_status_two';
+  const SECTION_FIELD_NAME = 'field_administration';
   const STATUS_FIELD_NAME = 'field_operating_status_facility';
   const STATUS_FIELD_MORE_INFO_NAME = 'field_operating_status_more_info';
   const SUPPLEMENTAL_STATUS_FIELD_NAME = 'field_supplemental_status';
@@ -110,6 +111,8 @@ class FacilityStatusQueueTest extends ExistingSiteBase {
       $nodeProphecy->get(self::STATUS_FIELD_NAME)->willReturn((object) ['value' => 'a']);
       $nodeProphecy->hasField(self::STATUS_FIELD_MORE_INFO_NAME)->willReturn(TRUE);
       $nodeProphecy->get(self::STATUS_FIELD_MORE_INFO_NAME)->willReturn((object) ['value' => 'a']);
+      $nodeProphecy->hasField(self::SECTION_FIELD_NAME)->willReturn(TRUE);
+      $nodeProphecy->get(self::SECTION_FIELD_NAME)->willReturn((object) ['value' => 'a']);
       if ($contentType === 'health_care_local_facility') {
         if (!is_null($supplementalStatusChanged)) {
           $nodeProphecy->hasField(self::SUPPLEMENTAL_STATUS_FIELD_NAME)->willReturn(TRUE);


### PR DESCRIPTION
## Description

Closes #9943 

## Testing done

Manual testing

## QA steps

As a user with the admin role:
- [ ] Begin by opening up /admin/config/post-api/queue in a tab and noting the currently queued items
- [ ] In a second tab add a new VAMC Facility (or edit an existing one) - set the section to `Lovell - TriCare` (Under VISN 12)
- [ ] Save the Facility
- [ ] Revisit /admin/config/post-api/queue in your first tab and refresh - verify the facility you saved was not queued
- [ ] Create or edit a VAMC Facility Health Service for the Facility you just touched. Select `COVID-19 vaccines` as the VAMC system health service (these are the only health services we currently push to Lighthouse) and be sure the section is set to `Lovell - TriCare` for this as well.
- [ ] Save the health service
- [ ] Revisit /admin/config/post-api/queue in your first tab and refresh - verify the health service you saved was not queued

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`