### PR TITLE
VACMS-0000: Allow newer versions of Node 16 locally.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -322,7 +322,7 @@
         },
         "mouf": {
             "nodejs": {
-                "version": "16.0.0",
+                "version": "^16.0.0",
                 "targetDir": "docroot/vendor/nodejs/nodejs",
                 "forceLocal": true
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5c92298d57c3b3bc7a63b45e3f14785",
+    "content-hash": "de253e36eda880678bd1b2c1339eb5e8",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -4119,8 +4119,8 @@
                     "version": "1.0.1",
                     "datestamp": "1678245573",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -6029,8 +6029,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.0-beta10+1-dev",
-                    "datestamp": "1676966094",
+                    "version": "8.x-2.0-beta11+2-dev",
+                    "datestamp": "1678972577",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -7139,6 +7139,10 @@
                 {
                     "name": "japerry",
                     "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "mglaman",
+                    "homepage": "https://www.drupal.org/user/2416470"
                 },
                 {
                     "name": "pfaocle",
@@ -12231,10 +12235,6 @@
                     "name": "Stephen Mustgrave (smustgrave)",
                     "homepage": "https://www.drupal.org/u/smustgrave",
                     "role": "Maintainer"
-                },
-                {
-                    "name": "smustgrave",
-                    "homepage": "https://www.drupal.org/user/3252890"
                 }
             ],
             "description": "Integration with Slack.com service.",


### PR DESCRIPTION
Seeing issues attempting to download exactly v16.0.0 of Node.  Felt like it was worth at least opening a PR to check out the latest 16.x.x.

![Screenshot 2023-03-16 at 2 39 02 PM](https://user-images.githubusercontent.com/1318579/225720847-22e7f9b4-cc43-455f-9040-94707332aa5e.png)
