### PR TITLE
VACMS-11413: disable continuous content release on Tugboat.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -143,6 +143,9 @@ services:
         - find "${DOCROOT}/sites/default/files" -type d -print0 | xargs -0 chmod 2775
         - find "${DOCROOT}/sites/default/files" -type f -print0 | xargs -0 chmod 0664
 
+        # Prevent continuous releases from running on Tugboat.
+        - drush sset va_gov_build_trigger.continuous_release_enabled 0
+
       # Commands that build the site. This is where you would add things
       # like feature reverts or any other drush commands required to
       # set up or configure the site. When a preview is built from a

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
@@ -103,11 +103,12 @@ class ReleaseRequest extends JobTypeBase implements ContainerFactoryPluginInterf
   public function process(Job $job) {
     switch ($this->releaseStateManager->canAdvanceStateTo(ReleaseStateManager::STATE_REQUESTED)) {
       case ReleaseStateManager::STATE_TRANSITION_OK:
+        $payload = $job->getPayload();
         $dispatch_job = Job::create('va_gov_content_release_dispatch', ['placeholder' => 'placeholder']);
         $this->dispatchQueue->enqueueJob($dispatch_job);
         $this->releaseStateManager->advanceStateTo(ReleaseStateManager::STATE_REQUESTED);
-        $message = 'Content release dispatch has been queued.';
-        $this->logger->info($message);
+        $message = 'Content release dispatch has been queued. Reason: @reason';
+        $this->logger->info($message, $payload);
         return JobResult::success($message);
 
       case ReleaseStateManager::STATE_TRANSITION_WAIT:

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
@@ -108,7 +108,9 @@ class ReleaseRequest extends JobTypeBase implements ContainerFactoryPluginInterf
         $this->dispatchQueue->enqueueJob($dispatch_job);
         $this->releaseStateManager->advanceStateTo(ReleaseStateManager::STATE_REQUESTED);
         $message = 'Content release dispatch has been queued. Reason: @reason';
-        $this->logger->info($message, $payload);
+        $this->logger->info($message, [
+          '@reason' => $payload['reason'],
+        ]);
         return JobResult::success($message);
 
       case ReleaseStateManager::STATE_TRANSITION_WAIT:


### PR DESCRIPTION
## Description

Relates to #11413.

## Testing done
will be filled in.

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Go here, https://pr11694-atynigsghbaog27askiih45iiyuz7gqh.ci.cms.va.gov/admin/reports/dblog?type%5B%5D=va_gov_build_trigger
   - [x] Validate that there are no releases queue from today 11/23/   The existing ones are from the DB copy from prod.
   
![image](https://user-images.githubusercontent.com/5752113/203659181-2f0e5cb5-7518-46e6-928d-700518d04102.png)

2. Then go here https://pr11694-atynigsghbaog27askiih45iiyuz7gqh.ci.cms.va.gov/admin/content/deploy  and trigger a content release.
   - [x] Validate that the one is actually kicked off.
   
![image](https://user-images.githubusercontent.com/5752113/203659465-006355d2-109f-4636-8c18-fdc7f4d1a077.png)

![image](https://user-images.githubusercontent.com/5752113/203659594-65abd851-f5fc-4504-a310-7f6827770370.png)


3. Refresh the log page and visit the content release request
   - [x] Validate that the reason now shows
![image](https://user-images.githubusercontent.com/5752113/203659796-5bee8d47-9244-4e44-8f37-4768aaec3d54.png)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
