### PR TITLE
VACMS-11744: external link status report view added

### DIFF
--- a/config/sync/views.view.managed_links.yml
+++ b/config/sync/views.view.managed_links.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - system.menu.admin
+    - user.role.administrator
   module:
     - link
     - linky
@@ -19,95 +20,12 @@ base_table: linky
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'administer linky entities'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            link__title: link__title
-            link__uri: link__uri
-            operations: operations
-          info:
-            link__title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            link__uri:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            operations:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: false
-      row:
-        type: fields
+      title: 'External Link Status'
       fields:
         link__title:
           id: link__title
@@ -116,6 +34,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -175,9 +96,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: linky
-          entity_field: link
-          plugin_id: field
         link__uri:
           id: link__uri
           table: linky
@@ -185,6 +103,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: field
           label: Destination
           exclude: false
           alter:
@@ -244,19 +165,16 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: linky
-          entity_field: link
-          plugin_id: field
         operations:
+          id: operations
           table: linky
           field: operations
-          id: operations
-          entity_type: null
-          entity_field: null
-          plugin_id: entity_operations
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: entity_operations
           label: 'Operations links'
           exclude: false
           alter:
@@ -299,6 +217,274 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
+        http_status:
+          id: http_status
+          table: linky
+          field: http_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: http_status
+          plugin_id: field
+          label: 'HTTP Status'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        error:
+          id: error
+          table: linky
+          field: error
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: error
+          plugin_id: field
+          label: Error
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        message:
+          id: message
+          table: linky
+          field: message
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: message
+          plugin_id: field
+          label: 'Error message'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'There are no managed links yet.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        changed:
+          id: changed
+          table: linky
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: changed
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         link__uri:
           id: link__uri
@@ -307,6 +493,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -317,6 +506,8 @@ display:
             description: ''
             use_operator: false
             operator: link__uri_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: uri
             required: false
             remember: false
@@ -328,8 +519,6 @@ display:
               blog_editor: '0'
               user_manager: '0'
               super_administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -342,9 +531,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: linky
-          entity_field: link
-          plugin_id: string
         link__title:
           id: link__title
           table: linky
@@ -352,6 +538,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -362,6 +551,8 @@ display:
             description: ''
             use_operator: false
             operator: link__title_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: title
             required: false
             remember: false
@@ -373,8 +564,6 @@ display:
               blog_editor: '0'
               user_manager: '0'
               super_administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -387,73 +576,548 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: linky
-          entity_field: link
-          plugin_id: string
-      sorts:
-        changed:
-          id: changed
+        http_status:
+          id: http_status
           table: linky
-          field: changed
+          field: http_status
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: changed
-          granularity: second
           entity_type: linky
-          entity_field: changed
-          plugin_id: date
-      title: 'Managed links'
-      header: {  }
-      footer: {  }
-      empty:
-        area:
-          id: area
+          entity_field: http_status
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: http_status_op
+            label: 'HTTP Status'
+            description: ''
+            use_operator: false
+            operator: http_status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: http_status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            link__title: link__title
+            link__uri: link__uri
+            operations: operations
+            http_status: http_status
+            error: error
+            message: message
+          default: '-1'
+          info:
+            link__title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            link__uri:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            http_status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            error:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            message:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: 'External link status results'
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        result:
+          id: result
           table: views
-          field: area
+          field: result
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'There are no managed links yet.'
-            format: basic_html
-          plugin_id: text
-      relationships: {  }
-      arguments: {  }
+          plugin_id: result
+          empty: false
+          content: '<p>Displaying @start - @end of @total</p>'
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.permissions
+        - user.roles
       tags: {  }
-  page_1:
+  external_link_status_page:
+    id: external_link_status_page
+    display_title: 'External Link Status'
     display_plugin: page
-    id: page_1
-    display_title: Page
     position: 1
     display_options:
-      display_extenders: {  }
+      display_description: ''
+      display_extenders:
+        jsonapi_views:
+          enabled: true
+      path: admin/content/linky/status
+      menu:
+        type: normal
+        title: 'External Link Status'
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: admin
+        parent: entity.linky.collection
+        context: '0'
+        as_local_task: false
+        local_task_link_title: 'External Link Status'
+        local_task_parent: 'views_view:view.managed_links.page_1'
+        local_task_weight: 1
+        local_task_custom_parent_route: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.roles
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      title: 'Manage Links'
+      fields:
+        link__title:
+          id: link__title
+          table: linky
+          field: link__title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: title
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        link__uri:
+          id: link__uri
+          table: linky
+          field: link__uri
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: field
+          label: Destination
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: true
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        operations:
+          id: operations
+          table: linky
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          plugin_id: entity_operations
+          label: 'Operations links'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+      filters:
+        link__uri:
+          id: link__uri
+          table: linky
+          field: link__uri
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: link__uri_op
+            label: Destination
+            description: ''
+            use_operator: false
+            operator: link__uri_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: uri
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              blog_editor: '0'
+              user_manager: '0'
+              super_administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        link__title:
+          id: link__title
+          table: linky
+          field: link__title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linky
+          entity_field: link
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: link__title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: link__title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              blog_editor: '0'
+              user_manager: '0'
+              super_administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            link__title: link__title
+            link__uri: link__uri
+            operations: operations
+          default: '-1'
+          info:
+            link__title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            link__uri:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options: {  }
+      defaults:
+        title: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/linky
       menu:
         type: normal
         title: 'Managed links'
         menu_name: admin
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.permissions
+        - user.roles
       tags: {  }

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -1,4 +1,3 @@
-
 @api
 Feature: Views
   In order to present and expose content and configuration
@@ -210,6 +209,7 @@ Feature: Views
       | Local facilities entity reference view | Master | default | Default |
       | Locked content | Master | default | Default |
       | Locked content | Page | page_1 | Page |
+      | Managed links | External Link Status | external_link_status_page | Page |
       | Managed links | Master | default | Default |
       | Managed links | Page | page_1 | Page |
       | Media | Browser | entity_browser_1 | Entity browser |


### PR DESCRIPTION
## Description

Closes #11744.

## Testing done
Tested locally.

## Screenshots
![CleanShot 2022-12-12 at 12 50 30](https://user-images.githubusercontent.com/109987005/207151772-689a6ad2-44eb-4463-b420-944188a2ad86.png)


## QA steps

- [x] Configure link checking to run  Linkychecker (/admin/config/linkychecker) to run on cron with a crawl interval of 7 days.
- [x] Clone our existing Linky View display  "Managed links"  (/admin/content/linky) to "External Link Status"  (/admin/content/linky/status) 
  - [x] title: External Link Status
  - [x] machine name: external_link_status
  - [x] access: admin only
  - [x] caption: External link status results
  - [x] Add  field Linky status  or whatever it is called by Linkychecker module
  - [x] Add filter if one exists, to filter by link status.
  - [x] Add field error (boolean)
  - [x] Add field Error message
  -  ignore the normally Views Style guide requirements as this is just to see if the link checker is going to have too many false alarms, or if it gives us meaningful information.

To access the Status Report:
- [x] Go to https://pr11920-w3wuffu341dmfxrcwvxwdlsprz4pp2qo.ci.cms.va.gov/admin/content/linky/status (Main Nav > Content > Managed Links > External Link status)
- [x] Verify the results can be filters by:
  - [x] Title
  - [x] Destination
  - [x] HTTP Status

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
