### PR TITLE
VACMS-10249: Directly require phpspec/prophecy.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -180,6 +180,7 @@
         "npm-asset/yarn": "1.21.1",
         "oomphinc/composer-installers-extender": "^2.0",
         "php-http/guzzle6-adapter": "^2.0",
+        "phpspec/prophecy": "^1.15",
         "phpstan/phpstan": "^0.12.94",
         "phpstan/phpstan-deprecation-rules": "^0.12.6",
         "phpunit/phpunit": "^8.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc747cb4f9c6e510002821d3a1d302b3",
+    "content-hash": "ef666f51fa191e95401fe0bb1e6cdbc1",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",


### PR DESCRIPTION
## Description

Relates to #10249.

`phpspec/prophecy` is being dropped as a dependency by `phpunit/phpunit` in 8.5.29.  This is causing PRs to fail.

See #10385.

If tests pass, this is good to merge.