### PR TITLE
VACMS-10675: Tablefield patch with tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -472,7 +472,8 @@
                 "3100109 - 0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch",
                 "3163841 - Fix Undefined index: caption notice": "https://www.drupal.org/files/issues/2020-08-10/tablefield-empty-caption-notice-2.patch",
                 "3176982 - Tablefield input elements have no title or label": "https://www.drupal.org/files/issues/2020-10-14/tablefield-add_title_to_input_elements-3176982-2.patch",
-                "3195203 - Copying caption to value breaks some data exports 3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch"
+                "3195203 - Copying caption to value breaks some data exports 3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch",
+                "3128030 - Make tablefield heading orientation per entity": "https://www.drupal.org/files/issues/2022-09-22/8.x-2.3_tablefield-header-orientation-3128030-19.patch"
             },
             "drupal/textfield_counter": {
                 "3004457 - Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb012795a18fecfca6c43683cb4c8b57",
+    "content-hash": "d832c7ba5d8592c0f0db66538035d55b",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1889,28 +1889,33 @@ function _va_gov_backend_set_file_type(FieldableEntityInterface $entity) {
 function _va_gov_backend_apply_filter_to_tablefield_cells(FieldableEntityInterface $entity) {
   // We need to make sure this entity is fieldable before we start digging.
   $entity_type = $entity->getEntityTypeId();
-  $sanitized_items = [];
   $field_definitions = Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type, $entity->bundle());
 
   foreach ($field_definitions as $field) {
     if ($field->getType() === 'tablefield') {
       $field_name = $field->getName();
-      $raw_table = $entity->get($field_name)->value;
+      try {
+        $values = $entity->get($field_name)->first()->getValue();
+      } catch (\Drupal\Core\TypedData\Exception\MissingDataException $e) {
+        // No field data, return early.
+        return;
+      }
+      $raw_table = $values['value'] ?? [];
       $format = $entity->get($field_name)->format ?? 'plain_text';
       if (!empty($raw_table) && is_array($raw_table)) {
         foreach ($raw_table as $row_key => $row_item) {
           if (is_array($row_item)) {
             foreach ($row_item as $cell_key => $cell_item) {
               $clean_html = check_markup($cell_item, $format, '', ['autop']);
-              $sanitized_items['value'][$row_key][$cell_key] = (string) $clean_html;
+              $values['value'][$row_key][$cell_key] = (string) $clean_html;
             }
           }
         }
 
         // Tablefield caption does not support html.
-        $sanitized_items['caption'] = strip_tags(trim($entity->get($field_name)->caption));
-        $sanitized_items['format'] = $format;
-        $entity->$field_name->setValue($sanitized_items);
+        $values['caption'] = strip_tags(trim($entity->get($field_name)->caption));
+        $values['format'] = $format;
+        $entity->$field_name->setValue($values);
       }
     }
   }

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -28,7 +28,7 @@ use Psr\Log\LogLevel;
  *   no longer needed for simple module disables,  It is still appropriate when
  *   order matters, if multiple uninstalls have a weighting problem. So may
  *   never be fully removed.
- *
+ // phpcs:ignore
  * @see https://github.com/department-of-veterans-affairs/va.gov-cms/pull/10650#issuecomment-1240819457
  *
  * @throws Drupal\Core\Utility\UpdateException
@@ -1058,4 +1058,13 @@ function va_gov_db_update_9009() {
   }
 
   return 'Removed field_hours_for_copay_inquiries_ from billing.';
+}
+
+/**
+ * Clean up field_table field storage definitions.
+ */
+function va_gov_db_update_9010() {
+  $manager = \Drupal::entityDefinitionUpdateManager();
+  $field_storage_definition = $manager->getFieldStorageDefinition('field_table', 'paragraph');
+  $manager->updateFieldStorageDefinition($field_storage_definition);
 }


### PR DESCRIPTION
## Description

Closes #10675

This PR comprises 3 different code changes to achieve the desired result:
1) A tablefield patch that allows for per-entity defined header orientation for table rows/columns.
2) An update hook that takes care of field storage definition mismatch errors for the field_table field, which exist after applying the new tablefield patch. Note that the change to correct the field storage definitions was not included in the tablefield patch due to problem (a race condition?) that caused the an occasional error. Moving it to a separate update hook allows for consistent updates.
3) A bug fix to an existing va_gov_backend entity presave hook that was squashing the new field properties unexpectedly.

The tablefield patch contains new unit tests that cover the changes made to the module.

## QA steps

As a content admin
1. Create a [new Landing Page node.](https://pr10809-qcgktelaypjiwn0fprxwi3wkbe7eae9t.ci.cms.va.gov/node/add/basic_landing_page) Add a table paragraph to the content block field on the node.
   - [ ] Validate that new checkboxes exist for setting table header on either row or columns or both.

<img width="935" alt="Screen Shot 2022-09-22 at 10 08 22 AM" src="https://user-images.githubusercontent.com/221539/191809654-6e04b157-1efa-4d95-9abc-7b4982436483.png">

2. Save the node as published
   - [ ] Validate that there were no errors when saving
3. Visit /graphql/explorer
4. Using the below graphql query example
   - [ ] Create a graphql query using the node id of the node saved in step 2.
   - [ ] Validate the output contains new rowHeader and columnHeader field values, and that the values match the state of the table on the node.

<img width="1715" alt="Screen Shot 2022-09-22 at 10 14 05 AM" src="https://user-images.githubusercontent.com/221539/191810539-cbe09325-e1c9-4ea8-8ffd-9322b32ed060.png">

Sample graphql query:
```
fragment fieldContentBlock on ParagraphTable {
  fieldTable {
    rowHeader
    columnHeader
  }
}

fragment landingPage on NodeBasicLandingPage {
  entityLabel
  entityId
  fieldContentBlock {
    entity {
      ... fieldContentBlock
    }
  }
}

query GetNodeLandingPages {
  nodeQuery(limit: 1000, filter: {
    conditions: [
      { field: "nid", value: "49535"}
    ]
  }) 
  {
    entities {
      ... landingPage
    }
  }
}
```

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
