### PR TITLE
VACMS-9956: add new section field to lovell menu items

### DIFF
--- a/config/sync/core.entity_form_display.menu_link_content.lovell-federal-health-care.default.yml
+++ b/config/sync/core.entity_form_display.menu_link_content.lovell-federal-health-care.default.yml
@@ -1,0 +1,36 @@
+uuid: 5e5c87bb-b742-4f41-b034-af28506551dd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.menu_link_content.lovell-federal-health-care.field_menu_section
+    - system.menu.lovell-federal-health-care
+  module:
+    - link
+    - menu_item_extras
+id: menu_link_content.lovell-federal-health-care.default
+targetEntityType: menu_link_content
+bundle: lovell-federal-health-care
+mode: default
+content:
+  field_menu_section:
+    type: options_select
+    weight: 21
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  view_mode:
+    type: menu_item_extras_view_mode_selector_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.menu_link_content.lovell-federal-health-care.default.yml
+++ b/config/sync/core.entity_view_display.menu_link_content.lovell-federal-health-care.default.yml
@@ -1,0 +1,28 @@
+uuid: 3d7889e8-ca9a-4585-ae73-d7822bdc2137
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.menu_link_content.lovell-federal-health-care.field_menu_section
+    - system.menu.lovell-federal-health-care
+  module:
+    - options
+id: menu_link_content.lovell-federal-health-care.default
+targetEntityType: menu_link_content
+bundle: lovell-federal-health-care
+mode: default
+content:
+  children:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_menu_section:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -217,6 +217,7 @@ module:
   va_gov_graphql: 0
   va_gov_help_center: 0
   va_gov_login: 0
+  va_gov_lovell: 0
   va_gov_media: 0
   va_gov_menu_access: 0
   va_gov_migrate: 0

--- a/config/sync/field.field.menu_link_content.lovell-federal-health-care.field_menu_section.yml
+++ b/config/sync/field.field.menu_link_content.lovell-federal-health-care.field_menu_section.yml
@@ -1,0 +1,28 @@
+uuid: d8f8f609-19e6-41fe-950a-529d8ead3710
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.menu_link_content.field_menu_section
+    - system.menu.lovell-federal-health-care
+  module:
+    - epp
+    - options
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: menu_link_content.lovell-federal-health-care.field_menu_section
+field_name: field_menu_section
+entity_type: menu_link_content
+bundle: lovell-federal-health-care
+label: 'Menu Section'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: main
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.menu_link_content.lovell-federal-health-care.field_menu_section.yml
+++ b/config/sync/field.field.menu_link_content.lovell-federal-health-care.field_menu_section.yml
@@ -22,7 +22,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: main
+    value: va
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/sync/field.storage.menu_link_content.field_menu_section.yml
+++ b/config/sync/field.storage.menu_link_content.field_menu_section.yml
@@ -12,8 +12,8 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: main
-      label: 'Lovell - Main'
+      value: va
+      label: 'Lovell - VA'
     -
       value: tricare
       label: 'Lovell - Tricare'

--- a/config/sync/field.storage.menu_link_content.field_menu_section.yml
+++ b/config/sync/field.storage.menu_link_content.field_menu_section.yml
@@ -1,0 +1,30 @@
+uuid: e7caa553-19c8-4af3-912c-ee13db0f089c
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+    - options
+id: menu_link_content.field_menu_section
+field_name: field_menu_section
+entity_type: menu_link_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: main
+      label: 'Lovell - Main'
+    -
+      value: tricare
+      label: 'Lovell - Tricare'
+    -
+      value: both
+      label: 'Lovell - Both'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -85,7 +85,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
         $nid = $params['node'];
         $node_storage = $this->entityTypeManager->getStorage('node');
         $node = $node_storage->load($nid);
