### PR TITLE
VACMS-000 Restore original spec took formatting (white space only)

### DIFF
--- a/tests/behat/drupal-spec-tool/content_model_bundles.feature
+++ b/tests/behat/drupal-spec-tool/content_model_bundles.feature
@@ -1,4 +1,3 @@
-
 @api
 Feature: Content model bundles
   In order to enter structured content into my site
@@ -6,119 +5,118 @@ Feature: Content model bundles
   I want to have content entity bundles that reflect my content model.
 
   @dst @content_type @dstbundles
-  Scenario: Bundles
-    Then exactly the following content entity type bundles should exist
+    Scenario: Bundles
+      Then exactly the following content entity type bundles should exist
       | Name | Machine name | Type | Description |
-      | Full Width Alert | banner | Content type | A full width dismissible banner |
-      | Landing Page | basic_landing_page | Content type | Basic Landing Page can be used to build one-off pages for various products. E.g. a homepage for a specific product. |
-      | Campaign Landing Page | campaign_landing_page | Content type |  |
-      | Centralized Content | centralized_content | Content type | Common content for reuse on other content types. |
-      | Checklist | checklist | Content type | A page that lists the items a Veteran or other beneficiary needs to complete a process. For example, a list of documents needed to apply for a benefit.   |
-      | CMS Knowledge Base Article | documentation_page | Content type | Articles about how to use the VA.gov Drupal Content Management System (CMS). |
-      | Event | event | Content type | For online or in-person events like support groups, outreach events, public lectures, and more. |
-      | Events List | event_listing | Content type | A listing of events. |
-      | FAQ page | faq_multiple_q_a | Content type | A collection of several Q&As related to one topic. |
-      | VAMC System Banner Alert with Situation Updates | full_width_banner_alert | Content type | A full-width alert that will be added to a VAMC system, or multiple VAMC systems. |
-      | VAMC Facility | health_care_local_facility | Content type | A clinic or hospital within a VAMC system. |
-      | VAMC Facility Health Service | health_care_local_health_service | Content type | A facility specific description of a health care service, always embedded within a VAMC system description. |
-      | VAMC Detail Page | health_care_region_detail_page | Content type | For static pages where there's not another content type already available.  |
-      | VAMC System | health_care_region_page | Content type | A VAMC system contains multiple VHA health facilities, including usually at least one VAMC, sometimes more. |
-      | Health Services List | health_services_listing | Content type | A listing of health services. |
-      | Benefits Hub Landing Page | landing_page | Content type | A special page for top-level Benefits content with its own one-off layout and content. |
-      | Leadership List | leadership_listing | Content type | A listing of staff profiles. |
-      | VAMC System Locations List | locations_listing | Content type | A listing of VA facilities. |
-      | Image list | media_list_images | Content type | A page that displays a series of related images. |
-      | Video list | media_list_videos | Content type | A page that displays a series of related videos.  |
-      | NCA Facility | nca_facility | Content type | A facility within National Cemetery Administration system. |
-      | Story | news_story | Content type | Community stories highlight the role of a VA facility, program, or healthcare system in a Veteran's journey. They may be a case study of a specific patient, a description of a new or successful program, or a community-interest story. |
-      | Office | office | Content type | An office at the VA, which may have contact info, events, news, and a leadership page in some cases. |
-      | Publication | outreach_asset | Content type | Contains a document, image, or video, for publication within a Publication library. |
-      | Benefits Detail Page | page | Content type | These pages hold all of the benefits overview content, such the detail pages linked to from va.gov/disability, va.gov/health-care, and va.gov/education. |
-      | Staff Profile | person_profile | Content type | Profiles of staff members for display in various places around the site. |
-      | News Release | press_release | Content type | Announcements directed at members of the media for the purpose of publicizing newsworthy events/happenings/programs at specific facilities or healthcare systems. |
-      | News Releases List | press_releases_listing | Content type | A listing of news releases. |
-      | Promo Banner | promo_banner | Content type | Promo banners are fixed content used for dismissible announcements such as new tools, news, etc. |
-      | Publication Listing Page | publication_listing | Content type | This allows the listing of publication materials such as documents, videos, and images all in one place. |
-      | Q&A - single | q_a | Content type | Reusable content that answers a single question from Veterans or other beneficiaries. A Q&A may appear on its own or as part of an FAQ page. |
-      | VAMC System Health Service | regional_health_care_service_des | Content type | A description of a health service specific to a VAMC system, which appears on a VAMC's health services page and on facility pages, within accordions. |
-      | Step-by-Step | step_by_step | Content type | A page that includes numbered steps a Veteran can take to complete an action. Use for instructions that must be completed in order. |
-      | Stories List | story_listing | Content type | A listing of stories. |
-      | Resources and Support Detail Page | support_resources_detail_page | Content type | A page that contains in-depth information about a single resource available to Veterans or other beneficiaries.  |
-      | Support Service | support_service | Content type | Help desks, hotlines, etc, to be contextually placed alongside relevant content. |
-      | VA Form | va_form | Content type | VA forms available for download. Used to populate search results and also generate form landing pages |
-      | VAMC System Operating Status | vamc_operating_status_and_alerts | Content type | Create one of these pages for each VAMC system. Then you can add banner alerts and update facilities' operating status, all from one place. |
-      | VAMC System Billing and Insurance | vamc_system_billing_insurance | Content type | A page about how Veterans can pay a bill within a VAMC system. |
-      | VAMC System Medical Records Office | vamc_system_medical_records_offi | Content type | A page about how Veterans can access their medical records within a VAMC system. |
-      | VAMC System Policies Page | vamc_system_policies_page | Content type | Add policies specific to this VA medical center to appear on the Policies page. Local policies will appear alongside national policies that apply to all VAMCs. |
-      | VAMC System Register for Care | vamc_system_register_for_care | Content type | A page about how Veterans can register for care at a specific VAMC system. |
-      | VBA Facility | vba_facility | Content type | A facility within Veterans Benefits Administration system. |
-      | Vet Center | vet_center | Content type | Location and page content for community-based counseling centers. |
-      | Vet Center - Community Access Point | vet_center_cap | Content type | Location information for Vet Center services situated in another organization. |
-      | Vet Center - Facility Service | vet_center_facility_health_servi | Content type | Facility-specific description of a health service available at a Vet Center. |
-      | Vet Center - Locations List | vet_center_locations_list | Content type | Page content that lists all facilities associated with a Vet Center, including nearby locations. |
-      | Vet Center - Mobile Vet Center | vet_center_mobile_vet_center | Content type | Location information for Vet Center services provided out of an RV. |
-      | Vet Center - Outstation | vet_center_outstation | Content type | Location information for remote facilities related to a main Vet Center. |
-      | VAMC Facility Non-clinical Service | vha_facility_nonclinical_service | Content type | Address and contact info for offices and other non-clinical service locations. This content is always embedded within a VAMC system non-clinical service page. |
-      | Alert | alert | Custom block type | An alert box that can be added to individual pages. |
-      | Benefit Promo | benefit_promo | Custom block type | A call to action with a title, description, CTA label and link. |
-      | CMS Announcement | cms_announcement | Custom block type | Display an announcement to CMS users. |
-      | News Promo | news_promo | Custom block type | Promote a news link with a title and description. |
-      | Promo | promo | Custom block type | Promote a link with an image, title, and description. |
-      | Document | document | Media type | A locally hosted document, such as a PDF. |
-      | Document - External | document_external | Media type |  |
-      | Image | image | Media type | Locally hosted images. |
-      | Video | video | Media type | A video hosted by YouTube, Vimeo, or some other provider. |
-      | Address | address | Paragraph type | An address block. |
-      | Alert | alert | Paragraph type | A reusable or non-reusable alert, either "information status" or "warning status". |
-      | Alert (single) | alert_single | Paragraph type |  |
-      | Audience & Topics | audience_topics | Paragraph type | Audience & Topic selection for "Resources and Support" articles. |
-      | Accordion | basic_accordion | Paragraph type |  |
-      | Call to action | button | Paragraph type | Button with a label and link field. |
-      | Centralized content descriptor | centralized_content_descriptor | Paragraph type | This should only be used on Centralized content nodes to provide a field level name and description for Centralized Content paragraphs. |
-      | Checklist | checklist | Paragraph type |  |
-      | Checklist section | checklist_item | Paragraph type |  |
-      | Accordion group | collapsible_panel | Paragraph type | A group of accordions. |
-      | Accordion Item | collapsible_panel_item | Paragraph type | An individual accordion. |
-      | Contact information | contact_information | Paragraph type |  |
-      | Link to file or video | downloadable_file | Paragraph type | A download link for an image or document, or a link to a YouTube video. |
-      | Email address | email_contact | Paragraph type |  |
-      | Embedded Video | embedded_video | Paragraph type | A component to add embedded videos to articles |
-      | Expandable Text | expandable_text | Paragraph type | Text that expands upon click. |
-      | Featured content | featured_content | Paragraph type |  |
-      | VAMC facility service (non-healthcare service) | health_care_local_facility_servi | Paragraph type | A service available at a specific health care facility, like Parking, or Chaplaincy. |
-      | Link teaser | link_teaser | Paragraph type | A link followed by a description. For building inline "menus" of content. |
-      | Link teaser with image | link_teaser_with_image | Paragraph type |  |
-      | List of link teasers | list_of_link_teasers | Paragraph type | A paragraph that contains only one type of paragraph: Link teaser. |
-      | List of links | list_of_links | Paragraph type | A set of links, with link text and URL required, and an optional header. |
-      | Lists of links | lists_of_links | Paragraph type | WARNING: Resources and support and Knowledge Base only! A list of links, or several lists of links, with an optional section header. |
-      | Embedded image | media | Paragraph type | For adding an image inline |
-      | Media list - Images | media_list_images | Paragraph type |  |
-      | Media list - Videos | media_list_videos | Paragraph type |  |
-      | Non-reusable Alert | non_reusable_alert | Paragraph type |  |
-      | Number callout | number_callout | Paragraph type | Number callouts can be used in the context of a question & answer, where the answer can be summarized in a short phrase that is number-oriented. |
-      | Phone number | phone_number | Paragraph type |  |
-      | Process list | process | Paragraph type | An ordered list (1, 2, 3, 4, N) of steps in a process. |
-      | Q&A | q_a | Paragraph type | Question and Answer |
-      | Q&A group | q_a_group | Paragraph type | Create a new group of existing Q&As. Use this (instead of Rich text) for better accessibility and easy rearranging. |
-      | Q&A Section | q_a_section | Paragraph type | For content formatted as a series of questions and answers. Use this (instead of Rich text) for better accessibility and easy rearranging. |
-      | React Widget | react_widget | Paragraph type | Advanced editors can use this to place react widgets (like a form) on the page. |
-      | Rich text - char limit 1000 | rich_text_char_limit_1000 | Paragraph type | An open-ended text field that uses "Rich Text Limited" with a character limit 1000. |
-      | Service location | service_location | Paragraph type |  |
-      | Service location address | service_location_address | Paragraph type |  |
-      | Situation update | situation_update | Paragraph type | A time-sensitive, added to a banner alert, and displayed on VAMC operating status pages. |
-      | Additional information | spanish_translation_summary | Paragraph type | Text that expands to display additional information upon click. |
-      | Staff profile | staff_profile | Paragraph type | Add a profile of a staff person. |
-      | Step | step | Paragraph type | Single step. |
-      | Step by step | step_by_step | Paragraph type | An ordered list (1, 2, 3, 4, N) of steps. |
-      | Table | table | Paragraph type | Add an HTML table with rows and columns. |
-      | Rich text | wysiwyg | Paragraph type | An open-ended text field. |
-      | Sections | administration | Vocabulary | Represents a hierarchy of the VA, partly for governance purposes. |
-      | Audience - Beneficiaries | audience_beneficiaries | Vocabulary |  |
-      | Audience - Non-beneficiaries | audience_non_beneficiaries | Vocabulary |  |
-      | Facility Supplemental Status | facility_supplemental_status | Vocabulary | Supplemental statuses to be used with facilities. |
-      | VA Services | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |
-      | Resources and support Categories | lc_categories | Vocabulary |  |
-      | Products | products | Vocabulary |  |
-      | Topics | topics | Vocabulary |  |
-      | Type of Redirect | type_of_redirect | Vocabulary |  |
-
+| Full Width Alert | banner | Content type | A full width dismissible banner |
+| Landing Page | basic_landing_page | Content type | Basic Landing Page can be used to build one-off pages for various products. E.g. a homepage for a specific product. |
+| Campaign Landing Page | campaign_landing_page | Content type |  |
+| Centralized Content | centralized_content | Content type | Common content for reuse on other content types. |
+| Checklist | checklist | Content type | A page that lists the items a Veteran or other beneficiary needs to complete a process. For example, a list of documents needed to apply for a benefit.   |
+| CMS Knowledge Base Article | documentation_page | Content type | Articles about how to use the VA.gov Drupal Content Management System (CMS). |
+| Event | event | Content type | For online or in-person events like support groups, outreach events, public lectures, and more. |
+| Events List | event_listing | Content type | A listing of events. |
+| FAQ page | faq_multiple_q_a | Content type | A collection of several Q&As related to one topic. |
+| VAMC System Banner Alert with Situation Updates | full_width_banner_alert | Content type | A full-width alert that will be added to a VAMC system, or multiple VAMC systems. |
+| VAMC Facility | health_care_local_facility | Content type | A clinic or hospital within a VAMC system. |
+| VAMC Facility Health Service | health_care_local_health_service | Content type | A facility specific description of a health care service, always embedded within a VAMC system description. |
+| VAMC Detail Page | health_care_region_detail_page | Content type | For static pages where there's not another content type already available.  |
+| VAMC System | health_care_region_page | Content type | A VAMC system contains multiple VHA health facilities, including usually at least one VAMC, sometimes more. |
+| Health Services List | health_services_listing | Content type | A listing of health services. |
+| Benefits Hub Landing Page | landing_page | Content type | A special page for top-level Benefits content with its own one-off layout and content. |
+| Leadership List | leadership_listing | Content type | A listing of staff profiles. |
+| VAMC System Locations List | locations_listing | Content type | A listing of VA facilities. |
+| Image list | media_list_images | Content type | A page that displays a series of related images. |
+| Video list | media_list_videos | Content type | A page that displays a series of related videos.  |
+| NCA Facility | nca_facility | Content type | A facility within National Cemetery Administration system. |
+| Story | news_story | Content type | Community stories highlight the role of a VA facility, program, or healthcare system in a Veteran's journey. They may be a case study of a specific patient, a description of a new or successful program, or a community-interest story. |
+| Office | office | Content type | An office at the VA, which may have contact info, events, news, and a leadership page in some cases. |
+| Publication | outreach_asset | Content type | Contains a document, image, or video, for publication within a Publication library. |
+| Benefits Detail Page | page | Content type | These pages hold all of the benefits overview content, such the detail pages linked to from va.gov/disability, va.gov/health-care, and va.gov/education. |
+| Staff Profile | person_profile | Content type | Profiles of staff members for display in various places around the site. |
+| News Release | press_release | Content type | Announcements directed at members of the media for the purpose of publicizing newsworthy events/happenings/programs at specific facilities or healthcare systems. |
+| News Releases List | press_releases_listing | Content type | A listing of news releases. |
+| Promo Banner | promo_banner | Content type | Promo banners are fixed content used for dismissible announcements such as new tools, news, etc. |
+| Publication Listing Page | publication_listing | Content type | This allows the listing of publication materials such as documents, videos, and images all in one place. |
+| Q&A - single | q_a | Content type | Reusable content that answers a single question from Veterans or other beneficiaries. A Q&A may appear on its own or as part of an FAQ page. |
+| VAMC System Health Service | regional_health_care_service_des | Content type | A description of a health service specific to a VAMC system, which appears on a VAMC's health services page and on facility pages, within accordions. |
+| Step-by-Step | step_by_step | Content type | A page that includes numbered steps a Veteran can take to complete an action. Use for instructions that must be completed in order. |
+| Stories List | story_listing | Content type | A listing of stories. |
+| Resources and Support Detail Page | support_resources_detail_page | Content type | A page that contains in-depth information about a single resource available to Veterans or other beneficiaries.  |
+| Support Service | support_service | Content type | Help desks, hotlines, etc, to be contextually placed alongside relevant content. |
+| VA Form | va_form | Content type | VA forms available for download. Used to populate search results and also generate form landing pages |
+| VAMC System Operating Status | vamc_operating_status_and_alerts | Content type | Create one of these pages for each VAMC system. Then you can add banner alerts and update facilities' operating status, all from one place. |
+| VAMC System Billing and Insurance | vamc_system_billing_insurance | Content type | A page about how Veterans can pay a bill within a VAMC system. |
+| VAMC System Medical Records Office | vamc_system_medical_records_offi | Content type | A page about how Veterans can access their medical records within a VAMC system. |
+| VAMC System Policies Page | vamc_system_policies_page | Content type | Add policies specific to this VA medical center to appear on the Policies page. Local policies will appear alongside national policies that apply to all VAMCs. |
+| VAMC System Register for Care | vamc_system_register_for_care | Content type | A page about how Veterans can register for care at a specific VAMC system. |
+| VBA Facility | vba_facility | Content type | A facility within Veterans Benefits Administration system. |
+| Vet Center | vet_center | Content type | Location and page content for community-based counseling centers. |
+| Vet Center - Community Access Point | vet_center_cap | Content type | Location information for Vet Center services situated in another organization. |
+| Vet Center - Facility Service | vet_center_facility_health_servi | Content type | Facility-specific description of a health service available at a Vet Center. |
+| Vet Center - Locations List | vet_center_locations_list | Content type | Page content that lists all facilities associated with a Vet Center, including nearby locations. |
+| Vet Center - Mobile Vet Center | vet_center_mobile_vet_center | Content type | Location information for Vet Center services provided out of an RV. |
+| Vet Center - Outstation | vet_center_outstation | Content type | Location information for remote facilities related to a main Vet Center. |
+| VAMC Facility Non-clinical Service | vha_facility_nonclinical_service | Content type | Address and contact info for offices and other non-clinical service locations. This content is always embedded within a VAMC system non-clinical service page. |
+| Alert | alert | Custom block type | An alert box that can be added to individual pages. |
+| Benefit Promo | benefit_promo | Custom block type | A call to action with a title, description, CTA label and link. |
+| CMS Announcement | cms_announcement | Custom block type | Display an announcement to CMS users. |
+| News Promo | news_promo | Custom block type | Promote a news link with a title and description. |
+| Promo | promo | Custom block type | Promote a link with an image, title, and description. |
+| Document | document | Media type | A locally hosted document, such as a PDF. |
+| Document - External | document_external | Media type |  |
+| Image | image | Media type | Locally hosted images. |
+| Video | video | Media type | A video hosted by YouTube, Vimeo, or some other provider. |
+| Address | address | Paragraph type | An address block. |
+| Alert | alert | Paragraph type | A reusable or non-reusable alert, either "information status" or "warning status". |
+| Alert (single) | alert_single | Paragraph type |  |
+| Audience & Topics | audience_topics | Paragraph type | Audience & Topic selection for "Resources and Support" articles. |
+| Accordion | basic_accordion | Paragraph type |  |
+| Call to action | button | Paragraph type | Button with a label and link field. |
+| Centralized content descriptor | centralized_content_descriptor | Paragraph type | This should only be used on Centralized content nodes to provide a field level name and description for Centralized Content paragraphs. |
+| Checklist | checklist | Paragraph type |  |
+| Checklist section | checklist_item | Paragraph type |  |
+| Accordion group | collapsible_panel | Paragraph type | A group of accordions. |
+| Accordion Item | collapsible_panel_item | Paragraph type | An individual accordion. |
+| Contact information | contact_information | Paragraph type |  |
+| Link to file or video | downloadable_file | Paragraph type | A download link for an image or document, or a link to a YouTube video. |
+| Email address | email_contact | Paragraph type |  |
+| Embedded Video | embedded_video | Paragraph type | A component to add embedded videos to articles |
+| Expandable Text | expandable_text | Paragraph type | Text that expands upon click. |
+| Featured content | featured_content | Paragraph type |  |
+| VAMC facility service (non-healthcare service) | health_care_local_facility_servi | Paragraph type | A service available at a specific health care facility, like Parking, or Chaplaincy. |
+| Link teaser | link_teaser | Paragraph type | A link followed by a description. For building inline "menus" of content. |
+| Link teaser with image | link_teaser_with_image | Paragraph type |  |
+| List of link teasers | list_of_link_teasers | Paragraph type | A paragraph that contains only one type of paragraph: Link teaser. |
+| List of links | list_of_links | Paragraph type | A set of links, with link text and URL required, and an optional header. |
+| Lists of links | lists_of_links | Paragraph type | WARNING: Resources and support and Knowledge Base only! A list of links, or several lists of links, with an optional section header. |
+| Embedded image | media | Paragraph type | For adding an image inline |
+| Media list - Images | media_list_images | Paragraph type |  |
+| Media list - Videos | media_list_videos | Paragraph type |  |
+| Non-reusable Alert | non_reusable_alert | Paragraph type |  |
+| Number callout | number_callout | Paragraph type | Number callouts can be used in the context of a question & answer, where the answer can be summarized in a short phrase that is number-oriented. |
+| Phone number | phone_number | Paragraph type |  |
+| Process list | process | Paragraph type | An ordered list (1, 2, 3, 4, N) of steps in a process. |
+| Q&A | q_a | Paragraph type | Question and Answer |
+| Q&A group | q_a_group | Paragraph type | Create a new group of existing Q&As. Use this (instead of Rich text) for better accessibility and easy rearranging. |
+| Q&A Section | q_a_section | Paragraph type | For content formatted as a series of questions and answers. Use this (instead of Rich text) for better accessibility and easy rearranging. |
+| React Widget | react_widget | Paragraph type | Advanced editors can use this to place react widgets (like a form) on the page. |
+| Rich text - char limit 1000 | rich_text_char_limit_1000 | Paragraph type | An open-ended text field that uses "Rich Text Limited" with a character limit 1000. |
+| Service location | service_location | Paragraph type |  |
+| Service location address | service_location_address | Paragraph type |  |
+| Situation update | situation_update | Paragraph type | A time-sensitive, added to a banner alert, and displayed on VAMC operating status pages. |
+| Additional information | spanish_translation_summary | Paragraph type | Text that expands to display additional information upon click. |
+| Staff profile | staff_profile | Paragraph type | Add a profile of a staff person. |
+| Step | step | Paragraph type | Single step. |
+| Step by step | step_by_step | Paragraph type | An ordered list (1, 2, 3, 4, N) of steps. |
+| Table | table | Paragraph type | Add an HTML table with rows and columns. |
+| Rich text | wysiwyg | Paragraph type | An open-ended text field. |
+| Sections | administration | Vocabulary | Represents a hierarchy of the VA, partly for governance purposes. |
+| Audience - Beneficiaries | audience_beneficiaries | Vocabulary |  |
+| Audience - Non-beneficiaries | audience_non_beneficiaries | Vocabulary |  |
+| Facility Supplemental Status | facility_supplemental_status | Vocabulary | Supplemental statuses to be used with facilities. |
+| VA Services | health_care_service_taxonomy | Vocabulary | Single source of truth for health service names, descriptions, patient-friendly names, and common conditions. |
+| Resources and support Categories | lc_categories | Vocabulary |  |
+| Products | products | Vocabulary |  |
+| Topics | topics | Vocabulary |  |
+| Type of Redirect | type_of_redirect | Vocabulary |  |

