### PR TITLE
VACMS-10093 Updates instruction from 'Owner' to 'Section'

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -151,6 +151,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       label: 'Editorial workflow'
       region: content
       parent_name: ''

--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -146,12 +146,11 @@ third_party_settings:
         classes: ''
         id: ''
         open: false
-        description: 'This should generally not be changed after the content is created.  If no choices present themselves, set the "Owner" first.'
+        description: 'This should generally not be changed after the content is created.  If no choices present themselves, set the "Section" first.'
         required_fields: true
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       label: 'Editorial workflow'
       region: content
       parent_name: ''


### PR DESCRIPTION
## Description

Closes #10093 

## Testing done

Manually

## Screenshots

<img width="1673" alt="Screen Shot 2022-08-08 at 5 02 49 PM" src="https://user-images.githubusercontent.com/766573/183645520-5ea6253a-ffa9-43c7-a388-ba4b4e7d0f8a.png">


## QA steps

As user with content edit permissions
1. Go to a add a VAMC Facility Health Service (/node/add/health_care_local_health_service)
2. Click on "Health service and facility basic info" to expand the field group
   - [ ] Validate that the instructions read as follows: 'This should generally not be changed after the content is created. If no choices present themselves, set the "Section" first.'


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`



### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
