### PR TITLE
VACMS-11040: limit number of VAMC system Banner Alerts

### DIFF
--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.default.yml
@@ -13,12 +13,14 @@ dependencies:
     - field.field.node.full_width_banner_alert.field_banner_alert_situationinfo
     - field.field.node.full_width_banner_alert.field_banner_alert_vamcs
     - field.field.node.full_width_banner_alert.field_body
+    - field.field.node.full_width_banner_alert.field_enforce_unique_combo
     - field.field.node.full_width_banner_alert.field_last_saved_by_an_editor
     - field.field.node.full_width_banner_alert.field_operating_status_sendemail
     - field.field.node.full_width_banner_alert.field_situation_updates
     - node.type.full_width_banner_alert
   module:
     - allowed_formats
+    - allow_only_one
     - field_group
     - paragraphs
     - text
@@ -88,6 +90,7 @@ third_party_settings:
         open: true
     group_type:
       children:
+        - field_enforce_unique_combo
         - field_banner_alert_vamcs
         - field_alert_inheritance_subpages
       label: 'Where will this banner appear?'
@@ -192,7 +195,7 @@ content:
     third_party_settings: {  }
   field_alert_inheritance_subpages:
     type: boolean_checkbox
-    weight: 3
+    weight: 28
     region: content
     settings:
       display_label: true
@@ -220,7 +223,7 @@ content:
     third_party_settings: {  }
   field_banner_alert_vamcs:
     type: options_buttons
-    weight: 1
+    weight: 27
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -240,6 +243,13 @@ content:
       allowed_formats:
         hide_help: '1'
         hide_guidelines: '1'
+  field_enforce_unique_combo:
+    type: allow_only_one_widget
+    weight: 26
+    region: content
+    settings:
+      size: 1
+    third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
     weight: 26

--- a/config/sync/core.entity_form_display.node.full_width_banner_alert.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.full_width_banner_alert.inline_entity_form.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.full_width_banner_alert.field_banner_alert_situationinfo
     - field.field.node.full_width_banner_alert.field_banner_alert_vamcs
     - field.field.node.full_width_banner_alert.field_body
+    - field.field.node.full_width_banner_alert.field_enforce_unique_combo
     - field.field.node.full_width_banner_alert.field_last_saved_by_an_editor
     - field.field.node.full_width_banner_alert.field_operating_status_sendemail
     - field.field.node.full_width_banner_alert.field_situation_updates
@@ -241,6 +242,7 @@ content:
 hidden:
   created: true
   field_banner_alert_vamcs: true
+  field_enforce_unique_combo: true
   field_last_saved_by_an_editor: true
   langcode: true
   moderation_state: true

--- a/config/sync/core.entity_view_display.node.full_width_banner_alert.default.yml
+++ b/config/sync/core.entity_view_display.node.full_width_banner_alert.default.yml
@@ -13,11 +13,13 @@ dependencies:
     - field.field.node.full_width_banner_alert.field_banner_alert_situationinfo
     - field.field.node.full_width_banner_alert.field_banner_alert_vamcs
     - field.field.node.full_width_banner_alert.field_body
+    - field.field.node.full_width_banner_alert.field_enforce_unique_combo
     - field.field.node.full_width_banner_alert.field_last_saved_by_an_editor
     - field.field.node.full_width_banner_alert.field_operating_status_sendemail
     - field.field.node.full_width_banner_alert.field_situation_updates
     - node.type.full_width_banner_alert
   module:
+    - allow_only_one
     - entity_reference_revisions
     - field_group
     - options
@@ -141,6 +143,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_enforce_unique_combo:
+    type: allow_only_one
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 15
     region: content
   field_operating_status_sendemail:
     type: boolean

--- a/config/sync/core.entity_view_display.node.full_width_banner_alert.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.full_width_banner_alert.ief_table.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.full_width_banner_alert.field_banner_alert_situationinfo
     - field.field.node.full_width_banner_alert.field_banner_alert_vamcs
     - field.field.node.full_width_banner_alert.field_body
+    - field.field.node.full_width_banner_alert.field_enforce_unique_combo
     - field.field.node.full_width_banner_alert.field_last_saved_by_an_editor
     - field.field.node.full_width_banner_alert.field_operating_status_sendemail
     - field.field.node.full_width_banner_alert.field_situation_updates
@@ -81,6 +82,7 @@ hidden:
   field_alert_operating_status_cta: true
   field_banner_alert_situationinfo: true
   field_body: true
