### PR TITLE
VACMS-10652: Update inline alt text guidance string in CMS

### DIFF
--- a/docroot/modules/custom/va_gov_media/va_gov_media.module
+++ b/docroot/modules/custom/va_gov_media/va_gov_media.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
+use Drupal\image\Plugin\Field\FieldWidget\ImageWidget;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -71,4 +72,36 @@ function _va_gov_media_image_style_warmer_warm_up(EntityInterface $entity) {
       }
     }
   }
+}
+
+/**
+ * Implements hook_field_widget_form_alter().
+ */
+function va_gov_media_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // If this is an image field type of instance.
+  if ($context['widget'] instanceof ImageWidget) {
+    $element['#process'][] = 'va_gov_media_image_field_widget_process';
+  }
+}
+
+/**
+ * Changes the alt text description to be more helpful.
+ *
+ * @param array $element
+ *   The element to change the alt text description.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ * @param array $form
+ *   The form.
+ *
+ * @return array
+ *   The element.
+ */
+function va_gov_media_image_field_widget_process(array $element, FormStateInterface &$form_state, array $form) {
+  if (isset($element['alt'])) {
+    $element['alt']['#description'] = t('Alternative text is important for accessibility. Tips for writing alternative text: include a short, specific description of the image. Avoid words such as “image,” "picture," “photo,” or “graphic”. Do not use the file name of the image.');
+  }
+
+  // Return the altered element.
+  return $element;
 }

--- a/docroot/modules/custom/va_gov_media/va_gov_media.module
+++ b/docroot/modules/custom/va_gov_media/va_gov_media.module
@@ -99,7 +99,7 @@ function va_gov_media_field_widget_form_alter(&$element, FormStateInterface $for
  */
 function va_gov_media_image_field_widget_process(array $element, FormStateInterface &$form_state, array $form) {
   if (isset($element['alt'])) {
-    $element['alt']['#description'] = t('Alternative text is important for accessibility. Tips for writing alternative text: include a short, specific description of the image. Avoid words such as “image,” "picture," “photo,” or “graphic”. Do not use the file name of the image.');
+    $element['alt']['#description'] = t('Alternative text is important for accessibility. Tips for writing alternative text: include a short, specific description of the image. Avoid words such as "image," "picture," "photo," or "graphic". Do not use the file name of the image.');
   }
 
   // Return the altered element.


### PR DESCRIPTION
## Description

Closes #10652.

## Testing done
Tested locally on ddev.

## Screenshots
![CleanShot 2022-09-15 at 10 12 16](https://user-images.githubusercontent.com/109987005/190468219-7eea842b-33f3-46db-bfb4-0f2bc5c0a295.png)


## QA steps
Log in as any user who can create content. Add a Story. Click on Add media and add a new image. Drag any jpg into the drop are when the image details window opens you should see the new alt text guuidance. "Alternative text is important for accessibility. Tips for writing alternative text: include a short, specific description of the image. Avoid words such as “image,” "picture," “photo,” or “graphic”. Do not use the file name of the image." See screenshot. 

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`
