### PR TITLE
VACMS-12286 Add content_model_documentation module and enable.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "drupal/consumer_image_styles": "^4.0",
         "drupal/consumers": "1.16.0",
         "drupal/content_lock": "^2.0@alpha",
+        "drupal/content_model_documentation": "^1.0@alpha",
         "drupal/core-composer-scaffold": "~9.5.0",
         "drupal/core-recommended": "~9.5.0",
         "drupal/crop": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd1fb7de310155b728e3a21c23d75951",
+    "content-hash": "efba0d14b7f59344a5b47241a28507c0",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -3937,6 +3937,54 @@
             }
         },
         {
+            "name": "drupal/config_views",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_views.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_views-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "e1ca72fe7b5dd7ff7445059f3dd75c2bbc824de9"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1645191041",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "cosmicdreams",
+                    "homepage": "https://www.drupal.org/user/42579"
+                },
+                {
+                    "name": "vijaycs85",
+                    "homepage": "https://www.drupal.org/user/93488"
+                }
+            ],
+            "description": "Views handler implementation for configuration entities.",
+            "homepage": "https://www.drupal.org/project/config_views",
+            "support": {
+                "source": "https://git.drupalcode.org/project/config_views"
+            }
+        },
+        {
             "name": "drupal/consumer_image_styles",
             "version": "4.0.8",
             "source": {
@@ -4097,6 +4145,55 @@
             "homepage": "https://www.drupal.org/project/content_lock",
             "support": {
                 "source": "https://git.drupalcode.org/project/content_lock"
+            }
+        },
+        {
+            "name": "drupal/content_model_documentation",
+            "version": "1.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/content_model_documentation.git",
+                "reference": "1.0.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/content_model_documentation-1.0.0-alpha3.zip",
+                "reference": "1.0.0-alpha3",
+                "shasum": "deb4689e0f441b42fda2aa276080625cd661b6e7"
+            },
+            "require": {
+                "drupal/config_views": "~2.0",
+                "drupal/core": "^9.3 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha3",
+                    "datestamp": "1674850672",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "swirt",
+                    "homepage": "https://www.drupal.org/user/138230"
+                }
+            ],
+            "description": "Provide reports and documentation for fields and entities.",
+            "homepage": "https://www.drupal.org/project/content_model_documentation",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/content_model_documentation",
+                "issues": "http://drupal.org/project/issues/content_model_documentation"
             }
         },
         {
@@ -28670,6 +28767,7 @@
         "drupal/change_labels": 20,
         "drupal/components": 10,
         "drupal/content_lock": 15,
+        "drupal/content_model_documentation": 15,
         "drupal/entity_block": 10,
         "drupal/entity_clone": 10,
         "drupal/entity_field_fetch": 10,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -30,10 +30,12 @@ module:
   config_ignore: 0
   config_override_warn: 0
   config_split: 0
+  config_views: 0
   consumer_image_styles: 0
   consumers: 0
   content_lock: 0
   content_lock_timeout: 0
+  content_model_documentation: 0
   content_moderation: 0
   contextual: 0
   core_event_dispatcher: 0

--- a/config/sync/views.view.content_model_fields.yml
+++ b/config/sync/views.view.content_model_fields.yml
@@ -1,0 +1,1114 @@
+uuid: e4c3968b-6fe5-4bf4-aaf1-c460616ecaa0
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_views
+    - content_model_documentation
+    - user
+  enforced:
+    module:
+      - content_model_documentation
+_core:
+  default_config_hash: vjuKGEn7Xpn0qMyqYJRpRigp66WFNWhe1FXBGsNDGSw
+id: content_model_fields
+label: 'Content Model Fields'
+module: views
+description: 'Displays field configuration for the content model.'
+tag: ''
+base_table: config_field_field
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Content Model Fields'
+      fields:
+        field_name:
+          id: field_name
+          table: config_field_field
+          field: field_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: 'Field name'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        field_entity_reference_targets:
+          id: field_entity_reference_targets
+          table: config_field_field
+          field: field_entity_reference_targets
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: configuration_field_entity_reference_targets
+          label: 'Field entity reference targets setting'
+          exclude: true
+          alter:
+            alter_text: true
+            text: '</br > Target: {{ field_entity_reference_targets }} '
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: true
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        field_type:
+          id: field_type
+          table: config_field_field
+          field: field_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: 'Field type'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_type }}  {{ field_entity_reference_targets }} '
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: true
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        entity_type:
+          id: entity_type
+          table: config_field_field
+          field: entity_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: 'Entity type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        bundle:
+          id: bundle
+          table: config_field_field
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: Bundle
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        label:
+          id: label
+          table: config_field_field
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: Label
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        description:
+          id: description
+          table: config_field_field
+          field: description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: Description
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        required:
+          id: required
+          table: config_field_field
+          field: required
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: 'Required field'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        'field_cardinality setting':
+          id: 'field_cardinality setting'
+          table: config_field_field
+          field: 'field_cardinality setting'
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: configuration_field_cardinality
+          label: Cardinality
+          exclude: false
+          alter:
+            alter_text: false
+            text: undefined
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: undefined
+          hide_empty: false
+          empty_zero: true
+          hide_alter_empty: false
+        translatable:
+          id: translatable
+          table: config_field_field
+          field: translatable
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: Translatable
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        langcode:
+          id: langcode
+          table: config_field_field
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: standard
+          label: 'Language code'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        operation:
+          id: operation
+          table: config_field_field
+          field: operation
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: config_entity_operations
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view content model documentation'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: 'No results for filter'
+          plugin_id: text_custom
+          empty: true
+          content: 'There are no fields that match your current filters.  Please change your filters or reset them.'
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
+      filters:
+        field_name:
+          id: field_name
+          table: config_field_field
+          field: field_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: config_entity_string
+          operator: CONTAINS
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_name_op
+            label: 'Field name'
+            description: ''
+            use_operator: false
+            operator: field_name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_type:
+          id: field_type
+          table: config_field_field
+          field: field_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: config_entity_string
+          operator: CONTAINS
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_type_op
+            label: 'Field type'
+            description: ''
+            use_operator: false
+            operator: field_type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        entity_type:
+          id: entity_type
+          table: config_field_field
+          field: entity_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: config_entity_string
+          operator: CONTAINS
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: entity_type_op
+            label: 'Entity type'
+            description: ''
+            use_operator: false
+            operator: entity_type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: entity_type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        bundle:
+          id: bundle
+          table: config_field_field
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: config_entity_string
+          operator: CONTAINS
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: bundle_op
+            label: Bundle
+            description: ''
+            use_operator: false
+            operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: bundle
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        label:
+          id: label
+          table: config_field_field
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: field_config
+          plugin_id: config_entity_string
+          operator: CONTAINS
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: label_op
+            label: Label
+            description: ''
+            use_operator: false
+            operator: label_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: label
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            field_name: field_name
+            field_type: field_type
+            entity_type: entity_type
+            bundle: bundle
+            label: label
+            description: description
+            required: required
+            'field_cardinality setting': 'field_cardinality setting'
+            translatable: translatable
+            langcode: langcode
+            operation: operation
+            id: id
+          default: field_name
+          info:
+            field_name:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_type:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+            entity_type:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+            bundle:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+            label:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+            description:
+              sortable: false
+              default_sort_order: asc
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+            required:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-center
+              separator: ''
+              empty_column: false
+              responsive: ''
+            'field_cardinality setting':
+              align: views-align-center
+              separator: ''
+              empty_column: false
+              responsive: ''
+            translatable:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-center
+              separator: ''
+              empty_column: false
+              responsive: ''
+            langcode:
+              sortable: true
+              default_sort_order: asc
+              align: views-align-center
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operation:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: false
+          caption: 'List of fields used across the content model.'
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  content_model_documentation_fields:
+    id: content_model_documentation_fields
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_comment: 'Created by the content_model_documentation module.'
+      display_extenders:
+        jsonapi_views:
+          enabled: false
+      path: admin/reports/fields/content-model
+      menu:
+        type: tab
+        title: 'Content Model'
+        description: 'Displays field settings of the content model.'
+        weight: 0
+        expanded: false
+        menu_name: admin
+        parent: entity.field_storage_config.collection
+        context: '0'
+        as_local_task: false
+        local_task_link_title: ''
+        local_task_parent: _custom
+        local_task_weight: 20
+        local_task_custom_parent_route: entity.field_storage_config.collection
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/tests/behat/drupal-spec-tool/views.feature
+++ b/tests/behat/drupal-spec-tool/views.feature
@@ -23,6 +23,7 @@ Feature: Views
 | Content | content | Content | Enabled | Find and manage content. |
 | Content entity browsers | content_entity_browsers | Content | Enabled | Collection of Entity Browsers to use for field widgets configuration in form displays. |
 | Content Entity Reference Source | content_entity_reference_source | Content | Enabled | Various views used to populate options on entity reference fields |
