### PR TITLE
VACMS-12800: Bug Fixes for Editing Reusable Q&A Inside Entity Browser Modal

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -521,9 +521,9 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
 /**
  * Implements hook_field_group_build_pre_render_alter().
  */
-function va_gov_backend_field_group_form_process_build_alter(array $form, FormStateInterface $form_state, &$element) {
+function va_gov_backend_field_group_form_process_build_alter(array &$form, FormStateInterface $form_state, &$element) {
   // Toggle group Q&A component visibility.
-  $form['group_q_a_page_components']['#states']['visible']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+  $form['group_q_a_page_components']['#states']['visible']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
 }
 
 /**
@@ -793,14 +793,15 @@ function _va_gov_backend_audience_topics_validation(array $form, FormStateInterf
 function _va_gov_backend_alter_standalone_page_validation(array &$form) {
   // Add states + custom validation if the Standalone Page field is present.
   if (isset($form['field_standalone_page'])) {
-    $form['field_primary_category']['widget']['#states']['required']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
-    $form['field_tags']['widget'][0]['subform']['field_topics']['#states']['required']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
-    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['uri']['#states']['required']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
-    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['title']['#states']['required']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+    $form['field_primary_category']['widget']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+    $form['field_tags']['widget'][0]['subform']['field_topics']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['uri']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['title']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
 
     // Change field uri and title widget to optional.
     $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['uri']['#required'] = FALSE;
     $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['title']['#required'] = FALSE;
+    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['#required'] = FALSE;
     // Buttons paragraph.
     foreach ($form['field_buttons']['widget'] as $key => $button) {
       if (is_numeric($key)) {
@@ -811,8 +812,8 @@ function _va_gov_backend_alter_standalone_page_validation(array &$form) {
 
     foreach ($form['field_buttons']['widget'] as $idx => $val) {
       if (is_numeric($idx)) {
-        $form['field_buttons']['widget'][$idx]['subform']['field_button_label']['widget'][0]['value']['#states']['required']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
-        $form['field_buttons']['widget'][$idx]['subform']['field_button_link']['widget'][0]['uri']['#states']['required']['input[id="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+        $form['field_buttons']['widget'][$idx]['subform']['field_button_label']['widget'][0]['value']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+        $form['field_buttons']['widget'][$idx]['subform']['field_button_link']['widget'][0]['uri']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
       }
     }
 


### PR DESCRIPTION
## Description
Bug fixes for reusable Q&A editing within FAQ and R&S nodes. There were hidden form validation errors being thrown inside the entity browser modal.

Relates to #12800

## Testing done
Manual testing

## Screenshots
![Screenshot 2023-03-22 at 10 55 13 AM](https://user-images.githubusercontent.com/221539/226995476-f951c038-4ee3-45dc-82ac-e4491bcfda00.png)

## QA steps
As a content admin
1. Visit /node/8475/edit
2. Then check the `Enable standalone Resources and support page for this Q&A.` field
   - [x] Validate that the `Q&A page components` fieldset gets displayed along with its child fields: Include Alert, Calls to action, VA Benefit Hubs, Related information, etc.
   - [x] Validate that the Link Teaser URL and Link Text fields are now required
3. Then un-check the `Enable standalone Resources and support page for this Q&A.` field
   - [x] Validate that the `Q&A page components` fieldset gets hidden
4. Save the node with the `Enable standalone Resources and support page for this Q&A.` field unset.
   - [x] Validate the node saved.
5. Visit /node/8483/edit
6. Under Q&A's, click the 'Edit' button next to 'What’s Premium DS Logon?' Q&A label.
7. Then check the `Enable standalone Resources and support page for this Q&A.` field
   - [x] Validate that the `Q&A page components` fieldset gets displayed along with its child fields: Include Alert, Calls to action, VA Benefit Hubs, Related information, etc.
   - [x] Validate that the Link Teaser URL and Link Text fields are now required
8. Then un-check the `Enable standalone Resources and support page for this Q&A.` field
   - [x] Validate that the `Q&A page components` fieldset gets hidden
9. Save the node with the `Enable standalone Resources and support page for this Q&A.` field unset.
   - [x] Validate the node saved.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
