### PR TITLE
VACMS-10408: Update staged_content entityqueue allowed content types.

### DIFF
--- a/config/sync/entityqueue.entity_queue.staged_content.yml
+++ b/config/sync/entityqueue.entity_queue.staged_content.yml
@@ -12,12 +12,14 @@ entity_settings:
   target_type: node
   handler: 'default:node'
   handler_settings:
-    target_bundles: null
+    target_bundles:
+      page: page
+      support_resources_detail_page: support_resources_detail_page
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: page
 queue_settings:
   min_size: 0
   max_size: 0


### PR DESCRIPTION
## Description

Closes  #10408

## QA steps
Validate the staged_content entityqueue only allows 'Benefits Detail Page', and 'Resources & Support Detail Page'
1. Login to https://cms-srjwv2ajtra1pntckggf0rv5xdwuavlq.ci.cms.va.gov/user/login as a content admin or administrator
2. Visit https://cms-srjwv2ajtra1pntckggf0rv5xdwuavlq.ci.cms.va.gov/admin/structure/entityqueue/staged_content/staged_content?destination=/admin/structure/entityqueue
3. Then
   - [x] Validate that `Resources & Support Detail Page` and `Benefits Detail Page` are the only types of nodes allowed.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`