### PR TITLE
VACMS-11761: Delay accessibility tests to allow CSS transitions to complete.

### DIFF
--- a/tests/cypress/integration/accessibility/accessibility.spec.js
+++ b/tests/cypress/integration/accessibility/accessibility.spec.js
@@ -64,6 +64,7 @@ describe("Component accessibility test", () => {
     it(testName, () => {
       cy.visit(route);
       cy.injectAxe();
+      cy.wait(1000);
       cy.checkA11y(axeContext, axeRuntimeOptions, (violations) => {
         cy.accessibilityLog(violations);
         const violationData = violations.map((violation) => ({


### PR DESCRIPTION
## Description

Closes #11761.  We're using CSS transitions with a short-but-nonzero duration when we draw various links, including in the toolbar.  Unfortunately, during this time the accessibility tests can run, and we're not _always_ accessible.

This change simply delays a second after page load and script injection to allow these transitions to complete before actually checking the accessibility of the DOM.

If accessibility tests pass, this should be safe to merge.