### PR TITLE
VACMS-0000: Use substring of generated text in link-text field to avoid running afoul of character limit.

### DIFF
--- a/tests/cypress/integration/common/i_create_a_node.js
+++ b/tests/cypress/integration/common/i_create_a_node.js
@@ -43,9 +43,12 @@ const creators = {
     cy.findAllByLabelText("Link").type(faker.internet.url(), {
       force: true,
     });
-    cy.findAllByLabelText("Link text").type(faker.lorem.sentence(), {
-      force: true,
-    });
+    cy.findAllByLabelText("Link text").type(
+      faker.lorem.sentence().substring(0, 35),
+      {
+        force: true,
+      }
+    );
 
     // Hero banner
     cy.contains("Hero banner").scrollIntoView().click({ force: true });


### PR DESCRIPTION
Rarely, this test would break because there's a 40-character limit on this field, and Faker might generate 41 or 43 😩 