### PR TITLE
VACMS-12215: Reënable status-error test.

### DIFF
--- a/.github/workflows/set-tugboat-tests-pending.yml
+++ b/.github/workflows/set-tugboat-tests-pending.yml
@@ -30,6 +30,7 @@ jobs:
             va/tests/cypress
             va/tests/phpunit
             va/tests/content-build-gql
+            va/tests/status-error
           )
           for test_name in "${test_names[@]}"; do 
             gh api \


### PR DESCRIPTION
## Description

Closes #12215.  Work done in #12192 should have fixed this test.

## Testing done


## Screenshots


## QA steps

- [ ] Verify that the status-error test executed and completed successfully.

## Followup Actions

- [ ] Reënable status-error in branch protection rules.