### PR TITLE
VACMS-10170: override breadcrumbs for lovell tricare to use correct system

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -165,6 +165,7 @@ module:
   pathologic: 0
   pfm: 0
   post_api: 0
+  preprocess_event_dispatcher: 0
   prometheus_exporter: 0
   rdf: 0
   redirect: 0

--- a/docroot/modules/custom/va_gov_lovell/src/Event/BreadcrumbPreprocessEvent.php
+++ b/docroot/modules/custom/va_gov_lovell/src/Event/BreadcrumbPreprocessEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\va_gov_lovell\Event;
+
+use Drupal\preprocess_event_dispatcher\Event\AbstractPreprocessEvent;
+
+/**
+ * Represents a breadcrumb preprocess event.
+ */
+class BreadcrumbPreprocessEvent extends AbstractPreprocessEvent {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHook(): string {
+    return 'breadcrumb';
+  }
+
+}

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -194,7 +194,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
   /**
    * Update breadcrumbs for Lovell content.
    *
-   * @param Drupal\va_gov_lovell\Variables\BreadcrumbEventVariables $variables
+   * @param \Drupal\va_gov_lovell\Variables\BreadcrumbEventVariables $variables
    *   BreadcrumbEventVariables.
    */
   protected function updateLovellBreadcrumbs(BreadcrumbEventVariables $variables): void {

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -5,15 +5,18 @@ namespace Drupal\va_gov_lovell\EventSubscriber;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
+use Drupal\va_gov_lovell\Event\BreadcrumbPreprocessEvent;
 use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\NodeInterface;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\pathauto\PathautoGenerator;
+use Drupal\va_gov_lovell\Variables\BreadcrumbEventVariables;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -37,6 +40,13 @@ class LovellEventSubscriber implements EventSubscriberInterface {
   private $entityTypeManager;
 
   /**
+   * The route match interface.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
    * The pathauto generator.
    *
    * @var \Drupal\pathauto\PathautoGenerator
@@ -56,6 +66,8 @@ class LovellEventSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
    *   The string entity type service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   Provides an interface for classes representing the result of routing.
    * @param \Drupal\pathauto\PathautoGenerator $pathautoGenerator
    *   The pathauto generator service.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
@@ -63,10 +75,12 @@ class LovellEventSubscriber implements EventSubscriberInterface {
    */
   public function __construct(
     EntityTypeManager $entityTypeManager,
+    RouteMatchInterface $route_match,
     PathautoGenerator $pathautoGenerator,
     MessengerInterface $messenger
   ) {
     $this->entityTypeManager = $entityTypeManager;
+    $this->routeMatch = $route_match;
     $this->pathautoGenerator = $pathautoGenerator;
     $this->messenger = $messenger;
   }
@@ -79,6 +93,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
       EntityHookEvents::ENTITY_PRE_SAVE => 'entityPresave',
       EntityHookEvents::ENTITY_INSERT => 'entityInsert',
       EntityHookEvents::ENTITY_UPDATE => 'entityUpdate',
+      BreadcrumbPreprocessEvent::name() => 'preprocessBreadcrumb',
     ];
   }
 
