### PR TITLE
VACMS-0000: Remove distracting test output.

### DIFF
--- a/tests/phpunit/Performance/ScalabilityCreateNodeTest.php
+++ b/tests/phpunit/Performance/ScalabilityCreateNodeTest.php
@@ -27,9 +27,6 @@ class ScalabilityCreateNodeTest extends ExistingSiteBase {
     $secs = number_format($microsecs / 1000, 2);
 
     Timer::stop(static::TIMER_NAME);
-
-    $message = __METHOD__ . "\nOperation took " . $secs . " and completed $count iterations.\n";
-    fwrite(STDERR, print_r($message, TRUE));
   }
 
   /**


### PR DESCRIPTION
## Description

This bit of spam can be misinterpreted as an error message and distract from actual error messages.

This should be safe to merge if tests pass.