### PR TITLE
[docs] Update team options in CMS github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/__cms-task.md
+++ b/.github/ISSUE_TEMPLATE/__cms-task.md
@@ -16,13 +16,10 @@ assignees: ''
 - [ ] Testable_Outcome_Z
 - [ ] Requires design review
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/_cms-epic.md
+++ b/.github/ISSUE_TEMPLATE/_cms-epic.md
@@ -86,13 +86,10 @@ Editor-centered
 - [x] CMS workstream (orange)
 - [ ] CMS-supported product (black)
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/change-management-epic.md
+++ b/.github/ISSUE_TEMPLATE/change-management-epic.md
@@ -52,13 +52,10 @@ If existing videos, list URLs:
 ## Acceptance Criteria
 - [ ] All tickets have been created and assigned per [Change Management Runbook](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/change-management)
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/cms-notification-trigger.md
+++ b/.github/ISSUE_TEMPLATE/cms-notification-trigger.md
@@ -2,7 +2,7 @@
 name: CMS Notification Trigger
 about: Use this template to formalize a CMS trigger for notification
 title: "[CMS Notification Trigger] "
-labels: Needs refining, ⭐️ Sitewide CMS
+labels: Needs refining, CMS Team
 assignees: ''
 
 ---
@@ -27,3 +27,11 @@ A trigger is a flag in the CMS that indicates there is an action for a user to c
 **6. Are there any change management implications for this trigger?**
 
 > All requests should be submitted to the Sitewide CMS team for prioritization. Please make sure to notify the Sitewide CMS team after you submit this issue on the #sitewide-cms team slack channel.
+
+### Team
+Please check the team(s) that will do this work.
+
+- [X] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/cms-section-request.md
+++ b/.github/ISSUE_TEMPLATE/cms-section-request.md
@@ -78,13 +78,10 @@ Examples:
 
 
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [X] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/cms-team-and-sitewide-crew-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/cms-team-and-sitewide-crew-member-onboarding.md
@@ -268,10 +268,10 @@ By this point you should have enough context and access to be able to start cont
 
 </details>
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+### Team
+Please check the team(s) that will do this work.
+
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
-### CMS Team
+### Team
 
 Please leave only the team that will do this work selected. If you're not sure, it's fine to leave both selected.
 

--- a/.github/ISSUE_TEMPLATE/content-audit.md
+++ b/.github/ISSUE_TEMPLATE/content-audit.md
@@ -23,13 +23,10 @@ Please provide any context for the audit, any related terms or alternate spellin
 ## 5. When do you need the audit to be completed
 
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [x] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [x] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/cross-team-intake-request.md
+++ b/.github/ISSUE_TEMPLATE/cross-team-intake-request.md
@@ -33,13 +33,10 @@ Please provide:
 - [ ] The Product Manager has discussed with the respective Product Owner to determine prioritization
 - [ ] Any decisions made on prioritization or implementation are communicated back to the originating team
 
-### CMS Team
+### Team
 Please check the team you project will do this work. If not sure, select "Program".
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/defect-report.md
+++ b/.github/ISSUE_TEMPLATE/defect-report.md
@@ -40,13 +40,10 @@ Add any other context about the problem here. Reach out to the Product Managers 
 - [x] CMS workstream (orange) (not needed for bug tickets)
 - [ ] CMS-supported product (black)
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/devops-task.md
+++ b/.github/ISSUE_TEMPLATE/devops-task.md
@@ -11,13 +11,10 @@ assignees: ''
 - [ ] Task 1...
 
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [x] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [x] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -41,13 +41,10 @@ Editor-centered
 - [ ] `Consistent`: Reduce user’s mental load by allowing them to fall back on pattern recognition to complete tasks.
 - [ ] `Empowering`: Provide clear information to help editors make decisions about their work.
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/linky-update-request.md
+++ b/.github/ISSUE_TEMPLATE/linky-update-request.md
@@ -2,7 +2,7 @@
 name: Linky Reference Update Request
 about: Submit a request to update a Linky Reference
 title: 'Linky Reference Update Request'
-labels: "⭐️ User Support"
+labels: "User Support"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/pw-dark-launch.md
+++ b/.github/ISSUE_TEMPLATE/pw-dark-launch.md
@@ -3,7 +3,7 @@ name: "(PW) Dark launch request"
 about: Request to dark launch CMS content that includes React widget, owned by Public
   Websites team
 title: 'CMS/React content dark launch request: <content info>'
-labels: Drupal engineering, Needs refining, ⭐️ Public Websites, VA.gov frontend
+labels: Drupal engineering, Needs refining, Public Websites, VA.gov frontend
 assignees: jilladams, wesrowe
 
 ---
@@ -42,13 +42,10 @@ Please tick the boxes for completed steps as we go, for cross-team visibility.
 - [ ] Page is **not** live on Prod
 - [ ] Ticket is cut for production launch planning, e.g. #10627 
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [X] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [X] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/pw-forms-bad-pdf-link-pw.md
+++ b/.github/ISSUE_TEMPLATE/pw-forms-bad-pdf-link-pw.md
@@ -2,7 +2,7 @@
 name: "(PW) Forms/Bad PDF link defect"
 about: Forms outages / Bad PDF links, owned by Public Websites team
 title: 'Forms defect: <form name>'
