### PR TITLE
VACMS-9950: Add alternate alias to nodes that are Lovell both

### DIFF
--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -185,7 +185,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
       // Define valid url prefixes for Lovell content.
       $valid_prefixes = [
         '1039' => 'lovell-federal-tricare-health-care',
-        '1040' => 'lovell-federal-health-care',
+        '1040' => 'lovell-federal-va-health-care',
       ];
 
       // If section is not both remove invalid prefixes.

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -131,6 +131,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
         return;
       }
       // If this node is in a Lovell section disable pathauto pattern.
+      // @phpstan-ignore-next-line
       $entity->path->pathauto = 0;
     }
   }

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -8,13 +8,24 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent;
+use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
+use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
 use Drupal\menu_link_content\MenuLinkContentInterface;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\Entity\PathAlias;
+use Drupal\pathauto\PathautoGenerator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * VA.gov Lovell Entity Event Subscriber.
  */
 class LovellEventSubscriber implements EventSubscriberInterface {
+  const LOVELL_SECTIONS = [
+    '1040' => 'va',
+    '1039' => 'tricare',
+    '347' => 'both',
+  ];
+
   use StringTranslationTrait;
 
   /**
@@ -24,6 +35,14 @@ class LovellEventSubscriber implements EventSubscriberInterface {
    *  The entity manager.
    */
   private $entityTypeManager;
+
+  /**
+   * The pathauto generator.
+   *
+   * @var \Drupal\pathauto\PathautoGenerator
+   *  The pathauto generator.
+   */
+  private $pathautoGenerator;
 
   /**
    * The Messenger service.
@@ -37,14 +56,18 @@ class LovellEventSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
    *   The string entity type service.
+   * @param \Drupal\pathauto\PathautoGenerator $pathautoGenerator
+   *   The pathauto generator service.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    */
   public function __construct(
     EntityTypeManager $entityTypeManager,
+    PathautoGenerator $pathautoGenerator,
     MessengerInterface $messenger
   ) {
     $this->entityTypeManager = $entityTypeManager;
+    $this->pathautoGenerator = $pathautoGenerator;
     $this->messenger = $messenger;
   }
 
@@ -54,6 +77,8 @@ class LovellEventSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents(): array {
     return [
       EntityHookEvents::ENTITY_PRE_SAVE => 'entityPresave',
+      EntityHookEvents::ENTITY_INSERT => 'entityInsert',
+      EntityHookEvents::ENTITY_UPDATE => 'entityUpdate',
     ];
   }
 
@@ -66,6 +91,49 @@ class LovellEventSubscriber implements EventSubscriberInterface {
   public function entityPresave(EntityPresaveEvent $event): void {
     $entity = $event->getEntity();
     $this->setMenuSection($entity);
+    $this->blockLovellPathauto($entity);
+  }
+
+  /**
+   * Entity insert Event call.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent $event
+   *   The event.
+   */
+  public function entityInsert(EntityInsertEvent $event): void {
+    $entity = $event->getEntity();
+    $this->updatePathAliases($entity);
+  }
+
+  /**
+   * Entity update Event call.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent $event
+   *   The event.
+   */
+  public function entityUpdate(EntityUpdateEvent $event): void {
+    $entity = $event->getEntity();
+    $this->updatePathAliases($entity);
+  }
+
+  /**
+   * Disable pathauto for Lovell nodes.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   */
+  protected function blockLovellPathauto(EntityInterface $entity): void {
+    if (($entity instanceof NodeInterface)
+    && ($entity->hasField('path'))
+    && ($entity->hasField('field_administration'))) {
+      $section_id = $entity->get('field_administration')->target_id;
+      if (!array_key_exists($section_id, self::LOVELL_SECTIONS)) {
+        return;
+      }
+      // If this node is in a Lovell section disable pathauto.
+      // This module will take it from here.
+      $entity->path->pathauto = 0;
+    }
   }
 
   /**
@@ -88,15 +156,112 @@ class LovellEventSubscriber implements EventSubscriberInterface {
         /** @var \Drupal\node\NodeInterface $node*/
         if ($node->hasField('field_administration')) {
           $section_id = $node->get('field_administration')->target_id;
-          $section_map = [
-            '1040' => 'va',
-            '1039' => 'tricare',
-            '347' => 'both',
-          ];
-
           // Set section for this menu item.
-          if (!empty($section_map[$section_id])) {
-            $entity->set('field_menu_section', $section_map[$section_id]);
+          if (!empty(self::LOVELL_SECTIONS[$section_id])) {
+            $entity->set('field_menu_section', self::LOVELL_SECTIONS[$section_id]);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Update path aliases for Lovell content.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   */
+  protected function updatePathAliases(EntityInterface $entity): void {
+    if (($entity instanceof NodeInterface)
+    && ($entity->isDefaultRevision())
+    && ($entity->hasField('path'))
+    && ($entity->hasField('field_administration'))) {
+      // If this content does not belong to a Lovell section do nothing.
+      $section_id = $entity->get('field_administration')->target_id;
+      if (!array_key_exists($section_id, self::LOVELL_SECTIONS)) {
+        return;
+      }
+
+      // Define valid url prefixes for Lovell content.
+      $valid_prefixes = [
+        '1039' => 'lovell-federal-tricare-health-care',
+        '1040' => 'lovell-federal-health-care',
+      ];
+
+      // If section is not both remove invalid prefixes.
+      if ($section_id !== '347') {
+        $valid_prefixes = array_intersect_key($valid_prefixes, [$section_id => 'keep']);
+      }
+
+      // Generate valid aliases from the provided prefixes.
+      $valid_aliases = $this->generateValidAliases($valid_prefixes, $entity);
+
+      // Retrieve existing aliases for this node.
+      $path = '/node/' . $entity->id();
+      $path_alias_manager = $this->entityTypeManager->getStorage('path_alias');
+      $existing_aliases = $path_alias_manager->loadByProperties([
+        'path'     => $path,
+        'langcode' => 'en',
+      ]);
+
+      // Omit existing aliases with a valid match from further processing.
+      $this->omitAliasMatches($valid_aliases, $existing_aliases);
+
+      // Commit any remaining valid aliases to the database.
+      foreach ($valid_aliases as $key => $valid_alias) {
+        $valid_alias->save();
+        unset($valid_aliases[$key]);
+      }
+
+      // Remove unused existing aliases.
+      foreach ($existing_aliases as $existing_alias) {
+        $existing_alias->delete();
+      }
+    }
+  }
+
+  /**
+   * Generate an array of valid Pathalias objects for this node.
+   *
+   * @param array $prefixes
+   *   An array of prefix strings.
+   * @param \Drupal\node\NodeInterface $node
+   *   Node.
+   *
+   * @return array
+   *   An array of Pathalias objects.
+   */
+  protected function generateValidAliases(array $prefixes, NodeInterface $node): array {
+    $new_url = $this->pathautoGenerator->createEntityAlias($node, 'return');
+    $url_pieces = explode('/', $new_url);
+    foreach ($prefixes as $section => $prefix) {
+      $new_alias = PathAlias::Create([
+        'path' => '/node/' . $node->id(),
+        'alias' => '/' . $prefix . '/' . implode('/', array_slice($url_pieces, 2)),
+        'langcode' => $node->language()->getId(),
+      ]);
+      $new_aliases[] = $new_alias;
+    }
+    return $new_aliases;
+  }
+
+  /**
+   * Omit aliases common to the supplied arrays.
+   *
+   * @param array $valid_aliases
+   *   An array of aliases a node should have.
+   * @param array $existing_aliases
+   *   An array of aliases a node currently has.
+   */
+  protected function omitAliasMatches(array &$valid_aliases, array &$existing_aliases): void {
+    if (count($valid_aliases) && count($existing_aliases)) {
+      foreach ($valid_aliases as $id => $valid_alias) {
+        foreach ($existing_aliases as $section => $existing_alias) {
+          if ($valid_alias->alias->value === $existing_alias->alias->value) {
+            // Remove matched elements.
+            unset($valid_aliases[$id]);
+            unset($existing_aliases[$section]);
+            break;
           }
         }
       }

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -130,8 +130,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
       if (!array_key_exists($section_id, self::LOVELL_SECTIONS)) {
         return;
       }
-      // If this node is in a Lovell section disable pathauto.
-      // This module will take it from here.
+      // If this node is in a Lovell section disable pathauto pattern.
       $entity->path->pathauto = 0;
     }
   }
@@ -234,6 +233,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
   protected function generateValidAliases(array $prefixes, NodeInterface $node): array {
     $new_url = $this->pathautoGenerator->createEntityAlias($node, 'return');
     $url_pieces = explode('/', $new_url);
+    $new_aliases = [];
     foreach ($prefixes as $section => $prefix) {
       $new_alias = PathAlias::Create([
         'path' => '/node/' . $node->id(),

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -238,7 +238,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
    *   Node.
    *
    * @return array
-   *   An array of existing aliases for this node.
+   *   An array of existing Pathalias objects for this node.
    */
   protected function getExistingNodeAliases(NodeInterface $node): array {
     // Retrieve existing aliases for this node.

--- a/docroot/modules/custom/va_gov_lovell/va_gov_lovell.services.yml
+++ b/docroot/modules/custom/va_gov_lovell/va_gov_lovell.services.yml
@@ -1,6 +1,6 @@
 services:
   va_gov_lovell.entity_event_subscriber:
     class: Drupal\va_gov_lovell\EventSubscriber\LovellEventSubscriber
-    arguments: ['@entity_type.manager', '@messenger']
+    arguments: ['@entity_type.manager', '@pathauto.generator', '@messenger']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
## Description

Closes #9950 

This PR should not be merged yet. This PR makes assumptions concerning what the URL prefixes for Lovell - VA and Lovell - Tricare should be. Once we have official approval that these assumptions are true we should update the existing node urls to match the new pattern and then merge this code.

## Testing done

Manual testing. 

## Screenshots

<img width="1713" alt="Screen Shot 2022-08-19 at 11 09 00 AM" src="https://user-images.githubusercontent.com/21045418/185649874-80e2a068-5c1f-403a-a25f-e7d9848b6e84.png">

## QA steps

As an admin user

- [x] Create a new VAMC Detail Page:
    - Choose Lovell Federal health care for the related office or health care system.
    - Choose Lovell Federal health care for the Section
    - Choose a parent link to place the item in the Lovell menu system
- [x] When the new node has been created check the URL. Manually replace `lovell-federal-va-health-care` with `lovell-federal-tricare-health-care` - both URLS should resolve (one may redirect to the other - this is okay, we just want to be sure they are both valid)
- [x] Edit this node and change the Section to Lovell - Tricare - save the node
- [x] When the node reloads the url should start with `lovell-federal-tricare-health-care` and if you manually change it to use `lovell-federal-va-health-care` it shouldn't work
- [x] Edit this node again and change the Section to Lovell - VA - save the node
- [x] When the node reloads the url should start with `lovell-federal-va-health-care` and if you manually change it to use `lovell-federal-tricare-health-care` it shouldn't work
- [x] Edit the node again and change the section back to Lovell Federal health care - save the node
- [x] Both url prefixes should be valid again
Added by swirt
- [x] Edit a [non Lovell facility](https://pr10336-nyricbdysazsmqglb2hmnpzidkyvlubn.ci.cms.va.gov/vba-facilities/locations/los-angeles-va-regional-benefit-office).  Validate that it's url is unaffected .


### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`

### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

