### PR TITLE
VACMS-10290: Upgrades Drupal to 9.3.21 [Security]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4218,16 +4218,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.3.19",
+            "version": "9.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "a2e0d65f7a4f31712ae829e1ff96827a8bb9e438"
+                "reference": "b32e65a1ebc76c24f6036924274d21c222e350ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/a2e0d65f7a4f31712ae829e1ff96827a8bb9e438",
-                "reference": "a2e0d65f7a4f31712ae829e1ff96827a8bb9e438",
+                "url": "https://api.github.com/repos/drupal/core/zipball/b32e65a1ebc76c24f6036924274d21c222e350ef",
+                "reference": "b32e65a1ebc76c24f6036924274d21c222e350ef",
                 "shasum": ""
             },
             "require": {
@@ -4469,13 +4469,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/9.3.19"
+                "source": "https://github.com/drupal/core/tree/9.3.21"
             },
-            "time": "2022-07-20T15:11:47+00:00"
+            "time": "2022-08-03T16:34:49+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "9.3.19",
+            "version": "9.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -4519,22 +4519,22 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.3.19"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.3.21"
             },
             "time": "2022-02-24T17:40:56+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "9.3.19",
+            "version": "9.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "a552529d38bc45b0b9a0ba9e60fce687b5cb3366"
+                "reference": "ed55850d6c38bf6dbd82561ff81a12a08974b098"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/a552529d38bc45b0b9a0ba9e60fce687b5cb3366",
-                "reference": "a552529d38bc45b0b9a0ba9e60fce687b5cb3366",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/ed55850d6c38bf6dbd82561ff81a12a08974b098",
+                "reference": "ed55850d6c38bf6dbd82561ff81a12a08974b098",
                 "shasum": ""
             },
             "require": {
@@ -4543,12 +4543,12 @@
                 "doctrine/annotations": "1.13.2",
                 "doctrine/lexer": "1.2.1",
                 "doctrine/reflection": "1.2.2",
-                "drupal/core": "9.3.19",
+                "drupal/core": "9.3.21",
                 "egulias/email-validator": "3.1.2",
                 "guzzlehttp/guzzle": "6.5.8",
                 "guzzlehttp/promises": "1.5.1",
                 "guzzlehttp/psr7": "1.9.0",
-                "laminas/laminas-diactoros": "2.8.0",
+                "laminas/laminas-diactoros": "2.11.1",
                 "laminas/laminas-escaper": "2.9.0",
                 "laminas/laminas-feed": "2.15.0",
                 "laminas/laminas-stdlib": "3.6.1",
@@ -4605,9 +4605,9 @@
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/9.3.19"
+                "source": "https://github.com/drupal/core-recommended/tree/9.3.21"
             },
-            "time": "2022-07-20T15:11:47+00:00"
+            "time": "2022-08-03T16:34:49+00:00"
         },
         {
             "name": "drupal/core_event_dispatcher",
@@ -14196,16 +14196,16 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.8.0",
+            "version": "2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199"
+                "reference": "25b11d422c2e5dad868f68619888763b30f91e2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
-                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/25b11d422c2e5dad868f68619888763b30f91e2d",
+                "reference": "25b11d422c2e5dad868f68619888763b30f91e2d",
                 "shasum": ""
             },
             "require": {
@@ -14291,7 +14291,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-22T03:54:36+00:00"
+            "time": "2022-06-28T21:07:29+00:00"
         },
         {
             "name": "laminas/laminas-escaper",


### PR DESCRIPTION
## Description

https://www.drupal.org/project/drupal/releases/9.3.21
https://github.com/ckeditor/ckeditor5/security/advisories/GHSA-42wq-rch8-6f6j
https://github.com/advisories/GHSA-8274-h5jp-97vr

Closes #10290.
