### PR TITLE
VACMS-12231: Removes `old_%` DB tables.

### DIFF
--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -1074,3 +1074,33 @@ function va_gov_db_update_9011(&$sandbox) {
   $mesages .= _va_gov_db_create_redirect_by_path('/admin/content/audit/rich-text-field-audit', '/admin/content/audit/search');
   return $mesages;
 }
+
+/**
+ * Remove a number of old tables from the database.
+ */
+function va_gov_db_update_9012(&$sandbox) {
+  $logger = \Drupal::logger('va_gov_db_update_9012');
+  $schema = \Drupal::database()->schema();
+  $tables = $schema->findTables("old_%");
+  $table_names = array_keys($tables);
+  $count = count($tables);
+  $logger->info("Found $count tables: " . json_encode($table_names));
+  foreach ($table_names as $table_name) {
+    $removed = $schema->dropTable($table_name);
+    if ($removed) {
+      $logger->info("Table $table_name successfully dropped.");
+    }
+    else {
+      $logger->warning("Table $table_name not found.");
+    }
+  }
+  $tables = $schema->findTables("old_%");
+  $table_names = array_keys($tables);
+  $count = count($tables);
+  if (!$count) {
+    $logger->info("Successfully removed all old tables.");
+  }
+  else {
+    $logger->warning("Found $count tables after update: " . json_encode($table_names));
+  }
+}


### PR DESCRIPTION
## Description

Closes #12231.

This update logs verbosely, so we should be able to easily verify that it completed successfully.

## Screenshots
![Screen Shot 2023-01-20 at 9 58 57 AM](https://user-images.githubusercontent.com/1318579/213729653-1b6a4541-d9fe-4201-9dd9-929cabbb8d49.png)
...
![Screen Shot 2023-01-20 at 9 58 49 AM](https://user-images.githubusercontent.com/1318579/213729678-f4b50075-6657-47d1-9903-e36a9042b1e2.png)

## QA steps

- [x] `tugboat shell 63caaa20a22f3f424b73d6db` followed by `drush sql-query 'SHOW TABLES LIKE "old_%";'` should return nothing.
- [x] Check logs for messages like:
  - [x] "Found 24 tables: " followed by a list of table names.  This indicates that we could actually find the tables.
  - [x] 24 occurrences of "Table old_something successfully dropped."
  - [x] 0 occurrences of "Table old_something not found."  This would indicate that I'm trying to delete a table that does not exist.
  - [x] "Successfully removed all old tables."
  - [x] NOT "Found $count tables after update: ".  This would indicate the operation was incomplete.
- [x] All tests otherwise pass and the site continues to function as normal.