### PR TITLE
VACMS-11315: Tugboat & DDEV: opcache.jit = disable

### DIFF
--- a/.ddev/php/zzz-va-overrides.ini
+++ b/.ddev/php/zzz-va-overrides.ini
@@ -2,11 +2,14 @@
 
 apc.enable_cli = 1
 
-# Enable PHP 8 jit (just-in-time compilation)
-# https://stitcher.io/blog/php-8-jit-setup
-opcache.enable_cli = 1"
-opcache.enable = 1"
-opcache.jit
+opcache.enable_cli = 1
+opcache.enable = 1
+; Disable JIT for now due to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11315
+opcache.jit = disable
+opcache.jit_buffer_size = 256M
+# Explicitly set opcache.validate_timestamps for documentation in code. PHP default is 1. PROD is 0.
+# https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.validate-timestamps
+opcache.validate_timestamps = 1
 
 ; Default is 90, this is higher because /graphql requests timeout locally for WEB builds otherwise.
 max_execution_time = 1800

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -71,8 +71,12 @@ services:
         # https://stitcher.io/blog/php-8-jit-setup
         - echo "opcache.enable_cli = 1" >> /usr/local/etc/php/conf.d/php-cli.ini
         - echo "opcache.enable = 1" >> /usr/local/etc/php/conf.d/my-php.ini
-        - echo "opcache.jit = 1255" >> /usr/local/etc/php/conf.d/my-php.ini
+        # Disable JIT for now due to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11315
+        - echo "opcache.jit = disable" >> /usr/local/etc/php/conf.d/my-php.ini
         - echo "opcache.jit_buffer_size = 256M" >> /usr/local/etc/php/conf.d/my-php.ini
+        # Explicitly set opcache.validate_timestamps for documentation in code. PHP default is 1. PROD is 0.
+        # https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.validate-timestamps
+        - echo "opcache.validate_timestamps = 1" >> /usr/local/etc/php/conf.d/my-php.ini
 
         # .tugboat/.env.j2 Jinja2 template file support
         - apt-get install python3-apt python3-distutils python3

--- a/composer.json
+++ b/composer.json
@@ -270,7 +270,7 @@
         "bin-dir": "bin",
         "vendor-dir": "docroot/vendor",
         "sort-packages": true,
-        "optimize-autoloader": false,
+        "optimize-autoloader": true,
         "platform": {
             "php": "8.1"
         },


### PR DESCRIPTION
Fixes #11315. This is against the `VACMS-10870-upgrade-to-php81` branch not `main`. 

This disables JIT and turns back on optimizing the PHP autoloader in composer. See #11315 for discussion. 

## Testing done



## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
