### PR TITLE
VACMS-10170 Enable preprocess_event_dispatcher

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -165,6 +165,7 @@ module:
   pathologic: 0
   pfm: 0
   post_api: 0
+  preprocess_event_dispatcher: 0
   prometheus_exporter: 0
   rdf: 0
   redirect: 0


### PR DESCRIPTION
## Description

Relates to #10170

This is simply to enable preprocess-event-dispatcher so that when we build integration that contains a reference to an abstract class, we don't have a chicken and egg problem like this
![image](https://user-images.githubusercontent.com/5752113/189339643-1b7ba956-ca36-4558-a0a4-c1eb7a9570ec.png)


## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As admin
- [ ] Go to the module page and validate the module is enabled.
- This module serves no testable use at this time so no further testing is needed.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
