### PR TITLE
VACMS-13025: Adds null check

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/SectionMatcherValidator.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/SectionMatcherValidator.php
@@ -20,7 +20,7 @@ class SectionMatcherValidator extends ConstraintValidator {
     $nodeStorage = \Drupal::entityTypeManager()->getStorage('node');
     $termStorage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
     // If the node is new, no Section has been set; so do not validate.
-    if (isset($sectionTermID)) {
+    if (!empty($sectionTermID)) {
       $sectionName = $termStorage->load($sectionTermID)->getName();
       foreach ($items as $item) {
         $referencedEntity = $nodeStorage->load($item->target_id);

--- a/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/SectionMatcherValidator.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/SectionMatcherValidator.php
@@ -19,7 +19,7 @@ class SectionMatcherValidator extends ConstraintValidator {
     $fieldLabel = $items->getFieldDefinition()->getLabel();
     $nodeStorage = \Drupal::entityTypeManager()->getStorage('node');
     $termStorage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
-    // If the node is new, no Section has been set; so do not validate.
+    // If the node is new, the Section is empty; so do not validate.
     if (!empty($sectionTermID)) {
       $sectionName = $termStorage->load($sectionTermID)->getName();
       foreach ($items as $item) {

--- a/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/SectionMatcherValidator.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/SectionMatcherValidator.php
@@ -19,16 +19,19 @@ class SectionMatcherValidator extends ConstraintValidator {
     $fieldLabel = $items->getFieldDefinition()->getLabel();
     $nodeStorage = \Drupal::entityTypeManager()->getStorage('node');
     $termStorage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
-    $sectionName = $termStorage->load($sectionTermID)->getName();
-    foreach ($items as $item) {
-      $referencedEntity = $nodeStorage->load($item->target_id);
-      if ($referencedEntity->field_administration->target_id !== $sectionTermID) {
-        /** @var \Drupal\va_gov_vamc\Plugin\Validation\Constraint\SectionMatcher $constraint */
-        $this->context->addViolation($constraint->notSectionMatch, [
-          '%section' => $sectionName,
-          '%fieldLabel' => $fieldLabel,
-        ]);
-        return;
+    // If the node is new, no Section has been set; so do not validate.
+    if (isset($sectionTermID)) {
+      $sectionName = $termStorage->load($sectionTermID)->getName();
+      foreach ($items as $item) {
+        $referencedEntity = $nodeStorage->load($item->target_id);
+        if ($referencedEntity->field_administration->target_id !== $sectionTermID) {
+          /** @var \Drupal\va_gov_vamc\Plugin\Validation\Constraint\SectionMatcher $constraint */
+          $this->context->addViolation($constraint->notSectionMatch, [
+            '%section' => $sectionName,
+            '%fieldLabel' => $fieldLabel,
+          ]);
+          return;
+        }
       }
     }
   }

--- a/tests/cypress/integration/content_editing_vamc_facility_service.feature
+++ b/tests/cypress/integration/content_editing_vamc_facility_service.feature
@@ -23,7 +23,7 @@ Scenario: Log in and create VAMC Facility Health Service as a Lovell editor
 
 # Phone number AJAX test
   Then I click the "Add new phone number" button
-  And I wait for "20" seconds
+  And I wait "20" seconds
   Then I should see an element with the selector "[data-drupal-selector*='edit-field-phone-numbers-paragraph-form-']"
 
 # Lovell Federal umbrella test

--- a/tests/cypress/integration/content_editing_vamc_facility_service.feature
+++ b/tests/cypress/integration/content_editing_vamc_facility_service.feature
@@ -21,6 +21,11 @@ Scenario: Log in and create VAMC Facility Health Service as a Lovell editor
   Then I select option "Captain James A. Lovell Federal Health Care Center | Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-facility-location"
   Then I select option "Cardiology at Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-regional-health-service"
 
+# Phone number AJAX test
+  Then I click the "Add new phone number" button
+  And I wait for "20" seconds
+  Then I should see an element with the selector "[data-drupal-selector*='edit-field-phone-numbers-paragraph-form-']"
+
 # Lovell Federal umbrella test
   Then I scroll to position "bottom"
   Then an element with the selector "#edit-field-administration" should be visible


### PR DESCRIPTION
## Description

Closes #13025.

## Testing done
Manually
Cypress

## Screenshots
<img width="2168" alt="Screen Shot 2023-03-21 at 3 56 06 PM" src="https://user-images.githubusercontent.com/766573/226740142-162d77ca-d343-42cd-9c68-9e10ae13b7b8.png">
<img width="2168" alt="Screen Shot 2023-03-21 at 3 59 40 PM" src="https://user-images.githubusercontent.com/766573/226740171-9ede7faf-5c25-45e3-8d85-9c5146767152.png">


## QA steps

### Create new VAMC facility health service
- [x] Create [new VAMC facility health service](https://pr13027-mjhgn9zppigbzvtuomdnr5exa62yhfma.ci.cms.va.gov/node/add/health_care_local_health_service)
- [x] Click 'Add new phone number'
- [x] Validate that the phone number form fields display

### Edit VAMC facility health service
- [x] Log in as Ryan.Stubblebine@va.gov
- [x] Edit [My HealtheVet coordinator - Belmont County VA Clinic](https://pr12865-anjh0saa6ev6qhdgsr9wifu9sftbjnip.ci.cms.va.gov/node/2333/edit)
- [x] Click 'Add new phone number'
- [x] Validate that the phone number form fields display
- [x] Click "Add Service location"
- [x] Validate that "Address", "Hours", and "Contact info" fieldsets are loaded

#### Testing for a regression in the changed code
- [x] Change the Section to "---VA Lebanon health care" 
- [x] Click "Save draft and continue editing"
- [x] Validate that the Facility field presents a relevant error message
- [x] Validate that the VAMC system health service field presents a relevant error message
- [x] Change the Facility to "Berks County VA Clinic | VA Lebanon health care"
- [x] Click "Save draft and continue editing"
- [x] Validate that the VAMC system health service field presents a relevant error message
- [x] Change the Section to "---VA Pittsburgh health care"
- [x] Click "Save draft and continue editing"
- [x] Validate that the Facility field presents a relevant error message
- [x] Change the Facility to "Fayette County VA Clinic | VA Pittsburg health care"
- [x] Click "Save draft and continue editing"
- [x] Validate that the service is changed.


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`


### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
