### PR TITLE
VACMS-9905: Increase time limits on other performance tests.

### DIFF
--- a/tests/phpunit/Performance/CreateNodeTest.php
+++ b/tests/phpunit/Performance/CreateNodeTest.php
@@ -53,7 +53,7 @@ class CreateNodeTest extends ExistingSiteBase {
    *   Array containing entity type as string and expected count as int
    */
   public function benchmarkTime() {
-    return [[5]];
+    return [[8]];
   }
 
 }

--- a/tests/phpunit/Performance/CreateTaxonomyTermTest.php
+++ b/tests/phpunit/Performance/CreateTaxonomyTermTest.php
@@ -50,7 +50,7 @@ class CreateTaxonomyTermTest extends ExistingSiteBase {
    *   Array containing entity type as string and expected count as int
    */
   public function benchmarkTime() {
-    return [[2]];
+    return [[4]];
   }
 
 }

--- a/tests/phpunit/Performance/EditNodeTest.php
+++ b/tests/phpunit/Performance/EditNodeTest.php
@@ -57,8 +57,8 @@ class EditNodeTest extends ExistingSiteBase {
    */
   public function benchmarkTime() {
     return [
-      ["page", 5],
-      ["landing_page", 5],
+      ["page", 8],
+      ["landing_page", 8],
     ];
   }
 

--- a/tests/phpunit/Performance/LoginTest.php
+++ b/tests/phpunit/Performance/LoginTest.php
@@ -62,7 +62,7 @@ class LoginTest extends ExistingSiteBase {
    */
   public function benchmarkTime() {
     return [
-      [3],
+      [6],
     ];
   }
 

--- a/tests/phpunit/Performance/PreviewTest.php
+++ b/tests/phpunit/Performance/PreviewTest.php
@@ -110,7 +110,7 @@ class PreviewTest extends ExistingSiteBase {
    */
   public function benchmarkTime() {
     return [
-      [5],
+      [8],
     ];
   }
 


### PR DESCRIPTION
## Description

See #9905 and #10522, a previous PR with similar intent.  This is a similar change to increase some other time limits, since I'm seeing some similar failures there too.

![Screen Shot 2022-09-01 at 9 11 57 AM](https://user-images.githubusercontent.com/1318579/187922315-318d086c-22ed-439f-a085-2c4573bdc25a.png)

This should all ultimately be remedied soon in #9905.

## QA Steps

Provided all tests pass, this should be safe to merge.