### PR TITLE
VACMS-8084: Move `revision_log` field check into GitHub Actions.

### DIFF
--- a/.github/workflows/check-revision-log-fields.yml
+++ b/.github/workflows/check-revision-log-fields.yml
@@ -1,0 +1,11 @@
+name: Check Revision Log Fields
+on: [pull_request]
+jobs:
+  check-revision-logs:
+    name: runner / check-revision-log-fields
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Revision Log fields
+        run: |
+          ./tests/scripts/check-revision-logs.sh

--- a/tests.yml
+++ b/tests.yml
@@ -137,31 +137,6 @@ tasks:
           fi
         EOF
 
-  va/tests/revision-log:
-    desc: Ensure revision log field is present
-    cmds:
-      - |
-        cat <<EOF | bash
-          : "${SKIP_REPORTING:=0}"
-          : "${RETURN_EXIT_CODE:=0}"
-          set -o pipefail
-          output="\$(mktemp -d)/output"
-          mkfifo \$output
-          (cat \$output&)
-          result="\$(./tests/scripts/check-revision-logs.sh 2>&1 | tee \$output)"
-          exit_code=\$?
-          if [ "$SKIP_REPORTING" -ne 1 ]; then
-            if [ "\$exit_code" -eq 0 ]; then
-              github-status-updater -action=update_state -state=success -context='{{ .TASK }}' -description='Success'
-            else
-              github-status-updater -action=update_state -state=failure -context='{{ .TASK }}' -description='Failed'
-            fi
-          fi
-          if [ "$RETURN_EXIT_CODE" -ne 0 ]; then
-            exit "\$exit_code";
-          fi
-        EOF
-
   va/tests/status-error:
     desc: Check for Drupal status errors
     cmds:
@@ -257,12 +232,6 @@ tasks:
       - task: set-check-status
         vars:
           STATUS: pending
-          CONTEXT: va/tests/revision-log
-          DESCRIPTION: 'Revision Log'
-
-      - task: set-check-status
-        vars:
-          STATUS: pending
           CONTEXT: va/tests/status-error
           DESCRIPTION: 'Check for Drupal status errors'
 
@@ -285,6 +254,5 @@ tasks:
       - va/tests/check-cer
       - va/tests/phplint
       - va/tests/phpunit
-      - va/tests/revision-log
       - va/tests/status-error
       - va/tests/content-build-gql


### PR DESCRIPTION
## Description

Closes #8084.

## QA steps

If all tests pass, this should be good to go.

## Notes

![You_Shall_Not_Pass!_0-1_screenshot](https://user-images.githubusercontent.com/1318579/188155087-ef78a7e0-bfc5-43ef-aa9e-fd71ed3a3792.jpg)
This will not currently pass all checks because, well, one of them is removed in this PR.

- [ ] After merge, this needs to be added to the list of required status checks on PRs.
- [ ] Prior to merge, the Tugboat-based check needs to be removed from the list of required status checks on PRs.