### PR TITLE
VACMS-10394 Adds config for Table Audit to be in the menu

### DIFF
--- a/config/sync/views.view.table_audit.yml
+++ b/config/sync/views.view.table_audit.yml
@@ -1075,7 +1075,7 @@ display:
       path: admin/content/audit/table-audit
       menu:
         type: tab
-        title: 'Table Audit'
+        title: 'Content Audit - Tables'
         description: ''
         weight: 0
         expanded: false
@@ -1083,7 +1083,7 @@ display:
         parent: ''
         context: '0'
         as_local_task: true
-        local_task_link_title: 'Table Audit'
+        local_task_link_title: 'Tables'
         local_task_parent: 'views_view:view.content.content_audit_page'
         local_task_weight: 10
         local_task_custom_parent_route: ''

--- a/config/sync/views.view.table_audit.yml
+++ b/config/sync/views.view.table_audit.yml
@@ -1069,8 +1069,24 @@ display:
           plugin_id: result
           empty: false
           content: '<p>Displaying @start - @end of @total</p>'
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/audit/table-audit
+      menu:
+        type: tab
+        title: 'Table Audit'
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+        as_local_task: true
+        local_task_link_title: 'Table Audit'
+        local_task_parent: 'views_view:view.content.content_audit_page'
+        local_task_weight: 10
+        local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
## Description

Closes #10394

## Testing done
Manually

## Screenshots
![Screen Shot 2022-08-23 at 8 33 49 AM](https://user-images.githubusercontent.com/766573/186171865-8a1294b2-993b-4f42-8f82-7b4c5e916c69.png)

### After clicking on the local task Table Menu item
![Screen Shot 2022-08-23 at 8 36 17 AM](https://user-images.githubusercontent.com/766573/186172374-0b5a9dd7-94ee-4286-8b79-408dd31f4d46.png)

## QA steps

As an admin
1. Go to /admin/content/audit
2. Click on Table Audit
3. Confirm that the view loads 


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
