### PR TITLE
VACMS-10147: Help text for Q&A Group Reusability Components

### DIFF
--- a/config/sync/field.field.paragraph.q_a_group.field_rich_wysiwyg.yml
+++ b/config/sync/field.field.paragraph.q_a_group.field_rich_wysiwyg.yml
@@ -20,8 +20,8 @@ id: paragraph.q_a_group.field_rich_wysiwyg
 field_name: field_rich_wysiwyg
 entity_type: paragraph
 bundle: q_a_group
-label: Description
-description: ''
+label: Introduction
+description: 'Add a summary that helps the user figure out whether this information is relevant to them. This should be written in the 2nd person.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.paragraph.q_a_group.field_section_header.yml
+++ b/config/sync/field.field.paragraph.q_a_group.field_section_header.yml
@@ -5,11 +5,17 @@ dependencies:
   config:
     - field.storage.paragraph.field_section_header
     - paragraphs.paragraphs_type.q_a_group
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: paragraph.q_a_group.field_section_header
 field_name: field_section_header
 entity_type: paragraph
 bundle: q_a_group
-label: 'Section Header'
+label: Header
 description: ''
 required: false
 translatable: true

--- a/config/sync/paragraphs.paragraphs_type.q_a_group.yml
+++ b/config/sync/paragraphs.paragraphs_type.q_a_group.yml
@@ -11,5 +11,5 @@ id: q_a_group
 label: 'Q&A group'
 icon_uuid: null
 icon_default: null
-description: 'For content formatted as a series of questions and answers in "FAQ - multiple Q&A" content type. Use this (instead of Rich text) for better accessibility and easy rearranging.'
+description: 'Create a new group of existing Q&As. Use this (instead of Rich text) for better accessibility and easy rearranging.'
 behavior_plugins: {  }

--- a/config/sync/views.view.content_entity_reference_source.yml
+++ b/config/sync/views.view.content_entity_reference_source.yml
@@ -6,11 +6,16 @@ dependencies:
     - field.storage.node.field_administration
     - node.type.event_listing
     - node.type.health_care_local_facility
+    - node.type.nca_facility
     - node.type.office
     - node.type.person_profile
     - node.type.press_releases_listing
     - node.type.publication_listing
     - node.type.story_listing
+    - node.type.vba_facility
+    - node.type.vet_center
+    - node.type.vet_center_cap
+    - node.type.vet_center_outstation
   module:
     - node
     - user
@@ -1056,7 +1061,12 @@ display:
           plugin_id: bundle
           operator: in
           value:
+            nca_facility: nca_facility
             health_care_local_facility: health_care_local_facility
+            vba_facility: vba_facility
+            vet_center: vet_center
+            vet_center_cap: vet_center_cap
+            vet_center_outstation: vet_center_outstation
           group: 1
           exposed: false
           expose:

--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -96,7 +96,7 @@ Feature: Content model bundles
 | Phone number | phone_number | Paragraph type |  |
 | Process list | process | Paragraph type | An ordered list (1, 2, 3, 4, N) of steps in a process. |
 | Q&A | q_a | Paragraph type | Question and Answer |
-| Q&A group | q_a_group | Paragraph type | For content formatted as a series of questions and answers in "FAQ - multiple Q&A" content type. Use this (instead of Rich text) for better accessibility and easy rearranging. |
+| Q&A group | q_a_group | Paragraph type | Create a new group of existing Q&As. Use this (instead of Rich text) for better accessibility and easy rearranging. |
 | Q&A Section | q_a_section | Paragraph type | For content formatted as a series of questions and answers. Use this (instead of Rich text) for better accessibility and easy rearranging. |
 | React Widget | react_widget | Paragraph type | Advanced editors can use this to place react widgets (like a form) on the page. |
 | Rich text - char limit 1000 | rich_text_char_limit_1000 | Paragraph type | An open-ended text field that uses "Rich Text Limited" with a character limit 1000. |

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -89,8 +89,8 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  |
 | Paragraph type | Q&A group | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Paragraph type | Q&A group | Q&As | field_q_as | Entity reference | Required | Unlimited | Entity Browser - Table |  |
-| Paragraph type | Q&A group | Description | field_rich_wysiwyg | Text (formatted, long) |  | 1 | -- Disabled -- | Translatable |
-| Paragraph type | Q&A group | Section Header | field_section_header | Text (plain) |  | 1 | Textfield with counter | Translatable |
+| Paragraph type | Q&A group | Introduction | field_rich_wysiwyg | Text (formatted, long) |  | 1 | -- Disabled -- | Translatable |
+| Paragraph type | Q&A group | Header | field_section_header | Text (plain) |  | 1 | Textfield with counter | Translatable |
 | Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs (stable) |  |
 | Paragraph type | Q&A Section | Section Header | field_section_header | Text (plain) |  | 1 | Textfield |  |


### PR DESCRIPTION
## Description

Closes #10147

![Screen Shot 2022-08-19 at 10 25 28 AM](https://user-images.githubusercontent.com/22764938/185674569-7773c02a-8f79-45a6-a088-ffce22357d3b.png)



## Testing done
- Local
- Draft PR for automated tests

## Screenshots

![Screen Shot 2022-08-19 at 10 30 31 AM](https://user-images.githubusercontent.com/22764938/185675312-d0704c5b-1784-474d-ab14-5e1f93b712ab.png)

![Screen Shot 2022-08-19 at 10 31 03 AM](https://user-images.githubusercontent.com/22764938/185675326-d0a75170-f4c1-4cc2-9f80-f0bb962ae6b6.png)

Note: Introduction (formerly "description") field is disabled for now, you will have to check the code changes to see the help text change.

## QA steps

What needs to be checked to prove this works?  

- [ ] In CMS review instance, create R&S Page (node/add/support_resources_detail_page) > "Add content block" > Search "Q" and Add Q&A group > Read all text for inputs. 
- [ ]  Look for any lies in the text, see if the changes match what is outlined in #10147 or in screenshot below:

![Screen Shot 2022-08-19 at 10 25 14 AM](https://user-images.githubusercontent.com/22764938/185674423-0f7ddbea-dd90-406f-b632-1d616866e5ed.png)

What needs to be checked to prove it didn't break any related things?  

- [ ] In CMS review instance, create an FAQ page and populate the Q&A section. See if the text is true and same as above and that everything works as expected when adding (no need to save the page).
- [ ] See if the Introduction (formerly Description) field is named consistently in other places, try FAQ content.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [x] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
