### PR TITLE
VACMS-10418: Wrap CMS build stage in a retry block 

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -31,13 +31,15 @@ pipeline {
           commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
         }
 
-        build job: "builds/${params.app}", parameters: [
-          booleanParam(name: 'release', value: false),
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'slack_channel', value: "${params.slack_channel}"),
-          stringParam(name: 'ref', value: commit),
-          booleanParam(name: 'force_rebuild', value: false)
-        ], wait: true
+        retry(3){
+          build job: "builds/${params.app}", parameters: [
+            booleanParam(name: 'release', value: false),
+            booleanParam(name: 'notify_slack', value: true),
+            stringParam(name: 'slack_channel', value: "${params.slack_channel}"),
+            stringParam(name: 'ref', value: commit),
+            booleanParam(name: 'force_rebuild', value: true)
+          ], wait: true
+        }
       }
     }
 


### PR DESCRIPTION
## Description

This change is meant to smooth out errors related to transient failures in build jobs. The retry blocks are set to 3 retries after which we probably know we have a real problem that requires intervention. Otherwise let Jenkins silently retry and the issue corrects itself through another attempt.

Relates to #10418. (or closes?)

## Testing done
Similar changes made to va.gov-cms-test repo and CMS-Test Jenkins Jobs.

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
