### PR TITLE
VACMS-11905: Fixes "Undefined key: req_optional" warning message.

### DIFF
--- a/docroot/themes/custom/vagovclaro/vagovclaro.theme
+++ b/docroot/themes/custom/vagovclaro/vagovclaro.theme
@@ -270,7 +270,7 @@ function _vagovclaro_sort_and_alter_vetcenter_services(array &$variables) {
       if (!empty($form[$key]['form'])) {
         // Turn our required and name values into a string that can be used for
         // sorting.
-        $required_value = (string) $rows[$key]['req_optional']['#markup'] === 'Optional' ? 'z' : 'Required';
+        $required_value = (string) @$rows[$key]['req_optional']['#markup'] === 'Optional' ? 'z' : 'Required';
         $format_required_value = strtolower(str_replace(' ', '-', $required_value));
         $format_name_value = strtolower(str_replace(' ', '-', $cells['label']['#markup']));
 

--- a/docroot/themes/custom/vagovclaro/vagovclaro.theme
+++ b/docroot/themes/custom/vagovclaro/vagovclaro.theme
@@ -270,7 +270,8 @@ function _vagovclaro_sort_and_alter_vetcenter_services(array &$variables) {
       if (!empty($form[$key]['form'])) {
         // Turn our required and name values into a string that can be used for
         // sorting.
-        $required_value = (string) @$rows[$key]['req_optional']['#markup'] === 'Optional' ? 'z' : 'Required';
+        $markup = $rows[$key]['req_optional']['#markup'] ?? '';
+        $required_value = $markup === 'Optional' ? 'z' : 'Required';
         $format_required_value = strtolower(str_replace(' ', '-', $required_value));
         $format_name_value = strtolower(str_replace(' ', '-', $cells['label']['#markup']));
 


### PR DESCRIPTION
## Description

Closes #11905.  Another thing where a notice became a warning.  I added a null-coalescing operator to get rid of the notice, because I think that's generally better than the error-suppression operator, but eh.

![Screen Shot 2022-12-09 at 2 39 22 PM](https://user-images.githubusercontent.com/1318579/206783963-94ac3caa-8ca9-4f66-afad-29b686221e58.png)
![Screen Shot 2022-12-09 at 2 39 39 PM](https://user-images.githubusercontent.com/1318579/206783977-bbdba441-b8da-469e-b893-a2945d330da7.png)
