### PR TITLE
VACMS-10351 Reverts changes VACMS-9483

### DIFF
--- a/config/sync/views.view.content_entity_reference_source.yml
+++ b/config/sync/views.view.content_entity_reference_source.yml
@@ -6,16 +6,11 @@ dependencies:
     - field.storage.node.field_administration
     - node.type.event_listing
     - node.type.health_care_local_facility
-    - node.type.nca_facility
     - node.type.office
     - node.type.person_profile
     - node.type.press_releases_listing
     - node.type.publication_listing
     - node.type.story_listing
-    - node.type.vba_facility
-    - node.type.vet_center
-    - node.type.vet_center_cap
-    - node.type.vet_center_outstation
   module:
     - node
     - user
@@ -1061,12 +1056,7 @@ display:
           plugin_id: bundle
           operator: in
           value:
-            nca_facility: nca_facility
             health_care_local_facility: health_care_local_facility
-            vba_facility: vba_facility
-            vet_center: vet_center
-            vet_center_cap: vet_center_cap
-            vet_center_outstation: vet_center_outstation
           group: 1
           exposed: false
           expose:


### PR DESCRIPTION
## Description

Closes #10351 

## Testing done

Checked that the changes to the following file were reverted back to previous state:
config/sync/views.view.content_entity_reference_source.yml

## QA steps

- [ ] Look at config/sync/views.view.content_entity_reference_source.yml file and see that the changes in this screenshot are not there:

![Screen Shot 2022-08-19 at 2 09 54 PM](https://user-images.githubusercontent.com/22764938/185711649-5d29d03d-ace6-4d39-8cf1-209d2f239d03.png)

- [ ] CMS review instance should not show the work described in #10333:

![Screen Shot 2022-08-19 at 2 06 16 AM](https://user-images.githubusercontent.com/22764938/185711761-bbbe4c09-0b4b-40b2-aa0b-a04498a1cacc.png)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
