### PR TITLE
VACMS-6984: Removes Drupal Console.

### DIFF
--- a/READMES/drupal-memcache.md
+++ b/READMES/drupal-memcache.md
@@ -145,7 +145,7 @@ END
 
 #### Flushing Data
 
-If Memcache holds corrupted data, or for some other reason should be cleared manually (e.g. if Drush and Drupal Console do not work, or for debugging), the `flush_all` command can be used:
+If Memcache holds corrupted data, or for some other reason should be cleared manually (e.g. if Drush does not work, or for debugging), the `flush_all` command can be used:
 
 ```
 stats

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "drupal/console": "^1.9",
-        "drupal/console-extend-plugin": "^0.9.5",
         "drupal/devel": "^4.1",
         "drupal/html_tag_usage": "^1.0@beta",
         "drupal/media_entity_generic": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63717bd9ea3bfb4d61edee7474d62813",
+    "content-hash": "427cd5671f705734943389ab68943037",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -11845,7 +11845,7 @@
                     "datestamp": "1646693090",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "message": "RC releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -27601,6 +27601,7 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/advancedqueue": 5,
         "drupal/blazy": 5,
         "drupal/cer": 20,
         "drupal/components": 10,


### PR DESCRIPTION
## Description

Closes #6984 .

This should affect nothing.  We already don't use `drupal-console` anywhere because it no longer works 😭 