### PR TITLE
VACMS-10391: Add timestamp messages before/after each test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-# PHPUnit log output.
+# Automated test log output.
+behat.log
+cypress.log
 phpunit.log
 
 # Ignore binaries.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# PHPUnit log output.
+phpunit.log
+
 # Ignore binaries.
 /bin
 

--- a/tests/behat/Drupal/FeatureContext.php
+++ b/tests/behat/Drupal/FeatureContext.php
@@ -591,7 +591,7 @@ class FeatureContext extends RawDrupalContext {
    */
   public function logBeforeScenario($event) {
     $timestamp = time();
-    $date = date(DATE_RFC2822);
+    $date = gmdate(DATE_RFC2822);
     $featureFile = $event->getFeature()->getFile();
     $scenarioTitle = $event->getScenario()->getTitle();
     $testString = "$featureFile $scenarioTitle";
@@ -606,7 +606,7 @@ class FeatureContext extends RawDrupalContext {
    */
   public function logAfterScenario($event) {
     $timestamp = time();
-    $date = date(DATE_RFC2822);
+    $date = gmdate(DATE_RFC2822);
     $featureFile = $event->getFeature()->getFile();
     $scenarioTitle = $event->getScenario()->getTitle();
     $testString = "$featureFile $scenarioTitle";

--- a/tests/behat/Drupal/FeatureContext.php
+++ b/tests/behat/Drupal/FeatureContext.php
@@ -13,9 +13,9 @@ use Drupal\user\Entity\User;
  */
 class FeatureContext extends RawDrupalContext {
 
-  use \Traits\FieldTrait;
-  use \Traits\UserEntityTrait;
-  use \Traits\ContentTrait;
+  use Traits\FieldTrait;
+  use Traits\UserEntityTrait;
+  use Traits\ContentTrait;
 
   /**
    * Make DrushContext available.
@@ -561,6 +561,57 @@ class FeatureContext extends RawDrupalContext {
       file_put_contents($textPath, $text);
       echo "\nDumped HTML to $htmlPath\nDumped Text to $textPath\n";
     }
+  }
+
+  /**
+   * Retrieves the log file path.
+   *
+   * @return string
+   *   An absolute path to the log file.
+   */
+  public function getLogFilePath(): string {
+    $rootPath = getenv('DDEV_APPROOT') ?: getenv('TUGBOAT_ROOT') ?: getenv('RUNNER_TEMP') ?: '/var/www/cms';
+    return "$rootPath/behat.log";
+  }
+
+  /**
+   * Write a message to the log file.
+   *
+   * @param string $message
+   *   The message to write.
+   */
+  public function writeLogMessage(string $message) {
+    file_put_contents($this->getLogFilePath(), "$message\n", FILE_APPEND);
+  }
+
+  /**
+   * Log before scenario.
+   *
+   * @BeforeScenario
+   */
+  public function logBeforeScenario($event) {
+    $timestamp = time();
+    $date = date(DATE_RFC2822);
+    $featureFile = $event->getFeature()->getFile();
+    $scenarioTitle = $event->getScenario()->getTitle();
+    $testString = "$featureFile $scenarioTitle";
+    $message = "VA_GOV_DEBUG $timestamp $date BEFORE $testString";
+    $this->writeLogMessage($message);
+  }
+
+  /**
+   * Log after scenario.
+   *
+   * @AfterScenario
+   */
+  public function logAfterScenario($event) {
+    $timestamp = time();
+    $date = date(DATE_RFC2822);
+    $featureFile = $event->getFeature()->getFile();
+    $scenarioTitle = $event->getScenario()->getTitle();
+    $testString = "$featureFile $scenarioTitle";
+    $message = "VA_GOV_DEBUG $timestamp $date AFTER $testString";
+    $this->writeLogMessage($message);
   }
 
 }

--- a/tests/behat/Drupal/Traits/ContentTrait.php
+++ b/tests/behat/Drupal/Traits/ContentTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Support\Traits;
+namespace CustomDrupal\Traits;
 
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;

--- a/tests/behat/Drupal/Traits/FieldTrait.php
+++ b/tests/behat/Drupal/Traits/FieldTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Support\Traits;
+namespace CustomDrupal\Traits;
 
 use PHPUnit\Framework\Assert;
 

--- a/tests/behat/Drupal/Traits/UserEntityTrait.php
+++ b/tests/behat/Drupal/Traits/UserEntityTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Support\Traits;
+namespace CustomDrupal\Traits;
 
 use Drupal\user\Entity\Role;
 use PHPUnit\Framework\Assert;

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -184,6 +184,8 @@ compareSnapshotCommand();
 beforeEach(() => {
   const testTitle = Cypress.currentTest.title;
   const testPath = Cypress.currentTest.titlePath;
+  const date = new Date();
+  const timestamp = Math.floor(Date.now() / 1000);
   cy.log(`VA_GOV_DEBUG ${timestamp} ${date} BEFORE ${testPath} ${testTitle}`);
 });
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -180,3 +180,17 @@ Cypress.Commands.add("accessibilityLog", (violations) => {
 });
 
 compareSnapshotCommand();
+
+beforeEach(() => {
+  const testTitle = Cypress.currentTest.title;
+  const testPath = Cypress.currentTest.titlePath;
+  cy.log(`VA_GOV_DEBUG ${timestamp} ${date} BEFORE ${testPath} ${testTitle}`);
+});
+
+afterEach(() => {
+  const testTitle = Cypress.currentTest.title;
+  const testPath = Cypress.currentTest.titlePath;
+  const date = new Date();
+  const timestamp = Math.floor(Date.now() / 1000);
+  cy.log(`VA_GOV_DEBUG ${timestamp} ${date} AFTER ${testPath} ${testTitle}`);
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -186,7 +186,7 @@ let logText = '';
 beforeEach(() => {
   const testTitle = Cypress.currentTest.title;
   const testPath = Cypress.currentTest.titlePath;
-  const date = new Date();
+  const date = (new Date()).toUTCString();
   const timestamp = Math.floor(Date.now() / 1000);
   logText += `VA_GOV_DEBUG ${timestamp} ${date} BEFORE ${testPath} ${testTitle}\n`;
 });
@@ -194,7 +194,7 @@ beforeEach(() => {
 afterEach(() => {
   const testTitle = Cypress.currentTest.title;
   const testPath = Cypress.currentTest.titlePath;
-  const date = new Date();
+  const date = (new Date()).toUTCString();
   const timestamp = Math.floor(Date.now() / 1000);
   logText += `VA_GOV_DEBUG ${timestamp} ${date} AFTER ${testPath} ${testTitle}\n`;
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -181,12 +181,14 @@ Cypress.Commands.add("accessibilityLog", (violations) => {
 
 compareSnapshotCommand();
 
+let logText = '';
+
 beforeEach(() => {
   const testTitle = Cypress.currentTest.title;
   const testPath = Cypress.currentTest.titlePath;
   const date = new Date();
   const timestamp = Math.floor(Date.now() / 1000);
-  cy.log(`VA_GOV_DEBUG ${timestamp} ${date} BEFORE ${testPath} ${testTitle}`);
+  logText += `VA_GOV_DEBUG ${timestamp} ${date} BEFORE ${testPath} ${testTitle}\n`;
 });
 
 afterEach(() => {
@@ -194,5 +196,10 @@ afterEach(() => {
   const testPath = Cypress.currentTest.titlePath;
   const date = new Date();
   const timestamp = Math.floor(Date.now() / 1000);
-  cy.log(`VA_GOV_DEBUG ${timestamp} ${date} AFTER ${testPath} ${testTitle}`);
+  logText += `VA_GOV_DEBUG ${timestamp} ${date} AFTER ${testPath} ${testTitle}\n`;
+});
+
+
+after(() => {
+  cy.writeFile("cypress.log", logText, { flag: "a+" });
 });

--- a/tests/phpunit/API/BannerEndpointTest.php
+++ b/tests/phpunit/API/BannerEndpointTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\API;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm that the banner endpoint is working properly.
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class BannerEndpointTest extends ExistingSiteBase {
+class BannerEndpointTest extends VaGovExistingSiteBase {
 
   /**
    * Provides data to testBanner().

--- a/tests/phpunit/API/GraphQLTest.php
+++ b/tests/phpunit/API/GraphQLTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\API;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm amount of nodes by type.
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class GraphQLTest extends ExistingSiteBase {
+class GraphQLTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to check data returned by GraphQL service.

--- a/tests/phpunit/API/PostApiQueueTest.php
+++ b/tests/phpunit/API/PostApiQueueTest.php
@@ -5,7 +5,7 @@ namespace tests\phpunit\API;
 use Drupal\Core\Database\Database;
 use Drupal\Core\Queue\DatabaseQueue;
 use Drupal\Core\Site\Settings;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Tests Post API Queue functionality.
@@ -13,7 +13,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class PostApiQueueTest extends ExistingSiteBase {
+class PostApiQueueTest extends VaGovExistingSiteBase {
 
   /**
    * Modules to install.

--- a/tests/phpunit/Content/AliasesTest.php
+++ b/tests/phpunit/Content/AliasesTest.php
@@ -3,7 +3,7 @@
 namespace tests\phpunit\Content;
 
 use Drupal\taxonomy\Entity\Vocabulary;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm correct alias settings.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class AliasesTest extends ExistingSiteBase {
+class AliasesTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to test VAMC System & Facility Health Services Aliases.

--- a/tests/phpunit/Content/BulletinQueueTest.php
+++ b/tests/phpunit/Content/BulletinQueueTest.php
@@ -4,7 +4,7 @@ namespace tests\phpunit\Content;
 
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm that alerts and situation updates are queued.
@@ -12,7 +12,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class BulletinQueueTest extends ExistingSiteBase {
+class BulletinQueueTest extends VaGovExistingSiteBase {
 
   /**
    * Govdelivery bulletins queue.
@@ -31,7 +31,7 @@ class BulletinQueueTest extends ExistingSiteBase {
   /**
    * Wipe the queue clean so we can get reliable counts.
    */
-  protected function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->markTestSkipped('this test is flaky and not working correctly. will be re-enabled in #9839.');
     $this->deleteQueue();

--- a/tests/phpunit/Content/ContentModerationTest.php
+++ b/tests/phpunit/Content/ContentModerationTest.php
@@ -6,7 +6,7 @@ use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Form\FormStateInterface;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Test our requirements of the content moderation system.
@@ -14,7 +14,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class ContentModerationTest extends ExistingSiteBase {
+class ContentModerationTest extends VaGovExistingSiteBase {
 
   /**
    * Prevent accidental publication of un-proofed nodes.

--- a/tests/phpunit/Content/CreateMediaTest.php
+++ b/tests/phpunit/Content/CreateMediaTest.php
@@ -2,8 +2,8 @@
 
 namespace tests\phpunit\Content;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
 use Drupal\media\Entity\Media;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm ability to create media.
@@ -11,7 +11,7 @@ use Drupal\media\Entity\Media;
  * @group functional
  * @group all
  */
-class CreateMediaTest extends ExistingSiteBase {
+class CreateMediaTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to determine the ability and time to create media.

--- a/tests/phpunit/Content/DownloadableFileTest.php
+++ b/tests/phpunit/Content/DownloadableFileTest.php
@@ -5,8 +5,8 @@ namespace tests\phpunit\Content;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
 use Drupal\paragraphs\Entity\Paragraph;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
 use Drupal\Core\File\FileSystemInterface;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Confirm downloadable_file paragraphs are displayed correctly.
@@ -14,7 +14,7 @@ use Drupal\Core\File\FileSystemInterface;
  * @group functional
  * @group all
  */
-class DownloadableFileTest extends ExistingSiteBase {
+class DownloadableFileTest extends VaGovExistingSiteBase {
 
   /**
    * Create a File entity with the specified name and content.

--- a/tests/phpunit/Content/EmailLinkRepairFilterTest.php
+++ b/tests/phpunit/Content/EmailLinkRepairFilterTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Content;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm the proper functioning of the EmailLinkRepair filter.
@@ -13,7 +13,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  *
  * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Filter\EmailLinkRepairFilter
  */
-class EmailLinkRepairFilterTest extends ExistingSiteBase {
+class EmailLinkRepairFilterTest extends VaGovExistingSiteBase {
 
   /**
    * Tests the filter's processing.

--- a/tests/phpunit/Content/FacilityStatusQueueTest.php
+++ b/tests/phpunit/Content/FacilityStatusQueueTest.php
@@ -17,7 +17,7 @@ use Drupal\taxonomy\TermInterface;
 use Drupal\Tests\Traits\Core\GeneratePermutationsTrait;
 use Drupal\va_gov_post_api\Service\PostFacilityStatus;
 use Prophecy\Argument;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Functional test of the Facility status queueing for push to Lighthouse.
@@ -27,7 +27,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  *
  * @coversDefaultClass \Drupal\va_gov_post_api\Service\PostFacilityStatus
  */
-class FacilityStatusQueueTest extends ExistingSiteBase {
+class FacilityStatusQueueTest extends VaGovExistingSiteBase {
 
   use GeneratePermutationsTrait;
 

--- a/tests/phpunit/Content/MetaTagTest.php
+++ b/tests/phpunit/Content/MetaTagTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Content;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 define('IS_BEHAT', TRUE);
 
@@ -12,7 +12,7 @@ define('IS_BEHAT', TRUE);
  * @group functional
  * @group all
  */
-class MetaTagTest extends ExistingSiteBase {
+class MetaTagTest extends VaGovExistingSiteBase {
 
   /**
    * This comment intentionally left blank.

--- a/tests/phpunit/Content/NodeLinkEnforcementFilterTest.php
+++ b/tests/phpunit/Content/NodeLinkEnforcementFilterTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Content;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm the proper functioning of the NodeLinkEnforcement filter.
@@ -13,7 +13,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  *
  * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Filter\NodeLinkEnforcementFilter
  */
-class NodeLinkEnforcementFilterTest extends ExistingSiteBase {
+class NodeLinkEnforcementFilterTest extends VaGovExistingSiteBase {
 
   /**
    * Test node.

--- a/tests/phpunit/Content/PreventAbsoluteCmsLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventAbsoluteCmsLinksValidatorTest.php
@@ -2,10 +2,10 @@
 
 namespace tests\phpunit\Content;
 
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinksValidator;
-use Traits\ValidatorTestTrait;
+use Tests\Support\Traits\ValidatorTestTrait;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * A test to confirm the proper functioning of this validator.
@@ -16,7 +16,7 @@ use Traits\ValidatorTestTrait;
  *
  * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinksValidator
  */
-class PreventAbsoluteCmsLinksValidatorTest extends UnitTestCase {
+class PreventAbsoluteCmsLinksValidatorTest extends VaGovUnitTestBase {
 
   use ValidatorTestTrait;
 

--- a/tests/phpunit/Content/PreventLocalFileLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventLocalFileLinksValidatorTest.php
@@ -2,10 +2,10 @@
 
 namespace tests\phpunit\Content;
 
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventLocalFileLinks;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventLocalFileLinksValidator;
-use Traits\ValidatorTestTrait;
+use Tests\Support\Traits\ValidatorTestTrait;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * A test to confirm the proper functioning of this validator.
@@ -16,7 +16,7 @@ use Traits\ValidatorTestTrait;
  *
  * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventLocalFileLinksValidator
  */
-class PreventLocalFileLinksValidatorTest extends UnitTestCase {
+class PreventLocalFileLinksValidatorTest extends VaGovUnitTestBase {
 
   use ValidatorTestTrait;
 

--- a/tests/phpunit/Content/PreventProtocolRelativeLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventProtocolRelativeLinksValidatorTest.php
@@ -2,10 +2,10 @@
 
 namespace tests\phpunit\Content;
 
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinks;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinksValidator;
-use Traits\ValidatorTestTrait;
+use Tests\Support\Classes\VaGovUnitTestBase;
+use Tests\Support\Traits\ValidatorTestTrait;
 
 /**
  * A test to confirm the proper functioning of this validator.
@@ -16,7 +16,7 @@ use Traits\ValidatorTestTrait;
  *
  * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinksValidator
  */
-class PreventProtocolRelativeLinksValidatorTest extends UnitTestCase {
+class PreventProtocolRelativeLinksValidatorTest extends VaGovUnitTestBase {
 
   use ValidatorTestTrait;
 

--- a/tests/phpunit/Content/TrimNodeTitleWhitespaceTest.php
+++ b/tests/phpunit/Content/TrimNodeTitleWhitespaceTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Content;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm the proper functioning of TrimNodeTitleWhitespace.
@@ -12,7 +12,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  *
  * @coversDefaultClass \Drupal\va_gov_backend\EventSubscriber\EntityEventSubscriber
  */
-class TrimNodeTitleWhitespaceTest extends ExistingSiteBase {
+class TrimNodeTitleWhitespaceTest extends VaGovExistingSiteBase {
 
   /**
    * Confirm that the trimmed title is as expected.

--- a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
+++ b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
@@ -9,7 +9,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Provides automated tests for the va_gov_backend module.
@@ -17,7 +17,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class ContentReleaseStatusControllerTest extends ExistingSiteBase {
+class ContentReleaseStatusControllerTest extends VaGovExistingSiteBase {
 
   /**
    * History of requests/responses.

--- a/tests/phpunit/Deploy/DeployServiceTest.php
+++ b/tests/phpunit/Deploy/DeployServiceTest.php
@@ -3,12 +3,12 @@
 namespace test\phpunit\Deploy;
 
 use Drupal\Core\Site\Settings;
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_backend\Deploy\DeployService;
 use Drupal\va_gov_backend\Deploy\Plugin\DeployPluginInterface;
 use Drupal\va_gov_backend\Deploy\SuccessHTTPException;
 use Drupal\va_gov_backend\Test\DeployServiceMock;
 use Symfony\Component\HttpFoundation\Request;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Tests the DeployService.
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @covers \Drupal\va_gov_backend\Deploy\DeployService
  */
-class DeployServiceTest extends UnitTestCase {
+class DeployServiceTest extends VaGovUnitTestBase {
 
   /**
    * Test the deploy service run class.

--- a/tests/phpunit/Deploy/Plugins/HealthCheckTest.php
+++ b/tests/phpunit/Deploy/Plugins/HealthCheckTest.php
@@ -2,10 +2,10 @@
 
 namespace test\phpunit\Deploy\Plugins;
 
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_backend\Deploy\Plugin\HealthCheck;
 use Drupal\va_gov_backend\Deploy\SuccessHTTPException;
 use Symfony\Component\HttpFoundation\Request;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Test for Deploy mode health check plugin.
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @covers \Drupal\va_gov_backend\Deploy\Plugin\HealthCheck
  */
-class HealthCheckTest extends UnitTestCase {
+class HealthCheckTest extends VaGovUnitTestBase {
 
   /**
    * Test the Healthcheck plugin.

--- a/tests/phpunit/FrontendBuild/BuildMetricsTest.php
+++ b/tests/phpunit/FrontendBuild/BuildMetricsTest.php
@@ -5,7 +5,6 @@ namespace tests\phpunit\FrontendBuild;
 use Drupal\Core\Http\RequestStack;
 use Drupal\Core\KeyValueStore\KeyValueMemoryFactory;
 use Drupal\Core\State\State;
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_build_trigger\Plugin\MetricsCollector\ContentReleaseDuration;
 use Drupal\va_gov_build_trigger\Plugin\MetricsCollector\ContentReleaseDurationRollingAverage;
 use Drupal\va_gov_build_trigger\Plugin\MetricsCollector\ContentReleaseInterval;
@@ -13,6 +12,7 @@ use Drupal\va_gov_build_trigger\Plugin\MetricsCollector\ContentReleaseIntervalRo
 use Drupal\va_gov_build_trigger\Plugin\MetricsCollector\TimeSinceLastContentRelease;
 use Drupal\va_gov_build_trigger\Service\ReleaseStateManager;
 use Tests\Support\Mock\SpecifiedTime;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Unit test for build metrics.
@@ -20,7 +20,7 @@ use Tests\Support\Mock\SpecifiedTime;
  * @group unit
  * @group all
  */
-class BuildMetricsTest extends UnitTestCase {
+class BuildMetricsTest extends VaGovUnitTestBase {
 
   /**
    * The state service.

--- a/tests/phpunit/FrontendBuild/BuildRequesterTest.php
+++ b/tests/phpunit/FrontendBuild/BuildRequesterTest.php
@@ -8,8 +8,8 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\KeyValueStore\KeyValueMemoryFactory;
 use Drupal\Core\State\State;
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_build_trigger\Service\BuildRequester;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Unit test for the build requester..
@@ -17,7 +17,7 @@ use Drupal\va_gov_build_trigger\Service\BuildRequester;
  * @group unit
  * @group all
  */
-class BuildRequesterTest extends UnitTestCase {
+class BuildRequesterTest extends VaGovUnitTestBase {
 
   /**
    * The state service.

--- a/tests/phpunit/FrontendBuild/BuildSchedulerTest.php
+++ b/tests/phpunit/FrontendBuild/BuildSchedulerTest.php
@@ -8,11 +8,11 @@ use Drupal\Core\Http\RequestStack;
 use Drupal\Core\KeyValueStore\KeyValueMemoryFactory;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\State\State;
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_build_trigger\Service\BuildRequester;
 use Drupal\va_gov_build_trigger\Service\BuildScheduler;
 use Symfony\Component\DependencyInjection\Container;
 use Tests\Support\Mock\SpecifiedTime;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Unit test for the build scheduler.
@@ -20,7 +20,7 @@ use Tests\Support\Mock\SpecifiedTime;
  * @group unit
  * @group all
  */
-class BuildSchedulerTest extends UnitTestCase {
+class BuildSchedulerTest extends VaGovUnitTestBase {
 
   /**
    * The build requester service.

--- a/tests/phpunit/FrontendBuild/BuildStateEventSubscriberTest.php
+++ b/tests/phpunit/FrontendBuild/BuildStateEventSubscriberTest.php
@@ -5,7 +5,6 @@ namespace tests\phpunit\FrontendBuild;
 use Drupal\Core\KeyValueStore\KeyValueMemoryFactory;
 use Drupal\Core\State\State;
 use Drupal\prometheus_exporter\MetricsCollectorManager;
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_build_trigger\Event\ReleaseStateTransitionEvent;
 use Drupal\va_gov_build_trigger\EventSubscriber\ContentReleaseErrorSubscriber;
 use Drupal\va_gov_build_trigger\EventSubscriber\ContentReleaseIntervalSubscriber;
@@ -20,6 +19,7 @@ use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Symfony\Component\DependencyInjection\Container;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Unit test for build state event subscribers.
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\Container;
  * @group unit
  * @group all
  */
-class BuildStateEventSubscriberTest extends UnitTestCase {
+class BuildStateEventSubscriberTest extends VaGovUnitTestBase {
 
   /**
    * The state service.

--- a/tests/phpunit/FrontendBuild/BuildTriggerFormTest.php
+++ b/tests/phpunit/FrontendBuild/BuildTriggerFormTest.php
@@ -4,7 +4,7 @@ namespace tests\phpunit\FrontendBuild;
 
 use Drupal\Core\Site\Settings;
 use Drupal\user\Entity\User;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Functional test of the Build trigger Form.
@@ -12,7 +12,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class BuildTriggerFormTest extends ExistingSiteBase {
+class BuildTriggerFormTest extends VaGovExistingSiteBase {
 
   /**
    * Store the default environment.

--- a/tests/phpunit/FrontendBuild/EntityEventSubscriberTest.php
+++ b/tests/phpunit/FrontendBuild/EntityEventSubscriberTest.php
@@ -8,12 +8,12 @@ use Drupal\Core\Link;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\AbstractEntityEvent;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\UnitTestCase;
 use Drupal\user\UserInterface;
 use Drupal\va_gov_build_trigger\Environment\EnvironmentDiscovery;
 use Drupal\va_gov_build_trigger\EventSubscriber\EntityEventSubscriber;
 use Drupal\va_gov_build_trigger\Service\BuildRequester;
 use Symfony\Component\DependencyInjection\Container;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Unit test for the entity event subscriber.
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Container;
  * @group unit
  * @group all
  */
-class EntityEventSubscriberTest extends UnitTestCase {
+class EntityEventSubscriberTest extends VaGovUnitTestBase {
 
   /**
    * {@inheritDoc}

--- a/tests/phpunit/FrontendBuild/ReleaseStateManagerTest.php
+++ b/tests/phpunit/FrontendBuild/ReleaseStateManagerTest.php
@@ -5,11 +5,11 @@ namespace tests\phpunit\FrontendBuild;
 use Drupal\Core\Http\RequestStack;
 use Drupal\Core\KeyValueStore\KeyValueMemoryFactory;
 use Drupal\Core\State\State;
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_build_trigger\Event\ReleaseStateTransitionEvent;
 use Drupal\va_gov_build_trigger\Service\ReleaseStateManager;
 use Tests\Support\Mock\SpecifiedTime;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Unit test for the release state manager.
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * @group unit
  * @group all
  */
-class ReleaseStateManagerTest extends UnitTestCase {
+class ReleaseStateManagerTest extends VaGovUnitTestBase {
 
   /**
    * The event dispatcher service.

--- a/tests/phpunit/Logging/DatadogApmProcessorTest.php
+++ b/tests/phpunit/Logging/DatadogApmProcessorTest.php
@@ -2,9 +2,9 @@
 
 namespace test\phpunit\Deploy;
 
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_backend\Logger\Processor\DatadogApmProcessor;
 use Drupal\va_gov_backend\Service\DatadogContextProviderInterface;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Test the Datadog APM processor.
@@ -14,7 +14,7 @@ use Drupal\va_gov_backend\Service\DatadogContextProviderInterface;
  *
  * @covers \Drupal\va_gov_backend\Logger\Processor\DatadogApmProcessor
  */
-class DatadogApmProcessorTest extends UnitTestCase {
+class DatadogApmProcessorTest extends VaGovUnitTestBase {
 
   /**
    * Test ::getCurrentContext().

--- a/tests/phpunit/Migration/VaFormMigrationTest.php
+++ b/tests/phpunit/Migration/VaFormMigrationTest.php
@@ -5,7 +5,7 @@ namespace tests\phpunit\Migration;
 use Tests\Support\Entity\Storage as EntityStorage;
 use Tests\Support\Migration\Migrator;
 use Tests\Support\Mock\HttpClient as MockHttpClient;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm that the VA Form Migration works correctly.
@@ -13,7 +13,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class VaFormMigrationTest extends ExistingSiteBase {
+class VaFormMigrationTest extends VaGovExistingSiteBase {
 
   /**
    * Test the VA Form Migration.

--- a/tests/phpunit/Migration/VaHealthCareLocalFacilityMigrationTest.php
+++ b/tests/phpunit/Migration/VaHealthCareLocalFacilityMigrationTest.php
@@ -5,7 +5,7 @@ namespace tests\phpunit\Migration;
 use Tests\Support\Entity\Storage as EntityStorage;
 use Tests\Support\Migration\Migrator;
 use Tests\Support\Mock\HttpClient as MockHttpClient;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm that the VA HC Facility Migration works correctly.
@@ -13,7 +13,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class VaHealthCareLocalFacilityMigrationTest extends ExistingSiteBase {
+class VaHealthCareLocalFacilityMigrationTest extends VaGovExistingSiteBase {
 
   /**
    * Test the VA Health Care Local Facility Migration.

--- a/tests/phpunit/Migration/VaHealthCareLocalFacilityStatusMigrationTest.php
+++ b/tests/phpunit/Migration/VaHealthCareLocalFacilityStatusMigrationTest.php
@@ -5,7 +5,7 @@ namespace tests\phpunit\Migration;
 use Tests\Support\Entity\Storage as EntityStorage;
 use Tests\Support\Migration\Migrator;
 use Tests\Support\Mock\HttpClient as MockHttpClient;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm that the VA HC Facility Status Migration works correctly.
@@ -13,7 +13,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class VaHealthCareLocalFacilityStatusMigrationTest extends ExistingSiteBase {
+class VaHealthCareLocalFacilityStatusMigrationTest extends VaGovExistingSiteBase {
 
   /**
    * Variable for one-time operations.

--- a/tests/phpunit/Ops/DatadogTest.php
+++ b/tests/phpunit/Ops/DatadogTest.php
@@ -3,10 +3,10 @@
 namespace tests\phpunit\Ops;
 
 use PNX\Prometheus\Gauge;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
 use Drupal\Core\Site\Settings;
 use Drupal\va_gov_backend\Service\Datadog;
 use Tests\Support\Mock\HttpClient;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Test the Datadog service.
@@ -14,7 +14,7 @@ use Tests\Support\Mock\HttpClient;
  * @group functional
  * @group all
  */
-class DatadogTest extends ExistingSiteBase {
+class DatadogTest extends VaGovExistingSiteBase {
 
   /**
    * Mock client.

--- a/tests/phpunit/Ops/MetricsTest.php
+++ b/tests/phpunit/Ops/MetricsTest.php
@@ -6,7 +6,7 @@ use Drupal\Core\Site\Settings;
 use Drupal\prometheus_exporter\MetricsCollectorManager;
 use Drupal\va_gov_backend\Service\Datadog;
 use Drupal\va_gov_backend\Service\Metrics;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Test the Metrics service.
@@ -14,7 +14,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class MetricsTest extends ExistingSiteBase {
+class MetricsTest extends VaGovExistingSiteBase {
 
   /**
    * Tests the shouldSendMetrics method.

--- a/tests/phpunit/Performance/CreateNodeTest.php
+++ b/tests/phpunit/Performance/CreateNodeTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Performance;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm node creation performance.
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class CreateNodeTest extends ExistingSiteBase {
+class CreateNodeTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to determine the amount of time it takes to create a node.

--- a/tests/phpunit/Performance/CreateTaxonomyTermTest.php
+++ b/tests/phpunit/Performance/CreateTaxonomyTermTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Performance;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm taxonomy creation and performance.
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class CreateTaxonomyTermTest extends ExistingSiteBase {
+class CreateTaxonomyTermTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to determine the ability and time to create a node.

--- a/tests/phpunit/Performance/EditNodeTest.php
+++ b/tests/phpunit/Performance/EditNodeTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Performance;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm node editing performance.
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class EditNodeTest extends ExistingSiteBase {
+class EditNodeTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to deterine the amount of time to edit a node page.

--- a/tests/phpunit/Performance/LoginTest.php
+++ b/tests/phpunit/Performance/LoginTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Performance;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm login performance.
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class LoginTest extends ExistingSiteBase {
+class LoginTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to determine the amount of time to load the Login page.

--- a/tests/phpunit/Performance/PreviewTest.php
+++ b/tests/phpunit/Performance/PreviewTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Performance;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm the performance of edit preview.
@@ -10,7 +10,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class PreviewTest extends ExistingSiteBase {
+class PreviewTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to deterine the amount of time it takes to load preview.

--- a/tests/phpunit/Performance/ScalabilityCreateNodeTest.php
+++ b/tests/phpunit/Performance/ScalabilityCreateNodeTest.php
@@ -3,7 +3,7 @@
 namespace tests\phpunit\Performance;
 
 use Drupal\Component\Utility\Timer;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm amount of nodes by type.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class ScalabilityCreateNodeTest extends ExistingSiteBase {
+class ScalabilityCreateNodeTest extends VaGovExistingSiteBase {
 
   public const TIMER_NAME = 'php-unit-scalable-page-test';
 

--- a/tests/phpunit/Security/AdminDashboardTest.php
+++ b/tests/phpunit/Security/AdminDashboardTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Security;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm admin dashboard security.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group security
  * @group all
  */
-class AdminDashboardTest extends ExistingSiteBase {
+class AdminDashboardTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to check permissions to access the admin dashboard.

--- a/tests/phpunit/Security/CreateNodeTest.php
+++ b/tests/phpunit/Security/CreateNodeTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Security;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm node creation permissions.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group security
  * @group all
  */
-class CreateNodeTest extends ExistingSiteBase {
+class CreateNodeTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to deterine the amount of time it takes to create a node.

--- a/tests/phpunit/Security/GraphQLTest.php
+++ b/tests/phpunit/Security/GraphQLTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Security;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to check access to graphql data.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group security
  * @group all
  */
-class GraphQLTest extends ExistingSiteBase {
+class GraphQLTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to check access to GraphQL service.

--- a/tests/phpunit/Security/NodeEditTabsTest.php
+++ b/tests/phpunit/Security/NodeEditTabsTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Security;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm access to node edit form tabs.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group security
  * @group all
  */
-class NodeEditTabsTest extends ExistingSiteBase {
+class NodeEditTabsTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to determine whether users can access node edit form tabs.

--- a/tests/phpunit/Security/RoleCheckTest.php
+++ b/tests/phpunit/Security/RoleCheckTest.php
@@ -3,7 +3,7 @@
 namespace tests\phpunit\Security;
 
 use Drupal\user\Entity\Role;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm role names.
@@ -12,7 +12,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group security
  * @group all
  */
-class RoleCheckTest extends ExistingSiteBase {
+class RoleCheckTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to deterine if the role exists.

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -2,8 +2,8 @@
 
 namespace tests\phpunit\Security;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
 use Drupal\user\Entity\Role;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm that roles are associated with the correct permissions.
@@ -12,7 +12,7 @@ use Drupal\user\Entity\Role;
  * @group security
  * @group all
  */
-class RolesPermissionsTest extends ExistingSiteBase {
+class RolesPermissionsTest extends VaGovExistingSiteBase {
 
   /**
    * Determine if each role has the expected permissions.

--- a/tests/phpunit/Security/SectionAccessTest.php
+++ b/tests/phpunit/Security/SectionAccessTest.php
@@ -4,7 +4,7 @@ namespace tests\phpunit\Security;
 
 use Drupal\Core\Url;
 use Drupal\user\UserInterface;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm section access permissions.
@@ -13,7 +13,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group security
  * @group all
  */
-class SectionAccessTest extends ExistingSiteBase {
+class SectionAccessTest extends VaGovExistingSiteBase {
 
   /**
    * Test method to confirm section access permissions.

--- a/tests/phpunit/Security/WorkflowTest.php
+++ b/tests/phpunit/Security/WorkflowTest.php
@@ -2,7 +2,7 @@
 
 namespace tests\phpunit\Security;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * A test to confirm access to workflow moderation.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group security
  * @group all
  */
-class WorkflowTest extends ExistingSiteBase {
+class WorkflowTest extends VaGovExistingSiteBase {
 
   /**
    * A test method to determine whether users can access workflow moderation.

--- a/tests/phpunit/Service/EditorialWorkflowContentRepositoryServiceTest.php
+++ b/tests/phpunit/Service/EditorialWorkflowContentRepositoryServiceTest.php
@@ -3,7 +3,7 @@
 namespace tests\phpunit\Service;
 
 use Drupal\va_gov_workflow_assignments\Service\EditorialWorkflowContentRepository;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Test the EditorialWorkflowContentRepository service.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class EditorialWorkflowContentRepositoryServiceTest extends ExistingSiteBase {
+class EditorialWorkflowContentRepositoryServiceTest extends VaGovExistingSiteBase {
 
   /**
    * The tested EditorialWorkflowContentRepository service.

--- a/tests/phpunit/Service/ExclusionTypesServiceTest.php
+++ b/tests/phpunit/Service/ExclusionTypesServiceTest.php
@@ -3,8 +3,8 @@
 namespace tests\phpunit\Service;
 
 use Composer\Autoload\ClassLoader;
-use Drupal\Tests\UnitTestCase;
 use Drupal\va_gov_backend\Service\ExclusionTypes;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
  * Test the ExclusionTypes service.
@@ -12,7 +12,7 @@ use Drupal\va_gov_backend\Service\ExclusionTypes;
  * @group functional
  * @group all
  */
-class ExclusionTypesServiceTest extends UnitTestCase {
+class ExclusionTypesServiceTest extends VaGovUnitTestBase {
 
   /**
    * The mocked config factory.

--- a/tests/phpunit/Service/ModerationActionsServiceTest.php
+++ b/tests/phpunit/Service/ModerationActionsServiceTest.php
@@ -3,7 +3,7 @@
 namespace tests\phpunit\Service;
 
 use Drupal\va_gov_bulk\Service\ModerationActions;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Test the ModerationActions service.
@@ -11,7 +11,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class ModerationActionsServiceTest extends ExistingSiteBase {
+class ModerationActionsServiceTest extends VaGovExistingSiteBase {
 
   /**
    * The tested ModerationActions service.

--- a/tests/phpunit/Service/VaGovUrlServiceTest.php
+++ b/tests/phpunit/Service/VaGovUrlServiceTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
  * Test the VaGovUrl Service.
@@ -18,7 +18,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @group functional
  * @group all
  */
-class VaGovUrlServiceTest extends ExistingSiteBase {
+class VaGovUrlServiceTest extends VaGovExistingSiteBase {
 
   /**
    * History of requests/responses.

--- a/tests/phpunit/Support/Classes/VaGovExistingSiteBase.php
+++ b/tests/phpunit/Support/Classes/VaGovExistingSiteBase.php
@@ -18,7 +18,7 @@ abstract class VaGovExistingSiteBase extends ExistingSiteBase {
   public function setUp() {
     parent::setUp();
     $timestamp = time();
-    $date = date(DATE_RFC2822);
+    $date = gmdate(DATE_RFC2822);
     $testString = $this->toString();
     $message = "VA_GOV_DEBUG $timestamp $date BEFORE $testString";
     $this->writeLogMessage($message);
@@ -30,7 +30,7 @@ abstract class VaGovExistingSiteBase extends ExistingSiteBase {
   public function tearDown() {
     parent::tearDown();
     $timestamp = time();
-    $date = date(DATE_RFC2822);
+    $date = gmdate(DATE_RFC2822);
     $testString = $this->toString();
     $message = "VA_GOV_DEBUG $timestamp $date AFTER $testString";
     $this->writeLogMessage($message);

--- a/tests/phpunit/Support/Classes/VaGovExistingSiteBase.php
+++ b/tests/phpunit/Support/Classes/VaGovExistingSiteBase.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Support\Classes;
+
+use Tests\Support\Traits\FileLoggerTrait;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Common functionality for ExistingSiteBase derivative test classes.
+ */
+abstract class VaGovExistingSiteBase extends ExistingSiteBase {
+
+  use FileLoggerTrait;
+
+  /**
+   * Executed before each test case.
+   */
+  public function setUp() {
+    parent::setUp();
+    $timestamp = time();
+    $date = date(DATE_RFC2822);
+    $testString = $this->toString();
+    $message = "VA_GOV_DEBUG $timestamp $date BEFORE $testString";
+    $this->writeLogMessage($message);
+  }
+
+  /**
+   * Executed after each test case.
+   */
+  public function tearDown() {
+    parent::tearDown();
+    $timestamp = time();
+    $date = date(DATE_RFC2822);
+    $testString = $this->toString();
+    $message = "VA_GOV_DEBUG $timestamp $date AFTER $testString";
+    $this->writeLogMessage($message);
+  }
+
+}

--- a/tests/phpunit/Support/Classes/VaGovUnitTestBase.php
+++ b/tests/phpunit/Support/Classes/VaGovUnitTestBase.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Support\Classes;
+
+use Drupal\Tests\UnitTestCase;
+use Tests\Support\Traits\FileLoggerTrait;
+
+/**
+ * Common functionality for UnitTestCase derivative test classes.
+ */
+abstract class VaGovUnitTestBase extends UnitTestCase {
+
+  use FileLoggerTrait;
+
+  /**
+   * Executed before each test case.
+   */
+  public function setUp() {
+    parent::setUp();
+    $timestamp = time();
+    $date = date(DATE_RFC2822);
+    $testString = $this->toString();
+    $message = "VA_GOV_DEBUG $timestamp $date BEFORE $testString";
+    $this->writeLogMessage($message);
+  }
+
+  /**
+   * Executed after each test case.
+   */
+  public function tearDown() {
+    parent::tearDown();
+    $timestamp = time();
+    $date = date(DATE_RFC2822);
+    $testString = $this->toString();
+    $message = "VA_GOV_DEBUG $timestamp $date AFTER $testString";
+    $this->writeLogMessage($message);
+  }
+
+}

--- a/tests/phpunit/Support/Classes/VaGovUnitTestBase.php
+++ b/tests/phpunit/Support/Classes/VaGovUnitTestBase.php
@@ -18,7 +18,7 @@ abstract class VaGovUnitTestBase extends UnitTestCase {
   public function setUp() {
     parent::setUp();
     $timestamp = time();
-    $date = date(DATE_RFC2822);
+    $date = gmdate(DATE_RFC2822);
     $testString = $this->toString();
     $message = "VA_GOV_DEBUG $timestamp $date BEFORE $testString";
     $this->writeLogMessage($message);
@@ -30,7 +30,7 @@ abstract class VaGovUnitTestBase extends UnitTestCase {
   public function tearDown() {
     parent::tearDown();
     $timestamp = time();
-    $date = date(DATE_RFC2822);
+    $date = gmdate(DATE_RFC2822);
     $testString = $this->toString();
     $message = "VA_GOV_DEBUG $timestamp $date AFTER $testString";
     $this->writeLogMessage($message);

--- a/tests/phpunit/Support/Classes/VaGovUnitTestBase.php
+++ b/tests/phpunit/Support/Classes/VaGovUnitTestBase.php
@@ -3,37 +3,10 @@
 namespace Tests\Support\Classes;
 
 use Drupal\Tests\UnitTestCase;
-use Tests\Support\Traits\FileLoggerTrait;
 
 /**
  * Common functionality for UnitTestCase derivative test classes.
  */
 abstract class VaGovUnitTestBase extends UnitTestCase {
-
-  use FileLoggerTrait;
-
-  /**
-   * Executed before each test case.
-   */
-  public function setUp() {
-    parent::setUp();
-    $timestamp = time();
-    $date = gmdate(DATE_RFC2822);
-    $testString = $this->toString();
-    $message = "VA_GOV_DEBUG $timestamp $date BEFORE $testString";
-    $this->writeLogMessage($message);
-  }
-
-  /**
-   * Executed after each test case.
-   */
-  public function tearDown() {
-    parent::tearDown();
-    $timestamp = time();
-    $date = gmdate(DATE_RFC2822);
-    $testString = $this->toString();
-    $message = "VA_GOV_DEBUG $timestamp $date AFTER $testString";
-    $this->writeLogMessage($message);
-  }
 
 }

--- a/tests/phpunit/Support/Traits/ContentModerationTrait.php
+++ b/tests/phpunit/Support/Traits/ContentModerationTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Traits;
+namespace Tests\Support\Traits;
 
 use Drupal\node\Entity\Node;
 

--- a/tests/phpunit/Support/Traits/ContentTrait.php
+++ b/tests/phpunit/Support/Traits/ContentTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Traits;
+namespace Tests\Support\Traits;
 
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;

--- a/tests/phpunit/Support/Traits/FieldTrait.php
+++ b/tests/phpunit/Support/Traits/FieldTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Traits;
+namespace Tests\Support\Traits;
 
 use PHPUnit\Framework\Assert;
 

--- a/tests/phpunit/Support/Traits/FileLoggerTrait.php
+++ b/tests/phpunit/Support/Traits/FileLoggerTrait.php
@@ -16,7 +16,7 @@ trait FileLoggerTrait {
    *   An absolute path to the log file.
    */
   public function getLogFilePath(): string {
-    $rootPath = getenv('DDEV_APPROOT') ?? getenv('TUGBOAT_ROOT') ?? '/var/www/cms';
+    $rootPath = getenv('DDEV_APPROOT') ?: getenv('TUGBOAT_ROOT') ?: getenv('RUNNER_TEMP') ?: '/var/www/cms';
     return "$rootPath/phpunit.log";
   }
 

--- a/tests/phpunit/Support/Traits/FileLoggerTrait.php
+++ b/tests/phpunit/Support/Traits/FileLoggerTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Support\Traits;
+
+/**
+ * Allows for logging to a file to ease debugging in non-interactive settings.
+ *
+ * This trait is meant to be used only by test classes.
+ */
+trait FileLoggerTrait {
+
+  /**
+   * Retrieves the log file path.
+   *
+   * @return string
+   *   An absolute path to the log file.
+   */
+  public function getLogFilePath(): string {
+    $rootPath = getenv('DDEV_APPROOT') ?? getenv('TUGBOAT_ROOT') ?? '/var/www/cms';
+    return "$rootPath/phpunit.log";
+  }
+
+  /**
+   * Write a message to the log file.
+   *
+   * @param string $message
+   *   The message to write.
+   */
+  public function writeLogMessage(string $message) {
+    file_put_contents($this->getLogFilePath(), "$message\n", FILE_APPEND);
+  }
+
+}

--- a/tests/phpunit/Support/Traits/UserEntityTrait.php
+++ b/tests/phpunit/Support/Traits/UserEntityTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Traits;
+namespace Tests\Support\Traits;
 
 use Drupal\user\Entity\Role;
 use PHPUnit\Framework\Assert;

--- a/tests/phpunit/Support/Traits/ValidatorTestTrait.php
+++ b/tests/phpunit/Support/Traits/ValidatorTestTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Traits;
+namespace Tests\Support\Traits;
 
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemInterface;


### PR DESCRIPTION
## Description

Closes #10391.

This should be safe and can be merged provided tests pass.

By entering a command like this:

```
cat *.log | sort -h | grep VA_GOV_DEBUG
```

we can get a log, sorted by timestamp, of the concurrent Behat, PHPUnit, and Cypress tests:

```
...
VA_GOV_DEBUG 1666112762 Tue, 18 Oct 2022 17:06:02 +0000 BEFORE tests\phpunit\API\PostApiQueueTest::testPostApiQueueProcessing
VA_GOV_DEBUG 1666112763 Tue, 18 Oct 2022 17:06:03 +0000 AFTER tests\phpunit\API\PostApiQueueTest::testPostApiQueueDedupe
VA_GOV_DEBUG 1666112763 Tue, 18 Oct 2022 17:06:03 +0000 BEFORE tests\phpunit\API\PostApiQueueTest::testPostApiQueueDedupe
VA_GOV_DEBUG 1666112763 Tue, 18 Oct 2022 17:06:03 +0000 BEFORE tests\phpunit\Content\AliasesTest::testVamcFacilityHealthServiceAlias
VA_GOV_DEBUG 1666112763 Tue, 18 Oct 2022 17:06:03 +0000 BEFORE /var/lib/tugboat/tests/behat/features/content_editing.feature Log in and confirm that "Step by step" node edit has the correct field settings
VA_GOV_DEBUG 1666112766 Tue, 18 Oct 2022 17:06:06 +0000 AFTER tests\phpunit\Content\AliasesTest::testVamcFacilityHealthServiceAlias
VA_GOV_DEBUG 1666112766 Tue, 18 Oct 2022 17:06:06 +0000 AFTER tests\phpunit\Content\BulletinQueueTest::testBulletinQueue with data set "There should be no bulletin from published nodes with the "Send update" field unchecked in the govdelivery_bulletin queue." (array('full_width_banner_alert', 'PHPUnit Test Alert', '1', 0, 'warning', 'This is a test created by php...egard.', array(1010), 1), 0, '', 0, '')
VA_GOV_DEBUG 1666112766 Tue, 18 Oct 2022 17:06:06 +0000 AFTER tests\phpunit\Content\BulletinQueueTest::testBulletinQueue with data set "There should be no bulletin from unpublished nodes in the govdelivery_bulletin queue." (array('full_width_banner_alert', 'PHPUnit Test Alert', '1', '1', 'warning', 'This is a test created by php...egard.', array(1010), 0), 0, '', 0, '')
VA_GOV_DEBUG 1666112766 Tue, 18 Oct 2022 17:06:06 +0000 BEFORE tests\phpunit\Content\BulletinQueueTest::testBulletinQueue with data set "There should be no bulletin from published nodes with the "Send update" field unchecked in the govdelivery_bulletin queue." (array('full_width_banner_alert', 'PHPUnit Test Alert', '1', 0, 'warning', 'This is a test created by php...egard.', array(1010), 1), 0, '', 0, '')
VA_GOV_DEBUG 1666112766 Tue, 18 Oct 2022 17:06:06 +0000 BEFORE tests\phpunit\Content\BulletinQueueTest::testBulletinQueue with data set "There should be no bulletin from unpublished nodes in the govdelivery_bulletin queue." (array('full_width_banner_alert', 'PHPUnit Test Alert', '1', '1', 'warning', 'This is a test created by php...egard.', array(1010), 0), 0, '', 0, '')
VA_GOV_DEBUG 1666112767 Tue, 18 Oct 2022 17:06:07 +0000 AFTER tests\phpunit\Content\BulletinQueueTest::testBulletinQueue with data set "There should be a bulletin from published nodes with the "Send update" field checked in the govdelivery_bulletin queue." (array('full_width_banner_alert', 'PHPUnit Test Alert', '1', '1', 'warning', 'This is a test created by php...egard.', array(1010), 1), 1, 'This is a test created by php...egard.', 1, 'This is test phpUnit situatio...egard.')
VA_GOV_DEBUG 1666112767 Tue, 18 Oct 2022 17:06:07 +0000 AFTER tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #0 (array(), 'test', array())
VA_GOV_DEBUG 1666112767 Tue, 18 Oct 2022 17:06:07 +0000 AFTER tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #1 (array(array('null', 'Grand Poobah')), 'still_test_lol', array(array('null', 'Grand Poobah')))
VA_GOV_DEBUG 1666112767 Tue, 18 Oct 2022 17:06:07 +0000 BEFORE tests\phpunit\Content\BulletinQueueTest::testBulletinQueue with data set "There should be a bulletin from published nodes with the "Send update" field checked in the govdelivery_bulletin queue." (array('full_width_banner_alert', 'PHPUnit Test Alert', '1', '1', 'warning', 'This is a test created by php...egard.', array(1010), 1), 1, 'This is a test created by php...egard.', 1, 'This is test phpUnit situatio...egard.')
VA_GOV_DEBUG 1666112767 Tue, 18 Oct 2022 17:06:07 +0000 BEFORE tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #0 (array(), 'test', array())
VA_GOV_DEBUG 1666112767 Tue, 18 Oct 2022 17:06:07 +0000 BEFORE tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #1 (array(array('null', 'Grand Poobah')), 'still_test_lol', array(array('null', 'Grand Poobah')))
VA_GOV_DEBUG 1666112768 Tue, 18 Oct 2022 17:06:08 +0000 AFTER tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #2 (array(array('null', 'Grand Poobah')), 'node_form', array(array('null', 'Save as')))
VA_GOV_DEBUG 1666112768 Tue, 18 Oct 2022 17:06:08 +0000 AFTER tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #3 (array(array('null', 'Grand Poobah')), 'node_form', array(array('null', 'Save as')), true)
VA_GOV_DEBUG 1666112768 Tue, 18 Oct 2022 17:06:08 +0000 AFTER tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #4 (array(array('null', 'Grand Poobah')), 'node_form', array(array('draft', 'Save as')), true, true)
VA_GOV_DEBUG 1666112768 Tue, 18 Oct 2022 17:06:08 +0000 BEFORE tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #2 (array(array('null', 'Grand Poobah')), 'node_form', array(array('null', 'Save as')))
VA_GOV_DEBUG 1666112768 Tue, 18 Oct 2022 17:06:08 +0000 BEFORE tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #3 (array(array('null', 'Grand Poobah')), 'node_form', array(array('null', 'Save as')), true)
VA_GOV_DEBUG 1666112768 Tue, 18 Oct 2022 17:06:08 +0000 BEFORE tests\phpunit\Content\ContentModerationTest::testPreventPublishingUnproofedNodes with data set #4 (array(array('null', 'Grand Poobah')), 'node_form', array(array('draft', 'Save as')), true, true)
VA_GOV_DEBUG 1666112769 Tue, 18 Oct 2022 17:06:09 +0000 AFTER tests\phpunit\Content\CreateMediaTest::testCreateMedia with data set #0 (4)
VA_GOV_DEBUG 1666112769 Tue, 18 Oct 2022 17:06:09 +0000 BEFORE tests\phpunit\Content\CreateMediaTest::testCreateMedia with data set #0 (4)
VA_GOV_DEBUG 1666112770 Tue, 18 Oct 2022 17:06:10 +0000 BEFORE tests\phpunit\Content\DownloadableFileTest::testDocumentFilesPresentSpeciallyFormattedLink
VA_GOV_DEBUG 1666112773 Tue, 18 Oct 2022 17:06:13 GMT BEFORE CMS Users may effectively create & edit content,Log in and confirm that System-wide alerts can be created and edited Log in and confirm that System-wide alerts can be created and edited
VA_GOV_DEBUG 1666112777 Tue, 18 Oct 2022 17:06:17 +0000 AFTER /var/lib/tugboat/tests/behat/features/content_editing.feature Log in and confirm that "Step by step" node edit has the correct field settings
VA_GOV_DEBUG 1666112777 Tue, 18 Oct 2022 17:06:17 +0000 BEFORE /var/lib/tugboat/tests/behat/features/content_editing.feature Log in and confirm that "Checklist" node edit has the correct field settings
VA_GOV_DEBUG 1666112785 Tue, 18 Oct 2022 17:06:25 +0000 AFTER /var/lib/tugboat/tests/behat/features/content_editing.feature Log in and confirm that "Checklist" node edit has the correct field settings
VA_GOV_DEBUG 1666112785 Tue, 18 Oct 2022 17:06:25 +0000 BEFORE /var/lib/tugboat/tests/behat/features/content_editing.feature Confirm that the EWA block URL is shown correctly.
...
```

so ideally, this should help us troubleshoot deadlocks and things like that that might be the fault of one test but affect concurrent tests more visibly.