### PR TITLE
VACMS-10464 Make intro field for qa group visible

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
@@ -12,6 +12,7 @@ dependencies:
   module:
     - entity_browser_table
     - limited_field_widgets
+    - text
     - textfield_counter
 id: paragraph.q_a_group.default
 targetEntityType: paragraph
@@ -20,14 +21,14 @@ mode: default
 content:
   field_accordion_display:
     type: boolean_checkbox
-    weight: 1
+    weight: 2
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_q_as:
     type: entity_reference_browser_table_widget
-    weight: 2
+    weight: 3
     region: content
     settings:
       entity_browser: q_a_browser
@@ -41,6 +42,14 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
+  field_rich_wysiwyg:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_section_header:
     type: string_textfield_with_counter
     weight: 0
@@ -57,5 +66,4 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_rich_wysiwyg: true
   status: true

--- a/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_paragraph_fields.feature
@@ -89,7 +89,7 @@ Feature: Content model: Paragraph fields
 | Paragraph type | Q&A | Question | field_question | Text (plain) | Required | 1 | Textfield with counter |  |
 | Paragraph type | Q&A group | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox | Translatable |
 | Paragraph type | Q&A group | Q&As | field_q_as | Entity reference | Required | Unlimited | Entity Browser - Table |  |
-| Paragraph type | Q&A group | Introduction | field_rich_wysiwyg | Text (formatted, long) |  | 1 | -- Disabled -- | Translatable |
+| Paragraph type | Q&A group | Introduction | field_rich_wysiwyg | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Paragraph type | Q&A group | Header | field_section_header | Text (plain) |  | 1 | Textfield with counter | Translatable |
 | Paragraph type | Q&A Section | Display this set of Q&As as a group of accordions. | field_accordion_display | Boolean |  | 1 | Single on/off checkbox |  |
 | Paragraph type | Q&A Section | Questions | field_questions | Entity reference revisions | Required | Unlimited | Paragraphs (stable) |  |


### PR DESCRIPTION
## Description

Closes 10464

## Testing done
- As user [megan.zehnder@va.gov](https://cms-up9jcanzixoqdnqlxmfrk76ad33dponp.ci.cms.va.gov/user/4031) on https://cms-up9jcanzixoqdnqlxmfrk76ad33dponp.ci.cms.va.gov/ review instance, edit node [15062](https://cms-up9jcanzixoqdnqlxmfrk76ad33dponp.ci.cms.va.gov/node/15062/edit), add content block > Q&A Group > fill out header, introduction and select some Q&As, save as published, and trigger a content release.
Then go to https://web-up9jcanzixoqdnqlxmfrk76ad33dponp.ci.cms.va.gov/resources/life-insurance-dividend-payment-options/ and look at the changes made / added with the Q&A Group and make sure that they are reflected on the front end.

## Screenshots

![Screen Shot 2022-08-26 at 9 34 50 AM](https://user-images.githubusercontent.com/22764938/186951719-3fc3932a-428d-4619-8ab8-e114718425e2.png)


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user megan.zehnder@va.gov with editor and editor role for the R&S Content type, go to https://cms-up9jcanzixoqdnqlxmfrk76ad33dponp.ci.cms.va.gov/resources/life-insurance-dividend-payment-options and edit the page. Find the "Add content block" and add a Q&A Group. Make sure the "Introduction" field is there.

![Screen Shot 2022-08-29 at 2 36 50 PM](https://user-images.githubusercontent.com/22764938/187303792-94a28b26-0e1a-4de8-9fc8-438025146d8b.png)

![Screen Shot 2022-08-29 at 2 37 15 PM](https://user-images.githubusercontent.com/22764938/187303807-914f2f32-d0fb-4540-bee9-70caef82b55d.png)

![Screen Shot 2022-08-29 at 2 37 43 PM](https://user-images.githubusercontent.com/22764938/187303819-0fc8d203-298b-4489-bdc2-e19337b895ad.png)

Select some Q&A items and save the node as Published.

![Screen Shot 2022-08-29 at 2 38 46 PM](https://user-images.githubusercontent.com/22764938/187303961-cffffda4-6f02-437b-8aab-d194c95bfcec.png)

![Screen Shot 2022-08-29 at 2 38 57 PM](https://user-images.githubusercontent.com/22764938/187303974-63281e9d-9e4d-4894-82b5-cc86d46334de.png)

When you view the page in the CMS, you should see the content you just added, including the intro text:
![Screen Shot 2022-08-29 at 2 39 42 PM](https://user-images.githubusercontent.com/22764938/187304072-4d65e3f4-ddc3-4451-8592-99c664ef9b98.png)

Next, trigger a content build (Content > Release content) and make sure that this section of data shows up on the front end.
[TODO: Add screenshot].

To make sure that this didn't break anything, check that you can open and re-save and FAQ page that uses the Q&A group without making any changes, to make sure there aren't errors or unexpected requirements (https://cms-up9jcanzixoqdnqlxmfrk76ad33dponp.ci.cms.va.gov/node/47278/edit).

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
