### PR TITLE
VACMS-11421: add tricare description to service taxonomy

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vamc_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
@@ -70,6 +71,7 @@ third_party_settings:
         - field_also_known_as
         - field_commonly_treated_condition
         - description
+        - field_tricare_description
       label: VAMC
       region: content
       parent_name: ''
@@ -170,6 +172,14 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_tricare_description:
+    type: string_textarea
+    weight: 19
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   field_vba_com_conditions:
     type: string_textfield

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vamc_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
@@ -64,7 +65,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 11
+    weight: 12
     region: content
   field_health_service_api_id:
     type: string
@@ -89,7 +90,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 12
+    weight: 13
     region: content
   field_show_for_vba_facilities:
     type: boolean
@@ -99,7 +100,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 14
+    weight: 15
     region: content
   field_show_for_vet_centers:
     type: boolean
@@ -109,7 +110,14 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 13
+    weight: 14
+    region: content
+  field_tricare_description:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
     region: content
   field_vba_com_conditions:
     type: string
@@ -117,7 +125,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 16
+    weight: 17
     region: content
   field_vba_friendly_name:
     type: string
@@ -125,14 +133,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 15
+    weight: 16
     region: content
   field_vba_service_descrip:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 17
+    weight: 18
     region: content
   field_vet_center_com_conditions:
     type: string
@@ -158,7 +166,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 10
+    weight: 11
     region: content
   field_vet_center_service_descrip:
     type: basic_string

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description.yml
@@ -1,0 +1,25 @@
+uuid: f7f15d4a-ed22-4fc2-8bd9-a30fcf490ded
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_tricare_description
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.health_care_service_taxonomy.field_tricare_description
+field_name: field_tricare_description
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'TRICARE Service Description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description.yml
@@ -15,7 +15,7 @@ id: taxonomy_term.health_care_service_taxonomy.field_tricare_description
 field_name: field_tricare_description
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
-label: 'TRICARE Service Description'
+label: 'TRICARE service description'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.storage.taxonomy_term.field_tricare_description.yml
+++ b/config/sync/field.storage.taxonomy_term.field_tricare_description.yml
@@ -1,0 +1,19 @@
+uuid: c1920eb4-407f-429f-95fd-ee107bd15192
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_tricare_description
+field_name: field_tricare_description
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -27,6 +27,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Show for VAMC Facilities | field_show_for_vamc_facilities | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Show for VBA Facilities | field_show_for_vba_facilities | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Show for Vet Centers | field_show_for_vet_centers | Boolean |  | 1 | Single on/off checkbox |  |
+| Vocabulary | VA Services | TRICARE Service Description | field_tricare_description | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VA Services | VBA Common Conditions | field_vba_com_conditions | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA Patient Friendly Name | field_vba_friendly_name | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA Description | field_vba_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -27,7 +27,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Show for VAMC Facilities | field_show_for_vamc_facilities | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Show for VBA Facilities | field_show_for_vba_facilities | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Show for Vet Centers | field_show_for_vet_centers | Boolean |  | 1 | Single on/off checkbox |  |
-| Vocabulary | VA Services | TRICARE Service Description | field_tricare_description | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Vocabulary | VA Services | TRICARE service description | field_tricare_description | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VA Services | VBA Common Conditions | field_vba_com_conditions | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA Patient Friendly Name | field_vba_friendly_name | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA Description | field_vba_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |


### PR DESCRIPTION
## Description

Closes #11421 

## Testing done

Manual testing

## Screenshots

![Screen Shot 2022-11-03 at 2 12 26 PM](https://user-images.githubusercontent.com/21045418/199801984-8977de58-e71b-4be2-ad30-1d3fc979202b.png)

![Screen Shot 2022-11-03 at 2 12 54 PM](https://user-images.githubusercontent.com/21045418/199802012-f9887d38-12a8-43a2-a5f7-7164798d4d82.png)

![Screen Shot 2022-11-03 at 2 11 09 PM](https://user-images.githubusercontent.com/21045418/199801690-f2412ab3-c10c-4c1e-8725-048061f59632.png)

## QA steps

As an admin user
- [x] Visit /admin/structure/taxonomy/manage/health_care_service_taxonomy/overview/fields
- [x] field_tricare_description exists as a field on health_care_service_taxonomy
   - [x] label : TRICARE service description
   - [x] type: text plain long
   - [x] form location 
![image](https://user-images.githubusercontent.com/5752113/199572697-0ac2abed-a986-4fc0-b9ea-368357741f90.png)
   - [x] Widget Text area multiple rows
   - [x] cardinality 1
   - [x] not required
   - [x]  display location 
![image](https://user-images.githubusercontent.com/5752113/199573031-45f9e9e9-39c7-4c9a-af25-8f5dcf6b4c9f.png)

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
