### PR TITLE
VACMS-11473: Adds VBA-related view display and field label configuration

### DIFF
--- a/config/sync/field.field.node.vba_facility_service.field_body.yml
+++ b/config/sync/field.field.node.vba_facility_service.field_body.yml
@@ -20,7 +20,7 @@ id: node.vba_facility_service.field_body
 field_name: field_body
 entity_type: node
 bundle: vba_facility_service
-label: 'VBA Service Description'
+label: 'VBA service description'
 description: 'Use this short paragraph and up to six bullet points to detail how your VBA Facility provides this service.'
 required: false
 translatable: true

--- a/config/sync/field.field.node.vba_facility_service.field_service_name_and_descripti.yml
+++ b/config/sync/field.field.node.vba_facility_service.field_service_name_and_descripti.yml
@@ -20,7 +20,7 @@ id: node.vba_facility_service.field_service_name_and_descripti
 field_name: field_service_name_and_descripti
 entity_type: node
 bundle: vba_facility_service
-label: 'Service Name'
+label: 'Service name'
 description: ''
 required: true
 translatable: true

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_also_known_as.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_also_known_as.yml
@@ -5,11 +5,17 @@ dependencies:
   config:
     - field.storage.taxonomy_term.field_also_known_as
     - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: taxonomy_term.health_care_service_taxonomy.field_also_known_as
 field_name: field_also_known_as
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
-label: 'Patient-friendly name'
+label: 'Patient friendly name'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions.yml
@@ -5,11 +5,17 @@ dependencies:
   config:
     - field.storage.taxonomy_term.field_vba_com_conditions
     - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
 field_name: field_vba_com_conditions
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
-label: 'VBA Common Conditions'
+label: 'VBA common conditions'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name.yml
@@ -15,7 +15,7 @@ id: taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
 field_name: field_vba_friendly_name
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
-label: 'VBA Patient Friendly Name'
+label: 'VBA patient friendly name'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip.yml
@@ -15,7 +15,7 @@ id: taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
 field_name: field_vba_service_descrip
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
-label: 'VBA Description'
+label: 'VBA description'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode.yml
@@ -5,11 +5,17 @@ dependencies:
   config:
     - field.storage.taxonomy_term.field_vha_healthservice_stopcode
     - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
 id: taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode
 field_name: field_vha_healthservice_stopcode
 entity_type: taxonomy_term
 bundle: health_care_service_taxonomy
-label: 'VHA Stop code'
+label: 'VHA stop code'
 description: 'Must be an integer, no more than four digits. Eg: "279", "502", "1922".'
 required: false
 translatable: false

--- a/config/sync/views.view.health_care_service_names_and_descriptions.yml
+++ b/config/sync/views.view.health_care_service_names_and_descriptions.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.storage.taxonomy_term.field_cms_option_label
     - field.storage.taxonomy_term.field_guidance
     - field.storage.taxonomy_term.field_service_type_of_care
-    - field.storage.taxonomy_term.field_vba_friendly_name
     - field.storage.taxonomy_term.field_vet_center_type_of_care
     - taxonomy.vocabulary.facility_supplemental_status
     - taxonomy.vocabulary.health_care_service_taxonomy
@@ -820,14 +819,16 @@ display:
     position: 1
     display_options:
       fields:
-        field_vba_friendly_name:
-          id: field_vba_friendly_name
-          table: taxonomy_term__field_vba_friendly_name
-          field: field_vba_friendly_name
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: field
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
           label: ''
           exclude: false
           alter:
@@ -883,19 +884,22 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          convert_spaces: false
       pager:
         type: some
         options:
           offset: 0
           items_per_page: 0
       sorts:
-        field_vba_friendly_name_value:
-          id: field_vba_friendly_name_value
-          table: taxonomy_term__field_vba_friendly_name
-          field: field_vba_friendly_name_value
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
           plugin_id: standard
           order: ASC
           expose:
@@ -975,15 +979,13 @@ display:
         type: entity_reference
         options:
           search_fields:
-            field_vba_friendly_name: field_vba_friendly_name
-            name: '0'
+            name: name
       row:
         type: entity_reference_revisions
         options:
           default_field_elements: true
           inline:
             name: name
-            field_also_known_as: field_also_known_as
           separator: ' - '
           hide_empty: false
       defaults:
@@ -1003,8 +1005,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user.permissions
-      tags:
-        - 'config:field.storage.taxonomy_term.field_vba_friendly_name'
+      tags: {  }
   entity_reference_vet_center_services:
     id: entity_reference_vet_center_services
     display_title: 'Vet Center health service and type of care - entity reference'

--- a/tests/behat/drupal-spec-tool/content_model_vba_facility_content_type_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vba_facility_content_type_fields.feature
@@ -25,7 +25,7 @@ Feature: Content model: VBA facility Content Type fields
 | Content type | VBA Facility | Shared VHA location | field_shared_vha_location | Entity reference |  | 1 | Autocomplete |  |
 | Content type | VBA Facility | Services | field_vba_services | Entity reference |  | Unlimited | Inline entity form - Complex - Table View Mode |  |
 | Content type | VBA Facility Service | Section | field_administration | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VBA Facility Service | VBA Service Description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
