### PR TITLE
VACMS-10974: Pins GitHub Actions at commit SHAs instead of tags/branches.

### DIFF
--- a/.github/actions/post-checkout/action.yml
+++ b/.github/actions/post-checkout/action.yml
@@ -11,7 +11,8 @@ runs:
       shell: bash
 
     - name: Use the Composer cache, if possible
-      uses: actions/cache@v3
+      # https://github.com/actions/cache/releases/tag/v3.0.10
+      uses: actions/cache@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -19,7 +20,8 @@ runs:
           ${{ runner.os }}-composer-
 
     - name: Setup the PHP environment
-      uses: shivammathur/setup-php@v2
+      # https://github.com/shivammathur/setup-php/releases/tag/2.21.2
+      uses: shivammathur/setup-php@e04e1d97f0c0481c6e1ba40f8a538454fe5d7709
       with:
         php-version: '7.4'
         extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
@@ -31,4 +33,5 @@ runs:
       shell: bash
 
     - name: Setup ReviewDog
-      uses: reviewdog/action-setup@v1
+      # https://github.com/reviewdog/action-setup/releases/tag/v1.0.3
+      uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Check Corresponding Entity Reference Fields
         run: ./tests/scripts/check-cer.sh
       - name: Check Revision Log fields
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: composer validate
 
   # Analyze the codebase with GitHub's CodeQL tool.
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: CodeQL Init
         # https://github.com/github/codeql-action/releases/tag/v2.1.26
         uses: github/codeql-action/init@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: ReviewDog
         # https://github.com/reviewdog/action-eslint/releases/tag/v1.17.0
         uses: reviewdog/action-eslint@d3395027ea2cfc5cf8f460b1ea939b6c86fea656
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: ./.github/actions/post-checkout
       - name: Run PHP_CodeSniffer and ReviewDog
         run: |
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: ./.github/actions/post-checkout
       - name: Run PHPStan and ReviewDog
         run: |
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: ./.github/actions/post-checkout
       - name: Run PHPUnit (Unit Tests only)
         run: bin/phpunit \
@@ -127,7 +127,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Stylelint modules
         # https://github.com/reviewdog/action-stylelint/releases/tag/v1.14.0 
         uses: reviewdog/action-stylelint@a45bf7c5a91efc6f9443ae59b9cf7387b7868492

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,7 +7,9 @@ jobs:
     name: Check Fields
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
       - name: Check Corresponding Entity Reference Fields
         run: ./tests/scripts/check-cer.sh
       - name: Check Revision Log fields
@@ -18,7 +20,9 @@ jobs:
     name: Composer Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
       - run: composer validate
 
   # Analyze the codebase with GitHub's CodeQL tool.
@@ -26,17 +30,27 @@ jobs:
     name: CodeQL Analyze
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: github/codeql-action/init@v2
-    - uses: github/codeql-action/analyze@v2
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+      - name: CodeQL Init
+        # https://github.com/github/codeql-action/releases/tag/v2.1.26
+        uses: github/codeql-action/init@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44
+      - name: CodeQL Analyze
+        # https://github.com/github/codeql-action/releases/tag/v2.1.26
+        uses: github/codeql-action/analyze@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44
 
   # Check style of ES/JS files with ESLint and ReviewDog.
   eslint:
     name: ESLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: reviewdog/action-eslint@v1
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+      - name: ReviewDog
+        # https://github.com/reviewdog/action-eslint/releases/tag/v1.17.0
+        uses: reviewdog/action-eslint@d3395027ea2cfc5cf8f460b1ea939b6c86fea656
         with:
           reporter: github-pr-review
           eslint_flags: '--max-warnings 0 -c .eslintrc.json --no-eslintrc docroot/modules/custom/**/*.es6.js docroot/themes/custom/**/*.es6.js'
@@ -47,7 +61,9 @@ jobs:
     name: PHP_CodeSniffer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
       - uses: ./.github/actions/post-checkout
       - name: Run PHP_CodeSniffer and ReviewDog
         run: |
@@ -68,7 +84,9 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
       - uses: ./.github/actions/post-checkout
       - name: Run PHPStan and ReviewDog
         run: |
@@ -91,7 +109,9 @@ jobs:
     name: PHPUnit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
       - uses: ./.github/actions/post-checkout
       - name: Run PHPUnit (Unit Tests only)
         run: bin/phpunit \
@@ -105,8 +125,12 @@ jobs:
     name: Stylelint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: reviewdog/action-stylelint@v1
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+      - name: Stylelint modules
+        # https://github.com/reviewdog/action-stylelint/releases/tag/v1.14.0 
+        uses: reviewdog/action-stylelint@a45bf7c5a91efc6f9443ae59b9cf7387b7868492
         with:
           fail_on_error: true
           github_token: ${{ secrets.github_token }}
