### PR TITLE
VACMS-10053: Move PHPUnit unit tests to separate GitHub Action.

### DIFF
--- a/.github/workflows/phpunit-unit-tests.yml
+++ b/.github/workflows/phpunit-unit-tests.yml
@@ -5,7 +5,7 @@ jobs:
     name: runner / phpunit [PHPUnit Unit Tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: /tmp/composer-cache
@@ -17,4 +17,5 @@ jobs:
           tools: composer:v2
       - name: Run PHPUnit (Unit Tests only)
         run: |
+          composer install
           bin/phpunit --group unit tests/phpunit

--- a/.github/workflows/phpunit-unit-tests.yml
+++ b/.github/workflows/phpunit-unit-tests.yml
@@ -2,7 +2,7 @@ name: PHPUnit Unit Tests
 on: [pull_request]
 jobs:
   phpunit:
-    name: runner / phpunit [PHPUnit Unit Tests]
+    name: runner / phpunit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/phpunit-unit-tests.yml
+++ b/.github/workflows/phpunit-unit-tests.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Run PHPUnit (Unit Tests only)
         run: |
           composer install
-          bin/phpunit --group unit tests/phpunit
+          bin/phpunit --group unit --exclude-group disabled tests/phpunit

--- a/.github/workflows/phpunit-unit-tests.yml
+++ b/.github/workflows/phpunit-unit-tests.yml
@@ -1,0 +1,20 @@
+name: PHPUnit Unit Tests
+on: [pull_request]
+jobs:
+  phpunit:
+    name: runner / phpunit [PHPUnit Unit Tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
+          tools: composer:v2
+      - name: Run PHPUnit (Unit Tests only)
+        run: |
+          bin/phpunit --group unit tests/phpunit

--- a/tests.yml
+++ b/tests.yml
@@ -123,7 +123,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(time phpunit --exclude-group disabled tests/phpunit --colors=always 2>&1 | tee \$output)"
+          result="\$(time phpunit --exclude-group disabled --exclude-group unit tests/phpunit --colors=always 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then

--- a/tests.yml
+++ b/tests.yml
@@ -123,7 +123,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(time phpunit --group functional tests/phpunit --colors=always 2>&1 | tee \$output)"
+          result="\$(time phpunit --group functional --exclude-group disabled tests/phpunit --colors=always 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then

--- a/tests.yml
+++ b/tests.yml
@@ -123,7 +123,7 @@ tasks:
           output="\$(mktemp -d)/output"
           mkfifo \$output
           (cat \$output&)
-          result="\$(time phpunit --exclude-group disabled --exclude-group unit tests/phpunit --colors=always 2>&1 | tee \$output)"
+          result="\$(time phpunit --group functional tests/phpunit --colors=always 2>&1 | tee \$output)"
           exit_code=\$?
           if [ "$SKIP_REPORTING" -ne 1 ]; then
             if [ "\$exit_code" -eq 0 ]; then

--- a/tests/phpunit/API/BannerEndpointTest.php
+++ b/tests/phpunit/API/BannerEndpointTest.php
@@ -6,6 +6,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm that the banner endpoint is working properly.
+ *
+ * @group functional
+ * @group all
  */
 class BannerEndpointTest extends ExistingSiteBase {
 

--- a/tests/phpunit/API/GraphQLTest.php
+++ b/tests/phpunit/API/GraphQLTest.php
@@ -6,6 +6,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm amount of nodes by type.
+ *
+ * @group functional
+ * @group all
  */
 class GraphQLTest extends ExistingSiteBase {
 

--- a/tests/phpunit/API/PostApiQueueTest.php
+++ b/tests/phpunit/API/PostApiQueueTest.php
@@ -10,7 +10,8 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 /**
  * Tests Post API Queue functionality.
  *
- * @group PostApiQueue
+ * @group functional
+ * @group all
  */
 class PostApiQueueTest extends ExistingSiteBase {
 
@@ -152,9 +153,9 @@ class PostApiQueueTest extends ExistingSiteBase {
    */
   protected function processItem($data) {
     $apikey = Settings::get('post_api_apikey');
-    $endpoint_path = isset($data['endpoint_path']) ? $data['endpoint_path'] : NULL;
+    $endpoint_path = isset($data['endpoint_path']) ?? NULL;
     $endpoint = Settings::get('post_api_endpoint_host') . $endpoint_path;
-    $payload = isset($data['payload']) ? $data['payload'] : [];
+    $payload = $data['payload'] ?? [];
 
     $request_service = \Drupal::service('post_api.request');
 

--- a/tests/phpunit/API/PostApiQueueTest.php
+++ b/tests/phpunit/API/PostApiQueueTest.php
@@ -153,7 +153,7 @@ class PostApiQueueTest extends ExistingSiteBase {
    */
   protected function processItem($data) {
     $apikey = Settings::get('post_api_apikey');
-    $endpoint_path = isset($data['endpoint_path']) ?? NULL;
+    $endpoint_path = $data['endpoint_path'] ?? NULL;
     $endpoint = Settings::get('post_api_endpoint_host') . $endpoint_path;
     $payload = $data['payload'] ?? [];
 

--- a/tests/phpunit/Content/AliasesTest.php
+++ b/tests/phpunit/Content/AliasesTest.php
@@ -7,6 +7,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm correct alias settings.
+ *
+ * @group functional
+ * @group all
  */
 class AliasesTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Content/BulletinQueueTest.php
+++ b/tests/phpunit/Content/BulletinQueueTest.php
@@ -8,6 +8,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm that alerts and situation updates are queued.
+ *
+ * @group functional
+ * @group all
  */
 class BulletinQueueTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Content/ContentModerationTest.php
+++ b/tests/phpunit/Content/ContentModerationTest.php
@@ -11,7 +11,8 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 /**
  * Test our requirements of the content moderation system.
  *
- * @group content_moderation
+ * @group functional
+ * @group all
  */
 class ContentModerationTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Content/CreateMediaTest.php
+++ b/tests/phpunit/Content/CreateMediaTest.php
@@ -7,6 +7,9 @@ use Drupal\media\Entity\Media;
 
 /**
  * A test to confirm ability to create media.
+ *
+ * @group functional
+ * @group all
  */
 class CreateMediaTest extends ExistingSiteBase {
 
@@ -14,8 +17,6 @@ class CreateMediaTest extends ExistingSiteBase {
    * A test method to determine the ability and time to create media.
    *
    * @group performance
-   * @group functional
-   * @group all
    *
    * @dataProvider benchmarkTime
    */

--- a/tests/phpunit/Content/DownloadableFileTest.php
+++ b/tests/phpunit/Content/DownloadableFileTest.php
@@ -10,6 +10,9 @@ use Drupal\Core\File\FileSystemInterface;
 
 /**
  * Confirm downloadable_file paragraphs are displayed correctly.
+ *
+ * @group functional
+ * @group all
  */
 class DownloadableFileTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Content/FacilityStatusQueueTest.php
+++ b/tests/phpunit/Content/FacilityStatusQueueTest.php
@@ -22,6 +22,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 /**
  * Functional test of the Facility status queueing for push to Lighthouse.
  *
+ * @group functional
+ * @group all
+ *
  * @coversDefaultClass \Drupal\va_gov_post_api\Service\PostFacilityStatus
  */
 class FacilityStatusQueueTest extends ExistingSiteBase {

--- a/tests/phpunit/Content/MetaTagTest.php
+++ b/tests/phpunit/Content/MetaTagTest.php
@@ -8,6 +8,9 @@ define('IS_BEHAT', TRUE);
 
 /**
  * A test to confirm existence and correctness of metatags.
+ *
+ * @group functional
+ * @group all
  */
 class MetaTagTest extends ExistingSiteBase {
 
@@ -20,10 +23,6 @@ class MetaTagTest extends ExistingSiteBase {
 
   /**
    * Tests the existence of the twitter:image:alt metatag.
-   *
-   * @group functional
-   * @group all
-   * @group metatag
    */
   public function testImageAltTags() {
     $author = $this->createUser();

--- a/tests/phpunit/Content/PreventAbsoluteCmsLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventAbsoluteCmsLinksValidatorTest.php
@@ -10,7 +10,7 @@ use Traits\ValidatorTestTrait;
 /**
  * A test to confirm the proper functioning of this validator.
  *
- * @group functional
+ * @group unit
  * @group all
  * @group validation
  *

--- a/tests/phpunit/Content/PreventLocalFileLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventLocalFileLinksValidatorTest.php
@@ -10,7 +10,7 @@ use Traits\ValidatorTestTrait;
 /**
  * A test to confirm the proper functioning of this validator.
  *
- * @group functional
+ * @group unit
  * @group all
  * @group validation
  *

--- a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
+++ b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
@@ -13,6 +13,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Provides automated tests for the va_gov_backend module.
+ *
+ * @group functional
+ * @group all
  */
 class ContentReleaseStatusControllerTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Deploy/DeployServiceTest.php
+++ b/tests/phpunit/Deploy/DeployServiceTest.php
@@ -11,6 +11,11 @@ use Drupal\va_gov_backend\Test\DeployServiceMock;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * Tests the DeployService.
+ *
+ * @group unit
+ * @group all
+ *
  * @covers \Drupal\va_gov_backend\Deploy\DeployService
  */
 class DeployServiceTest extends UnitTestCase {

--- a/tests/phpunit/Deploy/Plugins/HealthCheckTest.php
+++ b/tests/phpunit/Deploy/Plugins/HealthCheckTest.php
@@ -10,6 +10,9 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Test for Deploy mode health check plugin.
  *
+ * @group unit
+ * @group all
+ *
  * @covers \Drupal\va_gov_backend\Deploy\Plugin\HealthCheck
  */
 class HealthCheckTest extends UnitTestCase {

--- a/tests/phpunit/FrontendBuild/BuildMetricsTest.php
+++ b/tests/phpunit/FrontendBuild/BuildMetricsTest.php
@@ -16,8 +16,12 @@ use Tests\Support\Mock\SpecifiedTime;
 
 /**
  * Unit test for build metrics.
+ *
+ * @group unit
+ * @group all
  */
 class BuildMetricsTest extends UnitTestCase {
+
   /**
    * The state service.
    *

--- a/tests/phpunit/FrontendBuild/BuildRequesterTest.php
+++ b/tests/phpunit/FrontendBuild/BuildRequesterTest.php
@@ -13,8 +13,12 @@ use Drupal\va_gov_build_trigger\Service\BuildRequester;
 
 /**
  * Unit test for the build requester..
+ *
+ * @group unit
+ * @group all
  */
 class BuildRequesterTest extends UnitTestCase {
+
   /**
    * The state service.
    *

--- a/tests/phpunit/FrontendBuild/BuildSchedulerTest.php
+++ b/tests/phpunit/FrontendBuild/BuildSchedulerTest.php
@@ -16,6 +16,9 @@ use Tests\Support\Mock\SpecifiedTime;
 
 /**
  * Unit test for the build scheduler.
+ *
+ * @group unit
+ * @group all
  */
 class BuildSchedulerTest extends UnitTestCase {
 

--- a/tests/phpunit/FrontendBuild/BuildStateEventSubscriberTest.php
+++ b/tests/phpunit/FrontendBuild/BuildStateEventSubscriberTest.php
@@ -23,6 +23,9 @@ use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Unit test for build state event subscribers.
+ *
+ * @group unit
+ * @group all
  */
 class BuildStateEventSubscriberTest extends UnitTestCase {
 

--- a/tests/phpunit/FrontendBuild/BuildTriggerFormTest.php
+++ b/tests/phpunit/FrontendBuild/BuildTriggerFormTest.php
@@ -8,6 +8,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Functional test of the Build trigger Form.
+ *
+ * @group functional
+ * @group all
  */
 class BuildTriggerFormTest extends ExistingSiteBase {
 

--- a/tests/phpunit/FrontendBuild/EntityEventSubscriberTest.php
+++ b/tests/phpunit/FrontendBuild/EntityEventSubscriberTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Unit test for the entity event subscriber.
+ *
+ * @group unit
+ * @group all
  */
 class EntityEventSubscriberTest extends UnitTestCase {
 

--- a/tests/phpunit/FrontendBuild/ReleaseStateManagerTest.php
+++ b/tests/phpunit/FrontendBuild/ReleaseStateManagerTest.php
@@ -13,6 +13,9 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * Unit test for the release state manager.
+ *
+ * @group unit
+ * @group all
  */
 class ReleaseStateManagerTest extends UnitTestCase {
 

--- a/tests/phpunit/Logging/DatadogApmProcessorTest.php
+++ b/tests/phpunit/Logging/DatadogApmProcessorTest.php
@@ -7,6 +7,11 @@ use Drupal\va_gov_backend\Logger\Processor\DatadogApmProcessor;
 use Drupal\va_gov_backend\Service\DatadogContextProviderInterface;
 
 /**
+ * Test the Datadog APM processor.
+ *
+ * @group unit
+ * @group all
+ *
  * @covers \Drupal\va_gov_backend\Logger\Processor\DatadogApmProcessor
  */
 class DatadogApmProcessorTest extends UnitTestCase {

--- a/tests/phpunit/Migration/VaFormMigrationTest.php
+++ b/tests/phpunit/Migration/VaFormMigrationTest.php
@@ -9,6 +9,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm that the VA Form Migration works correctly.
+ *
+ * @group functional
+ * @group all
  */
 class VaFormMigrationTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Migration/VaHealthCareLocalFacilityMigrationTest.php
+++ b/tests/phpunit/Migration/VaHealthCareLocalFacilityMigrationTest.php
@@ -9,6 +9,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm that the VA HC Facility Migration works correctly.
+ *
+ * @group functional
+ * @group all
  */
 class VaHealthCareLocalFacilityMigrationTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Migration/VaHealthCareLocalFacilityStatusMigrationTest.php
+++ b/tests/phpunit/Migration/VaHealthCareLocalFacilityStatusMigrationTest.php
@@ -9,6 +9,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm that the VA HC Facility Status Migration works correctly.
+ *
+ * @group functional
+ * @group all
  */
 class VaHealthCareLocalFacilityStatusMigrationTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Ops/DatadogTest.php
+++ b/tests/phpunit/Ops/DatadogTest.php
@@ -10,6 +10,9 @@ use Tests\Support\Mock\HttpClient;
 
 /**
  * Test the Datadog service.
+ *
+ * @group functional
+ * @group all
  */
 class DatadogTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Ops/MetricsTest.php
+++ b/tests/phpunit/Ops/MetricsTest.php
@@ -10,6 +10,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Test the Metrics service.
+ *
+ * @group functional
+ * @group all
  */
 class MetricsTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Performance/CreateNodeTest.php
+++ b/tests/phpunit/Performance/CreateNodeTest.php
@@ -6,6 +6,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm node creation performance.
+ *
+ * @group functional
+ * @group all
  */
 class CreateNodeTest extends ExistingSiteBase {
 
@@ -13,7 +16,6 @@ class CreateNodeTest extends ExistingSiteBase {
    * A test method to determine the amount of time it takes to create a node.
    *
    * @group performance
-   * @group all
    *
    * @dataProvider benchmarkTime
    */

--- a/tests/phpunit/Performance/CreateTaxonomyTermTest.php
+++ b/tests/phpunit/Performance/CreateTaxonomyTermTest.php
@@ -6,6 +6,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm taxonomy creation and performance.
+ *
+ * @group functional
+ * @group all
  */
 class CreateTaxonomyTermTest extends ExistingSiteBase {
 
@@ -13,8 +16,6 @@ class CreateTaxonomyTermTest extends ExistingSiteBase {
    * A test method to determine the ability and time to create a node.
    *
    * @group performance
-   * @group functional
-   * @group all
    *
    * @dataProvider benchmarkTime
    */

--- a/tests/phpunit/Performance/EditNodeTest.php
+++ b/tests/phpunit/Performance/EditNodeTest.php
@@ -6,6 +6,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm node editing performance.
+ *
+ * @group functional
+ * @group all
  */
 class EditNodeTest extends ExistingSiteBase {
 
@@ -13,7 +16,6 @@ class EditNodeTest extends ExistingSiteBase {
    * A test method to deterine the amount of time to edit a node page.
    *
    * @group performance
-   * @group all
    *
    * @dataProvider benchmarkTime
    */

--- a/tests/phpunit/Performance/LoginTest.php
+++ b/tests/phpunit/Performance/LoginTest.php
@@ -6,6 +6,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm login performance.
+ *
+ * @group functional
+ * @group all
  */
 class LoginTest extends ExistingSiteBase {
 
@@ -13,7 +16,6 @@ class LoginTest extends ExistingSiteBase {
    * A test method to determine the amount of time to load the Login page.
    *
    * @group performance
-   * @group all
    *
    * @dataProvider benchmarkTime
    */

--- a/tests/phpunit/Performance/PreviewTest.php
+++ b/tests/phpunit/Performance/PreviewTest.php
@@ -6,6 +6,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm the performance of edit preview.
+ *
+ * @group functional
+ * @group all
  */
 class PreviewTest extends ExistingSiteBase {
 

--- a/tests/phpunit/Performance/ScalabilityCreateNodeTest.php
+++ b/tests/phpunit/Performance/ScalabilityCreateNodeTest.php
@@ -7,6 +7,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm amount of nodes by type.
+ *
+ * @group functional
+ * @group all
  */
 class ScalabilityCreateNodeTest extends ExistingSiteBase {
 
@@ -16,7 +19,6 @@ class ScalabilityCreateNodeTest extends ExistingSiteBase {
    * A test method to determine the amount of time it takes to create a node.
    *
    * @group performance
-   * @group all
    */
   public function testScalabilityCreateNodeTest() {
     $count = $this->runPerformanceTest();

--- a/tests/phpunit/Security/AdminDashboardTest.php
+++ b/tests/phpunit/Security/AdminDashboardTest.php
@@ -6,14 +6,15 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm admin dashboard security.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class AdminDashboardTest extends ExistingSiteBase {
 
   /**
    * A test method to check permissions to access the admin dashboard.
-   *
-   * @group security
-   * @group all
    *
    * @dataProvider getRoles
    */

--- a/tests/phpunit/Security/CreateNodeTest.php
+++ b/tests/phpunit/Security/CreateNodeTest.php
@@ -6,14 +6,15 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm node creation permissions.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class CreateNodeTest extends ExistingSiteBase {
 
   /**
    * A test method to deterine the amount of time it takes to create a node.
-   *
-   * @group security
-   * @group all
    *
    * @dataProvider getRoles
    */

--- a/tests/phpunit/Security/GraphQLTest.php
+++ b/tests/phpunit/Security/GraphQLTest.php
@@ -6,14 +6,15 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to check access to graphql data.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class GraphQLTest extends ExistingSiteBase {
 
   /**
    * A test method to check access to GraphQL service.
-   *
-   * @group security
-   * @group all
    */
   public function testGraphqlAccess() {
     $router = $this->container->get('router');

--- a/tests/phpunit/Security/NodeEditTabsTest.php
+++ b/tests/phpunit/Security/NodeEditTabsTest.php
@@ -6,14 +6,15 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm access to node edit form tabs.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class NodeEditTabsTest extends ExistingSiteBase {
 
   /**
    * A test method to determine whether users can access node edit form tabs.
-   *
-   * @group edit
-   * @group all
    */
   public function testAccessNodeEditTab() {
     // Creates a user. Will be automatically cleaned up at the end of the test.

--- a/tests/phpunit/Security/RoleCheckTest.php
+++ b/tests/phpunit/Security/RoleCheckTest.php
@@ -7,14 +7,15 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm role names.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class RoleCheckTest extends ExistingSiteBase {
 
   /**
    * A test method to deterine if the role exists.
-   *
-   * @group security
-   * @group all
    */
   public function testRole() {
 

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -7,14 +7,15 @@ use Drupal\user\Entity\Role;
 
 /**
  * A test to confirm that roles are associated with the correct permissions.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class RolesPermissionsTest extends ExistingSiteBase {
 
   /**
    * Determine if each role has the expected permissions.
-   *
-   * @group security
-   * @group all
    *
    * @dataProvider expectedPerms
    */

--- a/tests/phpunit/Security/SectionAccessTest.php
+++ b/tests/phpunit/Security/SectionAccessTest.php
@@ -8,14 +8,15 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm section access permissions.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class SectionAccessTest extends ExistingSiteBase {
 
   /**
    * Test method to confirm section access permissions.
-   *
-   * @group edit
-   * @group all
    *
    * @dataProvider sectionDataProvider
    */

--- a/tests/phpunit/Security/WorkflowTest.php
+++ b/tests/phpunit/Security/WorkflowTest.php
@@ -6,14 +6,15 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * A test to confirm access to workflow moderation.
+ *
+ * @group functional
+ * @group security
+ * @group all
  */
 class WorkflowTest extends ExistingSiteBase {
 
   /**
    * A test method to determine whether users can access workflow moderation.
-   *
-   * @group edit
-   * @group all
    */
   public function testAccessWorkflow() {
 

--- a/tests/phpunit/Service/EditorialWorkflowContentRepositoryServiceTest.php
+++ b/tests/phpunit/Service/EditorialWorkflowContentRepositoryServiceTest.php
@@ -7,6 +7,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Test the EditorialWorkflowContentRepository service.
+ *
+ * @group functional
+ * @group all
  */
 class EditorialWorkflowContentRepositoryServiceTest extends ExistingSiteBase {
 
@@ -27,9 +30,6 @@ class EditorialWorkflowContentRepositoryServiceTest extends ExistingSiteBase {
 
   /**
    * Verify getLatestArchivedRevisionId method.
-   *
-   * @group functional
-   * @group all
    */
   public function testGetLatestArchivedRevisionId() {
     $author = $this->createUser();
@@ -47,9 +47,6 @@ class EditorialWorkflowContentRepositoryServiceTest extends ExistingSiteBase {
 
   /**
    * Verify getLatestPublishedRevisionId method.
-   *
-   * @group functional
-   * @group all
    */
   public function testGetLatestPublishedRevisionId() {
     $author = $this->createUser();

--- a/tests/phpunit/Service/ExclusionTypesServiceTest.php
+++ b/tests/phpunit/Service/ExclusionTypesServiceTest.php
@@ -8,6 +8,9 @@ use Drupal\va_gov_backend\Service\ExclusionTypes;
 
 /**
  * Test the ExclusionTypes service.
+ *
+ * @group functional
+ * @group all
  */
 class ExclusionTypesServiceTest extends UnitTestCase {
 
@@ -32,7 +35,12 @@ class ExclusionTypesServiceTest extends UnitTestCase {
     parent::setUp();
 
     $this->configFactory = $this->getConfigFactoryStub([
-      'exclusion_types_admin.settings' => ['types_to_exclude' => ['page' => 'page', 'office' => 'office']],
+      'exclusion_types_admin.settings' => [
+        'types_to_exclude' => [
+          'page' => 'page',
+          'office' => 'office',
+        ],
+      ],
     ]);
     $this->exclusionTypes = new ExclusionTypes($this->configFactory);
 
@@ -46,9 +54,6 @@ class ExclusionTypesServiceTest extends UnitTestCase {
 
   /**
    * Verify getExcludedTypes method.
-   *
-   * @group functional
-   * @group all
    */
   public function testGetExcludedTypes() {
     $this->assertEquals(['page' => 'page', 'office' => 'office'], $this->exclusionTypes->getExcludedTypes());
@@ -56,9 +61,6 @@ class ExclusionTypesServiceTest extends UnitTestCase {
 
   /**
    * Verify getJson method.
-   *
-   * @group functional
-   * @group all
    */
   public function testGetJson() {
     $this->assertEquals('{"page":"page","office":"office"}', $this->exclusionTypes->getJson());
@@ -66,9 +68,6 @@ class ExclusionTypesServiceTest extends UnitTestCase {
 
   /**
    * Verify typeIsExcluded method.
-   *
-   * @group functional
-   * @group all
    */
   public function testTypeIsExcluded() {
     $this->assertTrue($this->exclusionTypes->typeIsExcluded('page'));

--- a/tests/phpunit/Service/ModerationActionsServiceTest.php
+++ b/tests/phpunit/Service/ModerationActionsServiceTest.php
@@ -7,6 +7,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Test the ModerationActions service.
+ *
+ * @group functional
+ * @group all
  */
 class ModerationActionsServiceTest extends ExistingSiteBase {
 
@@ -27,9 +30,6 @@ class ModerationActionsServiceTest extends ExistingSiteBase {
 
   /**
    * Verify archiveNode method.
-   *
-   * @group functional
-   * @group all
    */
   public function testArchiveNode() {
     $author = $this->createUser();
@@ -51,9 +51,6 @@ class ModerationActionsServiceTest extends ExistingSiteBase {
 
   /**
    * Verify publishLatestRevision method.
-   *
-   * @group functional
-   * @group all
    */
   public function testPublishLatestRevision() {
     $author = $this->createUser();

--- a/tests/phpunit/Service/VaGovUrlServiceTest.php
+++ b/tests/phpunit/Service/VaGovUrlServiceTest.php
@@ -14,6 +14,9 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
  * Test the VaGovUrl Service.
+ *
+ * @group functional
+ * @group all
  */
 class VaGovUrlServiceTest extends ExistingSiteBase {
 
@@ -65,9 +68,6 @@ class VaGovUrlServiceTest extends ExistingSiteBase {
 
   /**
    * Verify getVaGovFrontEndUrl method.
-   *
-   * @group functional
-   * @group all
    */
   public function testGetVaGovFrontEndUrl() {
     $this->mockClient();
@@ -77,9 +77,6 @@ class VaGovUrlServiceTest extends ExistingSiteBase {
 
   /**
    * Verify that the prod URL may be over-ridden with settings.
-   *
-   * @group functional
-   * @group all
    */
   public function testOverrideVaGovFrontEndUrl() {
     $this->mockClient();
@@ -92,9 +89,6 @@ class VaGovUrlServiceTest extends ExistingSiteBase {
 
   /**
    * Verify getVaGovFrontEndUrlForEntity method.
-   *
-   * @group functional
-   * @group all
    */
   public function testGetVaGovFrontEndUrlForEntity() {
     $this->mockClient();
@@ -115,9 +109,6 @@ class VaGovUrlServiceTest extends ExistingSiteBase {
 
   /**
    * Verify getVaGovFrontEndUrlForEntityIsLive method.
-   *
-   * @group functional
-   * @group all
    */
   public function testVaGovFrontEndUrlForEntityIsLive() {
     $this->mockClient(new Response('200'), new Response('404'));


### PR DESCRIPTION
## Description

Relates to #10053.

This PR does the following:
- ensures every PHPUnit class has certain group annotations, e.g. either `functional` or `unit` as appropriate, and `all`.
- prevents the Tugboat `va/tests/phpunit` action from executing `unit` tests
- adds a new GitHub Action to execute `unit` tests

## Notes

This has implications for documentation, but I believe it is actually very difficult to update `testing.md` to reflect this change without completely restructuring and rewriting that file.  I've opened a separate issue (#10558) to encompass that work.

## QA steps

If both existing (in-Tugboat) and new (GHA) tests pass, this should be good to go.

## Followup

- [ ] After merging, this needs to be added to branch protection rules.
