### PR TITLE
VACMS-10324: Hide all-day checkbox in recurring events

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_recurring_events.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_recurring_events.scss
@@ -113,16 +113,6 @@
     margin: 0 5px 0 0;
   }
 
-  .allday-label {
-    clear: both;
-    /* display: block !important; // Don't allow display block override. */
-    float: none;
-    font-weight: 400;
-    left: -1000px;
-    margin: 10px 0 0;
-    position: absolute;
-  }
-
   .smartdate--time-inline {
     .form-datetime-wrapper {
       h4.form-item__label {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_recurring_events.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_recurring_events.scss
@@ -115,7 +115,7 @@
 
   .allday-label {
     clear: both;
-    display: block !important;
+    /* display: block !important; // Don't allow display block override. */
     float: none;
     font-weight: 400;
     left: -1000px;


### PR DESCRIPTION
## Description

~Closes va.gov-cms issue 10324.~  <- Has no magic
Closes #10324.   <-has magic properties

## Testing done
On existing event (https://va-gov-cms.ddev.site/node/48108/edit), using the Chrome browser inspect tool:
1. Extend the length of the "All Day" label to make it more visible and expose it.
2. See that the `.hidden` property being applied to `.allday-label` is overridden. 
3. Find the `display:block` override, deselected it to see if removing the override fixes the issue.
4. Test was successful

(See screenshots below.)

## Screenshots
![Screen Shot 2022-09-08 at 1 46 57 PM](https://user-images.githubusercontent.com/22764938/189243996-25c50f6e-626e-4734-87e4-64e704c0f524.png)

![Screen Shot 2022-09-08 at 1 47 02 PM](https://user-images.githubusercontent.com/22764938/189244011-5b700ad2-eeff-49aa-98f5-7ad3d33eae79.png)

![Screen Shot 2022-09-08 at 2 00 31 PM](https://user-images.githubusercontent.com/22764938/189244032-5766235a-b38c-4a94-af5d-7594a86bb51a.png)

![Screen Shot 2022-09-08 at 2 00 36 PM](https://user-images.githubusercontent.com/22764938/189244053-61aeb7bf-8b28-487a-8fce-408b12bbcc8b.png)

Notes: 

- This adds to work done in [PR #7981](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/7981)
- div sandwich:
![Screen Shot 2022-09-08 at 5 23 52 PM](https://user-images.githubusercontent.com/22764938/189247933-eca00ad0-b64f-4e7f-8dc4-802d4b2818ea.png)

## QA steps
On https://cms-o4w3pg1yv2dgakucmkw9flhpss6wydd3.ci.cms.va.gov/node/48108/edit, in Chrome inspect or similar tool:
1. Extend the length of the "All Day" label with at least 300 characters (cut and paste some lorem ipsum or the label over and over) to make it more visible and expose it.
2. See that the `.hidden` property being applied to `.allday-label` is *not* overridden. 
3. See that there is not a `display:block !important` `.allday-label` property.
4. See that you still can't see the All Day label or checkbox, despite its absurdly long length.
![Screen Shot 2022-09-08 at 5 31 26 PM](https://user-images.githubusercontent.com/22764938/189248647-bea20052-7c4f-4391-9cdf-1418485e44fc.png)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