@@ -114,6 +129,17 @@ class LovellEventSubscriber implements EventSubscriberInterface {
   public function entityUpdate(EntityUpdateEvent $event): void {
     $entity = $event->getEntity();
     $this->updatePathAliases($entity);
+  }
+
+  /**
+   * Breadcrumb preprocess Event call.
+   *
+   * @param \Drupal\va_gov_lovell\Event\BreadcrumbPreprocessEvent $event
+   *   The event.
+   */
+  public function preprocessBreadcrumb(BreadcrumbPreprocessEvent $event): void {
+    $variables = $event->getVariables();
+    $this->updateLovellBreadcrumbs($variables);
   }
 
   /**
@@ -162,6 +188,37 @@ class LovellEventSubscriber implements EventSubscriberInterface {
           }
         }
       }
+    }
+  }
+
+  /**
+   * Update breadcrumbs for Lovell content.
+   *
+   * @param Drupal\va_gov_lovell\Variables\BreadcrumbEventVariables $variables
+   *   BreadcrumbEventVariables.
+   */
+  protected function updateLovellBreadcrumbs(BreadcrumbEventVariables $variables): void {
+    $breadcrumb = $variables->getBreadcrumb();
+    $node = $this->routeMatch->getParameter('node');
+    if (($node instanceof NodeInterface)
+    && ($node->hasField('path'))
+    && ($node->hasField('field_administration'))) {
+      // If this content does not belong to Lovell Tricare do nothing.
+      $section_id = $node->get('field_administration')->target_id;
+      if ($section_id !== '1039') {
+        return;
+      }
+
+      foreach ($breadcrumb as $key => $link) {
+        if (str_contains($link['url'], 'lovell-federal-va-health-care')) {
+          $breadcrumb[$key]['url'] = str_replace('lovell-federal-va-health-care', 'lovell-federal-tricare-health-care', $link['url']);
+          if (is_string($link['text'])) {
+            $breadcrumb[$key]['text'] = str_replace('Lovell Federal VA health care', 'Lovell Federal Tricare health care', $link['text']);
+          }
+        }
+      }
+
+      $variables->set('breadcrumb', $breadcrumb);
     }
   }
 

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -11,11 +11,11 @@ use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
-use Drupal\va_gov_lovell\Event\BreadcrumbPreprocessEvent;
 use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\NodeInterface;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\pathauto\PathautoGenerator;
+use Drupal\va_gov_lovell\Event\BreadcrumbPreprocessEvent;
 use Drupal\va_gov_lovell\Variables\BreadcrumbEventVariables;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 

--- a/docroot/modules/custom/va_gov_lovell/src/Factory/BreadcrumbPreprocessEventFactory.php
+++ b/docroot/modules/custom/va_gov_lovell/src/Factory/BreadcrumbPreprocessEventFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\va_gov_lovell\Factory;
+
+use Drupal\preprocess_event_dispatcher\Event\AbstractPreprocessEvent;
+use Drupal\preprocess_event_dispatcher\Factory\PreprocessEventFactoryInterface;
+use Drupal\va_gov_lovell\Event\BreadcrumbPreprocessEvent;
+use Drupal\va_gov_lovell\Variables\BreadcrumbEventVariables;
+
+/**
+ * Creates breadcrumb preprocess events and corresponding variables.
+ */
+class BreadcrumbPreprocessEventFactory implements PreprocessEventFactoryInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createEvent(array &$variables): AbstractPreprocessEvent {
+    return new BreadcrumbPreprocessEvent(
+      new BreadcrumbEventVariables($variables)
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEventHook(): string {
+    return BreadcrumbPreprocessEvent::getHook();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_lovell/src/Variables/BreadcrumbEventVariables.php
+++ b/docroot/modules/custom/va_gov_lovell/src/Variables/BreadcrumbEventVariables.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\va_gov_lovell\Variables;
+
+use Drupal\preprocess_event_dispatcher\Variables\AbstractEventVariables;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Wrapper class for breadcrumb preprocess event variables.
+ */
+class BreadcrumbEventVariables extends AbstractEventVariables {
+
+  /**
+   * Get the breadcrumb.
+   *
+   * @return array
+   *   The breadcrumb.
+   */
+  public function getBreadcrumb(): array {
+    return $this->variables['breadcrumb'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntity(): EntityInterface {
+    return $this->getBreadcrumb();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_lovell/va_gov_lovell.info.yml
+++ b/docroot/modules/custom/va_gov_lovell/va_gov_lovell.info.yml
@@ -5,4 +5,5 @@ core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - drupal:hook_event_dispatcher
+  - drupal:preprocess_event_dispatcher
   - drupal:menu_item_extras

--- a/docroot/modules/custom/va_gov_lovell/va_gov_lovell.services.yml
+++ b/docroot/modules/custom/va_gov_lovell/va_gov_lovell.services.yml
@@ -1,6 +1,10 @@
 services:
   va_gov_lovell.entity_event_subscriber:
     class: Drupal\va_gov_lovell\EventSubscriber\LovellEventSubscriber
-    arguments: ['@entity_type.manager', '@pathauto.generator', '@messenger']
+    arguments: ['@entity_type.manager', '@current_route_match', '@pathauto.generator', '@messenger']
     tags:
       - { name: event_subscriber }
+  va_gov_lovell.factory.breadcrumb:
+    class: Drupal\va_gov_lovell\Factory\BreadcrumbPreprocessEventFactory
+    tags:
+      -  { name: preprocess_event_factory }


### PR DESCRIPTION
## Description

Closes #10170 

## Testing done

Manual testing

## Screenshots

![Screen Shot 2022-09-07 at 4 45 27 PM](https://user-images.githubusercontent.com/21045418/188974634-b271f151-3434-4cef-b884-13426e19bde5.png)

![Screen Shot 2022-09-07 at 4 56 45 PM](https://user-images.githubusercontent.com/21045418/188977446-68da0f02-9243-4372-840a-ecf66d62a597.png)

## QA steps

In order to properly test this PR some manual setup is required. 

As an admin user
1. Edit the existing Lovell Federal health care (VAMC System) node: **/node/15007/edit**
   - [x] Change the VAMC system plain language name to Lovell Federal VA health care
   - [x] Change the section to Lovell - VA
   - [x] Change the menu link title to Lovell Federal VA health care
   - [x] Check the box to generate automatic URL alias
   - [x] The new URL for this system node should be: /lovell-federal-va-health-care
(Note: this is to match the future pattern for Lovell page URLs that are NOT Tricare. This is important because the code in this PR looks for the future pattern.)
2. Evaluate breadcrumbs for a Lovell Tricare facility: 
   - [x] Navigate to: **/lovell-federal-tricare-health-care/locations/uss-red-rover**
   - [x] Verify that the breadcrumbs read as follows: Home > Lovell Federal Tricare health care > SERVICES AND LOCATIONS > Locations > USS Red Rover
   - [x] Verify that the second link from the left does indeed send you to /lovell-federal-tricare-health-care
3. Evaluate breadcrumbs for a Lovell VA facility:
   - [x] Navigate to: **/lovell-federal-va-health-care/locations/kenosha-va-clinic**
   - [x] Verify that the breadcrumbs read as follows: Home > Lovell Federal VA health care > SERVICES AND LOCATIONS > Locations > Kenosha VA Clinic
   - [x] Verify that the second link from the left still sends you to /lovell-federal-va-health-care

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`