### PR TITLE
VACMS-9649: Reset location values on toggle of event location type.

### DIFF
--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -15,8 +15,65 @@
   const fieldLinkWrapperLabel = document.querySelector(
     "#edit-field-link-wrapper label"
   );
+  const fieldLocationTypeFacility = document.getElementById(
+    "edit-field-location-type-facility"
+  );
+  const fieldLocationTypeNonFacility = document.getElementById(
+    "edit-field-location-type-non-facility"
+  );
   const includeLocationItemsRadios = document.getElementById(
     "edit-field-location-type"
+  );
+  const fieldLocationHumanreadable = document.getElementById(
+    "edit-field-location-humanreadable-0-value"
+  );
+  const fieldLocationHumanreadableWrapper = document.getElementById(
+    "edit-field-location-humanreadable-wrapper"
+  );
+  const targetLocationElements = document.querySelectorAll(
+    "#edit-field-facility-location-wrapper, #edit-field-url-of-an-online-event-wrapper, #edit-field-location-humanreadable-wrapper, #edit-field-address-wrapper"
+  );
+  const fieldFacilityLocationWrapper = document.getElementById(
+    "edit-field-facility-location-wrapper"
+  );
+  const fieldFacilityLocation = document.getElementById(
+    "edit-field-facility-location-0-target-id"
+  );
+  const fieldLocationTypeOnline = document.getElementById(
+    "edit-field-location-type-online"
+  );
+  const fieldAddressWrapper = document.getElementById(
+    "edit-field-address-wrapper"
+  );
+  const fieldUrlOfOnlineEvent = document.getElementById(
+    "edit-field-url-of-an-online-event-0-uri"
+  );
+  const fieldUrlOfOnlineEventWrapper = document.getElementById(
+    "edit-field-url-of-an-online-event-wrapper"
+  );
+  const fieldAddressLine1 = document.getElementById(
+    "edit-field-address-0-address-address-line1"
+  );
+  const fieldAddressLin1Label = document.querySelector(
+    "label[for='edit-field-address-0-address-address-line1']"
+  );
+  const fieldAddressLine2 = document.getElementById(
+    "edit-field-address-0-address-address-line2"
+  );
+  const fieldAddressLocality = document.getElementById(
+    "edit-field-address-0-address-locality"
+  );
+  const fieldAddressLocalityLabel = document.querySelector(
+    "label[for='edit-field-address-0-address-locality']"
+  );
+  const fieldAddressAdminArea = document.getElementById(
+    "edit-field-address-0-address-administrative-area"
+  );
+  const fieldAddressAdminAreaLabel = document.querySelector(
+    "label[for='edit-field-address-0-address-administrative-area']"
+  );
+  const targetRegistrationElements = document.querySelectorAll(
+    ".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper"
   );
 
   const toggleCtaLinkRequired = (required = true) => {
@@ -30,9 +87,6 @@
   };
 
   const toggleRegistrationElements = () => {
-    const targetRegistrationElements = document.querySelectorAll(
-      ".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper"
-    );
     const toggleVal = !!includeRegistrationsBool.checked;
     let elementDisplayStyle = "block";
     if (!toggleVal) {
@@ -69,90 +123,57 @@
 
   const toggleAddressRequiredFields = (enableDisable, addRemove) => {
     // Address field.
-    if (document.getElementById("edit-field-address-0-address-address-line1")) {
-      document.getElementById(
-        "edit-field-address-0-address-address-line1"
-      ).required = enableDisable;
+    if (fieldAddressLine1) {
+      fieldAddressLine1.required = enableDisable;
     }
-    if (
-      document.querySelector(
-        "label[for='edit-field-address-0-address-address-line1']"
-      )
-    ) {
-      document
-        .querySelector(
-          "label[for='edit-field-address-0-address-address-line1']"
-        )
-        .classList[addRemove]("form-required");
+    if (fieldAddressLin1Label) {
+      fieldAddressLin1Label.classList[addRemove]("form-required");
     }
     // City field.
-    if (document.getElementById("edit-field-address-0-address-locality")) {
-      document.getElementById(
-        "edit-field-address-0-address-locality"
-      ).required = enableDisable;
+    if (fieldAddressLocality) {
+      fieldAddressLocality.required = enableDisable;
     }
-    if (
-      document.querySelector(
-        "label[for='edit-field-address-0-address-locality']"
-      )
-    ) {
-      document
-        .querySelector("label[for='edit-field-address-0-address-locality']")
-        .classList[addRemove]("form-required");
+    if (fieldAddressLocalityLabel) {
+      fieldAddressLocalityLabel.classList[addRemove]("form-required");
     }
     // State field.
-    if (
-      document.getElementById(
-        "edit-field-address-0-address-administrative-area"
-      )
-    ) {
-      document.getElementById(
-        "edit-field-address-0-address-administrative-area"
-      ).required = enableDisable;
+    if (fieldAddressAdminArea) {
+      fieldAddressAdminArea.required = enableDisable;
     }
-    if (
-      document.querySelector(
-        "label[for='edit-field-address-0-address-administrative-area']"
-      )
-    ) {
-      document
-        .querySelector(
-          "label[for='edit-field-address-0-address-administrative-area']"
-        )
-        .classList[addRemove]("form-required");
+    if (fieldAddressAdminAreaLabel) {
+      fieldAddressAdminAreaLabel.classList[addRemove]("form-required");
     }
   };
 
   const toggleLocationElements = () => {
-    const targetLocationElements = document.querySelectorAll(
-      "#edit-field-facility-location-wrapper, #edit-field-url-of-an-online-event-wrapper, #edit-field-location-humanreadable-wrapper, #edit-field-address-wrapper"
-    );
     targetLocationElements.forEach((element) => {
       element.style.display = "none";
     });
     toggleAddressRequiredFields(false, "remove");
-    if (document.getElementById("edit-field-location-type-facility").checked) {
-      document.getElementById(
-        "edit-field-facility-location-wrapper"
-      ).style.display = "block";
-      document.getElementById(
-        "edit-field-location-humanreadable-wrapper"
-      ).style.display = "block";
+    if (fieldLocationTypeFacility.checked) {
+      fieldFacilityLocationWrapper.style.display = "block";
+      fieldLocationHumanreadableWrapper.style.display = "block";
+      fieldUrlOfOnlineEvent.value = "";
+      fieldAddressLine1.value = "";
+      fieldAddressLine2.value = "";
+      fieldAddressLocality.value = "";
+      fieldAddressAdminArea.value = "";
     }
-    if (
-      document.getElementById("edit-field-location-type-non-facility").checked
-    ) {
-      document.getElementById(
-        "edit-field-location-humanreadable-wrapper"
-      ).style.display = "block";
-      document.getElementById("edit-field-address-wrapper").style.display =
-        "block";
+    if (fieldLocationTypeNonFacility.checked) {
+      fieldLocationHumanreadableWrapper.style.display = "block";
+      fieldAddressWrapper.style.display = "block";
       toggleAddressRequiredFields(true, "add");
+      fieldUrlOfOnlineEvent.value = "";
+      fieldFacilityLocation.value = "";
     }
-    if (document.getElementById("edit-field-location-type-online").checked) {
-      document.getElementById(
-        "edit-field-url-of-an-online-event-wrapper"
-      ).style.display = "block";
+    if (fieldLocationTypeOnline.checked) {
+      fieldUrlOfOnlineEventWrapper.style.display = "block";
+      fieldAddressLine1.value = "";
+      fieldAddressLine2.value = "";
+      fieldAddressLocality.value = "";
+      fieldAddressAdminArea.value = "";
+      fieldFacilityLocation.value = "";
+      fieldLocationHumanreadable.value = "";
     }
   };
 

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -54,7 +54,7 @@
   const fieldAddressLine1 = document.getElementById(
     "edit-field-address-0-address-address-line1"
   );
-  const fieldAddressLin1Label = document.querySelector(
+  const fieldAddressLine1Label = document.querySelector(
     "label[for='edit-field-address-0-address-address-line1']"
   );
   const fieldAddressLine2 = document.getElementById(
@@ -126,8 +126,8 @@
     if (fieldAddressLine1) {
       fieldAddressLine1.required = enableDisable;
     }
-    if (fieldAddressLin1Label) {
-      fieldAddressLin1Label.classList[addRemove]("form-required");
+    if (fieldAddressLine1Label) {
+      fieldAddressLine1Label.classList[addRemove]("form-required");
     }
     // City field.
     if (fieldAddressLocality) {

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -12,7 +12,26 @@
   var fieldLinkWrapper = document.getElementById("edit-field-link-wrapper");
   var fieldLinkInput = document.getElementById("edit-field-link-0-uri");
   var fieldLinkWrapperLabel = document.querySelector("#edit-field-link-wrapper label");
+  var fieldLocationTypeFacility = document.getElementById("edit-field-location-type-facility");
+  var fieldLocationTypeNonFacility = document.getElementById("edit-field-location-type-non-facility");
   var includeLocationItemsRadios = document.getElementById("edit-field-location-type");
+  var fieldLocationHumanreadable = document.getElementById("edit-field-location-humanreadable-0-value");
+  var fieldLocationHumanreadableWrapper = document.getElementById("edit-field-location-humanreadable-wrapper");
+  var targetLocationElements = document.querySelectorAll("#edit-field-facility-location-wrapper, #edit-field-url-of-an-online-event-wrapper, #edit-field-location-humanreadable-wrapper, #edit-field-address-wrapper");
+  var fieldFacilityLocationWrapper = document.getElementById("edit-field-facility-location-wrapper");
+  var fieldFacilityLocation = document.getElementById("edit-field-facility-location-0-target-id");
+  var fieldLocationTypeOnline = document.getElementById("edit-field-location-type-online");
+  var fieldAddressWrapper = document.getElementById("edit-field-address-wrapper");
+  var fieldUrlOfOnlineEvent = document.getElementById("edit-field-url-of-an-online-event-0-uri");
+  var fieldUrlOfOnlineEventWrapper = document.getElementById("edit-field-url-of-an-online-event-wrapper");
+  var fieldAddressLine1 = document.getElementById("edit-field-address-0-address-address-line1");
+  var fieldAddressLin1Label = document.querySelector("label[for='edit-field-address-0-address-address-line1']");
+  var fieldAddressLine2 = document.getElementById("edit-field-address-0-address-address-line2");
+  var fieldAddressLocality = document.getElementById("edit-field-address-0-address-locality");
+  var fieldAddressLocalityLabel = document.querySelector("label[for='edit-field-address-0-address-locality']");
+  var fieldAddressAdminArea = document.getElementById("edit-field-address-0-address-administrative-area");
+  var fieldAddressAdminAreaLabel = document.querySelector("label[for='edit-field-address-0-address-administrative-area']");
+  var targetRegistrationElements = document.querySelectorAll(".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper");
 
   var toggleCtaLinkRequired = function toggleCtaLinkRequired() {
     var required = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
@@ -24,7 +43,6 @@
   };
 
   var toggleRegistrationElements = function toggleRegistrationElements() {
-    var targetRegistrationElements = document.querySelectorAll(".centralized.reduced-padding, #edit-field-event-registrationrequired-wrapper, #edit-field-event-cta-wrapper, #edit-group-registration-link, #group-registration-link, #edit-field-additional-information-abo-wrapper");
     var toggleVal = !!includeRegistrationsBool.checked;
     var elementDisplayStyle = "block";
     if (!toggleVal) {
@@ -57,45 +75,57 @@
   };
 
   var toggleAddressRequiredFields = function toggleAddressRequiredFields(enableDisable, addRemove) {
-    if (document.getElementById("edit-field-address-0-address-address-line1")) {
-      document.getElementById("edit-field-address-0-address-address-line1").required = enableDisable;
+    if (fieldAddressLine1) {
+      fieldAddressLine1.required = enableDisable;
     }
-    if (document.querySelector("label[for='edit-field-address-0-address-address-line1']")) {
-      document.querySelector("label[for='edit-field-address-0-address-address-line1']").classList[addRemove]("form-required");
-    }
-
-    if (document.getElementById("edit-field-address-0-address-locality")) {
-      document.getElementById("edit-field-address-0-address-locality").required = enableDisable;
-    }
-    if (document.querySelector("label[for='edit-field-address-0-address-locality']")) {
-      document.querySelector("label[for='edit-field-address-0-address-locality']").classList[addRemove]("form-required");
+    if (fieldAddressLin1Label) {
+      fieldAddressLin1Label.classList[addRemove]("form-required");
     }
 
-    if (document.getElementById("edit-field-address-0-address-administrative-area")) {
-      document.getElementById("edit-field-address-0-address-administrative-area").required = enableDisable;
+    if (fieldAddressLocality) {
+      fieldAddressLocality.required = enableDisable;
     }
-    if (document.querySelector("label[for='edit-field-address-0-address-administrative-area']")) {
-      document.querySelector("label[for='edit-field-address-0-address-administrative-area']").classList[addRemove]("form-required");
+    if (fieldAddressLocalityLabel) {
+      fieldAddressLocalityLabel.classList[addRemove]("form-required");
+    }
+
+    if (fieldAddressAdminArea) {
+      fieldAddressAdminArea.required = enableDisable;
+    }
+    if (fieldAddressAdminAreaLabel) {
+      fieldAddressAdminAreaLabel.classList[addRemove]("form-required");
     }
   };
 
   var toggleLocationElements = function toggleLocationElements() {
-    var targetLocationElements = document.querySelectorAll("#edit-field-facility-location-wrapper, #edit-field-url-of-an-online-event-wrapper, #edit-field-location-humanreadable-wrapper, #edit-field-address-wrapper");
     targetLocationElements.forEach(function (element) {
       element.style.display = "none";
     });
     toggleAddressRequiredFields(false, "remove");
-    if (document.getElementById("edit-field-location-type-facility").checked) {
-      document.getElementById("edit-field-facility-location-wrapper").style.display = "block";
-      document.getElementById("edit-field-location-humanreadable-wrapper").style.display = "block";
+    if (fieldLocationTypeFacility.checked) {
+      fieldFacilityLocationWrapper.style.display = "block";
+      fieldLocationHumanreadableWrapper.style.display = "block";
+      fieldUrlOfOnlineEvent.value = "";
+      fieldAddressLine1.value = "";
+      fieldAddressLine2.value = "";
+      fieldAddressLocality.value = "";
+      fieldAddressAdminArea.value = "";
     }
-    if (document.getElementById("edit-field-location-type-non-facility").checked) {
-      document.getElementById("edit-field-location-humanreadable-wrapper").style.display = "block";
-      document.getElementById("edit-field-address-wrapper").style.display = "block";
+    if (fieldLocationTypeNonFacility.checked) {
+      fieldLocationHumanreadableWrapper.style.display = "block";
+      fieldAddressWrapper.style.display = "block";
       toggleAddressRequiredFields(true, "add");
+      fieldUrlOfOnlineEvent.value = "";
+      fieldFacilityLocation.value = "";
     }
-    if (document.getElementById("edit-field-location-type-online").checked) {
-      document.getElementById("edit-field-url-of-an-online-event-wrapper").style.display = "block";
+    if (fieldLocationTypeOnline.checked) {
+      fieldUrlOfOnlineEventWrapper.style.display = "block";
+      fieldAddressLine1.value = "";
+      fieldAddressLine2.value = "";
+      fieldAddressLocality.value = "";
+      fieldAddressAdminArea.value = "";
+      fieldFacilityLocation.value = "";
+      fieldLocationHumanreadable.value = "";
     }
   };
 

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -25,7 +25,7 @@
   var fieldUrlOfOnlineEvent = document.getElementById("edit-field-url-of-an-online-event-0-uri");
   var fieldUrlOfOnlineEventWrapper = document.getElementById("edit-field-url-of-an-online-event-wrapper");
   var fieldAddressLine1 = document.getElementById("edit-field-address-0-address-address-line1");
-  var fieldAddressLin1Label = document.querySelector("label[for='edit-field-address-0-address-address-line1']");
+  var fieldAddressLine1Label = document.querySelector("label[for='edit-field-address-0-address-address-line1']");
   var fieldAddressLine2 = document.getElementById("edit-field-address-0-address-address-line2");
   var fieldAddressLocality = document.getElementById("edit-field-address-0-address-locality");
   var fieldAddressLocalityLabel = document.querySelector("label[for='edit-field-address-0-address-locality']");
@@ -78,8 +78,8 @@
     if (fieldAddressLine1) {
       fieldAddressLine1.required = enableDisable;
     }
-    if (fieldAddressLin1Label) {
-      fieldAddressLin1Label.classList[addRemove]("form-required");
+    if (fieldAddressLine1Label) {
+      fieldAddressLine1Label.classList[addRemove]("form-required");
     }
 
     if (fieldAddressLocality) {


### PR DESCRIPTION
## Description

Resolves https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9649

## QA steps
Go to /node/add/event
Set the location type to "At a VA facility"
Fill in the facility location
Fill in the building number

<img width="930" alt="Screen Shot 2022-09-01 at 9 21 28 AM" src="https://user-images.githubusercontent.com/221539/187964606-8efb1693-7b18-44d9-9a90-f3355fbd2477.png">

Without saving, switch the location type to "At a non-VA location"
<img width="883" alt="Screen Shot 2022-09-01 at 9 21 49 AM" src="https://user-images.githubusercontent.com/221539/187965222-ef1cea43-5f09-44f1-a06e-d9d4c0fd242d.png">
- [x] Verify the building, floor, or room field is left unchanged
- [x] Verify the address fields are all empty

Switch back to "At a VA facility" location type.
<img width="891" alt="Screen Shot 2022-09-01 at 9 21 59 AM" src="https://user-images.githubusercontent.com/221539/187965361-0135bb6e-2326-4dfb-80e9-dcebaf1b59d9.png">
- [x] Verify the building, floor, or room field is left unchanged
- [x] Verify the facility location value is empty

Switch the location type to "Online"
Fill in the URL
<img width="863" alt="Screen Shot 2022-09-01 at 9 22 59 AM" src="https://user-images.githubusercontent.com/221539/187965627-287a5111-2d19-49e6-8ffb-3e7c48931adb.png">

Switch back to the "At a non-VA location" location type
<img width="859" alt="Screen Shot 2022-09-01 at 9 23 17 AM" src="https://user-images.githubusercontent.com/221539/187965823-602205ff-f020-4947-9111-d7fa27f270a0.png">
- [x] Verify all field values are empty

Switch back to the "At a VA facility" location type
<img width="863" alt="Screen Shot 2022-09-01 at 9 23 24 AM" src="https://user-images.githubusercontent.com/221539/187966044-cbc81db2-b333-43c0-8f36-a84f4ec378b9.png">
- [x] Verify all field values are empty

Switch back to the "Online" location type
<img width="887" alt="Screen Shot 2022-09-01 at 9 23 31 AM" src="https://user-images.githubusercontent.com/221539/187966176-b8e9e6d8-da7d-4252-81a2-0a8a8ced7b00.png">
- [x] Verify url field is empty



### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`

