### PR TITLE
VACMS-11697: Default Alt Text Inline guidance to open

### DIFF
--- a/docroot/themes/custom/vagovclaro/components/inline-guidance/text-box.twig
+++ b/docroot/themes/custom/vagovclaro/components/inline-guidance/text-box.twig
@@ -8,6 +8,6 @@
  * - classes: Any classes to be added to the text box.
  */
 #}
-<div id="inline-guidance-text-box" class="inline-guidance-text hide {{ classes }}">
+<div id="inline-guidance-text-box" class="inline-guidance-text {{ classes }}">
   {{ content|raw }}
 </div>

--- a/docroot/themes/custom/vagovclaro/templates/content-edit/file-managed-file.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/content-edit/file-managed-file.html.twig
@@ -72,7 +72,7 @@
           {% endset %}
           {% include '@components/inline-guidance/text-box.twig' with {
             "content": inlineguidance,
-            "classes": '',
+            "classes": 'show',
           } %}
           {{ data.alt|without('#title', '#description') }}
 

--- a/docroot/themes/custom/vagovclaro/templates/field-group/field-group-html-element--node--banner--group-paths-group.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/field-group/field-group-html-element--node--banner--group-paths-group.html.twig
@@ -28,7 +28,7 @@
   </div>
   {% include '@components/inline-guidance/text-box.twig' with {
     "content": element.inline_guidance['#value'].value,
-    "classes": element.inline_guidance_classes['#value'],
+    "classes": element.inline_guidance_classes['#value'] ~ ' hide',
   } %}
   {% if collapsible %}
   <div class="field-group-wrapper">


### PR DESCRIPTION
## Description

Closes #11697.

## Testing done
Tested locally. 

## Screenshots


## QA steps

1. Go to Content > Media > Add Media > Image
   - [ ] select an image to upload and the alt text field should appear with the inline guidance open. It should still close when you click on the Tips for button. 
2. Then got to Content and filter for Full Width Alerts. Choose one and click edit. 
   - [ ] Validate that there is inline guidance above the Persistence label, below the Alert type field. When the form is opened the guidance should not be expanded and should expand when you click on the Tips for tripper. 
3. Then validate Acceptance Criteria from issue
   - [ ] Change default behavior for alt text inline guidance component to open
   - [ ] Ensure that the default behavior can be set separately for each instance of the component

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
