### PR TITLE
Changes config to erase geocoding on failed look-up

### DIFF
--- a/config/sync/field.field.node.vet_center_cap.field_geolocation.yml
+++ b/config/sync/field.field.node.vet_center_cap.field_geolocation.yml
@@ -25,7 +25,7 @@ third_party_settings:
     dumper: wkt
     delta_handling: default
     failure:
-      handling: preserve
+      handling: empty
       status_message: true
       log: true
 id: node.vet_center_cap.field_geolocation


### PR DESCRIPTION
## Description

Closes #9544 

## Testing done
Manually

## Screenshots
After changing the endpoint to a "bad" one to make the geocoding fail, I changed the address on a Vet Center CAP:
![Screen Shot 2022-08-08 at 13 55 49](https://user-images.githubusercontent.com/766573/183508527-7ba5c629-0e34-4ab8-9413-f9ec52ffb7a1.png)

Because of the failed look-up, the lat and long are now blank.

## QA steps

As an admin user
1. Change the Geocoding Mode on "/admin/config/system/geocoder/geocoder-provider/manage/mapbox" to "BREAKME"
2. Visit a Vet Center CAP, e.g. "node/47735/edit"
   - [ ] Change the address
   - [ ] Click "Save draft and continue editing"
   - [ ] Confirm that it was unable to geocode
   - [ ] Confirm that the latitude and longitude are now 0 and the map shows the middle of the ocean


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`

### Does this PR need review from a Product Owner

- [x] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