@@ -114,7 +138,9 @@ jobs:
           reporter: github-pr-review
           stylelint_config: '.stylelintrc'
           stylelint_input: 'docroot/modules/custom/**/*.css'
-      - uses: reviewdog/action-stylelint@v1
+      - name: Stylelint themes
+        # https://github.com/reviewdog/action-stylelint/releases/tag/v1.14.0 
+        uses: reviewdog/action-stylelint@a45bf7c5a91efc6f9443ae59b9cf7387b7868492
         with:
           fail_on_error: true
           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,13 +15,15 @@ jobs:
       # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        # https://github.com/dependabot/fetch-metadata/releases/tag/v1.3.4
+        uses: dependabot/fetch-metadata@bfc19f43c126171ed783cdcf9a125055b7831d32
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"    
     
       # Checkout repo to make package allow list available
       - name: Checkout
-        uses: actions/checkout@v3
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
         
       # Use a YAML formatted config file to list which dependencies can be auto-merged
       - name: Read list of Allowed Auto-merge Dependencies
@@ -31,7 +33,8 @@ jobs:
 
       # Get the initial AWS IAM User credentials. Only has basic permissions for sts:assumeRole
       - name: Configure AWS credentials (1)
-        uses: aws-actions/configure-aws-credentials@v1
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -39,7 +42,8 @@ jobs:
 
       # Get credentials from our SSM role. Least privilege method for AWS IAM.
       - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -50,7 +54,8 @@ jobs:
           
       # Get VA_CMS_BOT Github token from SSM. this will be used to approve a matching PR.
       - name: Get Parameter
-        uses: marvinpinto/action-inject-ssm-secrets@latest
+        # https://github.com/marvinpinto/action-inject-ssm-secrets/releases/tag/latest
+        uses: marvinpinto/action-inject-ssm-secrets@40db08dfe313758837e611cac1679e3a89b35531
         with:
           ssm_parameter: /cms/va-cms-bot/github_token
           env_variable_name: VA_CMS_BOT_TOKEN

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
       # Checkout repo to make package allow list available
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         
       # Use a YAML formatted config file to list which dependencies can be auto-merged
       - name: Read list of Allowed Auto-merge Dependencies

--- a/.github/workflows/pull-request-labels.yml
+++ b/.github/workflows/pull-request-labels.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Autolabel

--- a/.github/workflows/pull-request-labels.yml
+++ b/.github/workflows/pull-request-labels.yml
@@ -12,10 +12,14 @@ jobs:
   pr-team-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: harupy/auto-labeling@master
+      - name: Autolabel
+        # https://github.com/harupy/auto-labeling/releases/tag/v0.0.2
+        uses: harupy/auto-labeling@03cdc56d0b56e0c1d4eb1bf68b53f8ec8b5f03e9
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           label-pattern: '- \[(.*?)\] ?`(.+?)`' # matches '- [x] `label`'

--- a/.github/workflows/s3-backup-retention.yml
+++ b/.github/workflows/s3-backup-retention.yml
@@ -21,7 +21,8 @@ jobs:
 
       # Get the initial AWS IAM User credentials. Only has basic permissions for sts:assumeRole
       - name: Configure AWS credentials (1)
-        uses: aws-actions/configure-aws-credentials@v1
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -35,8 +36,9 @@ jobs:
       #          env_variable_name: AWS_VAGOV_CMS_PROD_S3_ROLE
 
       # Get credentials from our s3 role. Least privilege method for AWS IAM.
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS credentials (1)
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/set-tugboat-tests-pending.yml
+++ b/.github/workflows/set-tugboat-tests-pending.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/cache/releases/tag/v3.0.10
-        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Set status for Tugboat tasks.
         run: |
           test_names=(

--- a/.github/workflows/set-tugboat-tests-pending.yml
+++ b/.github/workflows/set-tugboat-tests-pending.yml
@@ -20,7 +20,9 @@ jobs:
     name: Set Tugboat Tests Pending
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        # https://github.com/actions/cache/releases/tag/v3.0.10
+        uses: actions/checkout@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
       - name: Set status for Tugboat tasks.
         run: |
           test_names=(


### PR DESCRIPTION
## Description

Closes #10974.  I did this fairly carefully, but possible I made a mistake copypastaing a SHA somewhere.  If so I might need to hotfix `main` after this is merged if I messed up one of the `pull_request_target` action SHAs.
