### PR TITLE
VACMS-10046: update link colors to meet WCAG 2.0 AAA contrast requirements

### DIFF
--- a/docroot/design-system/components/tokens/_variables.scss
+++ b/docroot/design-system/components/tokens/_variables.scss
@@ -5,7 +5,7 @@
   /*
    * Our unique design system variables.
    */
-  --va-gray-lightest: #f1f1f1;
+  --va-gray-lightest: #e5e3e1;
   --va-gray-lighter: #e4e2e0;
   --va-gray-light: #d3d3d3;
   --va-gray-med: #757576;

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_buttons.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_buttons.scss
@@ -41,6 +41,7 @@
 
 .button--outline.action-link {
   padding: calc((var(--space-m) - var(--space-l)/2 + var(--space-m)/2) - 2px) calc(var(--space-m) - 2px);
+  text-decoration: none;
 }
 
 // admin/content/deploy builds front-end button in nested markup

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
@@ -232,8 +232,19 @@ p.vc-help-text {
   width: 16px;
 }
 
-.breadcrumb__link:hover {
-  color: var(--va-blue-med);
+.breadcrumb__link {
+  color: var(--va-blue-dark);
+  text-decoration: underline;
+  transition-duration: 0.3s;
+  transition-property: color,background-color,border-color;
+  transition-timing-function: ease-in-out;
+  
+  &:hover,
+  &:focus {
+    background-color: var(--va-blue-lighter);
+    color: var(--va-blue-darker);
+    text-decoration: none;
+  }
 }
 
 .no-wrap {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_footer.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_footer.scss
@@ -46,6 +46,11 @@
   a {
     color: var(--color-white);
     margin-right: 1rem;
+
+    &:hover,
+    &:focus {
+      color: var(--va-blue-darker);
+    }
   }
 }
 

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_layout.scss
@@ -2,21 +2,6 @@
   background-color: var(--va-blue-darkest);
   color: var(--color-white);
 
-  .breadcrumb,
-  .breadcrumb__item,
-  .breadcrumb__link {
-    color: var(--va-gray-lighter);
-  }
-
-  .breadcrumb__link:hover {
-    color: var(--va-gold-med);
-  }
-
-  // claro inlines svgs & currentColor in url() doesn't work with css variables. need to inline here.
-  .breadcrumb__item + .breadcrumb__item::before {
-    content: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' height='8' width='5'%3e%3cpath fill='%23e4e2e0' d='M1.207.647L.5 1.354 3.146 4 .5 6.647l.707.707L4.561 4z'/%3e%3c/svg%3e");
-  }
-
   // only re-color primary tab links when not in menu layout.
   @include breakpoint('tabs') {
     .is-horizontal .tabs {

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_links.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_links.scss
@@ -1,78 +1,14 @@
-.layout-container {
-  a {
-    color: var(--va-blue-dark);
-    text-decoration: underline;
-    transition-duration: 0.3s;
-    transition-property: color,background-color,border-color;
-    transition-timing-function: ease-in-out;
+a {
+  color: var(--va-blue-dark);
+  text-decoration: underline;
+  transition-duration: 0.3s;
+  transition-property: color,background-color,border-color;
+  transition-timing-function: ease-in-out;
 
-    &:hover,
-    &:focus {
-      background-color: var(--va-blue-lighter);
-      color: var(--va-blue-darker);
-      text-decoration: none;
-    }
-
-    &.tabs__link {
-      text-decoration: none;
-    }
-
-    &.action-link.action-link--danger {
-      color: var(--color-white);
-      text-decoration: none;
-
-      &:hover {
-        color: var(--va-red-darker);
-      }
-    }
-
-    &.button,
-    &.pager__link.is-active,
-    &.feed-icon {
-      color: var(--color-white);
-      text-decoration: none;
-
-      &:hover,
-      &:focus {
-        background-color: var(--button--hover-bg-color--primary);
-        color: var(--button-fg-color--primary);
-      }
-    }
-  }
-
-  .view-user-admin-people {
-    a {
-      &.button {
-        color: var(--button-fg-color);
-
-        &:hover {
-          background-color: var(--va-gray-button-hover);
-        }
-      }
-    }
-  }
-
-  .region-footer {
-    a {
-      color: var(--color-white);
-
-      &:hover,
-      &:focus {
-        color: var(--va-blue-darker);
-      }
-    }
-  }
-
-  table {
-    a {
-      &.button,
-      &.button:not(:focus) {
-        color: var(--button-fg-color);
-
-        &:hover {
-          background-color: var(--button--hover-bg-color);
-        }
-      }
-    }
+  &:hover,
+  &:focus {
+    background-color: var(--va-blue-lighter);
+    color: var(--va-blue-darker);
+    text-decoration: none;
   }
 }

--- a/docroot/themes/custom/vagovclaro/assets/scss/styles.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/styles.scss
@@ -24,6 +24,7 @@
 @import 'components/tooltip';
 @import 'components/toolbar';
 @import 'components/footer';
+@import 'components/links';
 @import 'pages/login';
 @import 'pages/events-form';
 @import 'pages/kb-pages';


### PR DESCRIPTION
…quirements

## Description

Closes #10046 

## Testing done

Visual testing

## QA steps
Confirm that all links within the CMS follow the specified design patterns:

- **Standard links**
  - Color: `var(--va-blue-dark) #004795`
  - Underlined
  - 1rem/16px
  - Hover/Focus:
    - Color: `var(--va-blue-darker) #003e73`
   
    - Background: `var(--va-blue-lighter) #e4eff9`
    - No underline
- **Breadcrumbs**
  - Same as standard link pattern with 2 exceptions:
    - Bold
    - .79rem/12.64px
- **Login Screen Footer links**
  - Same as standard link pattern with 1 exception:
    - Color: `var(--color-white) #fff`

### Exception elements
There are elements within the CMS that do not visually appear as links however within the HTML they are `<a>` tags and therefore need to be tested to confirm the styles on these elements do not change.
- Tabs:
  - No tabs at all should have an underline
  - The main tabs (View, Roles, edit) should be gray with a yellow active state
  - The secondary tabs (i.e. Overview, Moderated content) should be gray with a blue active state)
- The admin content dropdown menu should have gray text for the various options and blue text for the selected option
- Edit buttons: The text on these buttons should always be the standard dark gray text color
- Links styled as buttons (i.e Delete buttons, Download buttons, etc.): The text on these buttons should not follow the above indicated pattern. These should remain as they are, for example:
  - The delete button on content nodes should have blue text as the background of the button is white
  - The download buttons should have white text as the button background is blue

## Screenshots
**Standard Links**
![image](https://user-images.githubusercontent.com/106678594/204546982-80b033a9-0b48-42ce-acea-eb7fef2a8f26.png)
![image](https://user-images.githubusercontent.com/106678594/204547086-443942f8-08fa-4c42-bb5b-9b0a5e43adce.png)

**Breadcrumbs**
![image](https://user-images.githubusercontent.com/106678594/204546699-8d35f405-ea31-4c9f-bdc4-160c85d91f44.png)
"Services and locations" and "Butler VA Medical Center" are not links which is why they do not follow the determined pattern

**Login screen footer links**
![image](https://user-images.githubusercontent.com/106678594/204547832-a99c4f81-d70f-456c-a292-d210c1ed60dc.png)

**Tabs**
![image](https://user-images.githubusercontent.com/106678594/204547275-c7e056f5-c295-4c33-99da-cb47d11d53ad.png)
![image](https://user-images.githubusercontent.com/106678594/204547357-2eac6879-f02a-43a2-961f-a1d11847e9e3.png)

**Admin content dropdown menu**
![image](https://user-images.githubusercontent.com/106678594/204547452-4f991b0d-64f1-4080-be66-1475edfe4634.png)

**Edit buttons**
![image](https://user-images.githubusercontent.com/106678594/204547542-83214833-5607-456b-8011-0f6e0d5616e9.png)

**Links styles as buttons**
![image](https://user-images.githubusercontent.com/106678594/204547661-1c0a8d85-527c-44e1-baba-aa5c4adb6335.png)
![image](https://user-images.githubusercontent.com/106678594/204547730-45831f92-f7db-42ac-9259-6c7603357191.png)

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`
