### PR TITLE
VACMS-12585: add tricare service name field to va services taxonomy

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
     - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
@@ -59,11 +60,11 @@ third_party_settings:
       format_type: details
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         open: true
         description: 'Add content to these fields if you want to "override" how the service is described on Vet Center pages.'
         required_fields: true
-        show_empty_fields: false
     group_vamc:
       children:
         - field_show_for_vamc_facilities
@@ -71,6 +72,7 @@ third_party_settings:
         - field_also_known_as
         - field_commonly_treated_condition
         - description
+        - field_tricare_name
         - field_tricare_description
       label: VAMC
       region: content
@@ -79,11 +81,11 @@ third_party_settings:
       format_type: details
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         open: true
         description: 'These values act as the default values for VHA health services, but can be overridden for Vet Centers, below.'
         required_fields: true
-        show_empty_fields: false
     group_vba:
       children:
         - field_show_for_vba_facilities
@@ -97,10 +99,10 @@ third_party_settings:
       format_type: fieldset
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         description: ''
         required_fields: true
-        show_empty_fields: false
         description_display: after
 id: taxonomy_term.health_care_service_taxonomy.default
 targetEntityType: taxonomy_term
@@ -175,10 +177,18 @@ content:
     third_party_settings: {  }
   field_tricare_description:
     type: string_textarea
-    weight: 19
+    weight: 20
     region: content
     settings:
       rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_tricare_name:
+    type: string_textfield
+    weight: 19
+    region: content
+    settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_vba_com_conditions:

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
     - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
@@ -65,7 +66,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 12
+    weight: 13
     region: content
   field_health_service_api_id:
     type: string
@@ -90,7 +91,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 13
+    weight: 14
     region: content
   field_show_for_vba_facilities:
     type: boolean
@@ -100,7 +101,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 15
+    weight: 16
     region: content
   field_show_for_vet_centers:
     type: boolean
@@ -110,12 +111,20 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 14
+    weight: 15
     region: content
   field_tricare_description:
     type: basic_string
     label: above
     settings: {  }
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  field_tricare_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
     weight: 10
     region: content
@@ -125,7 +134,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 17
+    weight: 18
     region: content
   field_vba_friendly_name:
     type: string
@@ -133,14 +142,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 16
+    weight: 17
     region: content
   field_vba_service_descrip:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 18
+    weight: 19
     region: content
   field_vet_center_com_conditions:
     type: string
@@ -166,7 +175,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 11
+    weight: 12
     region: content
   field_vet_center_service_descrip:
     type: basic_string

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vamc_facility_service.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vamc_facility_service.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
     - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
@@ -76,6 +77,7 @@ hidden:
   field_show_for_vba_facilities: true
   field_show_for_vet_centers: true
   field_tricare_description: true
+  field_tricare_name: true
   field_vba_com_conditions: true
   field_vba_friendly_name: true
   field_vba_service_descrip: true

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vba_facility_service.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vba_facility_service.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
     - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
@@ -73,6 +74,7 @@ hidden:
   field_show_for_vba_facilities: true
   field_show_for_vet_centers: true
   field_tricare_description: true
+  field_tricare_name: true
   field_vba_com_conditions: true
   field_vba_friendly_name: true
   field_vet_center_com_conditions: true

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vet_center_service.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vet_center_service.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vba_facilities
     - field.field.taxonomy_term.health_care_service_taxonomy.field_show_for_vet_centers
     - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_description
+    - field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_com_conditions
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_friendly_name
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vba_service_descrip
@@ -75,6 +76,7 @@ hidden:
   field_show_for_vba_facilities: true
   field_show_for_vet_centers: true
   field_tricare_description: true
+  field_tricare_name: true
   field_vba_com_conditions: true
   field_vba_friendly_name: true
   field_vba_service_descrip: true

--- a/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_name.yml
+++ b/config/sync/field.field.taxonomy_term.health_care_service_taxonomy.field_tricare_name.yml
@@ -1,0 +1,25 @@
+uuid: 602d5098-cd18-40c5-8027-b1870824b864
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_tricare_name
+    - taxonomy.vocabulary.health_care_service_taxonomy
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+id: taxonomy_term.health_care_service_taxonomy.field_tricare_name
+field_name: field_tricare_name
+entity_type: taxonomy_term
+bundle: health_care_service_taxonomy
+label: 'TRICARE service name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.taxonomy_term.field_tricare_name.yml
+++ b/config/sync/field.storage.taxonomy_term.field_tricare_name.yml
@@ -1,0 +1,21 @@
+uuid: e773e69e-5bbd-4025-bd5e-6318e027b3da
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_tricare_name
+field_name: field_tricare_name
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -30,7 +30,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Show for VBA Facilities | field_show_for_vba_facilities | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Show for Vet Centers | field_show_for_vet_centers | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | TRICARE service description | field_tricare_description | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
-| Vocabulary | VA Services | TRICARE service name | field_tricare_name | Text (plain) |  |  | Textfield |  |
+| Vocabulary | VA Services | TRICARE service name | field_tricare_name | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA common conditions | field_vba_com_conditions | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA patient friendly name | field_vba_friendly_name | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA description | field_vba_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |

--- a/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
+++ b/tests/behat/drupal-spec-tool/content_model_vocabulary_fields.feature
@@ -30,6 +30,7 @@ Feature: Content model: Vocabulary fields
 | Vocabulary | VA Services | Show for VBA Facilities | field_show_for_vba_facilities | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | Show for Vet Centers | field_show_for_vet_centers | Boolean |  | 1 | Single on/off checkbox |  |
 | Vocabulary | VA Services | TRICARE service description | field_tricare_description | Text (plain, long) |  | 1 | Text area (multiple rows) |  |
+| Vocabulary | VA Services | TRICARE service name | field_tricare_name | Text (plain) |  |  | Textfield |  |
 | Vocabulary | VA Services | VBA common conditions | field_vba_com_conditions | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA patient friendly name | field_vba_friendly_name | Text (plain) |  | 1 | Textfield |  |
 | Vocabulary | VA Services | VBA description | field_vba_service_descrip | Text (plain, long) |  | 1 | Text area (multiple rows) |  |


### PR DESCRIPTION
## Description

Closes #12585 

## Testing done

Visual testing

## Screenshots

![Screenshot 2023-02-16 at 2 38 26 PM](https://user-images.githubusercontent.com/21045418/219469529-f03a118d-d544-4615-97cb-dc85d27b7ada.png)

## QA steps

- [x] Ensure the new field is displayed in the proper order on term edit
- [x] Edit the service term Women Veteran Care
- [x] Provide a value for TRICARE service name: Women's Health Care
- [x] Save the term and verify the override field is displayed on term view

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
