### PR TITLE
VACMS-10997: Remove `better_field_descriptions` module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "drupal/animated_gif": "^2.0",
         "drupal/auto_entitylabel": "^3.0-beta3",
         "drupal/better_exposed_filters": "^6.0",
-        "drupal/better_field_descriptions": "^1.4",
         "drupal/blazy": "^2.0@RC",
         "drupal/block_content_permissions": "^1.6",
         "drupal/cer": "4.x-dev#f2ff7d6bf2a3e41757b7621a8367ede974750a84",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2bc4349d37531088ce98f2f3cd7ca89",
+    "content-hash": "a2a25c32fdd48da637bf1bc9d9048f0b",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -3374,54 +3374,6 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/better_exposed_filters",
                 "issues": "https://www.drupal.org/project/issues/better_exposed_filters"
-            }
-        },
-        {
-            "name": "drupal/better_field_descriptions",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/better_field_descriptions.git",
-                "reference": "8.x-1.7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/better_field_descriptions-8.x-1.7.zip",
-                "reference": "8.x-1.7",
-                "shasum": "33c37bb4111e022f9e7269cc88f91e5a99632c28"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.7",
-                    "datestamp": "1635315759",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "odegard",
-                    "homepage": "https://www.drupal.org/user/703222"
-                },
-                {
-                    "name": "yogeshmpawar",
-                    "homepage": "https://www.drupal.org/user/2922907"
-                }
-            ],
-            "description": "Allows users with certain roles to add themeable descriptions to fields in forms",
-            "homepage": "https://www.drupal.org/project/better_field_descriptions",
-            "support": {
-                "source": "https://git.drupalcode.org/project/better_field_descriptions"
             }
         },
         {


### PR DESCRIPTION
## Description

Closes #10997.

As far as I can tell, this module is not installed, nor is it referenced anywhere in the codebase.  This should be completely safe.