### PR TITLE
VACMS-10739: Cache preventing options from showing

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -413,12 +413,19 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
     _va_gov_backend_smart_date_formatting($form, $form_state);
   };
 
-  $targets = [
-    'field_office',
-    'field_listing',
-  ];
+  // Only run when on a node.
+  // Additionally, reduce the number of times called when editing a paragraph,
+  // which will have a triggering_element set.
+  if (isset($form['#entity_type'])
+    && $form['#entity_type'] === 'node'
+    && (!$form_state->getTriggeringElement())) {
+    $targets = [
+      'field_office',
+      'field_listing',
+    ];
+    _va_gov_backend_dropdown_field_access($form, $targets);
+  }
 
-  _va_gov_backend_dropdown_field_access($form, $targets);
 
   if ($form_id === 'workbench_access_assign_user') {
     $form['#submit'][] = 'va_gov_backend_workbench_assign_user_form_submit';

--- a/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+++ b/docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
@@ -207,13 +207,8 @@ class UserPermsService {
     foreach ($targets as $target) {
 
       if (in_array($target, $form) && !empty($form[$target]['widget']['#options'])) {
-        $cid = 'userpermservice-dropdown-access-' . $target . '-' . $user_id;
 
-        if ($target === 'field_listing') {
-          // Add form id to cid for field_listing, since lists for various
-          // content type are different.
-          $cid = 'userpermservice-dropdown-access-' . $form['#form_id'] . '-' . $target . '-' . $user_id;
-        }
+        $cid = "userpermservice-dropdown-access-{$form['#form_id']}-{$target}-{$user_id}";
 
         $cached_data = \Drupal::cache()->get($cid);
         // If we have a cache, return it.


### PR DESCRIPTION
## Description

Closes #10739.

## Testing done
Manually.

## Screenshots
<img width="1840" alt="Screen Shot 2022-11-03 at 12 04 39 AM" src="https://user-images.githubusercontent.com/766573/199652299-86220fba-de02-4c62-87af-70e9da4b1691.png">


## QA steps
Because the fix to this bug is to create more specific caches, the only way to test it (especially with memcache running), is to simply edit content types as the user. Even though we never determined a replicable set of steps to trigger the error, a tester should still no longer see the following on the VAMC Facility Detail Page:
![Error](https://user-images.githubusercontent.com/9059428/190473645-c403c7ff-a06b-481b-85aa-2cc8d1b63e62.png)


As stefanie.gray, edit a [Vet Center Facility Service](https://pr11412-50kwcdiqgmlwz7pgfz485okslscdo6mn.ci.cms.va.gov/node/41100/edit).
- [x] Validate that you can successfully edit the page.
- [x] _Note: there's no need to save it_

As stefanie.gray, start the process to create a new [Vet Center Service](https://pr11412-50kwcdiqgmlwz7pgfz485okslscdo6mn.ci.cms.va.gov/node/add/vet_center_facility_health_servi).
- [x] Validate that you select from the following dropdowns:
  - [x] Section
  - [x] Facility name
  - [x] Service 
- [x] _Note: there's no need to save it_

As stefanie.gray, edit a [VAMC Detail Page](https://pr11412-50kwcdiqgmlwz7pgfz485okslscdo6mn.ci.cms.va.gov/node/35189/edit).
- [x] Validate that the "Related Office or Health Care System" dropdown has "VA Milwaukee Health Care" selected
- [x] Try to edit a Rich Text paragraph under "Main Content"
- [x] Validate that it throws no error
- [x] _Note: there's no need to save it_

As stefanie.gray, start the process to create a new [VAMC Detail Page](https://pr11412-50kwcdiqgmlwz7pgfz485okslscdo6mn.ci.cms.va.gov/node/add/health_care_region_detail_page)
- [x] Select a "Section" of your choosing
- [x] Select a "Related Office or Health Care System" of your choosing
- [x] Validate that the "Related Office or Health Care System" field is populated
- [x] _Note: there's no need to save it_

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`




### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
