### PR TITLE
Revert "bump drupal/tablefield from 2.3.0 to 2.4.0"

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12411,26 +12411,26 @@
         },
         {
             "name": "drupal/tablefield",
-            "version": "2.4.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/tablefield.git",
-                "reference": "8.x-2.4"
+                "reference": "8.x-2.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/tablefield-8.x-2.4.zip",
-                "reference": "8.x-2.4",
-                "shasum": "ef024051b3a02aaf8c41b50fc27ab535d7618980"
+                "url": "https://ftp.drupal.org/files/projects/tablefield-8.x-2.3.zip",
+                "reference": "8.x-2.3",
+                "shasum": "ee37306ebb9710f954f0358b558e9d674b225a06"
             },
             "require": {
-                "drupal/core": "^9.1 || ^10"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.4",
-                    "datestamp": "1677254141",
+                    "version": "8.x-2.3",
+                    "datestamp": "1659345818",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Reverts department-of-veterans-affairs/va.gov-cms#12781

This is being reverted due to https://dsva.slack.com/archives/CDHBKAL9W/p1678134778777159    There were no db updates as part of the last release so this should be safe.

##QA and testing

- [x] Go to here.  https://web-6m9y4j2xgdtnqvfhwuoncclz1dpnabil.ci.cms.va.gov/education/survivor-dependent-benefits/
- [x] scroll to the first table and validate there are only two columns, not a weird counting column off to the right.