-
+        /** @var \Drupal\node\NodeInterface $node*/
         if ($node->hasField('field_administration')) {
           $section_id = $node->get('field_administration')->target_id;
           $section_map = [

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\va_gov_lovell\EventSubscriber;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\core_event_dispatcher\EntityHookEvents;
+use Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent;
+use Drupal\menu_link_content\MenuLinkContentInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * VA.gov Lovell Entity Event Subscriber.
+ */
+class LovellEventSubscriber implements EventSubscriberInterface {
+  use StringTranslationTrait;
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   *  The entity manager.
+   */
+  private $entityTypeManager;
+
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs the EventSubscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The string entity type service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(
+    EntityTypeManager $entityTypeManager,
+    MessengerInterface $messenger
+  ) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      EntityHookEvents::ENTITY_PRE_SAVE => 'entityPresave',
+    ];
+  }
+
+  /**
+   * Entity presave Event call.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent $event
+   *   The event.
+   */
+  public function entityPresave(EntityPresaveEvent $event): void {
+    $entity = $event->getEntity();
+    $this->setMenuSection($entity);
+  }
+
+  /**
+   * Set field_menu_section for Lovell menu items.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   */
+  protected function setMenuSection(EntityInterface $entity): void {
+    if (($entity instanceof MenuLinkContentInterface)
+    && ($entity->getMenuName() === 'lovell-federal-health-care')
+    && ($entity->hasfield('field_menu_section'))) {
+      // Load the node entity for this menu item.
+      $url_object = $entity->getUrlObject();
+      $params = $url_object->getRouteParameters();
+      if (array_key_exists('node', $params)) {
+        $nid = $params['node'];
+        $node_storage = $this->entityTypeManager->getStorage('node');
+        $node = $node_storage->load($nid);
+
+        if ($node->hasField('field_administration')) {
+          $section_id = $node->get('field_administration')->target_id;
+          $section_map = [
+            '1040' => 'va',
+            '1039' => 'tricare',
+            '347' => 'both',
+          ];
+
+          // Set section for this menu item.
+          $entity->set('field_menu_section', $section_map[$section_id]);
+        }
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -95,7 +95,9 @@ class LovellEventSubscriber implements EventSubscriberInterface {
           ];
 
           // Set section for this menu item.
-          $entity->set('field_menu_section', $section_map[$section_id]);
+          if (!empty($section_map[$section_id])) {
+            $entity->set('field_menu_section', $section_map[$section_id]);
+          }
         }
       }
     }

--- a/docroot/modules/custom/va_gov_lovell/va_gov_lovell.info.yml
+++ b/docroot/modules/custom/va_gov_lovell/va_gov_lovell.info.yml
@@ -1,0 +1,8 @@
+name: 'VA.gov Lovell'
+type: module
+description: 'Functionality to handle Lovell.'
+core_version_requirement: ^8 || ^9
+package: 'Custom'
+dependencies:
+  - drupal:hook_event_dispatcher
+  - drupal:menu_item_extras

--- a/docroot/modules/custom/va_gov_lovell/va_gov_lovell.services.yml
+++ b/docroot/modules/custom/va_gov_lovell/va_gov_lovell.services.yml
@@ -1,0 +1,6 @@
+services:
+  va_gov_lovell.entity_event_subscriber:
+    class: Drupal\va_gov_lovell\EventSubscriber\LovellEventSubscriber
+    arguments: ['@entity_type.manager', '@messenger']
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
## Description

Closes #9956 

## Testing done

Manual testing

## Screenshots

<img width="1446" alt="Screen Shot 2022-08-10 at 9 29 32 AM" src="https://user-images.githubusercontent.com/21045418/183913746-8620431e-57d1-4e52-9ace-bdda387ddc9c.png">

<img width="1714" alt="Screen Shot 2022-08-10 at 9 30 00 AM" src="https://user-images.githubusercontent.com/21045418/183913779-67bf1f4c-7f5f-4f8f-a07a-30461494060d.png">

## QA steps

As an admin user

- [x]  Visit /admin/structure/menu/manage/lovell-federal-health-care in one tab to get a list of links in the Lovell menu
- [x] Click manage fields and verify field_menu_section has been added to the menu
- [x] Click edit next to field_menu_section and then click field settings to verify the three available values
- [x] Go back to /admin/structure/menu/manage/lovell-federal-health-care and click edit next to the first link (opening in a new tab) - verify the existence of the Menu Section field at the bottom of the form (should be set to - None - initially)
- [x] Also click on the first link itself to open the node it points to in a new tab
- [x] Try editing and saving the node, changing the section from Lovell, Lovell - VA and Lovell - Tricare. After each save check the menu item edit page to verify the Menu Section has updated in kind.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`