### PR TITLE
VACMS-10657 deprecate uninstall process

### DIFF
--- a/READMES/workflow.md
+++ b/READMES/workflow.md
@@ -159,26 +159,11 @@ flowchart TD
   A[Module removal] --> B{Is the module installed?}
   B -- Yes --> D[Needs a full uninstall.];
   B -- NO --> C[Create and merge PR that removes module from composer.];
-  D --> E[Create PR with hook_update_N in va_gov_db.install AND Drupal config removal. ];
+  D --> E[Create PR with Drupal config removal.];
   E --> F[Wait until PR makes it to CMS Prod.];
   F --> C;
   C --> Z[Process complete];
 ```
-In va_gov_db.install we use this pattern to uninstall a module.
-
-```php
-/**
- * Uninstall moduile name module.
- */
-function va_gov_db_update_9099(&$sandbox) {
-  $messages = _va_gov_db_uninstall_modules(['module_machine_name']);
-
-  return $messages;
-}
-```
-
-Since our deploy process runs update db before config import this allows for the
-module to be uninstalled and then config changes/removals flow as they should.
 
 
 [Table of Contents](../README.md)

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -24,6 +24,13 @@ use Psr\Log\LogLevel;
  * @return string
  *   A message about what requested modules were uninstalled.
  *
+ * @deprecated in va_gov_db:9.1.1 and is removed from va_gov_db:15.1.1 This is
+ *   no longer needed for simple module disables,  It is still appropriate when
+ *   order matters, if multiple uninstalls have a weighting problem. So may
+ *   never be fully removed.
+ *
+ * @see https://github.com/department-of-veterans-affairs/va.gov-cms/pull/10650#issuecomment-1240819457
+ *
  * @throws Drupal\Core\Utility\UpdateException
  */
 function _va_gov_db_uninstall_modules(array $modules, $uninstall_dependents = TRUE) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -176,6 +176,11 @@ parameters:
 			path: docroot/modules/custom/va_gov_db/va_gov_db.install
 
 		-
+			message: "#^Call to deprecated function _va_gov_db_uninstall_modules#"
+			count: 20
+			path: docroot/modules/custom/va_gov_db/va_gov_db.install
+
+		-
 			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\EntityInterface\\:\\:setChangedTime\\(\\)\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_db/va_gov_db.post_update.php


### PR DESCRIPTION
## Description

Closes #10657

## Testing done


## Screenshots


## QA steps

- [ ] validate that ide shows the function as depricated
![image](https://user-images.githubusercontent.com/5752113/189185183-749c1e7b-995f-4f36-b2b6-f1ddbd14ce9f.png)

- [ ] validate that readme looks good. https://github.com/department-of-veterans-affairs/va.gov-cms/blob/692dae2381f58a117159cb2fd5865c8484a6502f/READMES/workflow.md

![image](https://user-images.githubusercontent.com/5752113/189185542-f0ac63d3-9e0e-4e2f-8311-c4ebb53b5799.png)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
