### PR TITLE
VACMS 10249: Add .ddev/providers/platform.yaml to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ datadog-setup.php
 
 # Temporary .deb packages
 *.deb
+
+# DDEV keeps adding this.  Not relevant to us.
+.ddev/providers/platform.yaml


### PR DESCRIPTION
## Description

Relates to #10249.

This file is continually recreated by at least some versions of DDEV.  I don't know why.  I know @edmund-dunn and I, at least, are affected by this.

I'm adding it to the .gitignore so that it doesn't pop up unexpectedly and annoy us.