### PR TITLE
VACMS-11850: lovell federal health care system should not be editable…

### DIFF
--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -3,13 +3,16 @@
 namespace Drupal\va_gov_lovell\EventSubscriber;
 
 use Drupal\core_event_dispatcher\EntityHookEvents;
+use Drupal\core_event_dispatcher\Event\Entity\EntityAccessEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\NodeInterface;
@@ -87,10 +90,25 @@ class LovellEventSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents(): array {
     return [
       BreadcrumbPreprocessEvent::name() => 'preprocessBreadcrumb',
+      EntityHookEvents::ENTITY_ACCESS => 'entityAccess',
       EntityHookEvents::ENTITY_INSERT => 'entityInsert',
       EntityHookEvents::ENTITY_PRE_SAVE => 'entityPresave',
       EntityHookEvents::ENTITY_UPDATE => 'entityUpdate',
     ];
+  }
+
+  /**
+   * Entity access Event call.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityAccessEvent $event
+   *   The event.
+   */
+  public function entityAccess(EntityAccessEvent $event): void {
+    $entity = $event->getEntity();
+    $operation = $event->getOperation();
+    $account = $event->getAccount();
+    $accessResult = $this->restrictLovellSystemToAdmin($entity, $operation, $account);
+    $event->setAccessResult($accessResult);
   }
 
   /**
@@ -160,6 +178,34 @@ class LovellEventSubscriber implements EventSubscriberInterface {
       // @phpstan-ignore-next-line
       $entity->path->pathauto = 0;
     }
+  }
+
+  /**
+   * Restrict non-admins to view only access for Lovell umbrella system.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity being accessed.
+   * @param string $operation
+   *   The type of access operation: view, edit, delete, etc.
+   * @param Drupal\Core\Session\AccountInterface $account
+   *   The account attempting access.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  protected function restrictLovellSystemToAdmin(EntityInterface $entity, string $operation, AccountInterface $account) {
+    if (($entity instanceof NodeInterface)
+    && ($entity->bundle() === 'health_care_region_page')
+    && ($entity->hasField('field_administration'))) {
+      $user_roles = $account->getRoles();
+      $section_id = $entity->get('field_administration')->target_id;
+      if (($section_id === LovellOps::BOTH_ID)
+      && (!in_array('administrator', $user_roles))
+      && ($operation != 'view')) {
+        return AccessResult::forbidden();
+      }
+    }
+    return AccessResult::neutral();
   }
 
   /**

--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -187,7 +187,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
    *   The entity being accessed.
    * @param string $operation
    *   The type of access operation: view, edit, delete, etc.
-   * @param Drupal\Core\Session\AccountInterface $account
+   * @param \Drupal\Core\Session\AccountInterface $account
    *   The account attempting access.
    *
    * @return \Drupal\Core\Access\AccessResult


### PR DESCRIPTION
… by non-admin

## Description

Closes #11850 

## Testing done

Manual/visual testing

## Screenshots

Admin on the left, non-admin editor on the right

![Screenshot 2022-12-08 at 3 42 38 PM](https://user-images.githubusercontent.com/21045418/206565920-52639092-5245-4bf3-880a-49b71b8800e5.png)

![Screenshot 2022-12-08 at 3 43 30 PM](https://user-images.githubusercontent.com/21045418/206566198-36db4a8a-3394-4dc5-81e5-a0fa974188ef.png)

![Screenshot 2022-12-08 at 3 44 03 PM](https://user-images.githubusercontent.com/21045418/206566245-d375497a-f058-46ed-bcc2-6517392cdad2.png)

## QA steps

As an admin user:

- [x] Visit /section/vha/vamc-facilities/lovell-federal-health-care (filter by Content type = VAMC System)
- [x] All VAMC systems should have an edit button
- [x] Click the title: Lovell Federal health care
- [x] All tabs (View, Edit, Delete, Revisions, Clone, Feedback) are visible
- [x] Click Edit (note the URL)
- [x] The edit page loads as expected

As a content editor for the Lovell system (example: Katie.Yearley@va.gov)

- [x] Visit /section/vha/vamc-facilities/lovell-federal-health-care (filter by Content type = VAMC System)
- [x] The Lovell Federal health care VAMC system should not have an edit button
- [x] Click the title: Lovell Federal health care
- [x] No tabs should be visible
- [x] Manually copy/paste the edit URL from the admin steps
- [x] The edit page should not load and an access denied message should be displayed

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
