### PR TITLE
VACMS-9821: Remove hidden edit link in main content listing

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -1820,7 +1820,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -1105,7 +1105,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -4071,7 +4071,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -5545,7 +5545,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type

--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -1173,7 +1173,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         moderation_state:
           id: moderation_state
@@ -2835,7 +2835,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -5675,7 +5675,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         field_facility_locator_api_id:
           id: field_facility_locator_api_id
@@ -8947,7 +8947,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         field_facility_locator_api_id:
           id: field_facility_locator_api_id
@@ -11999,7 +11999,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -15264,7 +15264,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -17581,7 +17581,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         field_administration:
           id: field_administration
@@ -18555,7 +18555,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         field_vamc_system_official_name:
           id: field_vamc_system_official_name
@@ -20765,7 +20765,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         title_1:
           id: title_1

--- a/config/sync/views.view.flagged_content.yml
+++ b/config/sync/views.view.flagged_content.yml
@@ -223,7 +223,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         flagged:
           id: flagged

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -275,7 +275,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         bundle:
           id: bundle
@@ -3680,7 +3680,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         uid:
           id: uid

--- a/config/sync/views.view.rich_text_field_audit.yml
+++ b/config/sync/views.view.rich_text_field_audit.yml
@@ -259,7 +259,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -1749,7 +1749,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -2640,7 +2640,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -3583,7 +3583,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type
@@ -4637,7 +4637,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type

--- a/config/sync/views.view.table_audit.yml
+++ b/config/sync/views.view.table_audit.yml
@@ -214,7 +214,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -216,7 +216,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         type:
           id: type

--- a/config/sync/views.view.va_forms.yml
+++ b/config/sync/views.view.va_forms.yml
@@ -283,7 +283,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: Edit
-          output_url_as_text: false
+          output_url_as_text: true
           absolute: false
         field_va_form_name:
           id: field_va_form_name


### PR DESCRIPTION
## Description

Closes #9821.

## Testing done
Tested locally. 

## Screenshots


## QA steps

Gop to main content admin view, inspect Edit button for a piece of content, There should be only one link. Do the same for the main images admin view. 

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


