### PR TITLE
VACMS-11289: updated filters

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -6282,27 +6282,27 @@ display:
             group_items:
               1:
                 title: '90 days until due'
-                operator: '<='
+                operator: between
                 value:
-                  min: ''
-                  max: ''
-                  value: '-275 days'
+                  min: '-365 days'
+                  max: '-275 days'
+                  value: ''
                   type: offset
               2:
                 title: '60 days until due'
-                operator: '<='
+                operator: between
                 value:
-                  min: ''
-                  max: ''
-                  value: '-305 days'
+                  min: '-365 days'
+                  max: '-305 days'
+                  value: ''
                   type: offset
               3:
                 title: '30 days until due'
-                operator: '<='
+                operator: between
                 value:
-                  min: ''
-                  max: ''
-                  value: '-335 days'
+                  min: '-365 days'
+                  max: '-335 days'
+                  value: ''
                   type: offset
               4:
                 title: '1 year outdated'


### PR DESCRIPTION
## Description

Closes #11289.

## Testing done
Tested locally.

## Screenshots


## QA steps
Navigate to main admin content view. Select the Outdate Content tab. You will see an Outdated filter element. It now has 30, 60 and 90 days until due options. These will filter the content shown to jus the content that will be outdate in the next 30, 60 or 90 days.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