+| Content Model Fields | content_model_fields | Field | Enabled | Displays field configuration for the content model. |
 | Content release logs | content_release_logs | Log entries | Enabled | Shows content release job log entries |
 | Content served from Drupal | content_served_from_drupal | Content | Enabled | An exportable list of all content served from Drupal |
 | Custom block entity browsers | custom_block_entity_browsers | Custom Block | Enabled | For placing on content forms |
@@ -137,6 +138,8 @@ Feature: Views
 | Content Entity Reference Source | Entity Reference: Story Listing | entity_reference_3 | Entity Reference |
 | Content Entity Reference Source | Entity Reference: Systems | entity_reference_6 | Entity Reference |
 | Content Entity Reference Source | Master | default | Default |
+| Content Model Fields | Default | default | Default |
+| Content Model Fields | Page | content_model_documentation_fields | Page |
 | Content release logs | Master | default | Default |
 | Content release logs | Page | page_1 | Page |
 | Content served from Drupal | Data export | data_export_1 | Data export |
@@ -298,9 +301,9 @@ Feature: Views
 | Users in section | Master | default | Default |
 | Users in section | Page | section_member_page | Page |
 | VA Forms | Audit | audit | Page |
+| VA Forms | CSV export | csv_export | Data export |
 | VA Forms | Master | default | Default |
 | VA Forms | Page | page_1 | Page |
