### PR TITLE
VACMS-11890: counter changes made to field_group hook weights

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -225,7 +225,6 @@ module:
   va_gov_build_trigger: 0
   va_gov_bulk: 0
   va_gov_clp: 0
-  va_gov_consumers: 0
   va_gov_dashboards: 0
   va_gov_db: 0
   va_gov_events: 0
@@ -269,6 +268,7 @@ module:
   formdazzle: 10
   views: 10
   paragraphs: 11
+  va_gov_consumers: 999
   minimal: 1000
 theme:
   seven: 0

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.info.yml
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.info.yml
@@ -2,6 +2,7 @@ name: VA.gov Consumers Module
 description: Consumes data from external sources
 package: Custom
 dependencies:
+  - field_group
   - va_gov_backend
 type: module
 core_version_requirement: ^8 || ^9

--- a/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+++ b/docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -9,6 +9,22 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
+ * Implements hook_module_implements_alter().
+ */
+function va_gov_consumers_module_implements_alter(&$implementations, $hook) {
+  switch ($hook) {
+    // Move our hook_form_alter() implementation to the end of the list.
+    // This was added to compensate for a similar call ignoring weights.
+    // See: docroot/modules/contrib/field_group/field_group.module.
+    case 'form_alter':
+      $va_gov_consumers = $implementations['va_gov_consumers'];
+      unset($implementations['va_gov_consumers']);
+      $implementations['va_gov_consumers'] = $va_gov_consumers;
+      break;
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function va_gov_consumers_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
## Description

Closes #11890 

## Testing done

Manual testing

## Screenshots

![Screenshot 2022-12-09 at 1 20 49 PM](https://user-images.githubusercontent.com/21045418/206767424-4477ee72-0fa3-4afc-845b-ceda84cb4b80.png)

## QA steps

1. Logn as Ryan.S___
2. Go to /node/1705/edit
3. Scroll down to 'Facility Data' field group.  
4. The facility data should not be editable but rendered in the same manner as node view 

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
