### PR TITLE
Patch that allows redirect_options module to work with content_transl…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -479,6 +479,9 @@
             "drupal/raven": {
                 "Sentry/Dsn throws a TypeError, blowing up everything.": "patches/raven-catch-typeerror.patch"
             },
+            "drupal/redirect_options": {
+                "form_alter hook check on classes fails in some cases": "https://www.drupal.org/files/issues/2023-01-23/redirect_options-form_alter_array_check-3335893-2.patch"
+            },
             "drupal/schemata": {
                 "3190131 - Possibly unnecessary logging in SchemaFactory::create().": "https://www.drupal.org/files/issues/2020-12-28/schemata-remove-logging-statement-3190131-2.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11f89d7ddca6bb17437e0e7bf4fa5ae9",
+    "content-hash": "3655ef443b44fc44cc3025fd64dd7f91",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -3543,6 +3543,11 @@
         {
             "name": "drupal/coder",
             "version": "8.3.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pfrenssen/coder.git",
+                "reference": "1c4662337418ab88c9ddf40348f0638e35d49182"
+            },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/pfrenssen/coder/zipball/1c4662337418ab88c9ddf40348f0638e35d49182",


### PR DESCRIPTION
## Description

Fulfills #12705 

## QA steps

What needs to be checked to prove this works?  
1. On Tugboat, enable Content Translation and its dependent modules.
2. Visit https://pr12892-1u1rftew00ni8t4ukdt3y4dmqd39gcfx.ci.cms.va.gov/admin/config/regional/content-language. The page should load without issue.

### Definition of Done

- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
