### PR TITLE
VACMS-11896: Make ContentReleaseStatusController test more reliable.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.routing.yml
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.routing.yml
@@ -11,7 +11,7 @@ va_gov_backend.exclusion_types_admin_form:
 va_gov_backend.content_release_status:
   path: '/admin/content/deploy/status'
   defaults:
-    _controller: '\Drupal\va_gov_backend\Controller\ContentReleaseStatusController::getLastReleaseStatus'
+    _controller: '\Drupal\va_gov_backend\Controller\ContentReleaseStatusController::getDefault'
     _title: 'Last Content Release'
   requirements:
     _permission: 'access content'

--- a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
+++ b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
@@ -85,21 +85,21 @@ class ContentReleaseStatusControllerTest extends VaGovExistingSiteBase {
    *   Test assertion data.
    */
   public function provideContentReleaseData() : \Generator {
-    date_default_timezone_set('America/New_York');
+    $time = time();
 
-    $today = strtotime('today 8am');
+    $today = strtotime('today 8am', $time);
     yield 'Last content release happened today' => [
       $this->generateBodyForTime($today),
       'VA.gov last updated<br />today at 08:00 am',
     ];
 
-    $yesterday = strtotime('yesterday 1405');
+    $yesterday = strtotime('yesterday 1405', $time);
     yield 'Last content release happened yesterday' => [
       $this->generateBodyForTime($yesterday),
       'VA.gov last updated<br />yesterday at 02:05 pm',
     ];
 
-    $four_days_ago = strtotime('-4 day 1038');
+    $four_days_ago = strtotime('-4 day 1038', $time);
     yield 'Last content release happened four days ago' => [
       $this->generateBodyForTime($four_days_ago),
       'VA.gov last updated<br />4 days ago at 10:38 am',

--- a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
+++ b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
@@ -2,109 +2,26 @@
 
 namespace tests\phpunit\Controller;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Render\Renderer;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\va_gov_backend\Controller\ContentReleaseStatusController;
 use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
+use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Tests\Support\Classes\VaGovExistingSiteBase;
+use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**
- * Provides automated tests for the va_gov_backend module.
+ * Provides automated tests for the ContentReleaseStatusController controller.
  *
- * @group functional
+ * @group unit
  * @group all
  */
-class ContentReleaseStatusControllerTest extends VaGovExistingSiteBase {
-
-  /**
-   * History of requests/responses.
-   *
-   * @var array
-   */
-  protected $history = [];
-
-  /**
-   * Mock client.
-   *
-   * @var \GuzzleHttp\ClientInterface
-   */
-  protected $mockClient;
-
-  /**
-   * The container object.
-   *
-   * @var \Symfony\Component\DependencyInjection\ContainerInterface
-   */
-  protected $newContainer;
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getInfo() {
-    return [
-      'name' => "va_gov_backend ContentReleaseStatusController's controller functionality",
-      'description' => 'Test Unit for module va_gov_backend and controller ContentReleaseStatusController.',
-      'group' => 'Other',
-    ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setUp() : void {
-    parent::setUp();
-
-    $this->newContainer = new ContainerBuilder();
-    $this->newContainer->set('date.formatter', \Drupal::service('date.formatter'));
-    $this->newContainer->set('renderer', \Drupal::service('renderer'));
-  }
-
-  /**
-   * Tests content release status controller.
-   *
-   * @dataProvider provideContentReleaseData
-   */
-  public function testContentReleaseStatusController(
-    string $responseBody,
-    string $expectedResult
-  ) : void {
-    $this->mockClient(new Response(200, [], $responseBody));
-    $this->assertStringContainsString(
-      $expectedResult,
-      ContentReleaseStatusController::create($this->newContainer)->getLastReleaseStatus()->getContent()
-    );
-  }
-
-  /**
-   * Data provider for testContentReleaseStatusController.
-   *
-   * @return \Generator
-   *   Test assertion data.
-   */
-  public function provideContentReleaseData() : \Generator {
-    $time = time();
-
-    $today = strtotime('today 8am', $time);
-    yield 'Last content release happened today' => [
-      $this->generateBodyForTime($today),
-      'VA.gov last updated<br />today at 08:00 am',
-    ];
-
-    $yesterday = strtotime('yesterday 1405', $time);
-    yield 'Last content release happened yesterday' => [
-      $this->generateBodyForTime($yesterday),
-      'VA.gov last updated<br />yesterday at 02:05 pm',
-    ];
-
-    $four_days_ago = strtotime('-4 day 1038', $time);
-    yield 'Last content release happened four days ago' => [
-      $this->generateBodyForTime($four_days_ago),
-      'VA.gov last updated<br />4 days ago at 10:38 am',
-    ];
-  }
+class ContentReleaseStatusControllerTest extends VaGovUnitTestBase {
 
   /**
    * Generate a response body matching va.gov/BUILD.txt.
@@ -115,28 +32,256 @@ class ContentReleaseStatusControllerTest extends VaGovExistingSiteBase {
    * @return string
    *   Response body text.
    */
-  protected function generateBodyForTime(int $timestamp) : string {
+  protected function getBuildFileForTimestamp(int $timestamp) : string {
     return "BUILDTYPE=vagovprod\nNODE_ENV=production\nBRANCH_NAME=null\nCHANGE_TARGET=null\nBUILD_ID=799\nBUILD_NUMBER=799\nREF=80ff0a2438f1a0d038ab8637f553a83792596bd4\nBUILDTIME={$timestamp}";
+  }
+
+  /**
+   * Generate a timestamp with a relative portion, timestamp, and timezone.
+   *
+   * @param string $relative
+   *   Relative portion.
+   * @param int $baseTimestamp
+   *   Base timestamp.
+   * @param string $timezone
+   *   Timezone.
+   *
+   * @return int
+   *   An adjusted timestamp.
+   */
+  protected function getTimestamp(string $relative, int $baseTimestamp, string $timezone = 'America/New_York'): int {
+    $timezone = new \DateTimeZone($timezone);
+    $datetime = new \DateTime('@' . $baseTimestamp);
+    $datetime->setTimezone($timezone);
+    $datetime->modify($relative);
+    return $datetime->getTimestamp();
+  }
+
+  /**
+   * Format a timestamp with a timezone.
+   *
+   * @param int $timestamp
+   *   Base timestamp.
+   * @param string $format
+   *   Format string.
+   * @param string $timezone
+   *   Timezone.
+   *
+   * @return string
+   *   The formatted date.
+   */
+  protected function formatTimestamp(int $timestamp, string $format, string $timezone = 'America/New_York'): string {
+    $timezone = new \DateTimeZone($timezone);
+    $datetime = new \DateTime('@' . $timestamp);
+    $datetime->setTimezone($timezone);
+    return $datetime->format($format);
   }
 
   /**
    * Mock the http client.
    *
-   * @param \GuzzleHttp\Psr7\Response $responses
-   *   Guzzle responses.
+   * @param string $responseBody
+   *   The desired response body.
+   *
+   * @return \GuzzleHttp\ClientInterface
+   *   Guzzle client.
    */
-  protected function mockClient(Response ...$responses) : void {
-    if (!isset($this->mockClient)) {
-      // Create a mock and queue responses.
-      $mock = new MockHandler($responses);
+  protected function getMockHttpClient(string $responseBody): ClientInterface {
+    $prophecy = $this->prophesize(Client::CLASS);
 
-      $handler_stack = HandlerStack::create($mock);
-      $history = Middleware::history($this->history);
-      $handler_stack->push($history);
-      $this->mockClient = new Client(['handler' => $handler_stack]);
-    }
+    $responseProphecy = $this->prophesize(Response::CLASS);
+    $responseProphecy->getBody()->willReturn($responseBody);
 
-    $this->newContainer->set('http_client', $this->mockClient);
+    $prophecy->request(Argument::type('string'), Argument::type('string'))->willReturn($responseProphecy->reveal());
+
+    return $prophecy->reveal();
+  }
+
+  /**
+   * Tests content release status controller.
+   *
+   * @dataProvider dataProviderContentReleaseStatusController
+   */
+  public function testContentReleaseStatusController(
+    int $lastTimestamp,
+    int $currentTimestamp,
+    int $expectedDays,
+    string $expectedStatus,
+    string $timezone = 'America/New_York'
+  ) : void {
+    $buildFile = $this->getBuildFileForTimestamp($lastTimestamp);
+
+    $container = new ContainerBuilder();
+    $dateFormatterProphecy = $this->prophesize(DateFormatter::CLASS);
+    $dateFormatterProphecy
+      ->format(Argument::type('int'), Argument::type('string'), Argument::type('string'))
+      ->will(function ($args) use ($timezone) {
+        $baseTimestamp = $args[0];
+        $format = $args[2];
+        $datetime = new \DateTime('@' . $baseTimestamp);
+        $datetime->setTimezone(new \DateTimeZone($timezone));
+        return $datetime->format($format);
+      });
+    $container->set('date.formatter', $dateFormatterProphecy->reveal());
+    $container->set('http_client', $this->getMockHttpClient($buildFile));
+    $rendererProphecy = $this->prophesize(Renderer::CLASS);
+    $rendererProphecy
+      ->renderPlain(Argument::type('array'))
+      ->will(function ($args) {
+        return $args[0]['#markup'];
+      });
+    $container->set('renderer', $rendererProphecy->reveal());
+    $container->set('datetime.time', $this->prophesize(Renderer::CLASS)->reveal());
+    $translationProphecy = $this->prophesize(TranslationInterface::CLASS);
+    $translationProphecy
+      ->translateString(Argument::any())
+      ->will(function ($args) {
+        return $args[0]->getUntranslatedString();
+      });
+    $container->set('string_translation', $translationProphecy->reveal());
+    $systemDateConfigProphecy = $this->prophesize(ImmutableConfig::CLASS);
+    $systemDateConfigProphecy
+      ->get(Argument::type('string'))
+      ->willReturn('America/New_York');
+    $configFactoryProphecy = $this->prophesize(ConfigFactoryInterface::CLASS);
+    $configFactoryProphecy
+      ->get(Argument::type('string'))
+      ->willReturn($systemDateConfigProphecy->reveal());
+    $container->set('config.factory', $configFactoryProphecy->reveal());
+    $controller = ContentReleaseStatusController::create($container);
+
+    $actualDays = $controller->getDifferenceInDays($lastTimestamp, $currentTimestamp);
+    $this->assertEquals($expectedDays, $actualDays);
+    $actualStatus = $controller->getLastReleaseStatus($currentTimestamp);
+    $actualContent = $controller->getLastReleaseResponse($actualStatus)->getContent();
+    $this->assertEquals($expectedStatus, $actualStatus['#markup']);
+    $this->assertEquals($actualStatus['#markup'], $actualContent);
+  }
+
+  /**
+   * Data provider for testContentReleaseStatusController.
+   *
+   * @return array
+   *   Test assertion data.
+   */
+  public function dataProviderContentReleaseStatusController() : array {
+    $time = time();
+    return [
+      [
+        $this->getTimestamp('today', $time),
+        $this->getTimestamp('today', $time),
+        0,
+        'VA.gov last updated<br />today at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('today 12am', $time),
+        $time,
+        0,
+        'VA.gov last updated<br />today at 12:00 am',
+      ],
+      [
+        $time,
+        $time,
+        0,
+        'VA.gov last updated<br />today at ' . $this->formatTimestamp($time, 'h:i a'),
+      ],
+      [
+        $this->getTimestamp('today 12am', $time) - 5,
+        $time,
+        1,
+        'VA.gov last updated<br />yesterday at 11:59 pm',
+      ],
+      [
+        $this->getTimestamp('yesterday 12am', $time),
+        $this->getTimestamp('yesterday 12am', $time),
+        0,
+        'VA.gov last updated<br />today at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('yesterday 12am', $time),
+        $this->getTimestamp('today 12am', $time),
+        1,
+        'VA.gov last updated<br />yesterday at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('yesterday 12am', $time),
+        $time,
+        1,
+        'VA.gov last updated<br />yesterday at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('yesterday 1405', $time),
+        $time,
+        1,
+        'VA.gov last updated<br />yesterday at 02:05 pm',
+      ],
+      [
+        $this->getTimestamp('-1 day 12am', $time),
+        $this->getTimestamp('yesterday 12am', $time),
+        0,
+        'VA.gov last updated<br />today at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-1 day 12am', $time),
+        $this->getTimestamp('-1 day 12am', $time),
+        0,
+        'VA.gov last updated<br />today at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-1 day 12am', $time),
+        $time,
+        1,
+        'VA.gov last updated<br />yesterday at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-1 day 12am', $time),
+        $this->getTimestamp('today 12am', $time),
+        1,
+        'VA.gov last updated<br />yesterday at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-2 day 12am', $time),
+        $this->getTimestamp('today 12am', $time),
+        2,
+        'VA.gov last updated<br />2 days ago at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-2 day 12am', $time),
+        $time,
+        2,
+        'VA.gov last updated<br />2 days ago at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-3 day 12am', $time),
+        $this->getTimestamp('today 12am', $time),
+        3,
+        'VA.gov last updated<br />3 days ago at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-3 day 12am', $time),
+        $time,
+        3,
+        'VA.gov last updated<br />3 days ago at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-4 day 12am', $time),
+        $this->getTimestamp('today 12am', $time),
+        4,
+        'VA.gov last updated<br />4 days ago at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-4 day 12am', $time),
+        $time,
+        4,
+        'VA.gov last updated<br />4 days ago at 12:00 am',
+      ],
+      [
+        $this->getTimestamp('-4 day 1038', $time),
+        $time,
+        4,
+        'VA.gov last updated<br />4 days ago at 10:38 am',
+      ],
+    ];
   }
 
 }


### PR DESCRIPTION
## Description

Closes #11896.  

![Screen Shot 2022-12-12 at 3 45 56 PM](https://user-images.githubusercontent.com/1318579/207150907-7c6810e2-df1e-4de2-94ed-903b28fbba70.png)

We shouldn't muck around with [`date_​default_​timezone_​set()`](https://www.php.net/manual/en/function.date-default-timezone-set.php) generally, but in this case I don't think it's necessary anyway since we're operating with a timestamp.

**EDIT**: Wrong.  The `date_default_timezone_set()` call actually affects `ContentReleaseStatusController`, making the test work across environments.  So I'll need to dig in a bit further, I think.

The actual date figuring is done in `ContentReleaseStatusController`, and Drupal's relationship with time zones is substantially more complicated than this would indicate.

I might revisit this when I add unit tests for `ContentReleaseStatusController` and add DI, etc.

## QA Steps

- [ ] Check that the code makes sense
- [x] Confirm that the status tippy thing showing the last-release date still has good formatting and matches prod values.