-labels: Defect, Find a form, Needs refining, ⭐️ Public Websites
+labels: Defect, Find a form, Needs refining, Public Websites
 assignees: jilladams, wesrowe
 
 ---
@@ -41,13 +41,10 @@ Steps to reproduce the behavior:
 ## Acceptance Criteria
 - [ ] Form page loads & form can be downloaded
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [X] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [X] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/pw-injected-header-publish.md
+++ b/.github/ISSUE_TEMPLATE/pw-injected-header-publish.md
@@ -2,7 +2,7 @@
 name: "(PW) Injected Header/Footer - publish to prod"
 about: Submit a request to publish the injected header/footer to prod.
 title: 'Injected header/footer: Publish to prod: <domain(s)>'
-labels: Injected header, Needs refining, ⭐️ Public Websites, VA.gov frontend
+labels: Injected header, Needs refining, Public Websites, VA.gov frontend
 assignees: jilladams
 
 ---
@@ -21,13 +21,10 @@ This ticket adds new domain(s) to allowlists that gate the injected header. When
 - [ ] Requesting team has signed off that they're ready to publish
 - [ ] On requested domain(s) the global header is injected on page load, with no cookie updates required
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [X] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [X] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/pw-injected-header.md
+++ b/.github/ISSUE_TEMPLATE/pw-injected-header.md
@@ -2,7 +2,7 @@
 name: "(PW) Injected Header/Footer - prep for testing"
 about: Submit a request to add the injected header/footer an existing site.
 title: 'Injected header/footer: <domain(s)>'
-labels: Injected header, Needs refining, ⭐️ Public Websites, VA.gov frontend
+labels: Injected header, Needs refining, Public Websites, VA.gov frontend
 assignees: jilladams
 
 ---
