### PR TITLE
VACMS-10866: updated color for pending url

### DIFF
--- a/docroot/modules/custom/va_gov_workflow_assignments/css/ewa_style.css
+++ b/docroot/modules/custom/va_gov_workflow_assignments/css/ewa_style.css
@@ -1,4 +1,4 @@
 /* Gray out pending va.gov URLs. */
 .va-gov-url-pending {
-  color: #949494;
+  color: var(--va-gray-dark);
 }


### PR DESCRIPTION
## Description

Closes #10866.

## Testing done
Tested locally

## Screenshots
![CleanShot 2022-10-04 at 13 11 30](https://user-images.githubusercontent.com/109987005/193920812-68ffcd1d-fafb-485d-94fe-1e254d187892.png)


## QA steps
Find a Sitewide Alert  with a pending url and verify color is correct. 

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`

