### PR TITLE
VACMS-11669: Apply patch to fix warning importing configuration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -435,6 +435,7 @@
                 "3058121 - Use persistent connections": "https://www.drupal.org/files/issues/2020-09-10/3058121-16.patch"
             },
             "drupal/menu_item_extras": {
+                "3302060 - Invalid argument supplied for foreach() ConfigImportSubscriber.php": "https://www.drupal.org/files/issues/2022-08-05/menu_items_extra_uninstall_config_import_warning.patch",
                 "3210468 - The 'bundle' field is not always populated with the menu name": "https://www.drupal.org/files/issues/2021-04-23/3210468.patch"
             },
             "drupal/migrate_plus": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83672aac9e737b36594fdc34600d446b",
+    "content-hash": "57d7872d44722e9fe09d511c25d05d6e",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",


### PR DESCRIPTION
## Description

Closes #11669.

See this `menu_item_extras` issue: https://www.drupal.org/project/menu_item_extras/issues/3302060

This patch changes the return value for a function called when modules are uninstalled.  As such this has effects only during config import, really.

I'll cook up some screenshots, I think.

## Base Preview / Local Dev
![Screen Shot 2022-12-07 at 1 44 07 PM](https://user-images.githubusercontent.com/1318579/206268673-34ff8161-18ec-4b09-b015-ad629eb033f9.png)

## This PR
![Screen Shot 2022-12-07 at 1 42 12 PM](https://user-images.githubusercontent.com/1318579/206268340-9fe1a296-d8a3-4fe4-87f9-9545ee4a5bf3.png)

