### PR TITLE
VACMS-10116: Radio Button labels on CMS Revision page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -373,6 +373,10 @@
             "drupal/decoupled_router": {
                 "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2021-05-05/3111456-34.patch"
             },
+            "drupal/diff": {
+                "3228798 - Make revisions overview page accessible": "https://www.drupal.org/files/issues/2022-01-21/diff-a11y-3228798-15.patch",
+                "2834253 - Missing column headings in Revisions list": "https://www.drupal.org/files/issues/2021-08-19/diff-missing-column-headers-2834253-15.patch"
+            },
             "drupal/entity_browser": {
                 "2856138 - Entity browser cardinality validation": "https://www.drupal.org/files/issues/0001-Issue-2856138-by-gordon-Error-messages-are-not-being.patch",
                 "3191302 - Make modal iframe tab accessible": "https://www.drupal.org/files/issues/2021-01-07/3191302-3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "864fa7119fc337e4e1c1a2e1ec886bf4",
+    "content-hash": "afea8fdcb7cde915f0f85aa7ad9e63f3",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",

--- a/docroot/themes/custom/vagovclaro/assets/scss/pages/_revisions.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/pages/_revisions.scss
@@ -1,0 +1,7 @@
+#revision-overview-form {
+  .diff-revisions {
+    caption {
+      font-size: 16px;
+    }
+  }
+}

--- a/docroot/themes/custom/vagovclaro/assets/scss/styles.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/styles.scss
@@ -30,3 +30,4 @@
 @import 'pages/node-view';
 @import 'pages/proofing';
 @import 'pages/vc-dashboard';
+@import 'pages/revisions';


### PR DESCRIPTION
## Description

Closes #10116.
Closes #10161.
Closes #10160.

## Testing done
Tested locally on ddev.

## Screenshots
![CleanShot 2022-09-16 at 09 04 02](https://user-images.githubusercontent.com/109987005/190682064-6b2ccd14-e4af-4b4b-9d63-1202bf4990f4.png)


## QA steps

Log in and go to any pice of content. Click on the revisions tab. It shoudl look like the screen shot above. 

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
