### PR TITLE
VACMS-12035: Last-saved-by-an-editor block rampaging unchecked throughout CMS

### DIFF
--- a/docroot/themes/custom/vagovclaro/templates/page/page--node.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/page/page--node.html.twig
@@ -72,10 +72,12 @@
       {% if page.sidebar_second %}
         <aside class="layout-sidebar-second" role="complementary">
           {{ page.sidebar_second }}
+          {% if page.last_saved_by_an_editor %}
           <div class="field field--name-field-last-saved-by-an-editor field--type-timestamp field--label-above">
             <div class="field__label">Last Saved by an Editor</div>
             <div class="field__item">{{ page.last_saved_by_an_editor }}</div>
           </div>
+          {% endif %}
         </aside>{# /.layout-sidebar-second #}
       {% endif %}
     </div>


### PR DESCRIPTION
## Description
Last saved by and editor block showing on /node/add page. It shouldn't.

Closes #12035.

## Testing done
Tested locally. Verified that Last Saved by an Editor is not showing on /node/add. 
I also checked that it is still showing on node views for Vet Center, VAMCS Detail Page, Event, Staff Profile, Vet Center - Facility Service, and Story.

## Screenshots
![CleanShot 2022-12-20 at 07 37 05](https://user-images.githubusercontent.com/109987005/208708659-0e4ee1d0-2260-4910-8e95-b9ef8da61b76.png)


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Navigate to /node/add
   - [x] Validate that Last Saved by and Editor is now not shown. 
2. Then view 5 pieces of content from different content types
   - [x] Validate that Last Saved by an Editor is still displayed. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