--- a/tests/behat/drupal-spec-tool/menus.feature
+++ b/tests/behat/drupal-spec-tool/menus.feature
@@ -1,4 +1,3 @@
-
 @api
 Feature: Menus
   In order to organize my content hierarchically
@@ -6,172 +5,171 @@ Feature: Menus
   I want to have menus that reflect my information architecture.
 
   @dst @menus
-  Scenario: Menus
-    Then exactly the following menus should exist
+    Scenario: Menus
+      Then exactly the following menus should exist
       | Name | Machine name | Description |
-      | Administration | admin | Administrative task links |
-      | Burials and memorials benefits hub | burials-and-memorials-benef | For pages in the /burials-and-memorials benefits hub |
-      | Careers & employment benefits hub | careers-employment-benefits | va.gov/careers-employment |
-      | CMS Knowledge Base | documentation | How-to's for editing content in the VA.gov CMS |
-      | Decision reviews | decision-reviews-benefits-h |  |
-      | Disability benefits hub | disability-benefits-hub | For pages in the /disability benefits hub |
-      | Education benefits hub | education-benefits-hub | For pages in the /education benefits hub |
-      | Footer | footer | Site information links displayed in global footer |
-      | Footer Bottom Rail | footer-bottom-rail | Horizontal list of links at the bottom of the page |
-      | Header megamenu | header-megamenu | Links and promos for the site's header menu. |
-      | Health Care benefits hub | health-care-benefits-hub | va.gov/health-care |
-      | Homepage top tasks blocks | homepage-top-tasks-blocks |  |
-      | Housing Assistance benefits hub | housing-assistance-benefits | va.gov/housing-assistance |
-      | Life insurance benefits hub | life-insurance-benefits-hub | va.gov/life-insurance |
-      | Lovell Federal health care | lovell-federal-health-care | VISN 12 \| va.gov/lovell-federal-health-care |
-      | Main navigation | main | Site section links |
-      | Other Search Tools | other-search-tools |  |
-      | Outreach and events | outreach-and-events |  |
-      | Pension benefits hub | pension-benefits-hub | va.gov/pension |
-      | Popular on VA.gov | popular-on-va-gov |  |
-      | Records benefits hub | records-benefits-hub | va.gov/records |
-      | Root pages | root-benefits-hub | For various pages that live at the top level of the URL structure. |
-      | Sections | sections | Automatically updated from the Sections taxonomy, and appears in admin toolbar. |
-      | Tools | tools | User tool links, often added by modules |
-      | User account menu | account | Links related to the active user account |
-      | VA Alaska health care | va-alaska-health-care | VISN 20 \| va.gov/alaska-health-care |
-      | VA Albany health care | va-albany-health-care | VISN 2 \| va.gov/albany-health-care |
-      | VA Alexandria health care | va-alexandria-health-care | VISN 16 \| va.gov/alexandria-health-care |
-      | VA Altoona health care | va-altoona-health-care | VISN 4 \| va.gov/altoona-health-care |
-      | VA Amarillo health care | va-amarillo-health-care | VISN 17 \| va.gov/amarillo-health-care |
-      | VA Ann Arbor health care | va-ann-arbor-health-care | VISN 10 \| va.gov/va-ann-arbor-health-care |
-      | VA Asheville health care | va-asheville-health-care | VISN 6 \| va.gov/asheville-health-care |
-      | VA Atlanta health care | va-atlanta-health-care | VISN 7 \| va.gov/atlanta-health-care |
-      | VA Augusta health care | va-augusta-health-care | VISN 7 \| va.gov/augusta-health-care |
-      | VA Battle Creek health care | va-battle-creek-health-care | VISN 10 \| va.gov/va-battle-creek-health-care |
-      | VA Bay Pines health care | va-bay-pines-health-care | VISN 8 \| va.gov/bay-pines-health-care |
-      | VA Beckley health care | va-beckley-health-care | VISN 5 \| va.gov/beckley-health-care |
-      | VA Bedford health care | va-bedford-health-care | VISN 1 \| va.gov/bedford-health-care |
-      | VA Birmingham health care | va-birmingham-health-care | VISN 7 \| va.gov/birmingham-health-care |
-      | VA Black Hills health care | va-black-hills-health-care | VISN 23 \| va.gov/blackhills-health-care |
-      | VA Boise health care | va-boise-health-care | VISN 20 \| va.gov/boise-health-care |
-      | VA Boston health care | va-boston-health-care | VISN 1 \| va.gov/va-boston-health-care |
-      | VA Bronx health care | va-bronx-health-care | VISN 2 \| va.gov/bronx-health-care |
-      | VA Butler health care | va-butler-health-care | VISN 4 \| va.gov/butler-health-care |
-      | VA Caribbean health care | va-caribbean-health-care | VISN 8 \| va.gov/caribbean-health-care |
-      | VA Central Alabama health care | va-central-alabama-health-care | VISN 7 \| va.gov/central-alabama-health-care |
-      | VA Central Arkansas health care | va-central-arkansas-health-care | VISN 16 \| va.gov/central-arkansas-health-care |
-      | VA Central California health care | va-central-california-health-car | VISN 21 \| va.gov/central-california-health-care |
-      | VA Central Iowa health care | va-central-iowa-health-care | VISN 23 \| va.gov/central-iowa-health-care |
-      | VA Central Ohio health care | va-central-ohio-health-care | VISN 10 \| va.gov/va-central-ohio-health-care |
-      | VA Central Texas health care | va-central-texas-health-care | VISN 17 \| va.gov/central-texas-health-care |
-      | VA Central Western Massachusetts health care | va-central-western-massachusetts | VISN 1 \| va.gov/central-western-massachusetts-health-care |
-      | VA Charleston health care | va-charleston-health-care | VISN 7 \| va.gov/charleston-health-care |
-      | VA Cheyenne health care | va-cheyenne-health-care | VISN 19 \| va.gov/cheyenne-health-care |
-      | VA Chicago health care | va-chicago-health-care | VISN 12 \| va.gov/chicago-health-care |
-      | VA Chillicothe health care | va-chillicothe-health-care | VISN 10 \| va.gov/va-chillicothe-health-care |
-      | VA Cincinnati health care | va-cincinnati-health-care | VISN 10 \| va.gov/va-cincinnati-health-care |
-      | VA Clarksburg health care | va-clarksburg-health-care | VISN 5 \| va.gov/clarksburg-health-care |
-      | VA Coatesville health care | va-coatesville-health-care | VISN 4 \| va.gov/coatesville-health-care |
-      | VA Columbia Missouri health care | va-columbia-missouri-health-care | VISN 15 \| va.gov/columbia-missouri-health-care |
-      | VA Columbia South Carolina health care | va-columbia-south-carolina-healt | VISN 7 \| va.gov/columbia-south-carolina-health-care |
-      | VA Connecticut health care | va-connecticut-health-care | VISN 1 \| va.gov/connecticut-health-care |
-      | VA Dayton health care | va-dayton-health-care | VISN 10 \| va.gov/va-dayton-health-care |
-      | VA Detroit health care | va-detroit-health-care | VISN 10 \| va.gov/va-detroit-health-care |
-      | VA Dublin health care | va-dublin-health-care | VISN 7 \| va.gov/dublin-health-care |
-      | VA Durham health care | va-durham-health-care | VISN 6 \| va.gov/durham-health-care |
-      | VA Eastern Colorado health care | va-eastern-colorado-health-care | VISN 19 \| va.gov/eastern-colorado-health-care |
-      | VA Eastern Kansas health care | va-eastern-kansas-health-care | VISN 15 \| va.gov/va-eastern-kansas-health-care |
-      | VA Eastern Oklahoma health care | va-eastern-oklahoma-health-care | VISN 19 \| va.gov/eastern-oklahoma-health-care |
-      | VA El Paso health care | va-el-paso-health-care | VISN 17 \| va.gov/el-paso-health-care |
-      | VA Erie health care | va-erie-health-care | VISN 4 \| va.gov/erie-health-care |
-      | VA Fargo health care | va-fargo-health-care | VISN 23 \| va.gov/fargo-health-care |
-      | VA Fayetteville Arkansas health care | va-fayetteville-arkansas-health- | VISN 16 \| va.gov/fayetteville-arkansas-health-care |
-      | VA Fayetteville Coastal health care | va-fayetteville-coastal-health-c | VISN 6 \| va.gov/fayetteville-coastal-health-care |
-      | VA Finger Lakes health care | va-finger-lakes-health-care | VISN 2 \| va.gov/finger-lakes-health-care |
-      | VA Greater Los Angeles health care | va-greater-los-angeles-health-ca | VISN 22 \| va.gov/greater-los-angeles-health-care |
-      | VA Gulf Coast health care | va-gulf-coast-health-care | VISN 16 \| va.gov/gulf-coast-health-care |
-      | VA Hampton health care | va-hampton-health-care | VISN 6 \| va.gov/hampton-health-care |
-      | VA Hines health care | va-hines-health-care | VISN 12 \| va.gov/hines-health-care |
-      | VA Houston health care | va-houston-health-care | VISN 16 \| va.gov/houston-health-care |
-      | VA Hudson Valley health care | va-hudson-valley-health-care | VISN 2 \| va.gov/hudson-valley-health-care |
-      | VA Huntington health care | va-huntington-health-care | VISN 5 \| va.gov/huntington-health-care |
-      | VA Illiana health care | va-illiana-health-care | VISN 12 \| va.gov/illiana-health-care |
-      | VA Indiana health care | va-indiana-health-care  | VISN 10 \| va.gov/va-indiana-health-care |
-      | VA Iowa City health care | va-iowa-city-health-care | VISN 23 \| va.gov/iowa-city-health-care |
-      | VA Iron Mountain health care | va-iron-mountain-health-care | VISN 12 \| va.gov/iron-mountain-health-care |
-      | VA Jackson health care | va-jackson-health-care | VISN 16 \| va.gov/jackson-health-care |
-      | VA Kansas City health care | va-kansas-city-health-care | VISN 15 \| va.gov/kansas-city-health-care |
-      | VA Leavenworth health care | va-leavenworth-health-care | VISN 15 \| va.gov/leavenworth-health-care |
-      | VA Lebanon health care | va-lebanon | VISN 4 \| va.gov/lebanon-health-care |
-      | VA Lexington health care | va-lexington-health-care | VISN 9 \| va.gov/lexington-health-care |
-      | VA Loma Linda health care | va-loma-linda-health-care | VISN 22 \| va.gov/loma-linda-health-care |
-      | VA Long Beach health care | va-long-beach-health-care | VISN 22 \| va.gov/long-beach-health-care |
-      | VA Louisville health care | va-louisville-health-care | VISN 9 \| va.gov/louisville-health-care |
-      | VA Madison health care | va-madison-health-care | VISN 12 \| va.gov/madison-health-care |
-      | VA Maine health care | va-maine-health-care | VISN 1 \| va.gov/maine-health-care |
-      | VA Manchester health care | va-manchester-health-care | VISN 1 \| va.gov/manchester-health-care |
-      | VA Marion health care | va-marion-health-care | VISN 15 \| va.gov/marion-health-care |
-      | VA Martinsburg health care | va-martinsburg-health-care | VISN 5 \| va.gov/martinsburg-health-care |
-      | VA Maryland health care | va-maryland-health-care | VISN 5 \| va.gov/maryland-health-care |
-      | VA Memphis health care | va-memphis-health-care | VISN 9 \| va.gov/memphis-health-care |
-      | VA Miami health care | va-miami-health-care | VISN 8 \| va.gov/miami-health-care |
-      | VA Milwaukee health care | va-milwaukee-health-care | VISN 12 \| va.gov/milwaukee-health-care |
-      | VA Minneapolis health care | va-minneapolis-health-care | VISN 23 \| va.gov/minneapolis-health-care |
-      | VA Montana health care | va-montana-health-care | VISN 19 \| va.gov/montana-health-care |
-      | VA Mountain Home health care | va-mountain-home-health-care | VISN 9 \| va.gov/mountain-home-health-care |
-      | VA Nebraska-Western Iowa health care | va-nebraska-western-iowa-health- | VISN 23 \| va.gov/nebraska-western-iowa-health-care |
-      | VA New Jersey health care | va-new-jersey-health-care | VISN 2 \| va.gov/new-jersey-health-care |
-      | VA New Mexico health care | va-new-mexico-health-care | VISN 22 \| va.gov/new-mexico-health-care |
-      | VA New York Harbor health care | va-new-york-harbor-health-care | VISN 2 \| va.gov/new-york-harbor-health-care |
-      | VA North Florida/South Georgia health care | va-north-florida-health-care | VISN 8 \| va.gov/north-florida-health-care |
-      | VA North Texas health care | va-north-texas-health-care | VISN 17 \| va.gov/north-texas-health-care |
-      | VA Northeast Ohio health care | va-northeast-ohio-health-care | VISN 10 \| va.gov/va-northeast-ohio-health-care |
-      | VA Northern Arizona health care | va-northern-arizona-health-care | VISN 22 \| va.gov/northern-arizona-health-care |
-      | VA Northern California health care | va-northern-california-health-ca | VISN 21 \| va.gov/northern-california-health-care |
-      | VA Northern Indiana health care | va-northern-indiana-health-care | VISN 10 \| va.gov/va-northern-indiana-health-care |
-      | VA Northport health care | va-northport-health-care | VISN 2 \| va.gov/northport-health-care |
-      | VA Oklahoma City health care | va-oklahoma-health-care | VISN 19 \| va.gov/oklahoma-city-health-care |
-      | VA Orlando health care | va-orlando-health-care | VISN 8 \| va.gov/orlando-health-care |
-      | VA Pacific Islands health care | va-pacific-islands-health-care | VISN 21 \| va.gov/pacific-islands-health-care |
-      | VA Palo Alto health care | va-palo-alto-health-care | VISN 21 \| va.gov/palo-alto-health-care |
-      | VA Philadelphia health care | va-philadelphia-health-care | VISN 4 \| va.gov/philadelphia-health-care |
-      | VA Phoenix health care | va-phoenix-health-care | VISN 22 \| va.gov/phoenix-health-care |
-      | VA Pittsburgh health care | pittsburgh-health-care | VISN 4 \| va.gov/pittsburgh-health-care |
-      | VA Poplar Bluff health care | va-poplar-bluff-health-care | VISN 15 \| va.gov/poplar-bluff-health-care |
-      | VA Portland health care | va-portland-health-care | VISN 20 \| va.gov/portland-health-care |
-      | VA Providence health care | va-providence-health-care | VISN 1 \| va.gov/providence-health-care |
-      | VA Puget Sound health care | va-puget-sound-health-care | VISN 20 \| va.gov/puget-sound-health-care |
-      | VA Richmond health care | va-richmond-health-care | VISN 6 \| va.gov/richmond-health-care |
-      | VA Roseburg health care | va-roseburg-health-care | VISN 20 \| va.gov/roseburg-health-care |
-      | VA Saginaw health care | va-saginaw-health-care | VISN 10 \| va.gov/va-saginaw-health-care |
-      | VA Salem health care | va-salem-health-care | VISN 6 \| va.gov/salem-health-care |
-      | VA Salisbury health care | va-salisbury-health-care | VISN 6 \| va.gov/salisbury-health-care |
-      | VA Salt Lake City health care | va-salt-lake-city-health-care | VISN 19 \| va.gov/saltlakecity-health-care |
-      | VA San Diego health care | va-san-diego-health-care | VISN 22 \| va.gov/san-diego-health-care |
-      | VA San Francisco health care | va-san-francisco-health-care | VISN 21 \| va.gov/san-francisco-health-care |
-      | VA Sheridan health care | va-sheridan-health-care | VISN 19 \| va.gov/sheridan-health-care |
-      | VA Shreveport health care | va-shreveport-health-care | VISN 16 \| va.gov/va-shreveport-health-care |
-      | VA Sierra Nevada health care | va-sierra-nevada-health-care | VISN 21 \| va.gov/sierra-nevada-health-care |
-      | VA Sioux Falls health care | va-sioux-falls-health-care | VISN 23 \| va.gov/sioux-falls-health-care |
-      | VA South Texas health care | va-south-texas-health-care | VISN 17 \| va.gov/south-texas-health-care |
-      | VA Southeast Louisiana health care | va-southeast-louisiana-health-ca | VISN 16 \| va.gov/va-southeast-louisiana-health-care |
-      | VA Southern Arizona health care | va-southern-arizona-health-care | VISN 22 \| va.gov/southern-arizona-health-care |
-      | VA Southern Nevada health care | va-southern-nevada-health-care | VISN 21 \| va.gov/southern-nevada-health-care |
-      | VA Southern Oregon health care | va-southern-oregon-health-care | VISN 20 \| va.gov/southern-oregon-health-care |
-      | VA Spokane health care | va-spokane-health-care | VISN 20 \| va.gov/spokane-health-care |
-      | VA St Cloud health care | va-st-cloud-health-care | VISN 23 \| va.gov/st-cloud-health-care |
-      | VA St Louis health care | va-st-louis-health-care | VISN 15 \| va.gov/st-louis-health-care |
-      | VA Syracuse health care | va-syracuse-health-care | VISN 2 \| va.gov/syracus-health-care |
-      | VA Tampa health care | va-tampa-health-care | VISN 8 \| va.gov/tampa-health-care |
-      | VA Tennessee Valley health care | va-tennessee-valley-health-care | VISN 9 \| va.gov/tennessee-valley-health-care |
-      | VA Texas Valley health care | va-texas-valley-health-care | VISN 17 \| va.gov/texas-valley-health-care |
-      | VA Tomah health care | va-tomah-health-care | VISN 12 \| va.gov/tomah-health-care |
-      | VA Topeka health care | va-topeka-health-care | VISN 15 \| va.gov/topeka-health-care |
-      | VA Tuscaloosa health care | va-tuscaloosa-health-care | VISN 7 \| va.gov/tuscaloosa-health-care |
-      | VA Walla Walla health care | va-walla-walla-health-care | VISN 20 \| va.gov/walla-walla-health-care |
-      | VA Washington DC health care | va-washington-dc-health-care | VISN 5 \| va.gov/washington-dc-health-care |
-      | VA West Palm Beach health care | va-west-palm-beach-health-care | VISN 8 \| va.gov/west-palm-beach-health-care |
-      | VA West Texas health care | va-west-texas-health-care | VISN 17 \| va.gov/west-texas-health-care |
-      | VA Western Colorado health care | va-western-colorado-health-care | VISN 19 \| va.gov/western-colorado-health-care |
-      | VA Western New York health care | va-western-new-york-health-care | VISN 2 \| va.gov/western-new-your-health-care |
-      | VA White River Junction health care | va-white-river-junction-health-c | VISN 1 \| va.gov/white-river-junction-health-care |
-      | VA Wichita health care | va-wichita-health-care | VISN 15 \| va.gov/wichita-health-care |
-      | VA Wilkes-Barre health care | va-wilkes-barre-health-care | VISN 4 \| va.gov/wilkes-barre-health-care |
-      | VA Wilmington health care | va-wilmington-health-care | VISN 4 \| va.gov/wilmington-health-care |
-
+| Administration | admin | Administrative task links |
+| Burials and memorials benefits hub | burials-and-memorials-benef | For pages in the /burials-and-memorials benefits hub |
+| Careers & employment benefits hub | careers-employment-benefits | va.gov/careers-employment |
+| CMS Knowledge Base | documentation | How-to's for editing content in the VA.gov CMS |
+| Decision reviews | decision-reviews-benefits-h |  |
+| Disability benefits hub | disability-benefits-hub | For pages in the /disability benefits hub |
+| Education benefits hub | education-benefits-hub | For pages in the /education benefits hub |
+| Footer | footer | Site information links displayed in global footer |
+| Footer Bottom Rail | footer-bottom-rail | Horizontal list of links at the bottom of the page |
+| Header megamenu | header-megamenu | Links and promos for the site's header menu. |
+| Health Care benefits hub | health-care-benefits-hub | va.gov/health-care |
+| Homepage top tasks blocks | homepage-top-tasks-blocks |  |
+| Housing Assistance benefits hub | housing-assistance-benefits | va.gov/housing-assistance |
+| Life insurance benefits hub | life-insurance-benefits-hub | va.gov/life-insurance |
+| Lovell Federal health care | lovell-federal-health-care | VISN 12 \| va.gov/lovell-federal-health-care |
+| Main navigation | main | Site section links |
+| Other Search Tools | other-search-tools |  |
+| Outreach and events | outreach-and-events |  |
+| Pension benefits hub | pension-benefits-hub | va.gov/pension |
+| Popular on VA.gov | popular-on-va-gov |  |
+| Records benefits hub | records-benefits-hub | va.gov/records |
+| Root pages | root-benefits-hub | For various pages that live at the top level of the URL structure. |
+| Sections | sections | Automatically updated from the Sections taxonomy, and appears in admin toolbar. |
+| Tools | tools | User tool links, often added by modules |
+| User account menu | account | Links related to the active user account |
+| VA Alaska health care | va-alaska-health-care | VISN 20 \| va.gov/alaska-health-care |
+| VA Albany health care | va-albany-health-care | VISN 2 \| va.gov/albany-health-care |
+| VA Alexandria health care | va-alexandria-health-care | VISN 16 \| va.gov/alexandria-health-care |
+| VA Altoona health care | va-altoona-health-care | VISN 4 \| va.gov/altoona-health-care |
+| VA Amarillo health care | va-amarillo-health-care | VISN 17 \| va.gov/amarillo-health-care |
+| VA Ann Arbor health care | va-ann-arbor-health-care | VISN 10 \| va.gov/va-ann-arbor-health-care |
+| VA Asheville health care | va-asheville-health-care | VISN 6 \| va.gov/asheville-health-care |
+| VA Atlanta health care | va-atlanta-health-care | VISN 7 \| va.gov/atlanta-health-care |
+| VA Augusta health care | va-augusta-health-care | VISN 7 \| va.gov/augusta-health-care |
+| VA Battle Creek health care | va-battle-creek-health-care | VISN 10 \| va.gov/va-battle-creek-health-care |
+| VA Bay Pines health care | va-bay-pines-health-care | VISN 8 \| va.gov/bay-pines-health-care |
+| VA Beckley health care | va-beckley-health-care | VISN 5 \| va.gov/beckley-health-care |
+| VA Bedford health care | va-bedford-health-care | VISN 1 \| va.gov/bedford-health-care |
+| VA Birmingham health care | va-birmingham-health-care | VISN 7 \| va.gov/birmingham-health-care |
+| VA Black Hills health care | va-black-hills-health-care | VISN 23 \| va.gov/blackhills-health-care |
+| VA Boise health care | va-boise-health-care | VISN 20 \| va.gov/boise-health-care |
+| VA Boston health care | va-boston-health-care | VISN 1 \| va.gov/va-boston-health-care |
+| VA Bronx health care | va-bronx-health-care | VISN 2 \| va.gov/bronx-health-care |
+| VA Butler health care | va-butler-health-care | VISN 4 \| va.gov/butler-health-care |
+| VA Caribbean health care | va-caribbean-health-care | VISN 8 \| va.gov/caribbean-health-care |
+| VA Central Alabama health care | va-central-alabama-health-care | VISN 7 \| va.gov/central-alabama-health-care |
+| VA Central Arkansas health care | va-central-arkansas-health-care | VISN 16 \| va.gov/central-arkansas-health-care |
+| VA Central California health care | va-central-california-health-car | VISN 21 \| va.gov/central-california-health-care |
+| VA Central Iowa health care | va-central-iowa-health-care | VISN 23 \| va.gov/central-iowa-health-care |
+| VA Central Ohio health care | va-central-ohio-health-care | VISN 10 \| va.gov/va-central-ohio-health-care |
+| VA Central Texas health care | va-central-texas-health-care | VISN 17 \| va.gov/central-texas-health-care |
+| VA Central Western Massachusetts health care | va-central-western-massachusetts | VISN 1 \| va.gov/central-western-massachusetts-health-care |
+| VA Charleston health care | va-charleston-health-care | VISN 7 \| va.gov/charleston-health-care |
+| VA Cheyenne health care | va-cheyenne-health-care | VISN 19 \| va.gov/cheyenne-health-care |
+| VA Chicago health care | va-chicago-health-care | VISN 12 \| va.gov/chicago-health-care |
+| VA Chillicothe health care | va-chillicothe-health-care | VISN 10 \| va.gov/va-chillicothe-health-care |
+| VA Cincinnati health care | va-cincinnati-health-care | VISN 10 \| va.gov/va-cincinnati-health-care |
+| VA Clarksburg health care | va-clarksburg-health-care | VISN 5 \| va.gov/clarksburg-health-care |
+| VA Coatesville health care | va-coatesville-health-care | VISN 4 \| va.gov/coatesville-health-care |
+| VA Columbia Missouri health care | va-columbia-missouri-health-care | VISN 15 \| va.gov/columbia-missouri-health-care |
+| VA Columbia South Carolina health care | va-columbia-south-carolina-healt | VISN 7 \| va.gov/columbia-south-carolina-health-care |
+| VA Connecticut health care | va-connecticut-health-care | VISN 1 \| va.gov/connecticut-health-care |
+| VA Dayton health care | va-dayton-health-care | VISN 10 \| va.gov/va-dayton-health-care |
+| VA Detroit health care | va-detroit-health-care | VISN 10 \| va.gov/va-detroit-health-care |
+| VA Dublin health care | va-dublin-health-care | VISN 7 \| va.gov/dublin-health-care |
+| VA Durham health care | va-durham-health-care | VISN 6 \| va.gov/durham-health-care |
+| VA Eastern Colorado health care | va-eastern-colorado-health-care | VISN 19 \| va.gov/eastern-colorado-health-care |
+| VA Eastern Kansas health care | va-eastern-kansas-health-care | VISN 15 \| va.gov/va-eastern-kansas-health-care |
+| VA Eastern Oklahoma health care | va-eastern-oklahoma-health-care | VISN 19 \| va.gov/eastern-oklahoma-health-care |
+| VA El Paso health care | va-el-paso-health-care | VISN 17 \| va.gov/el-paso-health-care |
+| VA Erie health care | va-erie-health-care | VISN 4 \| va.gov/erie-health-care |
+| VA Fargo health care | va-fargo-health-care | VISN 23 \| va.gov/fargo-health-care |
+| VA Fayetteville Arkansas health care | va-fayetteville-arkansas-health- | VISN 16 \| va.gov/fayetteville-arkansas-health-care |
+| VA Fayetteville Coastal health care | va-fayetteville-coastal-health-c | VISN 6 \| va.gov/fayetteville-coastal-health-care |
+| VA Finger Lakes health care | va-finger-lakes-health-care | VISN 2 \| va.gov/finger-lakes-health-care |
+| VA Greater Los Angeles health care | va-greater-los-angeles-health-ca | VISN 22 \| va.gov/greater-los-angeles-health-care |
+| VA Gulf Coast health care | va-gulf-coast-health-care | VISN 16 \| va.gov/gulf-coast-health-care |
+| VA Hampton health care | va-hampton-health-care | VISN 6 \| va.gov/hampton-health-care |
+| VA Hines health care | va-hines-health-care | VISN 12 \| va.gov/hines-health-care |
+| VA Houston health care | va-houston-health-care | VISN 16 \| va.gov/houston-health-care |
+| VA Hudson Valley health care | va-hudson-valley-health-care | VISN 2 \| va.gov/hudson-valley-health-care |
+| VA Huntington health care | va-huntington-health-care | VISN 5 \| va.gov/huntington-health-care |
+| VA Illiana health care | va-illiana-health-care | VISN 12 \| va.gov/illiana-health-care |
+| VA Indiana health care | va-indiana-health-care  | VISN 10 \| va.gov/va-indiana-health-care |
+| VA Iowa City health care | va-iowa-city-health-care | VISN 23 \| va.gov/iowa-city-health-care |
+| VA Iron Mountain health care | va-iron-mountain-health-care | VISN 12 \| va.gov/iron-mountain-health-care |
+| VA Jackson health care | va-jackson-health-care | VISN 16 \| va.gov/jackson-health-care |
+| VA Kansas City health care | va-kansas-city-health-care | VISN 15 \| va.gov/kansas-city-health-care |
+| VA Leavenworth health care | va-leavenworth-health-care | VISN 15 \| va.gov/leavenworth-health-care |
+| VA Lebanon health care | va-lebanon | VISN 4 \| va.gov/lebanon-health-care |
+| VA Lexington health care | va-lexington-health-care | VISN 9 \| va.gov/lexington-health-care |
+| VA Loma Linda health care | va-loma-linda-health-care | VISN 22 \| va.gov/loma-linda-health-care |
+| VA Long Beach health care | va-long-beach-health-care | VISN 22 \| va.gov/long-beach-health-care |
+| VA Louisville health care | va-louisville-health-care | VISN 9 \| va.gov/louisville-health-care |
+| VA Madison health care | va-madison-health-care | VISN 12 \| va.gov/madison-health-care |
+| VA Maine health care | va-maine-health-care | VISN 1 \| va.gov/maine-health-care |
+| VA Manchester health care | va-manchester-health-care | VISN 1 \| va.gov/manchester-health-care |
+| VA Marion health care | va-marion-health-care | VISN 15 \| va.gov/marion-health-care |
+| VA Martinsburg health care | va-martinsburg-health-care | VISN 5 \| va.gov/martinsburg-health-care |
+| VA Maryland health care | va-maryland-health-care | VISN 5 \| va.gov/maryland-health-care |
+| VA Memphis health care | va-memphis-health-care | VISN 9 \| va.gov/memphis-health-care |
+| VA Miami health care | va-miami-health-care | VISN 8 \| va.gov/miami-health-care |
+| VA Milwaukee health care | va-milwaukee-health-care | VISN 12 \| va.gov/milwaukee-health-care |
+| VA Minneapolis health care | va-minneapolis-health-care | VISN 23 \| va.gov/minneapolis-health-care |
+| VA Montana health care | va-montana-health-care | VISN 19 \| va.gov/montana-health-care |
+| VA Mountain Home health care | va-mountain-home-health-care | VISN 9 \| va.gov/mountain-home-health-care |
+| VA Nebraska-Western Iowa health care | va-nebraska-western-iowa-health- | VISN 23 \| va.gov/nebraska-western-iowa-health-care |
+| VA New Jersey health care | va-new-jersey-health-care | VISN 2 \| va.gov/new-jersey-health-care |
+| VA New Mexico health care | va-new-mexico-health-care | VISN 22 \| va.gov/new-mexico-health-care |
+| VA New York Harbor health care | va-new-york-harbor-health-care | VISN 2 \| va.gov/new-york-harbor-health-care |
+| VA North Florida/South Georgia health care | va-north-florida-health-care | VISN 8 \| va.gov/north-florida-health-care |
+| VA North Texas health care | va-north-texas-health-care | VISN 17 \| va.gov/north-texas-health-care |
+| VA Northeast Ohio health care | va-northeast-ohio-health-care | VISN 10 \| va.gov/va-northeast-ohio-health-care |
+| VA Northern Arizona health care | va-northern-arizona-health-care | VISN 22 \| va.gov/northern-arizona-health-care |
+| VA Northern California health care | va-northern-california-health-ca | VISN 21 \| va.gov/northern-california-health-care |
+| VA Northern Indiana health care | va-northern-indiana-health-care | VISN 10 \| va.gov/va-northern-indiana-health-care |
+| VA Northport health care | va-northport-health-care | VISN 2 \| va.gov/northport-health-care |
+| VA Oklahoma City health care | va-oklahoma-health-care | VISN 19 \| va.gov/oklahoma-city-health-care |
+| VA Orlando health care | va-orlando-health-care | VISN 8 \| va.gov/orlando-health-care |
+| VA Pacific Islands health care | va-pacific-islands-health-care | VISN 21 \| va.gov/pacific-islands-health-care |
+| VA Palo Alto health care | va-palo-alto-health-care | VISN 21 \| va.gov/palo-alto-health-care |
+| VA Philadelphia health care | va-philadelphia-health-care | VISN 4 \| va.gov/philadelphia-health-care |
+| VA Phoenix health care | va-phoenix-health-care | VISN 22 \| va.gov/phoenix-health-care |
+| VA Pittsburgh health care | pittsburgh-health-care | VISN 4 \| va.gov/pittsburgh-health-care |
+| VA Poplar Bluff health care | va-poplar-bluff-health-care | VISN 15 \| va.gov/poplar-bluff-health-care |
+| VA Portland health care | va-portland-health-care | VISN 20 \| va.gov/portland-health-care |
+| VA Providence health care | va-providence-health-care | VISN 1 \| va.gov/providence-health-care |
+| VA Puget Sound health care | va-puget-sound-health-care | VISN 20 \| va.gov/puget-sound-health-care |
+| VA Richmond health care | va-richmond-health-care | VISN 6 \| va.gov/richmond-health-care |
+| VA Roseburg health care | va-roseburg-health-care | VISN 20 \| va.gov/roseburg-health-care |
+| VA Saginaw health care | va-saginaw-health-care | VISN 10 \| va.gov/va-saginaw-health-care |
+| VA Salem health care | va-salem-health-care | VISN 6 \| va.gov/salem-health-care |
+| VA Salisbury health care | va-salisbury-health-care | VISN 6 \| va.gov/salisbury-health-care |
+| VA Salt Lake City health care | va-salt-lake-city-health-care | VISN 19 \| va.gov/saltlakecity-health-care |
+| VA San Diego health care | va-san-diego-health-care | VISN 22 \| va.gov/san-diego-health-care |
+| VA San Francisco health care | va-san-francisco-health-care | VISN 21 \| va.gov/san-francisco-health-care |
+| VA Sheridan health care | va-sheridan-health-care | VISN 19 \| va.gov/sheridan-health-care |
+| VA Shreveport health care | va-shreveport-health-care | VISN 16 \| va.gov/va-shreveport-health-care |
+| VA Sierra Nevada health care | va-sierra-nevada-health-care | VISN 21 \| va.gov/sierra-nevada-health-care |
+| VA Sioux Falls health care | va-sioux-falls-health-care | VISN 23 \| va.gov/sioux-falls-health-care |
+| VA South Texas health care | va-south-texas-health-care | VISN 17 \| va.gov/south-texas-health-care |
+| VA Southeast Louisiana health care | va-southeast-louisiana-health-ca | VISN 16 \| va.gov/va-southeast-louisiana-health-care |
+| VA Southern Arizona health care | va-southern-arizona-health-care | VISN 22 \| va.gov/southern-arizona-health-care |
+| VA Southern Nevada health care | va-southern-nevada-health-care | VISN 21 \| va.gov/southern-nevada-health-care |
+| VA Southern Oregon health care | va-southern-oregon-health-care | VISN 20 \| va.gov/southern-oregon-health-care |
+| VA Spokane health care | va-spokane-health-care | VISN 20 \| va.gov/spokane-health-care |
+| VA St Cloud health care | va-st-cloud-health-care | VISN 23 \| va.gov/st-cloud-health-care |
+| VA St Louis health care | va-st-louis-health-care | VISN 15 \| va.gov/st-louis-health-care |
+| VA Syracuse health care | va-syracuse-health-care | VISN 2 \| va.gov/syracus-health-care |
+| VA Tampa health care | va-tampa-health-care | VISN 8 \| va.gov/tampa-health-care |
+| VA Tennessee Valley health care | va-tennessee-valley-health-care | VISN 9 \| va.gov/tennessee-valley-health-care |
+| VA Texas Valley health care | va-texas-valley-health-care | VISN 17 \| va.gov/texas-valley-health-care |
+| VA Tomah health care | va-tomah-health-care | VISN 12 \| va.gov/tomah-health-care |
+| VA Topeka health care | va-topeka-health-care | VISN 15 \| va.gov/topeka-health-care |
+| VA Tuscaloosa health care | va-tuscaloosa-health-care | VISN 7 \| va.gov/tuscaloosa-health-care |
+| VA Walla Walla health care | va-walla-walla-health-care | VISN 20 \| va.gov/walla-walla-health-care |
+| VA Washington DC health care | va-washington-dc-health-care | VISN 5 \| va.gov/washington-dc-health-care |
+| VA West Palm Beach health care | va-west-palm-beach-health-care | VISN 8 \| va.gov/west-palm-beach-health-care |
+| VA West Texas health care | va-west-texas-health-care | VISN 17 \| va.gov/west-texas-health-care |
+| VA Western Colorado health care | va-western-colorado-health-care | VISN 19 \| va.gov/western-colorado-health-care |
+| VA Western New York health care | va-western-new-york-health-care | VISN 2 \| va.gov/western-new-your-health-care |
+| VA White River Junction health care | va-white-river-junction-health-c | VISN 1 \| va.gov/white-river-junction-health-care |
+| VA Wichita health care | va-wichita-health-care | VISN 15 \| va.gov/wichita-health-care |
+| VA Wilkes-Barre health care | va-wilkes-barre-health-care | VISN 4 \| va.gov/wilkes-barre-health-care |
+| VA Wilmington health care | va-wilmington-health-care | VISN 4 \| va.gov/wilmington-health-care |


### PR DESCRIPTION
## Description
Returns original formatting to spec tool tests that  were accidentally reformatted  by
https://github.com/department-of-veterans-affairs/va.gov-cms/pull/11114
and sibsequently https://github.com/department-of-veterans-affairs/va.gov-cms/pull/11204

## Testing done

These are whitespace changes only.

## QA steps

Passing tests will suffice.


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
