### PR TITLE
VACMS-11726: make VAMC alert checkbox list alpha sort and cleanup

### DIFF
--- a/config/sync/views.view.vamc_operating_statuses.yml
+++ b/config/sync/views.view.vamc_operating_statuses.yml
@@ -3,12 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_office
     - node.type.vamc_operating_status_and_alerts
-    - taxonomy.vocabulary.administration
   module:
     - node
-    - taxonomy
     - user
 id: vamc_operating_statuses
 label: 'VAMC operating statuses'
@@ -25,13 +22,15 @@ display:
     position: 0
     display_options:
       fields:
-        field_office:
-          id: field_office
-          table: node__field_office
-          field: field_office
-          relationship: none
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: field_office
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
           plugin_id: field
           label: ''
           exclude: false
@@ -74,11 +73,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
+          click_sort_column: value
+          type: string
           settings:
-            link: false
-          group_column: target_id
+            link_to_entity: false
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -125,75 +124,23 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          order: DESC
-          expose:
-            label: ''
-            field_identifier: created
-          exposed: false
-          granularity: second
-      arguments: {  }
-      filters:
         title:
           id: title
           table: node_field_data
           field: title
-          relationship: none
+          relationship: field_office
           group_type: group
           admin_label: ''
           entity_type: node
           entity_field: title
-          plugin_id: string
-          operator: word
-          value: ''
-          group: 1
-          exposed: true
+          plugin_id: standard
+          order: ASC
           expose:
-            operator_id: title_op
-            label: 'Title contains'
-            description: ''
-            use_operator: false
-            operator: title_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: title
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              content_api_consumer: '0'
-              documentation_editor: '0'
-              content_editor: '0'
-              content_reviewer: '0'
-              content_publisher: '0'
-              content_admin: '0'
-              redirect_administrator: '0'
-              admnistrator_users: '0'
-              administrator: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
             label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
+            field_identifier: ''
+          exposed: false
+      arguments: {  }
+      filters:
         status:
           id: status
           table: node_field_data
@@ -220,61 +167,6 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        field_administration_target_id:
-          id: field_administration_target_id
-          table: node__field_administration
-          field: field_administration_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_administration_target_id_op
-            label: Section
-            description: ''
-            use_operator: false
-            operator: field_administration_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: owner
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              content_api_consumer: '0'
-              documentation_editor: '0'
-              content_editor: '0'
-              content_reviewer: '0'
-              content_publisher: '0'
-              content_admin: '0'
-              redirect_administrator: '0'
-              admnistrator_users: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          vid: administration
-          type: select
-          hierarchy: true
-          limit: true
-          error_message: true
       filter_groups:
         operator: AND
         groups:
@@ -344,26 +236,15 @@ display:
           replica: false
           query_tags: {  }
       relationships:
-        field_administration:
-          id: field_administration
-          table: node__field_administration
-          field: field_administration
+        field_office:
+          id: field_office
+          table: node__field_office
+          field: field_office
           relationship: none
           group_type: group
-          admin_label: 'field_administration: Taxonomy term'
+          admin_label: 'field_office: Content'
           plugin_id: standard
-          required: false
-        parent_target_id:
-          id: parent_target_id
-          table: taxonomy_term__parent
-          field: parent_target_id
-          relationship: field_administration
-          group_type: group
-          admin_label: Parent
-          entity_type: taxonomy_term
-          entity_field: parent
-          plugin_id: standard
-          required: false
+          required: true
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -372,13 +253,10 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags:
-        - 'config:field.storage.node.field_office'
+      tags: {  }
   entity_reference_1:
     id: entity_reference_1
     display_title: 'Entity Reference'
@@ -393,7 +271,7 @@ display:
         type: entity_reference
         options:
           search_fields:
-            field_office: field_office
+            title: title
       row:
         type: entity_reference
         options:
@@ -401,15 +279,14 @@ display:
           inline: {  }
           separator: '-'
           hide_empty: false
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
-        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags:
-        - 'config:field.storage.node.field_office'
+      tags: {  }


### PR DESCRIPTION
## Description

Relates to #11726 

## Testing done

Visual/manual

## Screenshots

Previous checkbox presentation:
![204313312-32a8e866-ac92-4c16-b917-e610421d9429](https://user-images.githubusercontent.com/21045418/204899235-c3752299-b229-4739-aa7f-473b252ed91c.png)

Updated checkbox presentation:
<img width="1753" alt="Screen Shot 2022-11-30 at 3 06 33 PM" src="https://user-images.githubusercontent.com/21045418/204898394-fc1e41fe-e77a-4bd3-ad6e-8b264317b3af.png">

Previous view definition:
<img width="1761" alt="Screen Shot 2022-11-30 at 1 40 52 PM" src="https://user-images.githubusercontent.com/21045418/204898563-977ca131-666a-4a86-b8b5-b3efc7f33ed0.png">

New view definition:
<img width="1756" alt="Screen Shot 2022-11-30 at 3 12 08 PM" src="https://user-images.githubusercontent.com/21045418/204898674-6063c11e-70ac-4d8d-abe1-f9727962ca63.png">

## QA steps

As an admin user:

- [x] Visit /admin/content/bulk and filter by Section = **Lovell Federal health care**
- [x] Select all results and publish latest revision
- [x] Visit /node/add/full_width_banner_alert and select **Lovell Federal TRICARE** health care for the field **Pages for the following VAMC systems** and select Lovell - TRICARE for the Section field
- [x] Supply all remaining required fields and check the Published checkbox and save
- [x] Visit /admin/content/deploy and trigger a content release by clicking **Release content**
- [x] Visit the Lovell - TRICARE section of the front end and verify the alert you created is visible


### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`