### PR TITLE
VACMS-12513: Prevents relative links that start with `/www.`.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventDomainsAsPathsInLinks.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventDomainsAsPathsInLinks.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that the text does not contain any probable domains as path segments.
+ *
+ * For instance, we want to avoid links like this:
+ *
+ * `<a href="/www.navy.mil/philadelphia-experiment">Philadelphia Experiment</a>`
+ *
+ * @Constraint(
+ *   id = "PreventDomainsAsPathsInLinks",
+ *   label = @Translation("Prevent Domains as Paths in Links", context = "Validation"),
+ *   type = { "string_long", "text_long" }
+ * )
+ */
+class PreventDomainsAsPathsInLinks extends Constraint {
+
+  /**
+   * The error message for plain text fields.
+   *
+   * @var string
+   * @see \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinksValidator
+   */
+  public $plainTextMessage = 'Review the link ":url" and replace the leading slash with https://.';
+
+  /**
+   * The error message for rich text fields.
+   *
+   * @var string
+   * @see \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinksValidator
+   */
+  public $richTextMessage = 'Review the linked text ":link" (:url) and replace the leading slash with https://.';
+
+}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventDomainsAsPathsInLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventDomainsAsPathsInLinksValidator.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use Drupal\Component\Utility\Html;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the PreventDomainsAsPathsInLinks constraint.
+ */
+class PreventDomainsAsPathsInLinksValidator extends ConstraintValidator {
+
+  use ValidatorContextAccessTrait;
+
+  /**
+   * Add a violation message.
+   *
+   * @param int $delta
+   *   The field delta.
+   * @param string $message
+   *   The violation message.
+   * @param array $params
+   *   Message parameters.
+   */
+  public function addViolation(int $delta, string $message, array $params = []) {
+    $this->getContext()
+      ->buildViolation($message, $params)
+      ->atPath((string) $delta . '.value')
+      ->addViolation();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($items, Constraint $constraint) {
+    foreach ($items as $delta => $item) {
+      $type = $item->getFieldDefinition()->getType();
+      $fieldValue = $item->getValue();
+      /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint */
+      if ($type === 'text_long' && $fieldValue['format'] !== 'plain_text') {
+        $this->validateHtml($fieldValue['value'], $constraint, $delta);
+      }
+      else {
+        $this->validateText($fieldValue['value'], $constraint, $delta);
+      }
+    }
+  }
+
+  /**
+   * Validates plain text.
+   *
+   * @param string $text
+   *   A plain text string to validate.
+   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint
+   *   The constraint we're validating.
+   * @param int $delta
+   *   The field item delta.
+   */
+  public function validateText(string $text, PreventDomainsAsPathsInLinks $constraint, int $delta) {
+    /*
+     * Regular expression explanation:
+     *
+     * #              Begin delimiter (replace '/', since we're mucking about
+     *                with URLs, which contain slashes.)
+     *   [\s"\']      Match any whitespace or quotation mark...
+     *   (            Open capture group for reporting...
+     *     /www\.     ...followed by an exact 'www.'...
+     *     [^\s"\']+  ...and anything else that isn't a quotation mark or
+     *                whitespace.
+     *   )            Close capture group.
+     * #              End delimiter (replace '/')
+     *
+     * In other words, we look for a string like `/www.navy.mil/something` or
+     * `/www.whitehouse.gov/something-else`, but not a path with a domain-name
+     * beyond the first level, like `/some-path/www.example.com/`.
+     */
+    if (preg_match('#[\s"\'](/www\.[^\s"\']+)#', $text, $matches)) {
+      $this->addViolation($delta, $constraint->plainTextMessage, [
+        ':url' => $matches[1],
+      ]);
+    }
+  }
+
+  /**
+   * Validates HTML.
+   *
+   * @param string $html
+   *   An HTML string to validate.
+   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint
+   *   The constraint we're validating.
+   * @param int $delta
+   *   The field item delta.
+   */
+  public function validateHtml(string $html, PreventDomainsAsPathsInLinks $constraint, int $delta) {
+    $dom = Html::load($html);
+    $xpath = new \DOMXPath($dom);
+    foreach ($xpath->query('//a[starts-with(@href, "/www.")]') as $element) {
+      $url = $element->getAttribute('href');
+      $firstChild = $element->hasChildNodes() ? $element->childNodes[0] : NULL;
+      $link = $element->ownerDocument->saveHTML($firstChild ?? $element);
+      $this->getContext()
+        ->buildViolation($constraint->richTextMessage, [
+          ':link' => $link,
+          ':url' => $url,
+        ])
+        ->atPath((string) $delta . '.value')
+        ->addViolation();
+      return;
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1337,6 +1337,7 @@ function va_gov_backend_entity_bundle_field_info_alter(&$fields, EntityTypeInter
       $field->addConstraint('PreventProtocolRelativeLinks');
       $field->addConstraint('PreventAbsoluteUrlsAsPathsInLinks');
       $field->addConstraint('PreventVaGovDomainsAsPathsInLinks');
+      $field->addConstraint('PreventDomainsAsPathsInLinks');
     }
     elseif ($field->getType() === 'text_long') {
       $field->addConstraint('PreventAbsoluteCmsLinks');
@@ -1344,7 +1345,7 @@ function va_gov_backend_entity_bundle_field_info_alter(&$fields, EntityTypeInter
       $field->addConstraint('PreventProtocolRelativeLinks');
       $field->addConstraint('PreventMediaViewLinks');
       $field->addConstraint('PreventAbsoluteUrlsAsPathsInLinks');
-      $field->addConstraint('PreventVaGovDomainsAsPathsInLinks');
+      $field->addConstraint('PreventDomainsAsPathsInLinks');
     }
   }
   // Add paragraph checks on clp panels.

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1345,6 +1345,7 @@ function va_gov_backend_entity_bundle_field_info_alter(&$fields, EntityTypeInter
       $field->addConstraint('PreventProtocolRelativeLinks');
       $field->addConstraint('PreventMediaViewLinks');
       $field->addConstraint('PreventAbsoluteUrlsAsPathsInLinks');
+      $field->addConstraint('PreventVaGovDomainsAsPathsInLinks');
       $field->addConstraint('PreventDomainsAsPathsInLinks');
     }
   }

--- a/tests/phpunit/Content/PreventDomainsAsPathsInLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventDomainsAsPathsInLinksValidatorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace tests\phpunit\Content;
+
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinksValidator;
+use Tests\Support\Classes\VaGovUnitTestBase;
+use Tests\Support\Traits\ValidatorTestTrait;
+
+/**
+ * A test to confirm the proper functioning of this validator.
+ *
+ * @group functional
+ * @group all
+ * @group validation
+ *
+ * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinksValidator
+ */
+class PreventDomainsAsPathsInLinksValidatorTest extends VaGovUnitTestBase {
+
+  use ValidatorTestTrait;
+
+  /**
+   * Test ::addViolation().
+   *
+   * @covers ::addViolation
+   */
+  public function testAddViolation() {
+    $validator = new PreventDomainsAsPathsInLinksValidator();
+    $this->prepareValidator($validator, FALSE);
+    $validator->addViolation(3, 'Test violation');
+  }
+
+  /**
+   * Test ::validate().
+   *
+   * @param bool $willValidate
+   *   TRUE if the test string should validate, otherwise FALSE.
+   * @param string $testString
+   *   Some test string to attempt to validate.
+   * @param string $fieldType
+   *   The type of the text field, e.g. 'text_long' or 'string_long'.
+   * @param string $format
+   *   An optional format, like 'plain_text' or 'rich_text'.
+   *
+   * @covers validate
+   * @covers validateText
+   * @covers validateHtml
+   * @dataProvider validateDataProvider
+   */
+  public function testValidate(bool $willValidate, string $testString, string $fieldType = 'string_long', string $format = NULL) {
+    $value = [
+      'value' => $testString,
+    ];
+    if ($fieldType !== 'string_long') {
+      $value['format'] = $format;
+    }
+    $items = $this->getFieldItemList([
+      $this->getFieldItem($value, $fieldType),
+    ]);
+    $validator = new PreventDomainsAsPathsInLinksValidator();
+    $this->prepareValidator($validator, $willValidate);
+    $validator->validate($items, new PreventDomainsAsPathsInLinks());
+  }
+
+  /**
+   * Data provider.
+   */
+  public function validateDataProvider() {
+    return [
+      [
+        TRUE,
+        'Normal string_long text should not fail validation.',
+      ],
+      [
+        TRUE,
+        'Normal string_long text with the occasional // or / scattered throughout should not // fail validation.',
+      ],
+      [
+        FALSE,
+        'However, string_long text with a path that looks like a /www.navy.mil URL should fail validation.',
+      ],
+      [
+        FALSE,
+        'And string_long text with a path that looks like a /www.navy.mil/BUILD.txt URL should fail validation.',
+      ],
+      [
+        TRUE,
+        'But string_long text with a URL like https://www.navy.mil/BUILD.txt should pass validation.',
+      ],
+      [
+        TRUE,
+        'But string_long text with a relative URL like /some-path/another-path/www.navy.mil/BUILD.txt should pass validation.',
+      ],
+      [
+        TRUE,
+        'Normal text_long text should not fail validation.',
+        'text_long',
+      ],
+      [
+        FALSE,
+        'Something with a /www.navy.mil URL looks like it contains a domain as a relative path and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        FALSE,
+        'Something with a /www.navy.mil/ URL looks like it contains a URL as a relative path and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        FALSE,
+        'Something with a /www.navy.mil/test.txt URL looks like it contains a URL as a relative path and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        TRUE,
+        'But something with a https://www.navy.mil/test.txt URL should pass.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        FALSE,
+        'This contains a <a href="/www.navy.mil/test.txt">URL as a relative path</a> inside a tag and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        TRUE,
+        'This contains an <a href="https://www.navy.mil/test.txt">absolute URL</a> inside a tag and should not fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        FALSE,
+        'This <a href="http://www.navy.mil">absolute URL</a> should not trigger validation, while this <a href="/www.navy.mil/test">relative URL</a> should.',
+        'text_long',
+        'rich_text',
+      ],
+      [
+        TRUE,
+        'This <a href="/test-path/www.navy.mil">relative URL absolute URL</a> should not trigger validation either.',
+        'text_long',
+        'rich_text',
+      ],
+      [
+        TRUE,
+        '/www.navy.mil outside of <a href="https://www.navy.mil/">anchor tags</a> should not trigger the validator.',
+        'text_long',
+        'rich_text',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Description

Closes #12513.

## QA steps

As any user with the ability to edit content:
1. Edit a node, e.g. [VAMC System Health Service Whole health at VA Cincinnati health care](https://cms-vfislbxy0kemk1sfwjmanwmkes6yeq82.ci.cms.va.gov/node/24426/edit)
2. Insert a relative link containing a VA.gov domain into a rich text field.  For instance: `<a href="/www.navy.mil/test.txt">Example Link!</a>`.
3. Attempt to save the document.  You should see:
  - [x] An error message at the top of the screen:
![Screen Shot 2023-02-08 at 12 53 30 PM](https://user-images.githubusercontent.com/1318579/217612358-6c9da1ec-f063-4746-b43d-6e9da7ff68d6.png)

  - [x] An error message at the field:
![Screen Shot 2023-02-08 at 12 53 35 PM](https://user-images.githubusercontent.com/1318579/217612377-10ad3c52-9e52-4702-be0e-61cf292821da.png)

  - [x] An error message at the bottom of the field:
![Screen Shot 2023-02-08 at 12 53 42 PM](https://user-images.githubusercontent.com/1318579/217612417-5b6462c1-3d40-45d5-8189-aa74826bbed6.png)

4. Edit a media image item, e.g. [August2022.jpg](https://cms-vfislbxy0kemk1sfwjmanwmkes6yeq82.ci.cms.va.gov/media/image/16769)

5.  Insert a relative link containing a URL into a plain text field. For instance, `/www.navy.mil/test.txt`.

6. Attempt to save the media image item.  You should see:
  - [x] An error message at the top of the screen:
![Screen Shot 2023-02-08 at 12 55 36 PM](https://user-images.githubusercontent.com/1318579/217612779-45de8621-f4ca-4524-b7c9-cf5b7a3aba3f.png)

  - [x] An error message at the field:
![Screen Shot 2023-02-08 at 12 55 42 PM](https://user-images.githubusercontent.com/1318579/217612800-13a1f4e0-5665-438b-aa73-241b149d8ae0.png)

  - [x] An error message at the bottom of the field:
![Screen Shot 2023-02-08 at 12 55 46 PM](https://user-images.githubusercontent.com/1318579/217612814-6606fcf4-e9a0-4e21-8022-bb504c9e53e4.png)