@@ -43,13 +43,10 @@ After PW updates allowlists, the requesting team will need to test on Staging by
 - [ ] On the requested domains, when setting cookie in the console the global header is injected
 - [ ] Let DM know when your changes have deployed to production, so they can notify the requesting team
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [X] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [X] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/redirect-request-facility-url.md
+++ b/.github/ISSUE_TEMPLATE/redirect-request-facility-url.md
@@ -22,13 +22,10 @@ When does this request need to be live:
 | current URL | new URL |
 
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/research-plan-and-conversation-guide.md
+++ b/.github/ISSUE_TEMPLATE/research-plan-and-conversation-guide.md
@@ -29,13 +29,10 @@ Suggested workflow:
 - [ ] Convert artifacts to markdown format and store in github Research Folder
 - [ ] Get final approval from PO before sending to Research Review cycle
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/research-readout-and-documentation.md
+++ b/.github/ISSUE_TEMPLATE/research-readout-and-documentation.md
@@ -39,13 +39,10 @@ Recommendations are key outputs of the research process. They connect your findi
 - [ ] Document findings in Research Repo
 - [ ] Destroy or archive research materials
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/research-recruitment-and-scheduling.md
+++ b/.github/ISSUE_TEMPLATE/research-recruitment-and-scheduling.md
@@ -46,13 +46,10 @@ assignees: ''
 - [ ] Schedule Pilot session
 - [ ] Schedule Daily Research Debriefs and invite relevant team members 
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/research-review-cycle.md
+++ b/.github/ISSUE_TEMPLATE/research-review-cycle.md
@@ -21,13 +21,10 @@ Note: This step is a hard blocker for Veteran Recruitment, but less so for Edito
 - [ ] If there are significant alterations, consult your Product Manager or Product Owner
 - [ ] Once approved, move on to Participant Recruitment & Scheduling 
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/research-sessions.md
+++ b/.github/ISSUE_TEMPLATE/research-sessions.md
@@ -46,13 +46,10 @@ assignees: ''
 - [ ] You have conducted enough sessions to satify our intended demographics from research plan 
   - [ ] OR Product Owner has signed off that you've done enough to move forward
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/research-synthesis-and-topline-report.md
+++ b/.github/ISSUE_TEMPLATE/research-synthesis-and-topline-report.md
@@ -31,13 +31,10 @@ Next Steps:
 - [ ] Create Topline Report, share with PO, and update if needed 
 - [ ] Schedule a full research readout (if PM & PO request)
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/runbook---ux-research.md
+++ b/.github/ISSUE_TEMPLATE/runbook---ux-research.md
@@ -30,13 +30,10 @@ Here are the steps to follow when setting up a new UX research process:
 ## Acceptance Criteria
 - [ ] All tickets have been created and assigned
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-closed.md
@@ -89,13 +89,10 @@ If this facility has been removed from VAST in error, please notify our Support 
 - [ ] CMS engineer removes the Section.
 - [ ] CMS engineer edit facility node and remove flag `Removed from source`, sets moderation state to archived, then save node.
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/runbook-facility-new.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-new.md
@@ -65,13 +65,10 @@ CMS engineer
 CMS Help desk
 - [ ] 9. HD notifies editor and any other stakeholders.
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/runbook-facility-section-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-section-change.md
@@ -65,13 +65,10 @@ In [Lighthouse Facilties](https://github.com/department-of-veterans-affairs/ligh
 
 - [ ] HD notifies editor and any other stakeholders.
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-facility-name-change.md
@@ -30,13 +30,10 @@ assignees: ''
 - [ ] HD notifies editor and any other stakeholders
 </details>
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
@@ -34,13 +34,10 @@ Timing around these is critical and we may need more detail here.
 
 
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-name-change.md
@@ -30,13 +30,10 @@ In [Lighthouse Facilties](https://github.com/department-of-veterans-affairs/ligh
 - [ ] HD notifies editor and any other stakeholders.
 </details>
 
-## CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/sitewide-cms-collab.yml
+++ b/.github/ISSUE_TEMPLATE/sitewide-cms-collab.yml
@@ -1,7 +1,7 @@
 name: Sitewide CMS Collaboration Cycle Intake
 description: As a member of a VA team I can fill out a form to get information or begin a collaboration cycle with the Sitewide CMS team.
 title: "[CMS COLLAB CYCLE INTAKE] (Team Name, Product Name, Feature Name)"
-labels: "⭐️ Sitewide CMS"
+labels: "CMS Team"
 assignees:
   - ewashb
   - dawnpruitt

--- a/.github/ISSUE_TEMPLATE/tier-1-or-2-ongoing-work.md
+++ b/.github/ISSUE_TEMPLATE/tier-1-or-2-ongoing-work.md
@@ -21,13 +21,10 @@ Tier 2 expectations here: https://docs.google.com/document/d/15oe0wtGI_MdaScYpjJ
 | Date | Issue | Resolution | Time Spent |
 | -- | -- | -- | -- |
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [x] `⭐️ Facilities`
-- [x] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [x] `Facilities`
+- [x] `User support`

--- a/.github/ISSUE_TEMPLATE/ux-writing.md
+++ b/.github/ISSUE_TEMPLATE/ux-writing.md
@@ -39,13 +39,10 @@ E.g. *As a user who may be making changes to content, I'd like a message that wa
 - [ ] Finalize edits to text, and mark as ready to implement in the original issue
 - [ ] Document strategy behind language choices that are relevant to [the back end style guide](https://docs.google.com/document/d/1o3euR0eMoXRyp8G6sx1OCpmRtBShYGAm-Rb8MSXXir0/edit#)
 
-### CMS Team
+### Team
 Please check the team(s) that will do this work.
 
-- [ ] `Program`
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide Crew`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public Websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public Websites`
+- [ ] `Facilities`
+- [ ] `User support`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,12 +35,10 @@ As user _uid_ with _user_role_
 
 ### Select Team for PR review
 
-- [ ] `Platform CMS Team`
-- [ ] `Sitewide program`
-- [ ] `⭐️ Sitewide CMS`
-- [ ] `⭐️ Public websites`
-- [ ] `⭐️ Facilities`
-- [ ] `⭐️ User support`
+- [ ] `CMS Team`
+- [ ] `Public websites`
+- [ ] `Facilities`
+- [ ] `User support`
 
 
 ### Is this PR blocked by another PR?

--- a/READMES/code-review.md
+++ b/READMES/code-review.md
@@ -71,7 +71,7 @@ The Product Manager is a person on the CMS team who works with the Product Owner
 
 1. A Pull Request is created in Github as a `Draft`.
 1. The PR Owner is set as the Assignee of the Pull Request.
-1. Add `Platform CMS Team` or `Sitewide CMS Team` label.
+1. Add `CMS Team` label.
 1. If a PR is blocked by another PR add the `DO NOT MERGE` label and add `[DO NOT MERGE]` or `[WIP]` to the PR title.
 1. The PR Owner will test the changes in CI. When the PR Owner is confident the changes are ready for review, the PR Owner will set the Pull Request to `Ready for Review`.
 1. PR Owner will request one or multiple PR Reviewers for the Pull Request as needed.


### PR DESCRIPTION
In .github/ISSUETEMPLATES only: 
* Remove program team from CMS team options
* Combine Plat CMS and Sitewide CMS into new CMS Team label. (Checked with @EWashb & got approval for this change. )
* Remove ⭐ from team labels

Follow up steps required: 
* Update Github [label](https://github.com/department-of-veterans-affairs/va.gov-cms/labels?q=sitewide%20CMS) for `⭐ Sitewide CMS` to become `CMS Team`
* Update [issues](https://github.com/department-of-veterans-affairs/va.gov-cms/labels/Platform%20CMS%20Team) with `Platform CMS Team` label & apply `CMS Team` label 
* Update Github [label](https://github.com/department-of-veterans-affairs/va.gov-cms/labels?q=Public+websites) for `⭐ Public Websites` to remove ⭐ 
* Update Github [label](https://github.com/department-of-veterans-affairs/va.gov-cms/labels?q=Facilities) for `⭐ Facilities`  to remove ⭐ 
 


### Select Team for PR review

- [X] CMS Team
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [X] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
