### PR TITLE
VACMS-11906: Patches taxonomy_entity_index to fix rebuild error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -508,6 +508,9 @@
                 "3176982 - Tablefield input elements have no title or label": "https://www.drupal.org/files/issues/2020-10-14/tablefield-add_title_to_input_elements-3176982-2.patch",
                 "3195203 - Copying caption to value breaks some data exports 3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch"
             },
+            "drupal/taxonomy_entity_index": {
+                "3326616 - Callback must be a valid callback": "https://www.drupal.org/files/issues/2022-12-12/3326616-callback-must-be-a-valid-callback.patch"
+            },
             "drupal/textfield_counter": {
                 "3004457 - Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch",
                 "3182675 - Incompatibilities with Claro and Claro-based (e.g. Gin) themes": "https://www.drupal.org/files/issues/2022-08-04/textfield-counter-incompatible-with-claro-3182675-10.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10d2a6907f575e92151c2904cad6124b",
+    "content-hash": "df9c6a853b5078d9599004a1bae3e702",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -5950,8 +5950,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.0-beta7+3-dev",
-                    "datestamp": "1670443798",
+                    "version": "8.x-2.0-beta7+4-dev",
+                    "datestamp": "1670835820",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -11223,7 +11223,7 @@
             "extra": {
                 "drupal": {
                     "version": "4.0.10",
-                    "datestamp": "1670313643",
+                    "datestamp": "1670646806",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Description

Closes #11906.

See https://www.drupal.org/project/taxonomy_entity_index/issues/3326616

Need to run the daily tasks or at least the drush command to rebuild the taxonomy term index once this is deployed and tests have run.  If it succeeds, we should be good to merge.