### PR TITLE
VACMS-10379: Apply tableview patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -482,7 +482,8 @@
                 "0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch",
                 "Fix Undefined index: caption notice": "https://www.drupal.org/files/issues/2020-08-10/tablefield-empty-caption-notice-2.patch",
                 "Tablefield input elements have no title or label": "https://www.drupal.org/files/issues/2020-10-14/tablefield-add_title_to_input_elements-3176982-2.patch",
-                "Copying caption to value breaks some data exports https://www.drupal.org/project/tablefield/issues/3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch"
+                "Copying caption to value breaks some data exports https://www.drupal.org/project/tablefield/issues/3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch",
+                "3128030 - Adds row and column headers to field schema": "https://www.drupal.org/files/issues/2020-09-21/tablefield-header-orientation-3128030-13.patch"
             },
             "drupal/textfield_counter": {
                 "Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch",


### PR DESCRIPTION
## Description

Tests issue 10379: Will this tableview patch allow headers to be defined for screen readers?

## Context
Paragraph table input form now shows a checkbox to select whether or not the first row or first column is the table header:
![Screen Shot 2022-08-24 at 8 35 38 PM](https://user-images.githubusercontent.com/22764938/186568818-915d6a72-aeb7-448e-96e7-f10cb090f06e.png)

Understand the relationship with the tablefield and the table paragraph type:

With `tablefield` module installed, field_table paragraph type was created using the "Table Field" field type (previously).

![Screen Shot 2022-08-24 at 8 14 33 PM](https://user-images.githubusercontent.com/22764938/186566256-50bc5d5d-585b-4c56-a898-88fdfc92d475.png)

![Screen Shot 2022-08-24 at 8 15 28 PM](https://user-images.githubusercontent.com/22764938/186566356-8824e82b-dd32-46a4-a644-3aec10770f4d.png)

## Testing done

### Manual functional testing

https://cms-skjshobxv5cgqe08fjzvlyugqwyl1qpy.ci.cms.va.gov/node/42031/edit

![Screen Shot 2022-08-24 at 11 08 14 PM](https://user-images.githubusercontent.com/22764938/186588050-9ed2dd7a-f11c-4398-a742-1c7dc8d78089.png)


```
The website encountered an unexpected error. Please try again later.

Drupal\Core\Entity\EntityStorageException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'field_table_row_header' cannot be null: INSERT INTO "paragraph_revision__field_table" ("entity_id", "revision_id", "bundle", "delta", "langcode", "field_table_value", "field_table_format", "field_table_caption", "field_table_row_header", "field_table_column_header") VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5, :db_insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8, :db_insert_placeholder_9); Array ( [:db_insert_placeholder_0] => 96446 [:db_insert_placeholder_1] => 721105 [:db_insert_placeholder_2] => table [:db_insert_placeholder_3] => 0 [:db_insert_placeholder_4] => en [:db_insert_placeholder_5] => a:4:{i:0;a:3:{i:0;s:14:"Priority group";i:1;s:53:"Copay amount for first 3 visits in each calendar year";i:2;s:55:"Copay amount for each additional visit in the same year";}i:1;a:3:{i:0;s:23:"<strong>1 to 5</strong>";i:1;s:13:"$0 (no copay)";i:2;s:3:"$30";}i:2;a:3:{i:0;s:18:"<strong>6</strong>";i:1;s:203:"<strong>If related to a condition that's covered by a special authority*:</strong> $0 (no copay) <br /><br /><strong>If not related to a condition covered by a special authority*:</strong> $30 each visit";i:2;s:3:"$30";}i:3;a:3:{i:0;s:23:"<strong>7 to 8</strong>";i:1;s:3:"$30";i:2;s:3:"$30";}} [:db_insert_placeholder_6] => rich_text [:db_insert_placeholder_7] => 2021 urgent care copay rates [:db_insert_placeholder_8] => [:db_insert_placeholder_9] => ) in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 811 of core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).
```

### Table audit
- [ ] Looked at the table audit (/admin/content/audit/table-audit)  to see if table items are good (downloaded as a csv).
Noting concerns. It appears that any table's first row has been set as a heading by default or the heading has been stripped. 

Downloading a CSV of before and after the patch, I can see that there is missing data:
![Screen Shot 2022-08-24 at 9 19 12 PM](https://user-images.githubusercontent.com/22764938/186574048-d4147107-0b34-4788-91bd-e610fa4ea7be.png)

Or perhaps moved data due to schema changes:
![Screen Shot 2022-08-24 at 9 20 41 PM](https://user-images.githubusercontent.com/22764938/186574170-5f749981-e1e3-4318-b079-0adde5f07d01.png)

See table audit diffs here.
[tableauditdiffs.xlsx](https://github.com/department-of-veterans-affairs/va.gov-cms/files/9421303/tableauditdiffs.xlsx)


THIS NEEDS FURTHER TESTING. 

### Automated testing
  - [ ] GraphQL failure
  - [ ] Status Report failure

Status report failure:
This code creates a mismatched entity and/or field definitions:
`The paragraph.field_table field needs to be updated`

It's not safe to run general entity updates the old way. Need to find out what specifically is needed and write a hook, most likely. To troubleshoot this entity mismatch:
    -  Resaved the different components ([Paragraph table field settings](https://cms-skjshobxv5cgqe08fjzvlyugqwyl1qpy.ci.cms.va.gov/admin/structure/paragraphs_type/table/fields/paragraph.table.field_table) and [tablefield settings](https://cms-skjshobxv5cgqe08fjzvlyugqwyl1qpy.ci.cms.va.gov/admin/config/content/tablefield)) .
    -  I checked to see if any configs needed to be exported as well as a result of this work. There was not and I did not make any config changes.
    - Rebuilt caches and ran database updates

## QA steps

[TBD]
What needs to be checked to prove this works?  
- [ ] Go to content > add content > Benefit Detail Page > Add content block > Table > See if you are able to define if the first row or column is the header

What needs to be checked to prove it didn't break any related things?  
- [ ] Go to the table audit and spot check or download the csv: 
https://cms-skjshobxv5cgqe08fjzvlyugqwyl1qpy.ci.cms.va.gov/admin/content/audit/table-audit

What variations of circumstances (users, actions, values) need to be checked?  
- [ ] TBD

### Definition of Done
What needs to be done for this to be done:

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
