### PR TITLE
VACMS-0000: Disables failure-on-watchdog-messages in ExistingSiteBase tests.

### DIFF
--- a/tests/phpunit/Content/TrimNodeTitleWhitespaceTest.php
+++ b/tests/phpunit/Content/TrimNodeTitleWhitespaceTest.php
@@ -51,7 +51,6 @@ class TrimNodeTitleWhitespaceTest extends VaGovExistingSiteBase {
    * @dataProvider titleTrimRestrictedToNodesDataProvider
    */
   public function testTitleTrimRestrictedToNodes($entityTypeId, $titleInput, $expectedTitleOutput) {
-    $this->markTestSkipped('this test is encountering repeated failures. will be re-enabled in #11964.');
     // Creates a user. Will be automatically cleaned up at the end of the test.
     $author = $this->createUser();
     // Create a vocabulary for testing terms.

--- a/tests/phpunit/Support/Classes/VaGovExistingSiteBase.php
+++ b/tests/phpunit/Support/Classes/VaGovExistingSiteBase.php
@@ -24,6 +24,10 @@ abstract class VaGovExistingSiteBase extends ExistingSiteBase {
     $testString = $this->toString();
     $message = "VA_GOV_DEBUG $timestamp $date BEFORE $testString";
     $this->writeLogMessage($message);
+    // Disable failures on Watchdog messages.
+    // This is necessary since we're running at the same time as GraphQL,
+    // which can cause errors unrelated to the tests we're performing.
+    $this->failOnPhpWatchdogMessages = FALSE;
   }
 
   /**


### PR DESCRIPTION
Also reënables the TrimNodeWhitespaceTest test, since it's not inherently flawed and is just an innocent bystander in all this.

The query for watchdog messages isn't restricted to the running process, so they will fail any test that runs concurrently with _any_ failure of a concurrent process, e.g. `content-build-gql`.