### PR TITLE
VACMS-11045: fix for inline guidance bug with existing images

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/js/inline_guidance.es6.js
+++ b/docroot/themes/custom/vagovclaro/assets/js/inline_guidance.es6.js
@@ -13,7 +13,8 @@
     attach: () => {
       $("#inline-guidance-trigger")
         .once()
-        .click(() => {
+        .click((e) => {
+          e.preventDefault();
           if ($("#inline-guidance-text-box").hasClass("hide")) {
             $("#inline-guidance-text-box").removeClass("hide");
             $("#inline-guidance-text-box").addClass("show");
@@ -32,4 +33,4 @@
         });
     },
   };
-})(jQuery, window.Drupal);
+})(jQuery, Drupal);

--- a/docroot/themes/custom/vagovclaro/assets/js/inline_guidance.js
+++ b/docroot/themes/custom/vagovclaro/assets/js/inline_guidance.js
@@ -8,7 +8,8 @@
 (function ($, Drupal) {
   Drupal.behaviors.vaGovInlineGuidance = {
     attach: function attach() {
-      $("#inline-guidance-trigger").once().click(function () {
+      $("#inline-guidance-trigger").once().click(function (e) {
+        e.preventDefault();
         if ($("#inline-guidance-text-box").hasClass("hide")) {
           $("#inline-guidance-text-box").removeClass("hide");
           $("#inline-guidance-text-box").addClass("show");
@@ -22,7 +23,7 @@
           $("#inline-guidance-trigger").attr("aria-expanded", "false");
           setTimeout(function () {
             $("#inline-guidance-trigger").focus();
-          }, 500);;
+          }, 500);
         }
       });
     }

--- a/docroot/themes/custom/vagovclaro/templates/content-edit/file-managed-file.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/content-edit/file-managed-file.html.twig
@@ -67,7 +67,7 @@
               <li>Be concise, ideally no more that 150 characters.</li>
               <li>Avoid phrases like “image of”, “photo of”, “graphic of”, etc.</li>
               <li>Leave the file name of the image out of the alt text.</li>
-              <li><a href="https://github.com/help/cms-basics/alternative-text">Learn more about alt text guidelines</a></li>
+              <li><a href="/help/cms-basics/alternative-text">Learn more about alt text guidelines</a></li>
             </ul>
           {% endset %}
           {% include '@components/inline-guidance/text-box.twig' with {


### PR DESCRIPTION
## Description

Closes #11045.

## Testing done
Tested locally.

## Screenshots


## QA steps
Open an existing image to edit and verify that clicking Tips for Alternative Text does NOT reload the page. 

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`

