### PR TITLE
VACMS-10570: Protect `content-build-gql` against concurrent content builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -631,9 +631,11 @@
         ],
         "va:test:content-build-gql": [
             "@va:web:prepare-dotenv",
+            "touch .buildlock",
             "mkdir -p web/build/vagovdev",
             "echo {} > web/build/vagovdev/metalsmith-build-data.json",
-            "cd web; INSTALL_HOOKS=no NODE_ENV=production yarn build --pull-drupal --gql-queries-only --nosymlink --no-drupal-proxy --api=https://dev-api.va.gov --buildtype=vagovdev"
+            "cd web; INSTALL_HOOKS=no NODE_ENV=production yarn build --pull-drupal --gql-queries-only --nosymlink --no-drupal-proxy --api=https://dev-api.va.gov --buildtype=vagovdev",
+            "rm .buildlock"
         ],
         "va:web:prepare-dotenv": [
             "if [ -f web/.env.example ]; then cat web/.env.example | grep -v DRUPAL_ADDRESS > web/.env; fi",


### PR DESCRIPTION
## Description

Closes #10570.

`content-build-gql` doesn't create a `.buildlock` file, so it's at risk of being trampled by concurrent content build processes for its environment.  This PR creates and removes the lock file.

## Testing done

I'll rebuild this a few times to ensure all the tests pass and this doesn't mess up any other processes or tests.

## QA steps

If all tests pass reliably, this should be safe to merge.