+  field_enforce_unique_combo: true
   field_last_saved_by_an_editor: true
   field_operating_status_sendemail: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.full_width_banner_alert.teaser.yml
+++ b/config/sync/core.entity_view_display.node.full_width_banner_alert.teaser.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.full_width_banner_alert.field_banner_alert_situationinfo
     - field.field.node.full_width_banner_alert.field_banner_alert_vamcs
     - field.field.node.full_width_banner_alert.field_body
+    - field.field.node.full_width_banner_alert.field_enforce_unique_combo
     - field.field.node.full_width_banner_alert.field_last_saved_by_an_editor
     - field.field.node.full_width_banner_alert.field_operating_status_sendemail
     - field.field.node.full_width_banner_alert.field_situation_updates
@@ -41,6 +42,7 @@ hidden:
   field_banner_alert_situationinfo: true
   field_banner_alert_vamcs: true
   field_body: true
+  field_enforce_unique_combo: true
   field_last_saved_by_an_editor: true
   field_operating_status_sendemail: true
   field_situation_updates: true

--- a/config/sync/field.field.node.full_width_banner_alert.field_enforce_unique_combo.yml
+++ b/config/sync/field.field.node.full_width_banner_alert.field_enforce_unique_combo.yml
@@ -1,0 +1,44 @@
+uuid: 421d1e37-357a-40dd-a94e-4b5223268776
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_enforce_unique_combo
+    - node.type.full_width_banner_alert
+  module:
+    - allow_only_one
+    - epp
+third_party_settings:
+  allow_only_one:
+    field_administration: 1
+    field_alert_dismissable: 0
+    field_alert_email_updates_button: 0
+    field_alert_find_facilities_cta: 0
+    field_alert_inheritance_subpages: 0
+    field_alert_operating_status_cta: 0
+    field_alert_type: 0
+    field_banner_alert_situationinfo: 0
+    field_banner_alert_vamcs: 1
+    field_body: 0
+    field_operating_status_sendemail: 0
+    field_situation_updates: 0
+    title: 0
+    case_sensitive: null
+    limit_validation_to_published: 1
+  epp:
+    value: ''
+    on_update: 0
+id: node.full_width_banner_alert.field_enforce_unique_combo
+field_name: field_enforce_unique_combo
+entity_type: node
+bundle: full_width_banner_alert
+label: 'Enforce unique combo'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: allow_only_one


### PR DESCRIPTION
… Updates per system

## Description

Closes #11040 

## Testing done

Manual testing

## Screenshots

![Screen Shot 2022-10-24 at 2 57 20 PM](https://user-images.githubusercontent.com/21045418/197604140-550daa8e-a424-4b7b-9e8d-739025e7490c.png)

## QA steps

As an admin user
1. Navigate to `/admin/content?title=&type=full_width_banner_alert&moderation_state=All&owner=220`
2. You should see 7 VAMC System Banner Alert with Situation Updates nodes
3. Edit the Coronavirus item in a new tab: `/node/36504/edit` notice this item is published
4. Edit the Telephone Service item in a new tab `/node/49336/edit` notice this item is not published
5. Try to publish this item and it should fail with a notification: "There is existing content: Coronavirus, with identical values..."
6. Leave the Telephone Service item marked as unpublished and try to save it. There should be no error.
7. Edit the Telephone Service item again. Change the section for this item to VISN 6 (the parent section for VA Hampton health care) and try to publish it again. This time it should save with no error.
8. At this point VA Hampton Health care has two published Banner Alerts, one at the VISN level and the other at the individual facility level
9. Edit the Coronavirus item `/node/36504/edit`, uncheck the publish checkbox and save it.
10. Edit the Covid Tent Operations item: `/node/44769/edit`, check the publish checkbox and save it. You shouldn't see an error. (We've effectively swapped the Coronavirus item for the Covid Tent Operations item at the facility level)

**Implications**

- You can only have one published item with a given **Section** and **Pages for the following VAMC systems** fields.
- You can have 1 of these nodes for a given system/facility: VA Hampton health care/VA Hampton health care...
- But an editor with access to the parent VISN could also create 1 of these nodes for the VISN/facility: VISN6/VA Hampton health care
- This means a given facility could have 2 of these alerts published at a time
- Note: this does not unpublish existing items to reduce the total number of alerts displayed but it will not let editors save edits to existing published items unless enough items are unpublished to satisfy the allow_only_one rules.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
