### PR TITLE
VACMS-12476: Intercept GTM requests in Cypress.

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -239,3 +239,14 @@ Cypress.on("uncaught:exception", () => {
   // application exceptions.
   return false;
 });
+
+before(() => {
+  // Requests to Google Tag Manager can cause spurious test failures.
+  cy.intercept("https://www.googletagmanager.com/gtm.js", {
+    statusCode: 200,
+    body: "200 everything's fine come on in",
+    headers: {
+      "x-response-header": "ha ha ha disregard this",
+    },
+  });
+});


### PR DESCRIPTION
## Description

Closes #12476.

I'm gonna run the Cypress tests a few times to confirm this fixes the issue.
