### PR TITLE
toggle command outputs the wrong status

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Commands/ContentReleaseCommands.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Commands/ContentReleaseCommands.php
@@ -207,7 +207,7 @@ class ContentReleaseCommands extends DrushCommands {
   public function toggleContinuousRelease() {
     $current = $this->state->get(ContinuousReleaseSubscriber::CONTINUOUS_RELEASE_ENABLED, FALSE);
     $this->state->set(ContinuousReleaseSubscriber::CONTINUOUS_RELEASE_ENABLED, !$current);
-    $status_text = ($current === TRUE ? 'enabled' : 'disabled');
+    $status_text = (!$current === TRUE ? 'enabled' : 'disabled');
     $this->io()->writeln('Continuous release is now ' . $status_text);
   }
 


### PR DESCRIPTION
## Description

Relates to #7600. (or closes?)

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
