### PR TITLE
VACMS-10542: Consider some additions to the Dependabot allowlist.

### DIFF
--- a/.github/workflows/config/config.yml
+++ b/.github/workflows/config/config.yml
@@ -1,3 +1,6 @@
 dependabot:
   allow-list:
+    - aws/aws-sdk-php
+    - composer/installers
+    - datadog/dd-trace
     - va-gov/content-build

--- a/.github/workflows/config/config.yml
+++ b/.github/workflows/config/config.yml
@@ -1,6 +1,5 @@
 dependabot:
   allow-list:
     - aws/aws-sdk-php
-    - composer/installers
     - datadog/dd-trace
     - va-gov/content-build


### PR DESCRIPTION
## Description

Closes #10542.

I included the AWS SDK and Datadog's `dd-trace`.

I considered some others, like `phpstan`, `php_codesniffer`, `composer/installers`, etc, but felt like these were getting into a gray area.  

What is safe to automerge?  As little as possible, but I feel like the case can be made for automerging updates from large commercial organizations with dedicated teams, etc. 

I think it's somewhat harder to make this case for community-maintained packages -- not so much because they're maintained by the community, but because there's a very thin line between "maintained by the community" and "maintained by one increasingly radicalized guy in `$state`."

This is more of a security/policy RfC than anything else.  Provided this passes tests, it's good to merge _in theory_, but I welcome discussion on the particulars.