### PR TITLE
VACMS-11137 Add VBA fields VA service taxonomy

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -9,6 +9,12 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id
     - field.field.taxonomy_term.health_care_service_taxonomy.field_owner
     - field.field.taxonomy_term.health_care_service_taxonomy.field_service_type_of_care
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vamc_facilities
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_required_servic
@@ -29,7 +35,7 @@ third_party_settings:
       label: 'Section settings'
       region: hidden
       parent_name: ''
-      weight: 8
+      weight: 9
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -39,6 +45,7 @@ third_party_settings:
         weight: 0
     group_vet_center:
       children:
+        - field_show_for_vet_centers
         - field_vet_center_type_of_care
         - field_vet_center_friendly_name
         - field_vet_center_com_conditions
@@ -58,6 +65,7 @@ third_party_settings:
         required_fields: true
     group_vamc:
       children:
+        - field_show_for_vamc_facilities
         - field_service_type_of_care
         - field_also_known_as
         - field_commonly_treated_condition
@@ -74,6 +82,24 @@ third_party_settings:
         open: true
         description: 'These values act as the default values for VHA health services, but can be overridden for Vet Centers, below.'
         required_fields: true
+    group_vba:
+      children:
+        - field_show_for_vba_facilities
+        - field_vba_friendly_name
+        - field_vba_com_conditions
+        - field_vba_service_descrip
+      label: VBA
+      region: content
+      parent_name: ''
+      weight: 6
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.health_care_service_taxonomy.default
 targetEntityType: taxonomy_term
 bundle: health_care_service_taxonomy
@@ -81,7 +107,7 @@ mode: default
 content:
   description:
     type: text_textarea
-    weight: 11
+    weight: 18
     region: content
     settings:
       rows: 5
@@ -89,7 +115,7 @@ content:
     third_party_settings: {  }
   field_also_known_as:
     type: string_textfield
-    weight: 9
+    weight: 16
     region: content
     settings:
       size: 60
@@ -97,7 +123,7 @@ content:
     third_party_settings: {  }
   field_commonly_treated_condition:
     type: string_textfield
-    weight: 10
+    weight: 17
     region: content
     settings:
       size: 60
@@ -120,19 +146,32 @@ content:
     third_party_settings: {  }
   field_service_type_of_care:
     type: options_select
-    weight: 7
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_vet_center_com_conditions:
-    type: string_textfield
-    weight: 11
+  field_show_for_vamc_facilities:
+    type: boolean_checkbox
+    weight: 14
     region: content
     settings:
-      size: 60
-      placeholder: ''
+      display_label: true
     third_party_settings: {  }
-  field_vet_center_friendly_name:
+  field_show_for_vba_facilities:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_show_for_vet_centers:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_vba_com_conditions:
     type: string_textfield
     weight: 9
     region: content
@@ -140,16 +179,48 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_vba_friendly_name:
+    type: string_textfield
+    weight: 8
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_vba_service_descrip:
+    type: string_textarea
+    weight: 10
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_vet_center_com_conditions:
+    type: string_textfield
+    weight: 18
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_vet_center_friendly_name:
+    type: string_textfield
+    weight: 17
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_vet_center_required_servic:
     type: boolean_checkbox
-    weight: 13
+    weight: 20
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_vet_center_service_descrip:
     type: string_textarea
-    weight: 12
+    weight: 19
     region: content
     settings:
       rows: 5
@@ -157,7 +228,7 @@ content:
     third_party_settings: {  }
   field_vet_center_type_of_care:
     type: options_select