+| Content type | VBA Facility Service | VBA service description | field_body | Text (formatted, long) |  | 1 | Text area (multiple rows) | Translatable |
 | Content type | VBA Facility Service | Enforce unique combo | field_enforce_unique_combo | Allow Only One |  | 1 | Allow Only One widget | Translatable |
 | Content type | VBA Facility Service | Facility | field_office | Entity reference | Required | 1 | Select list | Translatable |
-| Content type | VBA Facility Service | Service Name | field_service_name_and_descripti | Entity reference | Required | 1 | Select list | Translatable |
+| Content type | VBA Facility Service | Service name | field_service_name_and_descripti | Entity reference | Required | 1 | Select list | Translatable |

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -1,4 +1,3 @@
-
 @api
 Feature: Content model: Vocabulary fields
   In order to enter structured content into my site
@@ -21,7 +20,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | Resources and support Categories | Topic ID | field_topic_id | Text (plain) | Required | 1 | Textfield |  |
 | Vocabulary | Sections | Description | field_description | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | Sections | Product | field_product | Entity reference |  | 1 | Select list |  |
-| Vocabulary | VA Services | Patient-friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VA Services | Patient friendly name | field_also_known_as | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | Common conditions | field_commonly_treated_condition | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | Enforce unique combo service | field_enforce_unique_combo_servi | Allow Only One |  | 1 | Allow Only One widget |  |
 | Vocabulary | VA Services | Health Service API ID | field_health_service_api_id | Text (plain) | Required | 1 | Textfield |  |
@@ -31,12 +30,12 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Show for VBA Facilities | field_show_for_vba_facilities | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Show for Vet Centers | field_show_for_vet_centers | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | TRICARE service description | field_tricare_description | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
-| Vocabulary | VA Services | VBA Common Conditions | field_vba_com_conditions | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VA Services | VBA Patient Friendly Name | field_vba_friendly_name | Text (plain) |  | 1 | Textfield |  |
-| Vocabulary | VA Services | VBA Description | field_vba_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Vocabulary | VA Services | VBA common conditions | field_vba_com_conditions | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VA Services | VBA patient friendly name | field_vba_friendly_name | Text (plain) |  | 1 | Textfield |  |
+| Vocabulary | VA Services | VBA description | field_vba_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VA Services | Common conditions | field_vet_center_com_conditions  | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | Patient friendly name | field_vet_center_friendly_name | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | This is a required Vet Center service | field_vet_center_required_servic | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Service description | field_vet_center_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
 | Vocabulary | VA Services | Type of Care | field_vet_center_type_of_care | List (text) |  | 1 | Select list |  |
-| Vocabulary | VA Services | VHA Stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |
+| Vocabulary | VA Services | VHA stop code | field_vha_healthservice_stopcode | Number (integer) |  | 1 | Number field |  |


### PR DESCRIPTION
## Description

Closes #11473
Closes #11468 

## Testing done

Manually.

## Screenshots
### After checking "Show for VBA Facilities" for the two terms
![Screen Shot 2022-11-07 at 4 19 51 PM](https://user-images.githubusercontent.com/766573/200429158-a52d8ffa-7511-41a4-bbc1-0c7cb7370732.png)

### Sentence case changes
#### VA Services taxonomy
![pr11483-nmzurj8zhebgxvjdxu7ewhlqfbcyw3gb ci cms va gov_taxonomy_term_112_edit_destination=_admin_structure_taxonomy_manage_health_care_service_taxonomy_overview](https://user-images.githubusercontent.com/766573/200429290-11d17962-5dc2-4e62-88d2-1f1b104a63cc.png)
#### VBA Facility Service
![Screen Shot 2022-11-07 at 7 19 56 PM](https://user-images.githubusercontent.com/766573/200450881-640e74c1-6de8-44c4-9cfd-71519a8e45bf.png)


## QA steps
### Acceptance Criteria
1.   [ ] Go to [Adpative Sports](https://pr11483-nmzurj8zhebgxvjdxu7ewhlqfbcyw3gb.ci.cms.va.gov/taxonomy/term/112/edit?destination=/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview)
2.  [ ] **Validate**: The fields labels follow sentence case, as per the ACs of #11468.
3.  [ ] Check the "Show for VBA Facilities" checkbox
4.  [ ] Go to [Addiction and substance abuse care](https://pr11483-nmzurj8zhebgxvjdxu7ewhlqfbcyw3gb.ci.cms.va.gov/taxonomy/term/47/edit?destination=/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview)
5.  [ ] Check the "Show for VBA Facilities" checkbox
6.  [ ] Go to a [VBA Facility](https://pr11483-nmzurj8zhebgxvjdxu7ewhlqfbcyw3gb.ci.cms.va.gov/node/4072/edit)
7.  [ ] Click "Add new service"
    - [ ] **Validate**: "Adaptive sports" and "Addition and substance abuse care" show in the "Service name" dropdown
    - [ ] **Validate**: The fields labels follow sentence case, as per the ACs of #11468.

### Regression tests
- [ ] Go to the [Health care service names and descriptions](https://pr11483-nmzurj8zhebgxvjdxu7ewhlqfbcyw3gb.ci.cms.va.gov/admin/structure/views/view/health_care_service_names_and_descriptions)
- [ ] **Validate**: The [correct lists](https://docs.google.com/spreadsheets/d/1u_h0DsdF8HC5MmI4KGKs2Bn_a5EsuIPqgxe-tBUCjdM/edit#gid=0) still being populated for the following:
  - [ ] Non-clinical service
  - [ ] VAMC health service
  - [ ] Vet Center health service


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`



### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
