### PR TITLE
VACMS-12189: Rollback `drupal/auto_entitylabel`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "drupal/allow_only_one": "1.0.1",
         "drupal/allowed_formats": "^2.0",
         "drupal/animated_gif": "^2.0",
-        "drupal/auto_entitylabel": "^3.0-beta3",
+        "drupal/auto_entitylabel": "3.0-beta3",
         "drupal/better_exposed_filters": "^6.0",
         "drupal/blazy": "^2.0@RC",
         "drupal/block_content_permissions": "^1.6",
@@ -356,9 +356,6 @@
         "composer-exit-on-patch-failure": true,
         "patches-ignore": {},
         "patches": {
-            "drupal/auto_entitylabel": {
-                "Reverse bad patch for 3076302": "patches/auto_entitylabel-reverse-3076302-bad.patch"
-            },
             "drupal/cer": {
                 "3197953-5 - Make d9 compatible": "https://www.drupal.org/files/issues/2021-03-19/cer-3197953-5.patch",
                 "3200122 - Remove delete hook": "https://www.drupal.org/files/issues/2021-02-24/delete-hook-added-in-dev-causes-test-failures.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef3f2f38b53966cb1ed22b2f07436844",
+    "content-hash": "33cd40e11f2f1d15b27197c11cb53752",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -3236,38 +3236,35 @@
         },
         {
             "name": "drupal/auto_entitylabel",
-            "version": "3.0.0",
+            "version": "3.0.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/auto_entitylabel.git",
-                "reference": "8.x-3.0"
+                "reference": "8.x-3.0-beta3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/auto_entitylabel-8.x-3.0.zip",
-                "reference": "8.x-3.0",
-                "shasum": "8dd54d4b677f2c7259a15afd7b71d0d1b6f6b4a6"
+                "url": "https://ftp.drupal.org/files/projects/auto_entitylabel-8.x-3.0-beta3.zip",
+                "reference": "8.x-3.0-beta3",
+                "shasum": "466358949b485461a77d600e3aa27af7b72b4eec"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10"
-            },
-            "require-dev": {
-                "drupal/token": "^1.0"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0",
-                    "datestamp": "1671545557",
+                    "version": "8.x-3.0-beta3",
+                    "datestamp": "1595625626",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {


### PR DESCRIPTION
## Description

Closes #12189.

See also #12187 and #12188.

This rolls back `drupal/auto_entitylabel` to a version we were using previously.  This reintroduces some bugs, but the update should be accomplished as part of #12188.

## QA Steps
1. Go [here](https://cms-rm43hk8f5exkbjgahinskc5mcqbfmm9k.ci.cms.va.gov/node/add/person_profile)
2. Add a first name, last name, section, and region.
3. Click Save.

If that works, we're good 🙂 