### PR TITLE
VACMS-000 Remove tugboat deploy deviation

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -164,7 +164,6 @@ services:
         - ./bin/npm install
         - composer va:theme:compile
         - composer va:web:install
-        - drush cim -y
         - drush deploy
 
         # Setup background processing service.  This uses runit to keep process up


### PR DESCRIPTION
## Description

This removes a change that caused our tugboat deploys to not match the process that is being use on all other environments.  Updb should continue to before an config import, which is the order utilized by 'drush deploy'

## Testing done
## QA steps
This returns up to the deploy process that has been working for over a year and removes a change that was mistakenly added as part of https://github.com/department-of-veterans-affairs/va.gov-cms/pull/11387


- [x] Validate the deploy on tugboat that config import only happens once.

![image](https://user-images.githubusercontent.com/5752113/199866266-08048b94-372c-4b9e-98a0-369cafcb0241.png)

![image](https://user-images.githubusercontent.com/5752113/199866435-0ad01d24-5fd3-4aed-a2a1-f8ec15b40dc8.png)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
