### PR TITLE
VACMS-11257: Sends GitHub Actions metrics to DataDog.

### DIFF
--- a/.github/workflows/actions-metrics.yml
+++ b/.github/workflows/actions-metrics.yml
@@ -1,0 +1,18 @@
+on:
+  workflow_run:
+    workflows:
+      - '**'
+    types:
+      - completed
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Send GitHub Actions metrics to DataDog
+        # https://github.com/int128/datadog-actions-metrics/releases/tag/v1.29.0
+        uses: int128/datadog-actions-metrics@2c0a53d3b1373ba2f085281b613963c36f9805b9
+        with:
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
+          collect-job-metrics: true


### PR DESCRIPTION
## Description

Closes #11257.

If this passes tests, it should be safe to merge.
