### PR TITLE
VACMS-11904: Fixes undefined array key warning in va_gov_links_form_editor_link_dialog_alter().

### DIFF
--- a/docroot/modules/custom/va_gov_links/va_gov_links.module
+++ b/docroot/modules/custom/va_gov_links/va_gov_links.module
@@ -13,7 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 function va_gov_links_form_editor_link_dialog_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Retrieve the link element's attributes from form state.
   $input = $form_state->get('link_element') ?: [];
-  if (preg_match('#/admin/content/linky/(\d+)#', $input['href'], $matches)) {
+  if (isset($input['href']) && preg_match('#/admin/content/linky/(\d+)#', $input['href'], $matches)) {
     $linky_id = $matches[1];
     $linky = \Drupal::entityTypeManager()->getStorage('linky')->load($linky_id);
     $link_uri = $linky->get('link')->getValue()[0]['uri'];


### PR DESCRIPTION
Unset-array-key messages are warnings now, whereas they were notices in PHP 7.4.

## Description

Closes #11904.

## Testing done

![Screen Shot 2022-12-09 at 2 19 44 PM](https://user-images.githubusercontent.com/1318579/206780703-5991667e-4bd6-46c3-afd4-f4d975503195.png)
