### PR TITLE
VCMS 10171-update page details block lovell

### DIFF
--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -264,7 +264,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
       }
 
       // Determine which prefixes are valid based on section.
-      $valid_prefixes = $this->getValidPrefixes($section_id);
+      $valid_prefixes = LovellOps::getValidPrefixes($section_id);
       $valid_aliases = $this->generateValidAliases($valid_prefixes, $entity);
 
       // Get any existing aliases for this node.
@@ -331,30 +331,6 @@ class LovellEventSubscriber implements EventSubscriberInterface {
     ]);
 
     return $existing_aliases;
-  }
-
-  /**
-   * Generate valid lovell url prefixes for the provided section.
-   *
-   * @param string $section_id
-   *   An id for a section taxonomy term.
-   *
-   * @return array
-   *   An array of valid url prefixes .
-   */
-  public static function getValidPrefixes(string $section_id): array {
-    // Define valid url prefixes for Lovell content.
-    $valid_prefixes = [
-      LovellOps::TRICARE_ID => LovellOps::TRICARE_PATH,
-      LovellOps::VA_ID => LovellOps::VA_PATH,
-    ];
-
-    // If section is not both remove invalid prefixes.
-    if ($section_id !== LovellOps::BOTH_ID) {
-      $valid_prefixes = array_intersect_key($valid_prefixes, [$section_id => 'keep']);
-    }
-
-    return $valid_prefixes;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -342,7 +342,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   An array of valid url prefixes .
    */
-  protected function getValidPrefixes(string $section_id): array {
+  public static function getValidPrefixes(string $section_id): array {
     // Define valid url prefixes for Lovell content.
     $valid_prefixes = [
       LovellOps::TRICARE_ID => LovellOps::TRICARE_PATH,

--- a/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
+++ b/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
@@ -28,6 +28,28 @@ class LovellOps {
   ];
 
   /**
+   * Build the Lovell URL to the front end with the correct prefix.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node entity to query for its original path.
+   * @param string $prefix
+   *   The prefix of the path to use.
+   * @param string $va_gov_url_front_end_url
+   *   The front-end URL domain.
+   *
+   * @return array
+   *   The complete Lovell URL.
+   */
+  public static function buildLovellUrlWithCorrectPrefix(NodeInterface $node, string $prefix, string $va_gov_url_front_end_url): string {
+    $url = "";
+    $original_path = $node->toUrl()->toString();
+    $pattern_to_trim = "/^\/([a-z]|\-)*/i";
+    $trimmed_path = preg_replace($pattern_to_trim, "/" . $prefix, $original_path);
+    $url = $va_gov_url_front_end_url . $trimmed_path;
+    return $url;
+  }
+
+  /**
    * Overrides the menu name if system path matches Lovell.
    *
    * @param string $system_path
@@ -65,6 +87,30 @@ class LovellOps {
       }
     }
     return $type;
+  }
+
+  /**
+   * Generate valid lovell url prefixes for the provided section.
+   *
+   * @param string $section_id
+   *   An id for a section taxonomy term.
+   *
+   * @return array
+   *   An array of valid url prefixes .
+   */
+  public static function getValidPrefixes(string $section_id): array {
+    // Define valid url prefixes for Lovell content.
+    $valid_prefixes = [
+      LovellOps::TRICARE_ID => LovellOps::TRICARE_PATH,
+      LovellOps::VA_ID => LovellOps::VA_PATH,
+    ];
+
+    // If section is not both remove invalid prefixes.
+    if ($section_id !== LovellOps::BOTH_ID) {
+      $valid_prefixes = array_intersect_key($valid_prefixes, [$section_id => 'keep']);
+    }
+
+    return $valid_prefixes;
   }
 
 }

--- a/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
+++ b/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_lovell;
 
 use Drupal\node\NodeInterface;
+use Drupal\va_gov_backend\Service\VaGovUrlInterface;
 
 /**
  * Wrapper class of largely static helper functions related to Lovell.
@@ -28,24 +29,48 @@ class LovellOps {
   ];
 
   /**
+   * Build the array of Lovell URLs.
+   *
+   * @param string $section_id
+   *   An id for a section taxonomy term.
+   * @param \Drupal\va_gov_backend\Service\VaGovUrlInterface $vaGovUrl
+   *   The va.gov URL service.
+   * @param \Drupal\node\NodeInterface $node
+   *   Node entity to query for its original path.
+   *
+   * @return array
+   *   Array of complete Lovell URLs.
+   */
+  public static function buildArrayLovellUrls(string $section_id, VaGovUrlInterface $vaGovUrl, NodeInterface $node): array {
+    $va_gov_urls_to_display = [];
+    $valid_prefixes = LovellOps::getValidPrefixes($section_id);
+    foreach ($valid_prefixes as $prefix) {
+      $va_gov_url_front_end_domain = $vaGovUrl->getVaGovFrontEndUrl();
+      $va_gov_urls_to_display[] = LovellOps::buildLovellUrlWithCorrectPrefix($node, $prefix, $va_gov_url_front_end_domain);
+    }
+    return $va_gov_urls_to_display;
+  }
+
+  /**
    * Build the Lovell URL to the front end with the correct prefix.
    *
    * @param \Drupal\node\NodeInterface $node
    *   Node entity to query for its original path.
    * @param string $prefix
-   *   The prefix of the path to use.
-   * @param string $va_gov_url_front_end_url
+   *   The prefix of the path to use, e.g. "lovell-federal-tricare-health-care",
+   *   "lovell-federal-va-health-care", or "lovell-federal-health-care".
+   * @param string $va_gov_url_front_end_domain
    *   The front-end URL domain.
    *
    * @return string
    *   The complete Lovell URL.
    */
-  public static function buildLovellUrlWithCorrectPrefix(NodeInterface $node, string $prefix, string $va_gov_url_front_end_url): string {
+  public static function buildLovellUrlWithCorrectPrefix(NodeInterface $node, string $prefix, string $va_gov_url_front_end_domain): string {
     $url = "";
     $original_path = $node->toUrl()->toString();
     $pattern_to_trim = "/^\/([a-z]|\-)*/i";
     $trimmed_path = preg_replace($pattern_to_trim, "/" . $prefix, $original_path);
-    $url = $va_gov_url_front_end_url . $trimmed_path;
+    $url = $va_gov_url_front_end_domain . $trimmed_path;
     return $url;
   }
 

--- a/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
+++ b/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
@@ -37,7 +37,7 @@ class LovellOps {
    * @param string $va_gov_url_front_end_url
    *   The front-end URL domain.
    *
-   * @return array
+   * @return string
    *   The complete Lovell URL.
    */
   public static function buildLovellUrlWithCorrectPrefix(NodeInterface $node, string $prefix, string $va_gov_url_front_end_url): string {

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -121,9 +121,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
    * {@inheritdoc}
    */
   public function build() {
-
     $node = $this->getNode();
-
     if (!$node) {
       return;
     }
@@ -174,7 +172,6 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
             '@va_gov_url' => $va_gov_url,
           ]);
         }
-
       }
       else {
         $output .= $this->t('<div><span class="va-gov-entity-meta__title"><strong>@block_key: </strong></span><span class="va-gov-entity-meta__content">@block_item</span></div>',
@@ -182,7 +179,6 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
           '@block_key' => $block_key,
           '@block_item' => $block_item,
         ]);
-
       }
     }
     $block['#markup'] = $output;
@@ -296,20 +292,14 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
   private function getUrlsToDisplay(NodeInterface $node): array {
     $va_gov_urls_to_display = [];
     $section_id = $node->get('field_administration')->target_id;
-    // If this is Lovell, we need to check for
-    // multiple front-end urls and the right prefix.
-    $lovell_type = LovellOps::getLovellType($node);
-    if ($lovell_type !== '') {
-      $valid_prefixes = LovellOps::getValidPrefixes($section_id);
-      foreach ($valid_prefixes as $prefix) {
-        $va_gov_url_front_end_url = $this->vaGovUrl->getVaGovFrontEndUrl();
-        $va_gov_urls_to_display[] = LovellOps::buildLovellUrlWithCorrectPrefix($node, $prefix, $va_gov_url_front_end_url);
-      }
+    if (LovellOps::getLovellType($node) !== '') {
+      $va_gov_urls_to_display = LovellOps::buildArrayLovellUrls($section_id, $this->vaGovUrl, $node);
     }
     else {
       $va_gov_url = $this->vaGovUrl->getVaGovFrontEndUrlForEntity($node);
       $va_gov_urls_to_display[] = $va_gov_url;
     }
+
     return $va_gov_urls_to_display;
   }
 

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -144,7 +144,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
         if ($this->vaGovUrl->vaGovFrontEndUrlForEntityIsLive($node)) {
           $link = Link::fromTextAndUrl($va_gov_url, Url::fromUri($va_gov_url))->toRenderable();
           $link['#attributes'] = ['class' => 'va-gov-url'];
-          $block_items['VA.gov URL'] = $this->renderer->render($link);
+          $block_items['VA.gov URL'][] = $this->renderer->render($link);
         }
         else {
           $block_items['VA.gov URL'][] = new FormattableMarkup('<span class="va-gov-url-pending">' . $va_gov_url . '</span> (pending)', []);
@@ -166,7 +166,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
         $output .= '<div><span class="va-gov-entity-meta__title"><strong>' . $block_key . ': </strong></span><span class="va-gov-entity-meta__content">' . $block_item . '</span></div>';
       }
       elseif ($block_key === 'VA.gov URL') {
-        foreach ($block_item as $va_gov_url) {
+        foreach ($block_items[$block_key] as $va_gov_url) {
           $output .= $this->t('<div><span class="va-gov-entity-meta__title"><strong>@block_key: </strong></span><span class="va-gov-entity-meta__content">@va_gov_url</span></div>',
           [
             '@block_key' => $block_key,
@@ -297,6 +297,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     $section_id = $node->get('field_administration')->target_id;
     // If this is Lovell, we need to check for
     // multiple front-end urls and the right prefix.
+    /** @var \Drupal\node\NodeInterface $node*/
     $lovell_type = LovellOps::getLovellType($node);
     if ($lovell_type !== '') {
       $valid_prefixes = LovellOps::getValidPrefixes($section_id);

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -13,9 +13,8 @@ use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\va_gov_backend\Service\ExclusionTypesInterface;
-// use Drupal\va_gov_backend\Service\VaGovUrl;
 use Drupal\va_gov_backend\Service\VaGovUrlInterface;
-use Drupal\va_gov_lovell\EventSubscriber\LovellEventSubscriber;
+use Drupal\va_gov_lovell\LovellOps;
 use Drupal\va_gov_workflow_assignments\Service\EditorialWorkflowContentRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -101,8 +100,6 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     $this->renderer = $renderer;
   }
 
-
-
   /**
    * {@inheritDoc}
    */
@@ -118,49 +115,6 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
       $container->get('va_gov_workflow_assignments.editorial_workflow'),
       $container->get('renderer')
     );
-  }
-
-  /**
-   * Returns the type of special case or null
-   *
-   * @param Drupal\node\NodeInterface
-   *   A node.
-   *
-   * @return string
-   *   Type of special case (or empty).
-   */
-  private function isLovell (string $section_id): bool {
-    $is_lovell = false;
-    $lovell_sections = LovellEventSubscriber::LOVELL_SECTIONS;
-    if (array_key_exists($section_id, $lovell_sections)) {
-      $is_lovell = true;
-    }
-    return $is_lovell;
-  }
-  private function buildLovellUrlWithCorrectPrefix(NodeInterface $node, string $prefix): string {
-    $url = "";
-    $original_path = $node->toUrl()->toString();
-    $pattern_to_trim = "/^\/([a-z]|\-)*/i";
-    $trimmed_path = preg_replace($pattern_to_trim,"/" . $prefix, $original_path);
-    $va_gov_url_front_end_url = $this->vaGovUrl->getVaGovFrontEndUrl();
-    $url = $va_gov_url_front_end_url . $trimmed_path;
-    return $url;
-  }
-  private function getPathsToPrint(NodeInterface $node) {
-    $paths_to_print = [];
-    $section_id = $node->get('field_administration')->target_id;
-    $is_lovell = $this->isLovell($section_id);
-    if ($is_lovell) {
-      $valid_prefixes = LovellEventSubscriber::getValidPrefixes($section_id);
-      foreach ($valid_prefixes as $prefix) {
-        $paths_to_print[] = $this->buildLovellUrlWithCorrectPrefix($node, $prefix);
-        }
-    }
-    else {
-      $va_gov_url = $this->vaGovUrl->getVaGovFrontEndUrlForEntity($node);
-      $paths_to_print[] = $va_gov_url;
-    }
-    return $paths_to_print;
   }
 
   /**
@@ -185,8 +139,8 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
       $block_items['Owner'] = $this->getSectionHierarchyBreadcrumbLinks($node);
     }
     if ($this->vaGovUrlShouldBeDisplayed($node)) {
-      $paths_to_print = $this->getPathstoPrint($node);
-      foreach ($paths_to_print as $va_gov_url) {
+      $va_gov_urls_to_display = $this->getUrlsToDisplay($node);
+      foreach ($va_gov_urls_to_display as $va_gov_url) {
         if ($this->vaGovUrl->vaGovFrontEndUrlForEntityIsLive($node)) {
           $link = Link::fromTextAndUrl($va_gov_url, Url::fromUri($va_gov_url))->toRenderable();
           $link['#attributes'] = ['class' => 'va-gov-url'];
@@ -211,7 +165,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
       if ($block_key === 'Owner') {
         $output .= '<div><span class="va-gov-entity-meta__title"><strong>' . $block_key . ': </strong></span><span class="va-gov-entity-meta__content">' . $block_item . '</span></div>';
       }
-      else if ($block_key === 'VA.gov URL') {
+      elseif ($block_key === 'VA.gov URL') {
         foreach ($block_item as $va_gov_url) {
           $output .= $this->t('<div><span class="va-gov-entity-meta__title"><strong>@block_key: </strong></span><span class="va-gov-entity-meta__content">@va_gov_url</span></div>',
           [
@@ -220,15 +174,13 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
           ]);
         }
 
-
       }
-      else  {
+      else {
         $output .= $this->t('<div><span class="va-gov-entity-meta__title"><strong>@block_key: </strong></span><span class="va-gov-entity-meta__content">@block_item</span></div>',
         [
           '@block_key' => $block_key,
           '@block_item' => $block_item,
         ]);
-
 
       }
     }
@@ -331,10 +283,34 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     )->toString();
   }
 
-  private function createLovellLink(NodeInterface $node) {
-    return true;
+  /**
+   * Returns the URLs to print (if any).
+   *
+   * @param Drupal\node\NodeInterface $node
+   *   A node.
+   *
+   * @return array
+   *   URL(s) to print.
+   */
+  private function getUrlsToDisplay(NodeInterface $node): array {
+    $va_gov_urls_to_display = [];
+    $section_id = $node->get('field_administration')->target_id;
+    // If this is Lovell, we need to check for
+    // multiple front-end urls and the right prefix.
+    $lovell_type = LovellOps::getLovellType($node);
+    if ($lovell_type !== '') {
+      $valid_prefixes = LovellOps::getValidPrefixes($section_id);
+      foreach ($valid_prefixes as $prefix) {
+        $va_gov_url_front_end_url = $this->vaGovUrl->getVaGovFrontEndUrl();
+        $va_gov_urls_to_display[] = LovellOps::buildLovellUrlWithCorrectPrefix($node, $prefix, $va_gov_url_front_end_url);
+      }
+    }
+    else {
+      $va_gov_url = $this->vaGovUrl->getVaGovFrontEndUrlForEntity($node);
+      $va_gov_urls_to_display[] = $va_gov_url;
+    }
+    return $va_gov_urls_to_display;
   }
-
 
   /**
    * Determine whether the va.gov URL should be displayed.
@@ -364,7 +340,5 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
 
     return TRUE;
   }
-
-
 
 }

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -13,7 +13,9 @@ use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\va_gov_backend\Service\ExclusionTypesInterface;
+// use Drupal\va_gov_backend\Service\VaGovUrl;
 use Drupal\va_gov_backend\Service\VaGovUrlInterface;
+use Drupal\va_gov_lovell\EventSubscriber\LovellEventSubscriber;
 use Drupal\va_gov_workflow_assignments\Service\EditorialWorkflowContentRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -99,6 +101,8 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     $this->renderer = $renderer;
   }
 
+
+
   /**
    * {@inheritDoc}
    */
@@ -117,10 +121,55 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
   }
 
   /**
+   * Returns the type of special case or null
+   *
+   * @param Drupal\node\NodeInterface
+   *   A node.
+   *
+   * @return string
+   *   Type of special case (or empty).
+   */
+  private function isLovell (string $section_id): bool {
+    $is_lovell = false;
+    $lovell_sections = LovellEventSubscriber::LOVELL_SECTIONS;
+    if (array_key_exists($section_id, $lovell_sections)) {
+      $is_lovell = true;
+    }
+    return $is_lovell;
+  }
+  private function buildLovellUrlWithCorrectPrefix(NodeInterface $node, string $prefix): string {
+    $url = "";
+    $original_path = $node->toUrl()->toString();
+    $pattern_to_trim = "/^\/([a-z]|\-)*/i";
+    $trimmed_path = preg_replace($pattern_to_trim,"/" . $prefix, $original_path);
+    $va_gov_url_front_end_url = $this->vaGovUrl->getVaGovFrontEndUrl();
+    $url = $va_gov_url_front_end_url . $trimmed_path;
+    return $url;
+  }
+  private function getPathsToPrint(NodeInterface $node) {
+    $paths_to_print = [];
+    $section_id = $node->get('field_administration')->target_id;
+    $is_lovell = $this->isLovell($section_id);
+    if ($is_lovell) {
+      $valid_prefixes = LovellEventSubscriber::getValidPrefixes($section_id);
+      foreach ($valid_prefixes as $prefix) {
+        $paths_to_print[] = $this->buildLovellUrlWithCorrectPrefix($node, $prefix);
+        }
+    }
+    else {
+      $va_gov_url = $this->vaGovUrl->getVaGovFrontEndUrlForEntity($node);
+      $paths_to_print[] = $va_gov_url;
+    }
+    return $paths_to_print;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function build() {
+
     $node = $this->getNode();
+
     if (!$node) {
       return;
     }
@@ -136,20 +185,21 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
       $block_items['Owner'] = $this->getSectionHierarchyBreadcrumbLinks($node);
     }
     if ($this->vaGovUrlShouldBeDisplayed($node)) {
-      $va_gov_url = $this->vaGovUrl->getVaGovFrontEndUrlForEntity($node);
+      $paths_to_print = $this->getPathstoPrint($node);
+      foreach ($paths_to_print as $va_gov_url) {
+        if ($this->vaGovUrl->vaGovFrontEndUrlForEntityIsLive($node)) {
+          $link = Link::fromTextAndUrl($va_gov_url, Url::fromUri($va_gov_url))->toRenderable();
+          $link['#attributes'] = ['class' => 'va-gov-url'];
+          $block_items['VA.gov URL'] = $this->renderer->render($link);
+        }
+        else {
+          $block_items['VA.gov URL'][] = new FormattableMarkup('<span class="va-gov-url-pending">' . $va_gov_url . '</span> (pending)', []);
+          $block['#attached']['library'][] = 'va_gov_workflow_assignments/ewa_style';
 
-      if ($this->vaGovUrl->vaGovFrontEndUrlForEntityIsLive($node)) {
-        $link = Link::fromTextAndUrl($va_gov_url, Url::fromUri($va_gov_url))->toRenderable();
-        $link['#attributes'] = ['class' => 'va-gov-url'];
-        $block_items['VA.gov URL'] = $this->renderer->render($link);
-      }
-      else {
-        $block_items['VA.gov URL'] = new FormattableMarkup('<span class="va-gov-url-pending">' . $va_gov_url . '</span> (pending)', []);
-        $block['#attached']['library'][] = 'va_gov_workflow_assignments/ewa_style';
-
-        // Cache the response for 5 minutes to avoid repeated longer
-        // page loads if va.gov is not responding.
-        $block['#cache']['max-age'] = 300;
+          // Cache the response for 5 minutes to avoid repeated longer
+          // page loads if va.gov is not responding.
+          $block['#cache']['max-age'] = 300;
+        }
       }
     }
 
@@ -161,12 +211,25 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
       if ($block_key === 'Owner') {
         $output .= '<div><span class="va-gov-entity-meta__title"><strong>' . $block_key . ': </strong></span><span class="va-gov-entity-meta__content">' . $block_item . '</span></div>';
       }
-      else {
+      else if ($block_key === 'VA.gov URL') {
+        foreach ($block_item as $va_gov_url) {
+          $output .= $this->t('<div><span class="va-gov-entity-meta__title"><strong>@block_key: </strong></span><span class="va-gov-entity-meta__content">@va_gov_url</span></div>',
+          [
+            '@block_key' => $block_key,
+            '@va_gov_url' => $va_gov_url,
+          ]);
+        }
+
+
+      }
+      else  {
         $output .= $this->t('<div><span class="va-gov-entity-meta__title"><strong>@block_key: </strong></span><span class="va-gov-entity-meta__content">@block_item</span></div>',
         [
           '@block_key' => $block_key,
           '@block_item' => $block_item,
         ]);
+
+
       }
     }
     $block['#markup'] = $output;
@@ -268,6 +331,11 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     )->toString();
   }
 
+  private function createLovellLink(NodeInterface $node) {
+    return true;
+  }
+
+
   /**
    * Determine whether the va.gov URL should be displayed.
    *
@@ -296,5 +364,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
 
     return TRUE;
   }
+
+
 
 }

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -166,6 +166,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
         $output .= '<div><span class="va-gov-entity-meta__title"><strong>' . $block_key . ': </strong></span><span class="va-gov-entity-meta__content">' . $block_item . '</span></div>';
       }
       elseif ($block_key === 'VA.gov URL') {
+        // We may have multiple URLs, e.g. Lovell Federal Health Care.
         foreach ($block_items[$block_key] as $va_gov_url) {
           $output .= $this->t('<div><span class="va-gov-entity-meta__title"><strong>@block_key: </strong></span><span class="va-gov-entity-meta__content">@va_gov_url</span></div>',
           [

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -287,7 +287,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
   /**
    * Returns the URLs to print (if any).
    *
-   * @param Drupal\node\NodeInterface $node
+   * @param \Drupal\node\NodeInterface $node
    *   A node.
    *
    * @return array
@@ -298,7 +298,6 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     $section_id = $node->get('field_administration')->target_id;
     // If this is Lovell, we need to check for
     // multiple front-end urls and the right prefix.
-    /** @var \Drupal\node\NodeInterface $node*/
     $lovell_type = LovellOps::getLovellType($node);
     if ($lovell_type !== '') {
       $valid_prefixes = LovellOps::getValidPrefixes($section_id);

--- a/docroot/modules/custom/va_gov_workflow_assignments/va_gov_workflow_assignments.info.yml
+++ b/docroot/modules/custom/va_gov_workflow_assignments/va_gov_workflow_assignments.info.yml
@@ -4,4 +4,5 @@ package: 'Custom'
 type: module
 dependencies:
   - va_gov_backend
+  - va_gov_lovell
 core_version_requirement: ^8 || ^9


### PR DESCRIPTION
## Description

Closes #10171 

## Testing done

Manually

## Screenshots
### Both 
![Screen Shot 2022-10-04 at 8 25 59 AM](https://user-images.githubusercontent.com/766573/193832464-d45cfea1-909e-44f3-805f-93dded60aeca.png)
### TRICARE
![Screen Shot 2022-10-04 at 8 25 30 AM](https://user-images.githubusercontent.com/766573/193832471-642e3c16-3a3b-40a5-a733-9b86e72a07b4.png)
### VA
![Screen Shot 2022-10-04 at 8 24 31 AM](https://user-images.githubusercontent.com/766573/193832474-99c72a7b-8022-47b9-8764-aa36ecac7f54.png)


## QA steps
### Lovell Tests
1. As an admin, go to ["Lovell both" page](https://pr10946-2rxm2pkngkybcmdpgz1hizncpmunqass.ci.cms.va.gov/node/49925/edit)
- [x] Publish the page
- [x] Validate that there are two front-end URLs
- [x] One path is for the VA page
- [x] One path is for the TRICARE page

2. As an admin, go to ["Lovell VA" page](https://pr10946-2rxm2pkngkybcmdpgz1hizncpmunqass.ci.cms.va.gov/node/49931/edit)
- [x] Publish the page
- [x] Validate that there is one front-end URL to a Lovell VA page

3. As an admin, go to ["Lovell TRICARE" page](https://pr10946-2rxm2pkngkybcmdpgz1hizncpmunqass.ci.cms.va.gov/node/49930/edit)
- [x] Publish the page
- [x] Validate that there is one front-end URL to a Lovell TRICARE page

### Regression Tests
As an admin, go to a non-Lovell *VAMC facility* page, such as [/fayetteville-coastal-health-care/locations/jacksonville-3-va-clinic](https://pr10946-2rxm2pkngkybcmdpgz1hizncpmunqass.ci.cms.va.gov/fayetteville-coastal-health-care/locations/jacksonville-3-va-clinic)
- [x] Validate that the front-end URL corresponds to the URL on production (except for the domain)

As an admin, go to a non-Lovell *VAMC facility health service* page, such as [/cheyenne-health-care/locations/northern-colorado-va-clinic/nutrition-food-and-dietary-care](https://pr10946-2rxm2pkngkybcmdpgz1hizncpmunqass.ci.cms.va.gov/cheyenne-health-care/locations/northern-colorado-va-clinic/nutrition-food-and-dietary-care)
- [x] Validate that the front-end URL corresponds to the URL on production (except for the domain)

As an admin, go to a non-Lovell *Locations listings* page, such as [/long-beach-health-care/locations](https://pr10946-2rxm2pkngkybcmdpgz1hizncpmunqass.ci.cms.va.gov/long-beach-health-care/locations)
- [x] Validate that the front-end URL corresponds to the URL on production (except for the domain)

As an admin, go to a non-Lovell *Benefits Detail Page* page, such as [/family-member-benefits/comprehensive-assistance-for-family-caregivers](https://pr10946-2rxm2pkngkybcmdpgz1hizncpmunqass.ci.cms.va.gov/family-member-benefits/comprehensive-assistance-for-family-caregivers)
- [x] Validate that the front-end URL corresponds to the URL on production (except for the domain)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`



### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
