### PR TITLE
VACMS-11084: Update tablefield help text.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1918,6 +1918,11 @@ function _va_gov_backend_apply_filter_to_tablefield_cells(FieldableEntityInterfa
 
 /**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ *
+ * Deprecated in va_gov_backend:9.2.3 and is removed from va_gov_backend:10.0.1
+ *   This should be removed in #10675.
+ *
+ * @see https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10675
  */
 function va_gov_backend_field_widget_tablefield_form_alter(&$element, FormStateInterface $form_state, $context): void {
   $element["#description"] = t('The first row will be formatted as the table header. The labels in the first row should accurately describe the corresponding columns.');

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1917,6 +1917,13 @@ function _va_gov_backend_apply_filter_to_tablefield_cells(FieldableEntityInterfa
 }
 
 /**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
+function va_gov_backend_field_widget_tablefield_form_alter(&$element, FormStateInterface $form_state, $context): void {
+  $element["#description"] = t('The first row will be formatted as the table header. The labels in the first row should accurately describe the corresponding columns.');
+}
+
+/**
  * Determine if pathauto alias should be enabled on node.
  *
  * @param \Drupal\Core\Entity\FieldableEntityInterface $entity


### PR DESCRIPTION
## Description

Closes #11084

## Screenshots
![Screen Shot 2022-10-14 at 1 07 01 PM](https://user-images.githubusercontent.com/221539/195939420-c57f2492-576f-4f7c-9796-6ca85cfeaaf5.png)


## QA steps
1. Create a new Landing Page node.
2. In the 'main content' field, add a 'Table' paragraph
   - [x] Validate the help text for the 'Table' element reads: `The first row will be formatted as the table header. The labels in the first row should accurately describe the corresponding columns.`

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [x] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
