### PR TITLE
VACMS-9905: Temporarily increase CreateMediaTest threshold.

### DIFF
--- a/tests/phpunit/Content/CreateMediaTest.php
+++ b/tests/phpunit/Content/CreateMediaTest.php
@@ -70,7 +70,7 @@ class CreateMediaTest extends ExistingSiteBase {
    */
   public function benchmarkTime() {
     return [
-      [2],
+      [4],
     ];
   }
 


### PR DESCRIPTION
## Description

Relates to #9905.

The CreateMediaTest threshold was set when the tests ran serially.  It frequently fails now that tests are run concurrently.

I have an issue dedicated to remediating this in the longterm (see #9905), but in the short-term, these spurious test failures are really annoying and do not serve any purpose.

This PR increases the time limit from 2 (which is frequently exceeded, in my experience) to 4, which is very rarely exceeded and may indicate the existence of an actual problem.

If tests pass, this should be good to go.