### PR TITLE
VACMS-11484 Make Covid status show even if empty.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "drupal/epp": "^1.1",
         "drupal/fast_404": "2.x-dev#5382a99335ee466f8261dc1774a3d56f1699da81",
         "drupal/feature_toggle": "^2.0",
-        "drupal/field_group": "^3.1",
+        "drupal/field_group": "^3.4",
         "drupal/fieldhelptext": "^1.0@beta",
         "drupal/flag": "^4.0@beta",
         "drupal/flood_control": "^2.2.2",
@@ -405,7 +405,6 @@
             },
             "drupal/field_group": {
                 "2787179 - Visibility of invalid fields": "https://www.drupal.org/files/issues/2021-01-05/2787179-highlight-html5-validation-59.patch",
-                "1482958 - Allow field_group with empty fields to be displayed via setting": "https://www.drupal.org/files/issues/2020-06-24/field_group-empty-config-1482958-47.patch",
                 "3053242 - Undefined index #description_display when adding a description to fieldset group type": "https://www.drupal.org/files/issues/2022-07-04/field_group-undefined-index-description-display-3053242-11.patch"
             },
             "drupal/flag": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "600f8aa1c7899c45297cb347de2bd9d7",
+    "content-hash": "83672aac9e737b36594fdc34600d446b",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -918,7 +918,7 @@
             "version": "v4.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fengyuanchen/cropper.git",
+                "url": "git@github.com:fengyuanchen/cropper.git",
                 "reference": "617d9bdb8688cc4edb3b03bc49a04b83c7facbe7"
             },
             "dist": {
@@ -6299,26 +6299,29 @@
         },
         {
             "name": "drupal/field_group",
-            "version": "dev-3.x",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/field_group.git",
-                "reference": "f2aaf409a82abcaa1434480a82168bc953857371"
+                "reference": "8.x-3.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/field_group-8.x-3.4.zip",
+                "reference": "8.x-3.4",
+                "shasum": "80b937e1a11f8b29c69d853fc4bf798c057c6f94"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-3.4+2-dev",
-                    "datestamp": "1667403745",
+                    "version": "8.x-3.4",
+                    "datestamp": "1667241979",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -7882,6 +7885,14 @@
                     "homepage": "https://www.drupal.org/user/1078742"
                 },
                 {
+                    "name": "nod_",
+                    "homepage": "https://www.drupal.org/user/598310"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
                     "name": "zrpnr",
                     "homepage": "https://www.drupal.org/user/1448368"
                 }
@@ -8232,12 +8243,12 @@
             ],
             "authors": [
                 {
-                    "name": "Deciphered",
-                    "homepage": "https://www.drupal.org/user/103796"
-                },
-                {
                     "name": "acbramley",
                     "homepage": "https://www.drupal.org/user/1036766"
+                },
+                {
+                    "name": "Deciphered",
+                    "homepage": "https://www.drupal.org/user/103796"
                 },
                 {
                     "name": "larowlan",
@@ -9995,6 +10006,14 @@
                 {
                     "name": "shadcn",
                     "homepage": "https://shadcn.com"
+                },
+                {
+                    "name": "rrrob",
+                    "homepage": "https://www.drupal.org/user/273533"
+                },
+                {
+                    "name": "shadcn",
+                    "homepage": "https://www.drupal.org/user/571032"
                 }
             ],
             "description": "Next.js + Drupal for Incremental Static Regeneration and Preview mode.",
@@ -10352,6 +10371,10 @@
                     "email": "mateu.aguilo.bosch@gmail.com"
                 },
                 {
+                    "name": "bradjones1",
+                    "homepage": "https://www.drupal.org/user/405824"
+                },
+                {
                     "name": "e0ipso",
                     "homepage": "https://www.drupal.org/user/550110"
                 },
