### PR TITLE
VACMS 9996:  Reëvaluate packages with composer repository overrides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "drupal/environment_indicator": "^4.0",
         "drupal/epp": "^1.1",
         "drupal/fast_404": "2.x-dev#5382a99335ee466f8261dc1774a3d56f1699da81",
-        "drupal/feature_toggle": "1.0",
+        "drupal/feature_toggle": "^2.0",
         "drupal/field_group": "^3.1",
         "drupal/fieldhelptext": "^1.0@beta",
         "drupal/flag": "^4.0@beta",
@@ -81,7 +81,7 @@
         "drupal/graphql_core": "^3.1.0",
         "drupal/graphql_menu": "^1.0@alpha",
         "drupal/graphql_metatag": "^1.0",
-        "drupal/health_check_url": "2.0",
+        "drupal/health_check_url": "^3.0",
         "drupal/hierarchy_manager": "^3.0",
         "drupal/hms_field": "1.0",
         "drupal/hook_event_dispatcher": "^3.0",
@@ -211,6 +211,19 @@
         ]
     },
     "repositories": {
+        "drupal/hms_field": {
+            "type": "package",
+            "package": {
+                "name": "drupal/hms_field",
+                "type": "drupal-module",
+                "version": "1.0.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://git.drupalcode.org/project/hms_field.git",
+                    "reference": "f138860c7b18c6aab00f5860b29d15b9ab2197f5"
+                }
+            }
+        },        
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
@@ -378,9 +391,6 @@
             "drupal/entity_reference_revisions": {
                 "2984027 Incorrect manipulation of default revision flag": "https://www.drupal.org/files/issues/2020-09-03/entity_reference_revisions-default_revision-2984027-10.patch"
             },
-            "drupal/feature_toggle": {
-                "3147452 - Make compatible with d9": "https://www.drupal.org/files/issues/2020-06-06/feature_toggle.1.x-dev.rector.patch"
-            },
             "drupal/field_group": {
                 "2787179 Visibility of invalid fields": "https://www.drupal.org/files/issues/2021-01-05/2787179-highlight-html5-validation-59.patch",
                 "1482958-47 Allow field_group with empty fields to be displayed via setting": "https://www.drupal.org/files/issues/2020-06-24/field_group-empty-config-1482958-47.patch",
@@ -392,9 +402,6 @@
             "drupal/graphql": {
                 "Fix Explorer with Layout Builder enabled - https://github.com/drupal-graphql/graphql/pull/1144": "patches/graphql_8x3x_layout_builder_incompat.patch",
                 "Remove outdated RouteQueryEnhancer controller reference - https://github.com/drupal-graphql/graphql/pull/1230": "patches/graphql_8x3x_query_route_enhancer_update.patch"
-            },
-            "drupal/health_check_url": {
-                "3147740 - Make d9 compatible": "https://www.drupal.org/files/issues/2020-06-06/health_check_url.2.x-dev.rector.patch"
             },
             "drupal/hms_field": {
                 "3145496 - Make d9 compatible": "https://www.drupal.org/files/issues/2020-06-05/3145496-6.patch"

--- a/composer.json
+++ b/composer.json
@@ -211,45 +211,6 @@
         ]
     },
     "repositories": {
-        "drupal/feature_toggle": {
-            "type": "package",
-            "package": {
-                "name": "drupal/feature_toggle",
-                "type": "drupal-module",
-                "version": "1.0.0",
-                "source": {
-                    "type": "git",
-                    "url": "https://git.drupalcode.org/project/feature_toggle.git",
-                    "reference": "8753ecb9a6a541fdea2de04a4640aa6b998a8df4"
-                }
-            }
-        },
-        "drupal/health_check_url": {
-            "type": "package",
-            "package": {
-                "name": "drupal/health_check_url",
-                "type": "drupal-module",
-                "version": "2.0.0",
-                "source": {
-                    "type": "git",
-                    "url": "https://git.drupalcode.org/project/health_check_url.git",
-                    "reference": "6eff12c076f6e0412b33e11201e33b1257431f4e"
-                }
-            }
-        },
-        "drupal/hms_field": {
-            "type": "package",
-            "package": {
-                "name": "drupal/hms_field",
-                "type": "drupal-module",
-                "version": "1.0.0",
-                "source": {
-                    "type": "git",
-                    "url": "https://git.drupalcode.org/project/hms_field.git",
-                    "reference": "f138860c7b18c6aab00f5860b29d15b9ab2197f5"
-                }
-            }
-        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b87aa21fffbcfea99083cb5d85e14c2d",
+    "content-hash": "b903b999d93e0d9cf67493e1006b0fca",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -6295,13 +6295,51 @@
         },
         {
             "name": "drupal/feature_toggle",
-            "version": "1.0.0",
+            "version": "2.0.1-beta1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/feature_toggle.git",
-                "reference": "8753ecb9a6a541fdea2de04a4640aa6b998a8df4"
+                "reference": "2.0.1-beta1"
             },
-            "type": "drupal-module"
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/feature_toggle-2.0.1-beta1.zip",
+                "reference": "2.0.1-beta1",
+                "shasum": "ba7dfcae5fbd6d55450aac0f04e11e02f0f10951"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1-beta1",
+                    "datestamp": "1634675424",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "plopesc",
+                    "homepage": "https://www.drupal.org/user/282415"
+                },
+                {
+                    "name": "TechNikh",
+                    "homepage": "https://www.drupal.org/user/372123"
+                }
+            ],
+            "description": "Enable or disable features.",
+            "homepage": "https://www.drupal.org/project/feature_toggle",
+            "support": {
+                "source": "https://git.drupalcode.org/project/feature_toggle"
+            }
         },
         {
             "name": "drupal/field_group",
@@ -7042,13 +7080,51 @@
         },
         {
             "name": "drupal/health_check_url",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/health_check_url.git",
-                "reference": "6eff12c076f6e0412b33e11201e33b1257431f4e"
+                "reference": "8.x-3.1"
             },
-            "type": "drupal-module"
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/health_check_url-8.x-3.1.zip",
+                "reference": "8.x-3.1",
+                "shasum": "cffab34de69a7dbb76d81421822835815b989a09"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.1",
+                    "datestamp": "1625500176",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "btobac",
+                    "homepage": "https://www.drupal.org/user/3630142"
+                },
+                {
+                    "name": "karthikeyan-manivasagam",
+                    "homepage": "https://www.drupal.org/user/1494424"
+                }
+            ],
+            "description": "Configurable string & end point for load balancers to check Drupal site health",
+            "homepage": "https://www.drupal.org/project/health_check_url",
+            "support": {
+                "source": "https://git.drupalcode.org/project/health_check_url"
+            }
         },
         {
             "name": "drupal/hierarchy_manager",


### PR DESCRIPTION
## Description

Closes #9996.

Two packages have upstream upgrades that have fixed the Drupal 9 compatibility.  The remaining, `hms_field`, appears completely abandoned, so I think we'll need to maintain this in the `composer.json` file moving forward.  Opened #10269 to deal with `hms_field`.

## Testing done
- [health_check_url](https://www.drupal.org/project/health_check_url/releases) does not indicate any major changes.  
- The `/health` endpoint functions similarly to prod, without any apparent delays or other effects.
- [feature_toggle](https://www.drupal.org/project/feature_toggle/releases) does not indicate any major changes.
- The `/admin/config/system/feature_toggle` page functions similarly to prod.
- Feature toggles appear normal (`drupalSettings.feature_toggle.enabled`).