-    weight: 8
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -178,7 +249,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -9,6 +9,12 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_health_service_api_id
     - field.field.taxonomy_term.health_care_service_taxonomy.field_owner
     - field.field.taxonomy_term.health_care_service_taxonomy.field_service_type_of_care
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vamc_facilities
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_required_servic
@@ -74,6 +80,59 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_show_for_vamc_facilities:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 12
+    region: content
+  field_show_for_vba_facilities:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 14
+    region: content
+  field_show_for_vet_centers:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 13
+    region: content
+  field_vba_com_conditions:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 16
+    region: content
+  field_vba_friendly_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 15
+    region: content
+  field_vba_service_descrip:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 17
     region: content
   field_vet_center_com_conditions:
     type: string

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vamc_facilities.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vamc_facilities.yml
@@ -1,0 +1,29 @@
+uuid: b435dc7b-0aa7-4a5a-8bb2-6d9393fd543d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_show_for_vamc_facilities
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.health_care_service_taxonomy.field_show_for_vamc_facilities
+field_name: field_show_for_vamc_facilities
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Show for VAMC Facilities'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Show
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities.yml
@@ -1,0 +1,29 @@
+uuid: be902036-1f1f-4310-ac80-259e67c332d5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_show_for_vba_facilities
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
+field_name: field_show_for_vba_facilities
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Show for VBA Facilities'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Show
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers.yml
@@ -1,0 +1,29 @@
+uuid: 5ba41148-712b-409f-8681-84397331a9b9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_show_for_vet_centers
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
+field_name: field_show_for_vet_centers
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'Show for Vet Centers'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Show
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions.yml
@@ -1,0 +1,19 @@
+uuid: 409cd108-9d38-4acf-a20b-6a836dfd6899
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_vba_com_conditions
+    - taxonomy.vocabulary.health_care_service_taxonomy
+id: taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
+field_name: field_vba_com_conditions
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'VBA Common Conditions'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name.yml
@@ -1,0 +1,25 @@
+uuid: c9629b85-afbd-4038-8f11-4c05b70f46db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_vba_friendly_name
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
+field_name: field_vba_friendly_name
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'VBA Patient Friendly Name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip.yml
@@ -1,0 +1,25 @@
+uuid: b268ccaa-2b49-48c9-a5a3-338883e47b98
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_vba_service_descrip
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
+field_name: field_vba_service_descrip
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'VBA Description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.storage.taxonomy_term.field_show_for_vamc_facilities.yml
+++ b/config/sync/field.storage.taxonomy_term.field_show_for_vamc_facilities.yml
@@ -1,0 +1,18 @@
+uuid: a1864462-a947-442e-a98d-6b756799d927
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_show_for_vamc_facilities
+field_name: field_show_for_vamc_facilities
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_show_for_vba_facilities.yml
+++ b/config/sync/field.storage.taxonomy_term.field_show_for_vba_facilities.yml
@@ -1,0 +1,18 @@
+uuid: 5c57907e-eb94-4a4c-af20-cd0df6200b42
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_show_for_vba_facilities
+field_name: field_show_for_vba_facilities
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_show_for_vet_centers.yml
+++ b/config/sync/field.storage.taxonomy_term.field_show_for_vet_centers.yml
@@ -1,0 +1,18 @@
+uuid: 3c3af7ac-1ecd-4f9c-8b7d-6ae364c0d745
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_show_for_vet_centers
+field_name: field_show_for_vet_centers
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_vba_com_conditions.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vba_com_conditions.yml
@@ -1,0 +1,21 @@
+uuid: 7237f7a9-7021-43c8-af5c-284b796decf2
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_vba_com_conditions
+field_name: field_vba_com_conditions
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_vba_friendly_name.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vba_friendly_name.yml
@@ -1,0 +1,21 @@
+uuid: 2ed539ba-6716-40ae-840f-1f82d508af30
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_vba_friendly_name
+field_name: field_vba_friendly_name
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_vba_service_descrip.yml
+++ b/config/sync/field.storage.taxonomy_term.field_vba_service_descrip.yml
@@ -1,0 +1,19 @@
+uuid: 9a4fcb01-453a-4e5f-98b3-56fc72d7cef8
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_vba_service_descrip
+field_name: field_vba_service_descrip
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -24,6 +24,12 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Health Service API ID | field_health_service_api_id | Text (plain) | Required | 1 | Textfield |  |
 | Vocabulary | VA Services | Section | field_owner | Entity reference | Required | 1 | -- Disabled -- |  |
 | Vocabulary | VA Services | Type of care | field_service_type_of_care | List (text) |  | 1 | Select list |  |
+| Vocabulary | VA Services | Show for VAMC Facilities | field_show_for_vamc_facilities | Boolean |  | 1 | Single on/off checkbox |  |
+| Vocabulary | VA Services | Show for VBA Facilities | field_show_for_vba_facilities | Boolean |  | 1 | Single on/off checkbox |  |
+| Vocabulary | VA Services | Show for Vet Centers | field_show_for_vet_centers | Boolean |  | 1 | Single on/off checkbox |  |
+| Vocabulary | VA Services | VBA Common Conditions | field_vba_com_conditions | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VA Services | VBA Patient Friendly Name | field_vba_friendly_name | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VA Services | VBA Description | field_vba_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VA Services | Common conditions | field_vet_center_com_conditions  | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | Patient friendly name | field_vet_center_friendly_name | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | This is a required Vet Center service | field_vet_center_required_servic | Boolean |  | 1 | Single on/off checkbox |  |


### PR DESCRIPTION
## Description

Closes #11137 

## Testing done

Manually

## Screenshots
![va-gov-cms ddev site_taxonomy_term_112_edit_destination=_admin_structure_taxonomy_manage_health_care_service_taxonomy_overview](https://user-images.githubusercontent.com/766573/197083768-77193a8e-90a5-4a81-8c45-49a7d1f13b2f.png)


## QA steps

As an admin, edit the Adaptive sports term: /taxonomy/term/112/edit
  - [x] Validate that the AC has been met.
  - [x] Select "Show for VAMC Facilities".
  - [x] Save the page.

As an admin, visit the Brockton VA Medical Center page: /boston-health-care/locations/brockton-va-medical-center
- [x] Validate that Adaptive Sports - Brockton VA Medial Center shows
- [x] Click the Adaptive Sports - Brockton VA Medial Center link
- [x] Validate that the "Show for VAMC Facilities" value is "Show"


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`


### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