@@ -10530,12 +10553,12 @@
                     "homepage": "https://www.drupal.org/user/103796"
                 },
                 {
-                    "name": "Mojiferous",
-                    "homepage": "https://www.drupal.org/user/1678298"
-                },
-                {
                     "name": "michaellander",
                     "homepage": "https://www.drupal.org/user/636494"
+                },
+                {
+                    "name": "Mojiferous",
+                    "homepage": "https://www.drupal.org/user/1678298"
                 },
                 {
                     "name": "tandroid",
@@ -10747,7 +10770,7 @@
             "require": {
                 "bjeavons/zxcvbn-php": "^1.3",
                 "drupal/core": "^8 || ^9",
-                "drupal/password_policy": "^3.1"
+                "drupal/password_policy": "^3.1|^4.0"
             },
             "type": "drupal-module",
             "extra": {
@@ -10755,8 +10778,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.0-beta1+3-dev",
-                    "datestamp": "1667431757",
+                    "version": "8.x-2.0-beta1+4-dev",
+                    "datestamp": "1668804356",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -11150,7 +11173,7 @@
             "extra": {
                 "drupal": {
                     "version": "4.0.10",
-                    "datestamp": "1670289783",
+                    "datestamp": "1670313643",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -11453,20 +11476,20 @@
             "authors": [
                 {
                     "name": "Adam Ross",
-                    "homepage": "https://www.drupal.org/user/346868",
+                    "homepage": "https://www.drupal.org/user/550110",
                     "email": "grayside@gmail.com"
-                },
-                {
-                    "name": "HalfChem",
-                    "homepage": "https://www.drupal.org/user/1608382"
-                },
-                {
-                    "name": "e0ipso",
-                    "homepage": "https://www.drupal.org/user/550110"
                 },
                 {
                     "name": "febbraro",
                     "homepage": "https://www.drupal.org/user/43670"
+                },
+                {
+                    "name": "Grayside",
+                    "homepage": "https://www.drupal.org/user/346868"
+                },
+                {
+                    "name": "HalfChem",
+                    "homepage": "https://www.drupal.org/user/1608382"
                 },
                 {
                     "name": "jhedstrom",
@@ -11521,20 +11544,20 @@
             ],
             "authors": [
                 {
-                    "name": "Grayside",
-                    "homepage": "https://www.drupal.org/user/346868"
-                },
-                {
-                    "name": "HalfChem",
-                    "homepage": "https://www.drupal.org/user/1608382"
-                },
-                {
                     "name": "e0ipso",
                     "homepage": "https://www.drupal.org/user/550110"
                 },
                 {
                     "name": "febbraro",
                     "homepage": "https://www.drupal.org/user/43670"
+                },
+                {
+                    "name": "Grayside",
+                    "homepage": "https://www.drupal.org/user/346868"
+                },
+                {
+                    "name": "HalfChem",
+                    "homepage": "https://www.drupal.org/user/1608382"
                 },
                 {
                     "name": "jhedstrom",

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -202,10 +202,11 @@ third_party_settings:
       format_type: fieldset
       format_settings:
         classes: ''
-        show_empty_fields: false
+        show_empty_fields: true
         id: ''
         description: 'Use these levels to help Veterans understand the current COVID-19 health protection guidelines at your facility. The preset guidelines will appear on your facility’s location and operating status pages.'
         required_fields: false
+        description_display: after
     group_current_covid_19_safety_gu:
       children: {  }
       label: 'Current Covid-19 safety guidelines'


### PR DESCRIPTION
## Description

Closes #11484
This is largely a contrib module jump with the removal of a patch that has already been merged upstream and released as the new version.

## Testing done
## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user  admin
1. Go to https://pr11809-reccqq790utweyyggpdzilvsgiwsyqk0.ci.cms.va.gov/montana-health-care/locations/miles-city-va-community-living-center
   - [x] Validate that the covid protection levels appear like this
   
![image](https://user-images.githubusercontent.com/5752113/205992783-1e73e9e4-a211-40e4-a9e1-c733d8fd85f8.png)

2. Then click the edit tab on that page and scroll down to Covid 19 section.
![image](https://user-images.githubusercontent.com/5752113/205993206-71a33175-ab70-4711-b7c0-790670a28ab7.png)

   - [x] 1 Validate that as you change to low medium or high, the related content in the gray area changes accordingly
   - [x] 2. Validate that the tooltip question mark appears and
   - [x]  hovertext guidance on the mark appears on hover
3. Save the node.
   - [x] Validate the change is saved.
4. Visit https://pr11809-reccqq790utweyyggpdzilvsgiwsyqk0.ci.cms.va.gov/node/add/health_care_local_facility  which will have no existing value.
5. Open your browser inspector to console
   - [x] Validate no error exists about covid not found.
   
![image](https://user-images.githubusercontent.com/5752113/205994381-1fa2e57c-66f7-44ab-80cd-bc3bdd7f32fa.png)

   - [x] Pick a covid status.  Validate that the matching text appears for that status
   - [ ] 
![image](https://user-images.githubusercontent.com/5752113/205994683-c58829b2-d700-4757-8830-4904d37e2786.png)


### Definition of Done



### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
