### PR TITLE
VACMS-10996: Removes obsolete permission from content_admin.

### DIFF
--- a/config/sync/user.role.content_admin.yml
+++ b/config/sync/user.role.content_admin.yml
@@ -54,7 +54,6 @@ permissions:
   - 'access media overview'
   - 'access taxonomy overview'
   - 'access user profiles'
-  - 'access vamc_operating_statuses entity browser pages'
   - 'administer menu'
   - 'administer nodes'
   - 'administer taxonomy'

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -99,7 +99,6 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
           'access media overview',
           'access taxonomy overview',
           'access user profiles',
-          'access vamc_operating_statuses entity browser pages',
           'administer menu',
           'administer nodes',
           'administer taxonomy',


### PR DESCRIPTION
## Description

Closes #10996.

This permission doesn't seem to actually exist anymore, and it should be _damnatio memoriae_'d.