### PR TITLE
VACMS-12108: lovell federal list pages should show urls with links

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Service/VaGovUrl.php
+++ b/docroot/modules/custom/va_gov_backend/src/Service/VaGovUrl.php
@@ -10,7 +10,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 
 /**
- * Class VaGovUrl.
+ * Class to check the status of va.gov URLs.
  */
 class VaGovUrl implements VaGovUrlInterface {
 
@@ -73,9 +73,7 @@ class VaGovUrl implements VaGovUrlInterface {
   /**
    * {@inheritDoc}
    */
-  public function vaGovFrontEndUrlForEntityIsLive(EntityInterface $entity) : bool {
-    $va_gov_url = $this->getVaGovFrontEndUrlForEntity($entity);
-
+  public function vaGovFrontEndUrlIsLive(string $va_gov_url) : bool {
     if (!empty($va_gov_url)) {
       try {
         // Keep the timeout low so that we don't block page loads for too long.

--- a/docroot/modules/custom/va_gov_backend/src/Service/VaGovUrlInterface.php
+++ b/docroot/modules/custom/va_gov_backend/src/Service/VaGovUrlInterface.php
@@ -5,7 +5,7 @@ namespace Drupal\va_gov_backend\Service;
 use Drupal\Core\Entity\EntityInterface;
 
 /**
- * Interface VaGovUrlInterface.
+ * Interface to check the status of va.gov URLs.
  */
 interface VaGovUrlInterface {
 
@@ -26,11 +26,11 @@ interface VaGovUrlInterface {
   public function getVaGovFrontEndUrlForEntity(EntityInterface $entity) : string;
 
   /**
-   * Get the va.gov URL status for an entity.
+   * Get the status for a va.gov URL.
    *
    * @return bool
    *   va.gov URL status.
    */
-  public function vaGovFrontEndUrlForEntityIsLive(EntityInterface $entity) : bool;
+  public function vaGovFrontEndUrlIsLive(string $va_gov_url) : bool;
 
 }

--- a/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
+++ b/docroot/modules/custom/va_gov_workflow_assignments/src/Plugin/Block/EntityMetaDisplay.php
@@ -146,7 +146,7 @@ class EntityMetaDisplay extends BlockBase implements ContainerFactoryPluginInter
     if ($this->vaGovUrlShouldBeDisplayed($node)) {
       $va_gov_urls_to_display = $this->getUrlsToDisplay($node);
       foreach ($va_gov_urls_to_display as $va_gov_url) {
-        if ($this->vaGovUrl->vaGovFrontEndUrlForEntityIsLive($node)) {
+        if ($this->vaGovUrl->vaGovFrontEndUrlIsLive($va_gov_url)) {
           $link = Link::fromTextAndUrl($va_gov_url, Url::fromUri($va_gov_url))->toRenderable();
           $link['#attributes'] = ['class' => 'va-gov-url'];
           $block_items['VA.gov URL'][] = $this->renderer->render($link);

--- a/tests/phpunit/Content/EntityMetaDisplayTest.php
+++ b/tests/phpunit/Content/EntityMetaDisplayTest.php
@@ -134,7 +134,7 @@ class EntityMetaDisplayTest extends VaGovUnitTestBase {
     // `va_gov_backend.va_gov_url`.
     $vaGovUrlProphecy = $this->prophesize(VaGovUrlInterface::CLASS);
     $vaGovUrlProphecy->getVaGovFrontEndUrlForEntity(Argument::type(NodeInterface::CLASS))->willReturn('https://www.example.org/');
-    $vaGovUrlProphecy->vaGovFrontEndUrlForEntityIsLive(Argument::type(NodeInterface::CLASS))->willReturn($isLive);
+    $vaGovUrlProphecy->vaGovFrontEndUrlIsLive('https://www.example.org/')->willReturn($isLive);
     $vaGovUrl = $vaGovUrlProphecy->reveal();
 
     // `va_gov_workflow_assignments.editorial_workflow`.

--- a/tests/phpunit/Service/VaGovUrlServiceTest.php
+++ b/tests/phpunit/Service/VaGovUrlServiceTest.php
@@ -108,9 +108,9 @@ class VaGovUrlServiceTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Verify getVaGovFrontEndUrlForEntityIsLive method.
+   * Verify getVaGovFrontEndUrlIsLive method.
    */
-  public function testVaGovFrontEndUrlForEntityIsLive() {
+  public function testVaGovFrontEndUrlIsLive() {
     $this->mockClient(new Response('200'), new Response('404'));
     $vaGovUrl = new VaGovUrl($this->mockClient, $this->settings, $this->container->get('va_gov.build_trigger.environment_discovery'));
 
@@ -121,9 +121,10 @@ class VaGovUrlServiceTest extends VaGovExistingSiteBase {
       'uid' => $author->id(),
     ]);
     $system_node->setPublished()->save();
+    $url = $vaGovUrl->getVaGovFrontEndUrlForEntity($system_node);
 
-    $this->assertTrue($vaGovUrl->vaGovFrontEndUrlForEntityIsLive($system_node));
-    $this->assertFalse($vaGovUrl->vaGovFrontEndUrlForEntityIsLive($system_node));
+    $this->assertTrue($vaGovUrl->vaGovFrontEndUrlIsLive($url));
+    $this->assertFalse($vaGovUrl->vaGovFrontEndUrlIsLive($url));
   }
 
   /**


### PR DESCRIPTION
## Description

Closes #12108 

## Testing done

Manual testing

## Screenshots

Events list page (for umbrella system)
<img width="1774" alt="Screenshot 2023-01-05 at 4 33 31 PM" src="https://user-images.githubusercontent.com/21045418/210884475-e81b456d-a1ab-48d3-aa47-bd31bda70411.png">

Stories list page (for umbrella system)
<img width="1773" alt="Screenshot 2023-01-05 at 4 34 16 PM" src="https://user-images.githubusercontent.com/21045418/210884557-c2be82e8-296c-4cfa-8080-29665f42690f.png">

News release list page (for umbrella system)
<img width="1773" alt="Screenshot 2023-01-05 at 4 35 02 PM" src="https://user-images.githubusercontent.com/21045418/210884577-b4aec383-dfc7-4164-9412-07f96e0a092a.png">

## QA steps

- [x] https://cms-vhijhwrq9t4gdmtjpx2b3ywasvito9ez.ci.cms.va.gov/lovell-federal-health-care/events the va.gov url should display 2 useable links in the right sidebar
- [x] https://cms-vhijhwrq9t4gdmtjpx2b3ywasvito9ez.ci.cms.va.gov/lovell-federal-health-care/news-releases the va.gov url should display 2 useable links in the right sidebar
- [x] https://cms-vhijhwrq9t4gdmtjpx2b3ywasvito9ez.ci.cms.va.gov/lovell-federal-health-care/stories the va.gov url should display 2 useable links in the right sidebar
- [ ] Separate curls should be made for each link showing in the right sidebar.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [ ] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [x] `⭐️ Facilities`
- [ ] `⭐️ User support`
