### PR TITLE
VACMS-0000: Downgrade Yarn to 1.19.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -175,7 +175,7 @@
         "mikey179/vfsstream": "^1.6",
         "mouf/nodejs-installer": "^1.0",
         "npm-asset/dropzone": "^5.5",
-        "npm-asset/yarn": "1.21.1",
+        "npm-asset/yarn": "1.19.1",
         "oomphinc/composer-installers-extender": "^2.0",
         "php-http/guzzle6-adapter": "^2.0",
         "phpspec/prophecy": "^1.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9974f306f3a5f5f66c2fcf77af9938c5",
+    "content-hash": "203af6d82d40a8763baa4857e74e2439",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -12030,8 +12030,8 @@
                     "homepage": "https://www.drupal.org/u/graber"
                 },
                 {
-                    "name": "benjy",
-                    "homepage": "https://www.drupal.org/user/1852732"
+                    "name": "Graber",
+                    "homepage": "https://www.drupal.org/user/1599440"
                 }
             ],
             "description": "Allows bulk edition of entity field values.",

--- a/composer.lock
+++ b/composer.lock
@@ -16119,10 +16119,10 @@
         },
         {
             "name": "npm-asset/yarn",
-            "version": "1.21.1",
+            "version": "1.19.1",
             "dist": {
                 "type": "tar",
-                "url": "https://registry.npmjs.org/yarn/-/yarn-1.21.1.tgz"
+                "url": "https://registry.npmjs.org/yarn/-/yarn-1.19.1.tgz"
             },
             "type": "npm-asset",
             "license": [


### PR DESCRIPTION
Thinking this might be necessary for recent versions of content-build.  Opening a separate PR to see if it causes any issues for us.