### PR TITLE
VACMS-12303: add menu section for lovell menu items in parent list

### DIFF
--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -9,7 +9,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\NodeForm;
 use Drupal\path_alias\AliasManagerInterface;
 use Drupal\va_gov_user\Service\UserPermsService;
-use Drupal\va_gov_lovell\LovellOps; // phpcs:ignore
+use Drupal\va_gov_lovell\LovellOps;
 
 /**
  * Class MenuReductionService a service for reducing possible menu items.
@@ -442,7 +442,6 @@ class MenuReductionService {
   protected function checkForLovellSubSystem(string $alias) {
     if ($alias === '/' . LovellOps::TRICARE_PATH
       || $alias === '/' . LovellOps::VA_PATH) {
-      // By setting this value this item will be excluded.
       return self::LOVELLSYS;
     }
     return NULL;

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -260,7 +260,8 @@ class MenuReductionService {
       $alias = $this->getAliasFromUri($menu_item->get('link')->uri);
       if ($alias) {
         $subject_uuid = $parent_options_menu_ids[$menu_item->get('uuid')->value];
-        // The Lovell menu contains section information for each menu item.
+        // The Lovell menu is the only system menu with field_menu_section.
+        // This field stores section information for Lovell menu items.
         // Display this information for editors to help with menu placement.
         if ($menu_item->hasfield('field_menu_section')) {
           $menu_section = ' - ' . strtoupper($menu_item->get('field_menu_section')->value);

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -9,6 +9,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\NodeForm;
 use Drupal\path_alias\AliasManagerInterface;
 use Drupal\va_gov_user\Service\UserPermsService;
+use Drupal\va_gov_lovell\LovellOps; // phpcs:ignore
 
 /**
  * Class MenuReductionService a service for reducing possible menu items.
@@ -23,6 +24,7 @@ class MenuReductionService {
   const ENABLED = 'enabled';
   const DISABLED = 'disabled';
   const SEPARATOR = 'separator';
+  const LOVELLSYS = 'lovellsys';
 
   /**
    * The alias manager interface.
@@ -258,6 +260,13 @@ class MenuReductionService {
       $alias = $this->getAliasFromUri($menu_item->get('link')->uri);
       if ($alias) {
         $subject_uuid = $parent_options_menu_ids[$menu_item->get('uuid')->value];
+        // The Lovell menu contains section information for each menu item.
+        // Display this information for editors to help with menu placement.
+        if ($menu_item->hasfield('field_menu_section')) {
+          $menu_section = ' - ' . strtoupper($menu_item->get('field_menu_section')->value);
+          $subject_uuid['option'] .= $menu_section;
+        }
+
         $menu_element_type = $this->getMenuItemType($alias);
         $menu_element_type = $menu_element_type ?? $this->checkForSeparator($allowed_separators, $menu_item);
 
@@ -422,6 +431,24 @@ class MenuReductionService {
   }
 
   /**
+   * Check for a match for a pattern of Lovell subsystem.
+   *
+   * @param string $alias
+   *   The current alias.
+   *
+   * @return string|null
+   *   A state of self::LOVELLSYS or NULL.
+   */
+  protected function checkForLovellSubSystem(string $alias) {
+    if ($alias === '/' . LovellOps::TRICARE_PATH
+      || $alias === '/' . LovellOps::VA_PATH) {
+      // By setting this value this item will be excluded.
+      return self::LOVELLSYS;
+    }
+    return NULL;
+  }
+
+  /**
    * Check for a match for a pattern of enabled allowed parent.
    *
    * @param string $alias
@@ -481,7 +508,8 @@ class MenuReductionService {
   protected function getMenuItemType($alias) {
     $type = NULL;
     if ($alias) {
-      $type = $this->checkForDisabledParentWithChildren($alias)
+      $type = $this->checkForLovellSubSystem($alias)
+      ?? $this->checkForDisabledParentWithChildren($alias)
       ?? $this->checkForTypeDisabledParent($alias)
       ?? $this->checkForSimpleMatch($alias);
     }


### PR DESCRIPTION
## Description

Closes #12303 

## Testing done

Manual testing

## Screenshots

LOVELL - Parent select list before code change
<img width="1689" alt="Screenshot 2023-02-09 at 5 31 56 PM" src="https://user-images.githubusercontent.com/21045418/217955654-a0ed948f-8309-4a13-8423-49c8684aa893.png">

LOVELL - Parent select list after code change
<img width="1699" alt="Screenshot 2023-02-09 at 5 32 19 PM" src="https://user-images.githubusercontent.com/21045418/217955725-0be1b0ea-d4e2-472c-b0ea-2e5995ae4e8d.png">

OTHER - Parent select list before code change
<img width="1693" alt="Screenshot 2023-02-09 at 5 52 31 PM" src="https://user-images.githubusercontent.com/21045418/217957358-c40d789e-863b-4d63-a3ef-466099687c9a.png">

OTHER - Parent select list after code change
<img width="1690" alt="Screenshot 2023-02-09 at 5 52 45 PM" src="https://user-images.githubusercontent.com/21045418/217957369-bf6c3625-3ddb-473a-b2eb-ac2b446be41a.png">

## QA steps

**Lovell Items**

- [x] Log into the site as an admin
- [x] Visit /admin/structure/menu/manage/lovell-federal-health-care (you'll be clicking edit for the menu items below)
- [x] In a separate browser window log in as Katie.Yearley@va.gov
- [x] Visit /node/53388/edit
- [x] Cross reference the list of menu options available in the **Parent link** field with the entire menu in your admin tab
- [x] Verify that the suffix added to each menu option in the **Parent link** field matches the **Menu Section** field for each menu item in your admin tab

**Other Items**

- [x] Log out as Katie.Yearley@va.gov
- [x] Log in as Samuel.Hudson@va.gov
- [x] Visit /node/23403/edit
- [x] Verify that the options for the Parent link are unchanged compared to the screenshot above

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`