### PR TITLE
VACMS-0000: Patch to stop Raven from exploding...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -463,6 +463,9 @@
             "drupal/prometheus_exporter": {
                 "3214628 - Add published/unpublished node statistics to NodeCount.": "https://www.drupal.org/files/issues/2021-06-29/prometheus_exporter-add_status_metrics_to_node_count-3214628-3.patch"
             },
+            "drupal/raven": {
+                "Sentry/Dsn throws a TypeError, blowing up everything.": "patches/raven-catch-typeerror.patch"
+            },
             "drupal/schemata": {
                 "3198409 - Plugin definitions are not cached": "https://www.drupal.org/files/issues/2021-02-14/3198409_2.patch",
                 "3190131 - Possibly unnecessary logging in SchemaFactory::create().": "https://www.drupal.org/files/issues/2020-12-28/schemata-remove-logging-statement-3190131-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddc1f1d73f5a12d940560ce7fe99896e",
+    "content-hash": "d3ad53e3812ee3d1f99fb03cc0471c22",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -6314,8 +6314,8 @@
                     "dev-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.4+1-dev",
-                    "datestamp": "1667316154",
+                    "version": "8.x-3.4+2-dev",
+                    "datestamp": "1667403745",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -9303,16 +9303,12 @@
             ],
             "authors": [
                 {
-                    "name": "Grayside",
-                    "homepage": "https://www.drupal.org/user/346868"
-                },
-                {
-                    "name": "RoySegall",
-                    "homepage": "https://www.drupal.org/user/1812910"
-                },
-                {
                     "name": "amitaibu",
                     "homepage": "https://www.drupal.org/user/57511"
+                },
+                {
+                    "name": "Grayside",
+                    "homepage": "https://www.drupal.org/user/346868"
                 },
                 {
                     "name": "itamar",
@@ -9321,6 +9317,10 @@
                 {
                     "name": "jhedstrom",
                     "homepage": "https://www.drupal.org/user/208732"
+                },
+                {
+                    "name": "RoySegall",
+                    "homepage": "https://www.drupal.org/user/1812910"
                 }
             ],
             "description": "Message",
@@ -9368,16 +9368,16 @@
             ],
             "authors": [
                 {
-                    "name": "RoySegall",
-                    "homepage": "https://www.drupal.org/user/1812910"
-                },
-                {
                     "name": "amitaibu",
                     "homepage": "https://www.drupal.org/user/57511"
                 },
                 {
                     "name": "jhedstrom",
                     "homepage": "https://www.drupal.org/user/208732"
+                },
+                {
+                    "name": "RoySegall",
+                    "homepage": "https://www.drupal.org/user/1812910"
                 }
             ],
             "description": "Notification framework for the Message module",
@@ -9435,10 +9435,6 @@
             ],
             "authors": [
                 {
-                    "name": "RoySegall",
-                    "homepage": "https://www.drupal.org/user/1812910"
-                },
-                {
                     "name": "amitaibu",
                     "homepage": "https://www.drupal.org/user/57511"
                 },
@@ -9449,6 +9445,10 @@
                 {
                     "name": "jhedstrom",
                     "homepage": "https://www.drupal.org/user/208732"
+                },
+                {
+                    "name": "RoySegall",
+                    "homepage": "https://www.drupal.org/user/1812910"
                 }
             ],
             "description": "Subscription API for the Message and Message notify modules",
@@ -10742,8 +10742,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.0-beta1+2-dev",
-                    "datestamp": "1661352550",
+                    "version": "8.x-2.0-beta1+3-dev",
+                    "datestamp": "1667431757",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."

--- a/patches/raven-catch-typeerror.patch
+++ b/patches/raven-catch-typeerror.patch
@@ -1,0 +1,15 @@
+diff --git a/src/Config/SecKitOverrides.php b/src/Config/SecKitOverrides.php
+index 3983ee5..5760958 100644
+--- a/src/Config/SecKitOverrides.php
++++ b/src/Config/SecKitOverrides.php
+@@ -52,6 +52,10 @@ class SecKitOverrides implements ConfigFactoryOverrideInterface {
+       // Raven is incorrectly configured.
+       return $overrides;
+     }
++    catch (\Throwable $e) {
++      // Raven is incorrectly configured.
++      return $overrides;
++    }
+     if ($config->get('seckit_set_report_uri')) {
+       $query = [];
+       if ($environment = empty($_SERVER['SENTRY_ENVIRONMENT']) ? $config->get('environment') : $_SERVER['SENTRY_ENVIRONMENT']) {


### PR DESCRIPTION
... and killing everyone inside.

## Description

Base preview builds are currently failing with the following:

```
TypeError: Argument 1 passed to Sentry\Dsn::createFromString() must be of the type string, null given, called in /var/lib/tugboat/docroot/modules/contrib/raven/src/Config/SecKitOverrides.php on line 49 in Sentry\Dsn::createFromString() (line 77 of /var/lib/tugboat/docroot/vendor/sentry/sentry/src/Dsn.php).
>  [warning] Drush command terminated abnormally.

In SiteProcess.php line 214:
                                                                               
  The command "/usr/local/bin/drush config:import --uri=default --root=/var/l  
  ib/tugboat/docroot" failed.                                                  
                                                                               
  Exit Code: 1(General error)                                                  
                                                                               
  Working directory:                                                           
                                                                               
  Output:                                                                      
  ================                                                             
  TypeError: Argument 1 passed to Sentry\Dsn::createFromString() must be of t  
  he type string, null given, called in /var/lib/tugboat/docroot/modules/cont  
  rib/raven/src/Config/SecKitOverrides.php on line 49 in Sentry\Dsn::createFr  
  omString() (line 77 of /var/lib/tugboat/docroot/vendor/sentry/sentry/src/Ds  
  n.php).                                                                      
...

2022-11-03T10:26:21.925Z - Command Failed (Tugboat Error 1064): Exit code (1)
```

This is because Sentry uses the following bit of code:

![Screen Shot 2022-11-03 at 7 43 26 AM](https://user-images.githubusercontent.com/1318579/199712241-2b258114-a1f8-4f13-91a6-8b129336379a.png)

and Raven uses:

![Screen Shot 2022-11-03 at 7 44 32 AM](https://user-images.githubusercontent.com/1318579/199712420-a557f13b-f91b-4515-951e-5c5708980850.png)

Raven is not configured on Tugboat, either through environment variables or config, and in fact would be disabled immediately by a config import, so the expression evaluates to NULL.

This leads to Sentry throwing a TypeError, which is not the same as an InvalidArgumentException so it blows up.

This patch catches TypeError, so it permits the rest of the operations to proceed normally.  It shouldn't have any negative effects.

I'm not sure why this is happening now.
