### PR TITLE
VACMS-11895: Adds Cypress support for counting Watchdog log messages.

### DIFF
--- a/tests/cypress/integration/behavioral/common/i_check_the_watchdog_log.js
+++ b/tests/cypress/integration/behavioral/common/i_check_the_watchdog_log.js
@@ -1,0 +1,12 @@
+import { Given } from "cypress-cucumber-preprocessor/steps";
+
+Given(`I check the watchdog log`, function watchdogLogHandler() {
+  cy.drupalGetWatchdogMessages(this.username).then(cy.log);
+});
+
+Given(
+  `I check the watchdog log for {string} messages`,
+  function watchdogLogHandler(severity) {
+    cy.drupalGetWatchdogMessages(this.username, severity).then(cy.log);
+  }
+);

--- a/tests/cypress/integration/behavioral/common/i_create_a_media.js
+++ b/tests/cypress/integration/behavioral/common/i_create_a_media.js
@@ -64,9 +64,9 @@ const creators = {
       const POINTER_DOWN = window.PointerEvent ? "pointerdown" : "mousedown";
       const POINTER_MOVE = window.PointerEvent ? "pointermove" : "mousemove";
       const POINTER_UP = window.PointerEvent ? "pointerup" : "mouseup";
-      const cropperType = window.jQuery("[data-drupal-iwc=wrapper]").data(
-        "ImageWidgetCrop"
-      ).types[0];
+      const cropperType = window
+        .jQuery("[data-drupal-iwc=wrapper]")
+        .data("ImageWidgetCrop").types[0];
       const { cropper } = cropperType;
       const { dragBox } = cropper;
       const $wrapper = window.jQuery(dragBox).closest(".crop-preview-wrapper");
@@ -129,6 +129,7 @@ Given("I create a {string} media", (contentType) => {
       "not.include",
       "/media/add"
     );
+    cy.drupalWatchdogHasNoNewErrors();
     cy.getDrupalSettings().then((drupalSettings) => {
       const { currentPath } = drupalSettings.path;
       const pathComponents = currentPath.split("/");

--- a/tests/cypress/integration/behavioral/common/i_create_a_node.js
+++ b/tests/cypress/integration/behavioral/common/i_create_a_node.js
@@ -1,145 +1,246 @@
+/* eslint-disable max-nested-callbacks */
 import { Given } from "cypress-cucumber-preprocessor/steps";
-import { faker } from '@faker-js/faker';
+import { faker } from "@faker-js/faker";
 
 const creators = {
   checklist: () => {
-    cy.visit('/node/add/checklist');
-    cy.scrollTo('top');
-    cy.findAllByLabelText('Page title').type('[Test Data] ' + faker.lorem.sentence(3), { force: true });
-    cy.findAllByLabelText('Page introduction').type(faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Section').select('VACO', { force: true });
-    cy.findAllByLabelText('Primary category').select('Burials and memorials', { force: true });
-    cy.get('#edit-field-related-information-0-subform-field-link-0-uri').type('http://www.example.com/', { force: true });
-    cy.get('#edit-field-related-information-0-subform-field-link-0-title').type('[Test Link Title]' + faker.lorem.sentence(), { force: true });
-    cy.get('#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-section-header-0-value').type('[Test Header Value]' + faker.lorem.sentence(3), { force: true });
-    cy.get('#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-checklist-items-0-value').type('[Test Items Value]' + faker.lorem.sentence(), { force: true });
-    cy.contains('All Veterans').parent().find('input').check({ force: true });
+    cy.visit("/node/add/checklist");
+    cy.scrollTo("top");
+    cy.findAllByLabelText(
+      "Page title"
+    ).type(`[Test Data] ${faker.lorem.sentence(3)}`, { force: true });
+    cy.findAllByLabelText("Page introduction").type(faker.lorem.sentence(), {
+      force: true,
+    });
+    cy.findAllByLabelText("Section").select("VACO", { force: true });
+    cy.findAllByLabelText("Primary category").select("Burials and memorials", {
+      force: true,
+    });
+    cy.get(
+      "#edit-field-related-information-0-subform-field-link-0-uri"
+    ).type("http://www.example.com/", { force: true });
+    cy.get(
+      "#edit-field-related-information-0-subform-field-link-0-title"
+    ).type(`[Test Link Title]${faker.lorem.sentence()}`, { force: true });
+    cy.get(
+      "#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-section-header-0-value"
+    ).type(`[Test Header Value]${faker.lorem.sentence(3)}`, { force: true });
+    cy.get(
+      "#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-checklist-items-0-value"
+    ).type(`[Test Items Value]${faker.lorem.sentence()}`, { force: true });
+    cy.contains("All Veterans").parent().find("input").check({ force: true });
     return cy.wait(1000);
   },
   documentation_page: () => {
-    cy.visit('/node/add/documentation_page');
-    cy.scrollTo('top');
-    cy.findAllByLabelText('Page title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Page introduction').type(faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Section').select('VACO', { force: true });
-    cy.findAllByLabelText('Parent link').select('-- CMS Knowledge Base (disabled)', { force: true });
+    cy.visit("/node/add/documentation_page");
+    cy.scrollTo("top");
+    cy.findAllByLabelText(
+      "Page title"
+    ).type(`[Test Data] ${faker.lorem.sentence()}`, { force: true });
+    cy.findAllByLabelText("Page introduction").type(faker.lorem.sentence(), {
+      force: true,
+    });
+    cy.findAllByLabelText("Section").select("VACO", { force: true });
+    cy.findAllByLabelText(
+      "Parent link"
+    ).select("-- CMS Knowledge Base (disabled)", { force: true });
     return cy.wait(1000);
   },
   event: () => {
-    cy.visit('/node/add/event');
-    cy.scrollTo('top');
-    cy.findAllByLabelText('Name').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.get('#edit-field-datetime-range-timezone-0-time-wrapper-value-date').type('2023-04-05', { force: true });
-    cy.get('#edit-field-datetime-range-timezone-0-time-wrapper-value-time').type('12:00', { force: true });
-    cy.findAllByLabelText('Where should the event be listed?').select('VA Alaska health care: Events', { force: true });
-    cy.findAllByLabelText('Street address').type(faker.address.streetAddress(), { force: true });
-    cy.findAllByLabelText('City').type(faker.address.city(), { force: true });
-    cy.findAllByLabelText('State').select('Alabama', { force: true });
-    cy.findAllByLabelText('Section').select('--Outreach Hub', { force: true });
-    cy.scrollToSelector('#edit-field-media-open-button');
-    cy.get('#edit-field-media-open-button').click({ force: true });
-    cy.get('.dropzone', {
+    cy.visit("/node/add/event");
+    cy.scrollTo("top");
+    cy.findAllByLabelText("Name").type(
+      `[Test Data] ${faker.lorem.sentence()}`,
+      { force: true }
+    );
+    cy.get(
+      "#edit-field-datetime-range-timezone-0-time-wrapper-value-date"
+    ).type("2023-04-05", { force: true });
+    cy.get(
+      "#edit-field-datetime-range-timezone-0-time-wrapper-value-time"
+    ).type("12:00", { force: true });
+    cy.findAllByLabelText(
+      "Where should the event be listed?"
+    ).select("VA Alaska health care: Events", { force: true });
+    cy.findAllByLabelText("Street address").type(
+      faker.address.streetAddress(),
+      { force: true }
+    );
+    cy.findAllByLabelText("City").type(faker.address.city(), { force: true });
+    cy.findAllByLabelText("State").select("Alabama", { force: true });
+    cy.findAllByLabelText("Section").select("--Outreach Hub", { force: true });
+    cy.scrollToSelector("#edit-field-media-open-button");
+    cy.get("#edit-field-media-open-button").click({ force: true });
+    cy.get(".dropzone", {
       timeout: 10000,
     });
-    cy.get('.dropzone').attachFile('images/polygon_image.png', {
-      subjectType: 'drag-n-drop',
+    cy.get(".dropzone").attachFile("images/polygon_image.png", {
+      subjectType: "drag-n-drop",
     });
     cy.wait(1000);
-    cy.findAllByLabelText('Alternative text').type(faker.lorem.sentence(), { force: true });
-    cy.get('[data-drupal-selector="edit-media-0-fields-field-owner"]').select('VACO', { force: true });
-    cy.get('button').contains('Save and insert').click({ force: true });
-    cy.get('div.media-library-item[data-drupal-selector="edit-field-media-selection-0"]', {
-      timeout: 15000,
+    cy.findAllByLabelText("Alternative text").type(faker.lorem.sentence(), {
+      force: true,
     });
+    cy.get(
+      '[data-drupal-selector="edit-media-0-fields-field-owner"]'
+    ).select("VACO", { force: true });
+    cy.get("button").contains("Save and insert").click({ force: true });
+    cy.get(
+      'div.media-library-item[data-drupal-selector="edit-field-media-selection-0"]',
+      {
+        timeout: 15000,
+      }
+    );
     return cy.wait(1000);
   },
   health_care_region_detail_page: () => {
-    cy.visit('/node/add/health_care_region_detail_page');
-    cy.scrollTo('top');
-    cy.findAllByLabelText('Page title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Page introduction').type(faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Section').select('VACO', { force: true });
-    cy.findAllByLabelText('Related office or health care system').select('VA Alaska health care', { force: true });
-    cy.findAllByLabelText('Parent link').select('-------- Anchorage VA Medical Center', { force: true });
-    cy.findAllByLabelText('Meta description').type(faker.lorem.sentence(), { force: true });
+    cy.visit("/node/add/health_care_region_detail_page");
+    cy.scrollTo("top");
+    cy.findAllByLabelText(
+      "Page title"
+    ).type(`[Test Data] ${faker.lorem.sentence()}`, { force: true });
+    cy.findAllByLabelText("Page introduction").type(faker.lorem.sentence(), {
+      force: true,
+    });
+    cy.findAllByLabelText("Section").select("VACO", { force: true });
+    cy.findAllByLabelText(
+      "Related office or health care system"
+    ).select("VA Alaska health care", { force: true });
+    cy.findAllByLabelText(
+      "Parent link"
+    ).select("-------- Anchorage VA Medical Center", { force: true });
+    cy.findAllByLabelText("Meta description").type(faker.lorem.sentence(), {
+      force: true,
+    });
     return cy.wait(1000);
   },
   landing_page: () => {
-    cy.visit('/node/add/landing_page');
-    cy.scrollTo('top');
-    cy.findAllByLabelText('Page title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Page introduction').type(faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Section').select('VACO', { force: true });
-    cy.findAllByLabelText('Meta description').type(faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Provide a menu link').check({ force: true });
-    cy.findAllByLabelText('Menu link title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Parent link').select('---- Disability', { force: true });
-    cy.contains('Add List of link teasers').click({ force: true });
-    cy.get('input[id^=edit-field-spokes-0-subform-field-va-paragraphs-0-subform-field-link-0-uri').type(faker.internet.url(), { force: true });
-    cy.get('input[id^=edit-field-spokes-0-subform-field-va-paragraphs-0-subform-field-link-0-title').type(faker.company.companyName(), { force: true });
+    cy.visit("/node/add/landing_page");
+    cy.scrollTo("top");
+    cy.findAllByLabelText(
+      "Page title"
+    ).type(`[Test Data] ${faker.lorem.sentence()}`, { force: true });
+    cy.findAllByLabelText("Page introduction").type(faker.lorem.sentence(), {
+      force: true,
+    });
+    cy.findAllByLabelText("Section").select("VACO", { force: true });
+    cy.findAllByLabelText("Meta description").type(faker.lorem.sentence(), {
+      force: true,
+    });
+    cy.findAllByLabelText("Provide a menu link").check({ force: true });
+    cy.findAllByLabelText(
+      "Menu link title"
+    ).type(`[Test Data] ${faker.lorem.sentence()}`, { force: true });
+    cy.findAllByLabelText("Parent link").select("---- Disability", {
+      force: true,
+    });
+    cy.contains("Add List of link teasers").click({ force: true });
+    cy.get(
+      "input[id^=edit-field-spokes-0-subform-field-va-paragraphs-0-subform-field-link-0-uri"
+    ).type(faker.internet.url(), { force: true });
+    cy.get(
+      "input[id^=edit-field-spokes-0-subform-field-va-paragraphs-0-subform-field-link-0-title"
+    ).type(faker.company.companyName(), { force: true });
     return cy.wait(3000);
   },
   office: () => {
-    cy.visit('/node/add/office');
-    cy.scrollTo('top');
-    cy.findAllByLabelText('Name').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Section').select('---VA Sheridan health care', { force: true });
-    cy.findAllByLabelText('Provide a menu link').check({ force: true });
-    cy.findAllByLabelText('Menu link title').type('[Test Data] ' + faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('Parent link').select('-- Outreach and events', { force: true });
+    cy.visit("/node/add/office");
+    cy.scrollTo("top");
+    cy.findAllByLabelText("Name").type(
+      `[Test Data] ${faker.lorem.sentence()}`,
+      { force: true }
+    );
+    cy.findAllByLabelText("Section").select("---VA Sheridan health care", {
+      force: true,
+    });
+    cy.findAllByLabelText("Provide a menu link").check({ force: true });
+    cy.findAllByLabelText(
+      "Menu link title"
+    ).type(`[Test Data] ${faker.lorem.sentence()}`, { force: true });
+    cy.findAllByLabelText("Parent link").select("-- Outreach and events", {
+      force: true,
+    });
     return cy.wait(1000);
   },
   step_by_step: () => {
-    cy.visit('/node/add/step_by_step');
-    cy.scrollTo('top');
-    cy.findAllByLabelText('Page title').type('[Test Data] ' + faker.lorem.word(), { force: true });
-    cy.findAllByLabelText('Page introduction').type(faker.lorem.sentence(), { force: true });
+    cy.visit("/node/add/step_by_step");
+    cy.scrollTo("top");
+    cy.findAllByLabelText(
+      "Page title"
+    ).type(`[Test Data] ${faker.lorem.word()}`, { force: true });
+    cy.findAllByLabelText("Page introduction").type(faker.lorem.sentence(), {
+      force: true,
+    });
 
     // Enter text into page intro ckeditor.
-    cy.type_ckeditor("edit-field-intro-text-limited-html-0-value", faker.lorem.sentence());
-    cy.findAllByLabelText('Section').select('VACO', { force: true });
-    cy.findAllByLabelText('Section Header').type(faker.lorem.word(), { force: true });
-    cy.findAllByLabelText('Text').type(faker.lorem.sentence(), { force: true });
-    cy.findAllByLabelText('URL').type('https://va.gov/', { force: true });
-    cy.findAllByLabelText('Link text').type('va.gov', { force: true });
-    cy.findAllByLabelText('Primary category').select('Records', { force: true });
-    cy.findAllByLabelText('Claims and appeals status').check({ force: true });
-    cy.type_ckeditor("edit-field-steps-0-subform-field-step-0-subform-field-wysiwyg-0-value", faker.lorem.sentence());
+    cy.type_ckeditor(
+      "edit-field-intro-text-limited-html-0-value",
+      faker.lorem.sentence()
+    );
+    cy.findAllByLabelText("Section").select("VACO", { force: true });
+    cy.findAllByLabelText("Section Header").type(faker.lorem.word(), {
+      force: true,
+    });
+    cy.findAllByLabelText("Text").type(faker.lorem.sentence(), { force: true });
+    cy.findAllByLabelText("URL").type("https://va.gov/", { force: true });
+    cy.findAllByLabelText("Link text").type("va.gov", { force: true });
+    cy.findAllByLabelText("Primary category").select("Records", {
+      force: true,
+    });
+    cy.findAllByLabelText("Claims and appeals status").check({ force: true });
+    cy.type_ckeditor(
+      "edit-field-steps-0-subform-field-step-0-subform-field-wysiwyg-0-value",
+      faker.lorem.sentence()
+    );
     return cy.wait(1000);
   },
 };
 
-Given('I create a {string} node', (contentType) => {
-  let creator = creators[contentType];
-  assert.isNotNull(creator, `I do not know how to create ${contentType} nodes yet.  Please add a definition in ${__filename}.`);
+Given("I create a {string} node", (contentType) => {
+  const creator = creators[contentType];
+  assert.isNotNull(
+    creator,
+    `I do not know how to create ${contentType} nodes yet.  Please add a definition in ${__filename}.`
+  );
   creator().then(() => {
-    cy.get('form.node-form').find('input#edit-submit').click();
-    cy.location('pathname', {timeout: 10000}).should('not.include', '/node/add');
+    cy.get("form.node-form").find("input#edit-submit").click();
+    cy.location("pathname", { timeout: 10000 }).should(
+      "not.include",
+      "/node/add"
+    );
+    cy.drupalWatchdogHasNoNewErrors();
     cy.getDrupalSettings().then((drupalSettings) => {
-      const currentPath = drupalSettings.path.currentPath;
-      cy.wrap(currentPath.split('/').pop()).as('nodeId');
+      const { currentPath } = drupalSettings.path;
+      cy.wrap(currentPath.split("/").pop()).as("nodeId");
       cy.window().then((window) => {
         const pagePath = window.location.pathname;
-        cy.wrap(pagePath).as('pagePath');
+        cy.wrap(pagePath).as("pagePath");
       });
     });
   });
 });
 
-Given('I create a {string} node and continue', (contentType) => {
-  let creator = creators[contentType];
-  assert.isDefined(creator, `I do not know how to create ${contentType} nodes yet.  Please add a definition in ${__filename}.`);
+Given("I create a {string} node and continue", (contentType) => {
+  const creator = creators[contentType];
+  assert.isDefined(
+    creator,
+    `I do not know how to create ${contentType} nodes yet.  Please add a definition in ${__filename}.`
+  );
   creator().then(() => {
-    cy.get('form.node-form').find('input#edit-save-continue').click();
-    cy.location('pathname', {timeout: 10000}).should('not.include', '/node/add');
+    cy.get("form.node-form").find("input#edit-save-continue").click();
+    cy.location("pathname", { timeout: 10000 }).should(
+      "not.include",
+      "/node/add"
+    );
+    cy.drupalWatchdogHasNoNewErrors();
     cy.getDrupalSettings().then((drupalSettings) => {
-      const currentPath = drupalSettings.path.currentPath;
-      const pathComponents = currentPath.split('/');
+      const { currentPath } = drupalSettings.path;
+      const pathComponents = currentPath.split("/");
       pathComponents.pop();
-      cy.wrap(pathComponents.pop()).as('nodeId');
+      cy.wrap(pathComponents.pop()).as("nodeId");
       cy.window().then((window) => {
         const pagePath = window.location.pathname;
-        cy.wrap(pagePath).as('pagePath');
+        cy.wrap(pagePath).as("pagePath");
       });
     });
   });

--- a/tests/cypress/integration/behavioral/common/watchdog_log.js
+++ b/tests/cypress/integration/behavioral/common/watchdog_log.js
@@ -1,0 +1,30 @@
+import { Given } from "cypress-cucumber-preprocessor/steps";
+
+Given(
+  `the watchdog log should not contain new {string} messages`,
+  function watchdogLogHandler(severity) {
+    return cy.drupalWatchdogHasNoNewMessages(this.username, severity);
+  }
+);
+
+Given(
+  `the watchdog log should not contain new errors`,
+  function watchdogLogHandler() {
+    return cy.drupalWatchdogHasNoNewMessages(this.username, "Error");
+  }
+);
+
+
+Given(
+  `the watchdog log should contain {int} new {string} messages`,
+  function watchdogLogHandler(count, severity) {
+    return cy.drupalWatchdogHasNewMessages(this.username, severity, count);
+  }
+);
+
+Given(
+  `the watchdog log should contain {int} new errors`,
+  function watchdogLogHandler(count) {
+    return cy.drupalWatchdogHasNewMessages(this.username, "Error", count);
+  }
+);

--- a/tests/cypress/integration/behavioral/permissions.feature
+++ b/tests/cypress/integration/behavioral/permissions.feature
@@ -21,6 +21,7 @@ Feature: Permissions
   Scenario: Content api consumer cannot alter existing menus
     Given I am logged in as a user with the "content_api_consumer" role
     And I should receive status code 403 when I request "/admin/structure/menu"
+    And the watchdog log should contain 1 new "Warning" messages
 
   Scenario: Content Admins should be able to browse sections from their profile even if none have been specifically assigned to them
     Given I am logged in as a user with the "content_admin" role

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-nested-callbacks */
 /* eslint-disable no-console */
 import "@testing-library/cypress/add-commands";
 import "cypress-axe";
@@ -64,9 +65,69 @@ Cypress.Commands.add("drupalAddUserWithRole", (role, username, password) => {
 
 Cypress.Commands.add("drupalAddUserWithRoles", (roles, username, password) => {
   cy.drupalDrushUserCreate(username, password);
-  roles.forEach(role => cy.drupalDrushUserRoleAdd(username, role));
+  roles.forEach((role) => cy.drupalDrushUserRoleAdd(username, role));
 
   return cy;
+});
+
+Cypress.Commands.add(
+  "drupalGetWatchdogMessages",
+  (username, severity = "Warning") => {
+    const fields = ["wid", "date", "type", "severity", "message", "username"];
+    const command = `watchdog:show --format=json --severity=${severity} --fields=${fields.join(
+      ","
+    )}`;
+    return cy.drupalDrushCommand(command).then((output) => {
+      return cy
+        .log(output)
+        .then(() => {
+          return JSON.parse(output.stdout || "{}");
+        })
+        .then((json) => {
+          return cy.log(json).then(() => {
+            return Object.values(json).filter(
+              (entry) => entry.username === username
+            );
+          });
+        })
+        .then((entries) => {
+          return cy.log(entries).then(() => {
+            return entries;
+          });
+        });
+    });
+  }
+);
+
+Cypress.Commands.add("drupalWatchdogHasNoNewMessages", (username, severity) => {
+  cy.drupalGetWatchdogMessages(username, severity).then((messages) => {
+    cy.log(messages);
+    expect(messages.length).to.equal(0);
+  });
+});
+
+Cypress.Commands.add("drupalWatchdogHasNoNewErrors", (username) => {
+  cy.drupalGetWatchdogMessages(username, "Error").then((messages) => {
+    cy.log(messages);
+    expect(messages.length).to.equal(0);
+  });
+});
+
+Cypress.Commands.add(
+  "drupalWatchdogHasNewMessages",
+  (username, severity, count) => {
+    cy.drupalGetWatchdogMessages(username, severity).then((messages) => {
+      cy.log(messages);
+      expect(messages.length).to.equal(count);
+    });
+  }
+);
+
+Cypress.Commands.add("drupalWatchdogHasNewErrors", (username, count) => {
+  cy.drupalGetWatchdogMessages(username, "Error").then((messages) => {
+    cy.log(messages);
+    expect(messages.length).to.equal(count);
+  });
 });
 
 Cypress.Commands.add(
@@ -172,7 +233,6 @@ Cypress.Commands.add("setWorkbenchAccessSections", (value) => {
     });
 });
 
-
 Cypress.Commands.add("accessibilityLog", (violations) => {
   const violationData = violations.map(
     ({ id, impact, description, nodes }) => ({
@@ -188,12 +248,12 @@ Cypress.Commands.add("accessibilityLog", (violations) => {
 
 compareSnapshotCommand();
 
-let logText = '';
+let logText = "";
 
 beforeEach(() => {
   const testTitle = Cypress.currentTest.title;
   const testPath = Cypress.currentTest.titlePath;
-  const date = (new Date()).toUTCString();
+  const date = new Date().toUTCString();
   const timestamp = Math.floor(Date.now() / 1000);
   logText += `VA_GOV_DEBUG ${timestamp} ${date} BEFORE ${testPath} ${testTitle}\n`;
 });
@@ -201,11 +261,10 @@ beforeEach(() => {
 afterEach(() => {
   const testTitle = Cypress.currentTest.title;
   const testPath = Cypress.currentTest.titlePath;
-  const date = (new Date()).toUTCString();
+  const date = new Date().toUTCString();
   const timestamp = Math.floor(Date.now() / 1000);
   logText += `VA_GOV_DEBUG ${timestamp} ${date} AFTER ${testPath} ${testTitle}\n`;
 });
-
 
 after(() => {
   cy.writeFile("cypress.log", logText, { flag: "a+" });


### PR DESCRIPTION
## Description

Closes #11895.

Also closes #11880.

## Testing done

It's all tests!  SOYLENT GREEN IS MADE OF TESTS

## Screenshots

Mebbe I'll upload some later, give you a little thrill.

## QA steps

Optionally check out locally and:
- [ ] Run `npm run test:cypress:interactive` to launch tests.
- [ ] Run at least the following tests:
  - [ ] `media.feature` -- by clicking into the steps where the log is tested, you can review the log entries.  Verify that the conditions, matching, and counts are accurate -- there should be no errors relevant to the test user.
  - [ ] `permissions.feature` -- As above, but this time we're looking for an access-denied warning for the user.