### PR TITLE
VACMS-10528: clear conditional fields that are hidden on node save

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/EntityEventSubscriber.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
 use Drupal\va_gov_notifications\Service\NotificationsManager;
 use Drupal\va_gov_user\Service\UserPermsService;
 use Drupal\va_gov_vamc\Service\ContentHardeningDeduper;
@@ -140,6 +141,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   public function entityPresave(EntityPresaveEvent $event): void {
     $entity = $event->getEntity();
     $this->contentHardeningDeduper->removeDuplicate($entity);
+    $this->clearCustomAppointmentIntroText($entity);
+    $this->clearUnusedServiceLocationHours($entity);
   }
 
   /**
@@ -303,6 +306,51 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       }
     }
     $form['#attached']['library'][] = 'va_gov_vamc/limit_vamcs_to_workbench';
+  }
+
+  /**
+   * Clear custom appointment intro text when unused.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   */
+  protected function clearCustomAppointmentIntroText(EntityInterface $entity): void {
+    if ($entity instanceof NodeInterface) {
+      $bundle = $entity->bundle();
+      /** @var \Drupal\node\NodeInterface $entity */
+      if (($bundle === 'health_care_local_health_service')
+      && ($entity->hasField('field_hservice_appt_intro_select'))
+      && ($entity->hasField('field_hservice_appt_leadin'))) {
+        $appt_select = $entity->get('field_hservice_appt_intro_select')->value;
+        $appt_leadin = $entity->get('field_hservice_appt_leadin')->value;
+        if ($appt_select !== 'custom_intro_text' && !empty($appt_leadin)) {
+          $entity->set('field_hservice_appt_leadin', '');
+        }
+      }
+    }
+  }
+
+  /**
+   * Clear service location hours when unused.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   */
+  protected function clearUnusedServiceLocationHours(EntityInterface $entity): void {
+    if ($entity instanceof ParagraphInterface) {
+      $type = $entity->getType();
+      /** @var \Drupal\paragraphs\ParagraphInterface $entity */
+      if (($type === 'service_location')
+      && ($entity->hasField('field_hours'))
+      && ($entity->hasField('field_office_hours'))) {
+        $hours = $entity->get('field_hours')->value;
+        $office_hours = $entity->get('field_office_hours')->getValue();
+        // 2 = Provide specific hours for this service.
+        if ($hours !== '2' && count($office_hours) > 0) {
+          $entity->set('field_office_hours', []);
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
## Description

Closes issue #10528 

## Testing done

Manual testing

## QA steps

**Appointment intro text (VAMC Facility Health Service)**
1. Go to node/25412/edit
2. Scroll down to "appointment intro text"
3. Select "customize text" and add some text
4. Now change your mind and select "use default"
5. Save the node and then go back to edit it again.
6. Scroll down to "appointment intro text" and select "customize text".
- [x] Validate that the details are empty.

**Service location hours (VAMC Facility Health Service)**
1. Go to node/25412/edit
2. Scroll down to "Service Locations -> hours"
3. Select "provide specific hours" and enter some hours if not already present
4. Now change your mind and select "use facility's hours"
5. Save the node and then go back to edit it again.
6. Scroll down to "Service Locations -> hours" and select "provide specific hours".
- [x] Validate that the hours fields are empty.

**Service location hours (VAMC Facility Non-Clinical Service)**
1. Go to node/46787/edit
2. Scroll down to "Service Locations -> hours"
3. Select "provide specific hours" and enter some hours if not already present
4. Now change your mind and select "use facility's hours"
5. Save the node and then go back to edit it again.
6. Scroll down to "Service Locations -> hours" and select "provide specific hours".
- [x] Validate that the hours fields are empty.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