-| VA Forms | CSV export | csv_export | Data export |
 | VA Services | Data export | data_export_1 | Data export |
 | VA Services | Master | default | Default |
 | VA Services | Page | page_1 | Page |


### PR DESCRIPTION
## Description

Closes #12286

## Testing done /QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As an admin  (this report only shows to admins)
1.  Login  https://pr12332-djcvxbj4y6ist5avej2dtuz3xylrdpu4.ci.cms.va.gov/ and pull down the reports menu, 
   - [ ] Validate that the "Content Model" appears in the menu under "Field list"  
   
![image](https://user-images.githubusercontent.com/5752113/214958176-947665c7-c9dc-44d0-b02d-581daaf125d9.png)

 - [ ] Click the Content Model menu link, validate that it takes you to /admin/reports/fields/content-model
 - [ ] Validate that the View contains a "Displaying ..." counter above the filters and that it is showing ~800 items.
 - [ ] Validate "Content Model" is in the tabs for navigating to other Field related reports
 
![image](https://user-images.githubusercontent.com/5752113/214959634-486d2989-9a9a-425f-81dc-781bd7c16b0a.png)

  - [ ] Validate Field name  (Machine name)  is in results and filterable
   - [ ] Validate Field Type is in results and filterable
      - [ ] Validate entity reference targets are present in the Field Type column on entity reference-like fields
   - [ ] Entity Type is in results and filterable
   - [ ] Bundle is in results and filterable
   - [ ] ~Used in (link to manage fields)~ This was replaced by the combination of entity type and bundle.
   - [ ] Label (Field Label) is in results and filterable
   - [ ] Description is in results
   - [ ] cardinality is in results
   - [ ] required is in results
   - Views Style guide  This View is provided via a contrib module we control and as such is only loosely bound to our style guide, however I have tried to maintain as much it that makes sense.
      - [ ] All columns have headings (508)
      - [ ] Has table caption "List of fields used across the content model." (508)
      - [ ] Filter order matches column order
      - [ ] Buttons says "filter"
      - [ ] has a "reset" button
      - [ ] columns that can be sortable, are sortable
   
As content admin
- Login as Randi.Hecht@va.gov
- go to https://pr12332-djcvxbj4y6ist5avej2dtuz3xylrdpu4.ci.cms.va.gov/admin/reports/fields/content-model
- [ ] validate access denied  (we may open this up to other roles later, but  for now it is only admins.)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] ~Tests have been added if necessary.~  This is largely contrib, we do not usually test contrib.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `Platform CMS Team`
- [ ] `Sitewide program`
- [x] `⭐️ Sitewide CMS`
- [ ] `⭐️ Public websites`
- [ ] `⭐️ Facilities`
- [ ] `⭐️ User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
