### PR TITLE
Use Drupal package, not source.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -284,7 +284,6 @@
             "php": "8.1"
         },
         "preferred-install": {
-            "drupal/core": "source",
             "va-gov/content-build": "source",
             "*": "dist"
         },


### PR DESCRIPTION

## Description

We don't have to use the git source for Drupal Core anymore as our composer install builds are not getting run through the TIC anymore. The only reason we used source is because they were getting blocked sometimes by the TIC (firewall) and we moved our builds out of that network a long time ago and never changed this back. This is old technical debt.

>  - Upgrading drupal/core (9.4.7 => 9.4.10):     Update failed (The .git directory is missing from /var/www/html/docroot/core, see https://getcomposer.org/comm
it-deps for more information)
    Would you like to try reinstalling the package instead [yes]? 

This is a follow up to https://github.com/department-of-veterans-affairs/va.gov-cms/pull/11893. 

This PR will speed up the composer install on all environments.

## Testing done
`ddev composer install`

## Screenshots

![image](https://user-images.githubusercontent.com/1504756/213820403-84d6263a-a01c-4a28-8ab5-9587a4e3684b.png)






## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
