### PR TITLE
VACMS-10366: Removes no-reply@va.gov from Update Manager preferences.

### DIFF
--- a/config/sync/update.settings.yml
+++ b/config/sync/update.settings.yml
@@ -8,6 +8,5 @@ fetch:
   max_attempts: 2
   timeout: 30
 notification:
-  emails:
-    - no-reply@va.gov
+  emails: []
   threshold: all


### PR DESCRIPTION
## Description

Closes #10366.

## Testing done

Logged into CMS and verified email address was no longer displayed.  

Also ran `drush cex` on CI instance and verified that config is clean.

## Screenshots

![Screen Shot 2022-08-22 at 11 54 40 AM](https://user-images.githubusercontent.com/1318579/185965003-946877af-7c0a-4d96-addb-e8fc64e936e5.png)


## QA steps

As any user with admin privileges:
- [ ] visit `/admin/reports/updates/settings` and verify that `no-reply@va.gov` is not listed under **Email addresses to notify when updates are available**
