### PR TITLE
VACMS-11049: Fix 'attributes' error.

### DIFF
--- a/docroot/themes/custom/vagovclaro/templates/field/field--node--field-products.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/field/field--node--field-products.html.twig
@@ -52,11 +52,11 @@
       {% else %}
         {% set separator = ", " %}
       {% endif %}
-      {{ item }}{{ separator }}
+      <span{{ item.attributes }}>{{ item.content }}</span>{{ separator }}
     {% endfor %}
   {% else %}
     {% for item in items %}
-      {{item}}
+      <span{{ item.attributes }}>{{ item.content }}</span>
     {% endfor %}
   {% endif %}
 </div>


### PR DESCRIPTION
## Description

Closes #11049.

This was a bear.

## Testing done


## Screenshots

Before:

![Screen Shot 2022-12-08 at 10 49 56 AM](https://user-images.githubusercontent.com/1318579/206493490-157c3f00-44a9-46c0-8220-5e684a6715ed.png)

After:

![Screen Shot 2022-12-08 at 10 50 16 AM](https://user-images.githubusercontent.com/1318579/206493598-0f75ce0e-c605-4238-9007-d2bd3c906ee7.png)

## QA steps

As user _uid_ with _user_role_
1. Do this
   - [x] Visit a KB article on another preview instance or DDEV and verify that you see the message.  Might need a cache clear if you've already visited it.  Or, just visit a different one 💅🏻 
2. Then
   - [x] Visit the same KB article on this preview instance and verify that:
     - [x] no message is displayed
     - [x] the "This Article Is For" field is still displayed and populated correctly
