### PR TITLE
VACMS-11413: tugboat content release modification

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -143,6 +143,9 @@ services:
         - find "${DOCROOT}/sites/default/files" -type d -print0 | xargs -0 chmod 2775
         - find "${DOCROOT}/sites/default/files" -type f -print0 | xargs -0 chmod 0664
 
+        # Prevent continuous releases from running on Tugboat.
+        - drush sset va_gov_build_trigger.continuous_release_enabled 0
+
       # Commands that build the site. This is where you would add things
       # like feature reverts or any other drush commands required to
       # set up or configure the site. When a preview is built from a

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -143,9 +143,6 @@ services:
         - find "${DOCROOT}/sites/default/files" -type d -print0 | xargs -0 chmod 2775
         - find "${DOCROOT}/sites/default/files" -type f -print0 | xargs -0 chmod 0664
 
-        # Prevent continuous releases from running on Tugboat.
-        - drush sset va_gov_build_trigger.continuous_release_enabled 0
-
       # Commands that build the site. This is where you would add things
       # like feature reverts or any other drush commands required to
       # set up or configure the site. When a preview is built from a
@@ -169,6 +166,9 @@ services:
         - composer va:web:install
         # https://www.drush.org/latest/deploycommand/ (updatedb, cache:rebuild, config:import, deploy:hook)
         - drush deploy
+
+        # Prevent continuous releases from running on Tugboat.
+        - drush sset va_gov_build_trigger.continuous_release_enabled 0
 
         # Setup background processing service.  This uses runit to keep process up
         # See https://docs.tugboat.qa/setting-up-services/how-to-set-up-services/running-a-background-process

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -167,8 +167,9 @@ services:
         # https://www.drush.org/latest/deploycommand/ (updatedb, cache:rebuild, config:import, deploy:hook)
         - drush deploy
 
-        # Prevent continuous releases from running on Tugboat.
+        # Prevent continuous releases from running on Tugboat, and reset to ready.
         - drush sset va_gov_build_trigger.continuous_release_enabled 0
+        - drush sset va_gov_build_trigger.release_state ready
 
         # Setup background processing service.  This uses runit to keep process up
         # See https://docs.tugboat.qa/setting-up-services/how-to-set-up-services/running-a-background-process

--- a/docroot/modules/custom/va_gov_build_trigger/src/Commands/ContentReleaseCommands.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Commands/ContentReleaseCommands.php
@@ -161,7 +161,7 @@ class ContentReleaseCommands extends DrushCommands {
    */
   public function requestFrontendBuild() {
     $this->buildRequester->resetFrontendVersion();
-    $this->buildRequester->requestFrontendBuild('Manually requested build');
+    $this->buildRequester->requestFrontendBuild('Build requested via Drush.');
     $this->io()->writeln('Frontend build has been requested');
   }
 

--- a/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Form/BuildTriggerForm.php
@@ -123,7 +123,7 @@ class BuildTriggerForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->messenger()->addStatus($this->t('Content release requested successfully.'));
-    $this->buildRequester->requestFrontendBuild('Manual build request');
+    $this->buildRequester->requestFrontendBuild('Build requested via form.');
   }
 
 }

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
@@ -103,11 +103,12 @@ class ReleaseRequest extends JobTypeBase implements ContainerFactoryPluginInterf
   public function process(Job $job) {
     switch ($this->releaseStateManager->canAdvanceStateTo(ReleaseStateManager::STATE_REQUESTED)) {
       case ReleaseStateManager::STATE_TRANSITION_OK:
+        $payload = $job->getPayload();
         $dispatch_job = Job::create('va_gov_content_release_dispatch', ['placeholder' => 'placeholder']);
         $this->dispatchQueue->enqueueJob($dispatch_job);
         $this->releaseStateManager->advanceStateTo(ReleaseStateManager::STATE_REQUESTED);
-        $message = 'Content release dispatch has been queued.';
-        $this->logger->info($message);
+        $message = 'Content release dispatch has been queued. Reason: @reason';
+        $this->logger->info($message, $payload);
         return JobResult::success($message);
 
       case ReleaseStateManager::STATE_TRANSITION_WAIT:

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/AdvancedQueue/JobType/ReleaseRequest.php
@@ -108,7 +108,9 @@ class ReleaseRequest extends JobTypeBase implements ContainerFactoryPluginInterf
         $this->dispatchQueue->enqueueJob($dispatch_job);
         $this->releaseStateManager->advanceStateTo(ReleaseStateManager::STATE_REQUESTED);
         $message = 'Content release dispatch has been queued. Reason: @reason';
-        $this->logger->info($message, $payload);
+        $this->logger->info($message, [
+          '@reason' => $payload['reason'],
+        ]);
         return JobResult::success($message);
 
       case ReleaseStateManager::STATE_TRANSITION_WAIT:


### PR DESCRIPTION
## Description

#11413 

## Testing done
1. Created PR, which set up a Tugboat instance.
2. Observed Tugboat instance. Currently a front-end build is started as part of the Tugboat update process, after tests run (see https://github.com/department-of-veterans-affairs/va.gov-cms/blob/main/.tugboat/config.yml#L189). 
3. Once front-end build completed, waited to see if any subsequent builds started on their own. None did. 
4. Manually triggered a front-end build and let it start running, confirming it was running. Then, pushed an update to the PR, in order to re-trigger the test & front-end build process. This a) interrupted the running front-end build; b) allowed tests to run; c) Started another front-end build once the tests were complete, as expected. 
5. Once the build triggered in 4 completed, no additional front-end builds triggered continuously. 

## Follow-up steps

A previous version of this PR broke base preview updating. When this is merged, the main preview should be immediately rebuilt to ensure that this is no longer happening; or else, reverted if it is still causing problems.

