### PR TITLE
VACMS-9923: fix display for Lovell sub-sections in user section block

### DIFF
--- a/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
+++ b/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
@@ -146,6 +146,15 @@ class UserSections extends BlockBase implements ContainerFactoryPluginInterface 
           ];
           break;
 
+        case 7:
+          $links[$parent_path[6]][$parent_path[5]][$parent_path[4]][$parent_path[3]][$parent_path[2]][$parent_path[1]][$parent_path[0]]['items'][$term->tid] = [
+            '#type' => 'link',
+            '#weight' => $term->weight,
+            '#title' => $term->name,
+            '#url' => Url::fromRoute('entity.taxonomy_term.canonical', ['taxonomy_term' => $term->tid]),
+          ];
+          break;
+
         default:
           $section_link = Link::fromTextAndUrl($term->name, Url::fromRoute('entity.taxonomy_term.canonical', ['taxonomy_term' => $term->tid]))->toString();
           $expand_button = $sections[$term->tid]['hasChildren'] ? Markup::create('<button class="toggle" aria-label="Toggle ' . $term->name . ' section" aria-pressed="false" aria-expanded="false" aria-controls="section-' . $term->tid . '"></button>') : NULL;

--- a/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
+++ b/docroot/modules/custom/va_gov_user/src/Plugin/Block/UserSections.php
@@ -111,8 +111,13 @@ class UserSections extends BlockBase implements ContainerFactoryPluginInterface 
 
       // Compose render array of section links while preserving hierarchy.
       // This switch accounts for taxonomy terms that are 5 levels deep.
-      // Sections vocabulary is 4 levels deep. If it grows over 5, this logic
-      // must be expanded.
+      // Sections vocabulary is 5 levels deep.
+      // If it grows over 5, this logic must be expanded.
+      // Each case below, including default, represents a level of term depth.
+      // The count represents the nesting level of parent items in $links[].
+      // The count values are always odd because of the structure of $links[].
+      // Each parent item has a sub array called items containing child items.
+      // Case 3 example: $links['parent_id = 3']['items']['parent_id = 8'].
       $count = count($parent_path);
       switch ($count) {
         case 1:


### PR DESCRIPTION
## Description

Closes #9923 

## Testing done

Manual testing

## Screenshots

Logged in as an admin before:
<img width="801" alt="Screen Shot 2022-11-01 at 2 49 40 PM" src="https://user-images.githubusercontent.com/21045418/199314243-2911092d-3030-4a2b-b8a8-b5ed5640f4f2.png">

Logged in as an admin after the fix:
<img width="826" alt="Screen Shot 2022-11-01 at 2 39 27 PM" src="https://user-images.githubusercontent.com/21045418/199314324-1deba54e-5704-496e-b808-55b854f12763.png">

Expanded:
<img width="435" alt="Screen Shot 2022-11-01 at 2 40 01 PM" src="https://user-images.githubusercontent.com/21045418/199314404-2a9afce7-aca3-410f-988f-9af2dbdcdc0f.png">

Logged in as a Lovell editor after the fix:
![Screen Shot 2022-11-01 at 2 40 10 PM](https://user-images.githubusercontent.com/21045418/199314429-4501d093-4de9-43b6-af2e-866713ca0ae0.png)

## QA steps

As an admin user
- [ ] Log into the site and verify the user sections list doesn't display either Lovell subsection at the top level
- [ ] Expand the VHA item, scroll down to find Lovell and verify all 3 sections are properly displayed

As a Lovell editor (example: Katie.Yearley@va.gov
- [ ] Log into the site and verify the Lovell subsections are properly displayed under Lovell Federal health care

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
