### PR TITLE
VACMS-12861: Applied D.o patch disabling tablefield drag drop controls.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -503,7 +503,7 @@
                 "3163841 - Fix Undefined index: caption notice": "https://www.drupal.org/files/issues/2020-08-10/tablefield-empty-caption-notice-2.patch",
                 "3176982 - Tablefield input elements have no title or label": "https://www.drupal.org/files/issues/2020-10-14/tablefield-add_title_to_input_elements-3176982-2.patch",
                 "3195203 - Copying caption to value breaks some data exports 3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch",
-		"3341971 - Drag & drop addition adds meaningless numbers to table data, could break integrating code": "https://www.drupal.org/files/issues/2023-03-22/tablefield-disable-drag-drop-controls_0.patch"
+		"3341971 - Drag & drop addition adds meaningless numbers to table data, could break integrating code": "https://www.drupal.org/files/issues/2023-03-23/tablefield-disable-drag-drop-controls.patch"
             },
             "drupal/textfield_counter": {
                 "3004457 - Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch",

--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,7 @@
         "drupal/social_media_links": "^2.8",
         "drupal/string_field_formatter": "^2.0",
         "drupal/styleguide": "^2.0@beta",
-        "drupal/tablefield": "^2.1",
+        "drupal/tablefield": "^2.4",
         "drupal/taxonomy_entity_index": "^1.1",
         "drupal/taxonomy_menu": "3.x-dev#e89d1e8",
         "drupal/textfield_counter": "^2.0",
@@ -502,7 +502,8 @@
                 "3100109 - 0 string value in cell throws empty error": "https://www.drupal.org/files/issues/2019-12-10/0-value-throwing-empty-error.patch",
                 "3163841 - Fix Undefined index: caption notice": "https://www.drupal.org/files/issues/2020-08-10/tablefield-empty-caption-notice-2.patch",
                 "3176982 - Tablefield input elements have no title or label": "https://www.drupal.org/files/issues/2020-10-14/tablefield-add_title_to_input_elements-3176982-2.patch",
-                "3195203 - Copying caption to value breaks some data exports 3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch"
+                "3195203 - Copying caption to value breaks some data exports 3195203": "https://www.drupal.org/files/issues/2021-01-28/tablefield-caption-copied-to-value-3195203-2.patch",
+		"3341971 - Drag & drop addition adds meaningless numbers to table data, could break integrating code": "https://www.drupal.org/files/issues/2023-03-22/tablefield-disable-drag-drop-controls_0.patch"
             },
             "drupal/textfield_counter": {
                 "3004457 - Prevent form submission when character limit exceeded option does not work": "https://www.drupal.org/files/issues/2018-10-04/textfield_counter-prevent_form_submission_does_not_work-3004457-2.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2e4e973769d9871af85fd6d0a315c53",
+    "content-hash": "f4b29a2c43e12c3a9696ede7bf7133c5",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c954ef89b5efba248906331f6f6161e",
+    "content-hash": "b2e4e973769d9871af85fd6d0a315c53",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -12541,26 +12541,26 @@
         },
         {
             "name": "drupal/tablefield",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/tablefield.git",
-                "reference": "8.x-2.3"
+                "reference": "8.x-2.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/tablefield-8.x-2.3.zip",
-                "reference": "8.x-2.3",
-                "shasum": "ee37306ebb9710f954f0358b558e9d674b225a06"
+                "url": "https://ftp.drupal.org/files/projects/tablefield-8.x-2.4.zip",
+                "reference": "8.x-2.4",
+                "shasum": "ef024051b3a02aaf8c41b50fc27ab535d7618980"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^9.1 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.3",
-                    "datestamp": "1659345818",
+                    "version": "8.x-2.4",
+                    "datestamp": "1677254141",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Description

Modifies [tablefield](https://drupal.org/project/tablefield) >= v2.4, disabling its drag-drop functionality.  This follows the comment @swirtSJW added to existing D.o issue [3341971](https://www.drupal.org/project/tablefield/issues/3341971).

Relates to #12861. 

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works? 

Review of tablefield widgets in https://www.va.gov/education/survivor-dependent-benefits/ should have no superfluous columns.
 
What needs to be checked to prove it didn't break any related things?  

This change should be isolated to the tablefield widget and have near zero impact on anything else.

What variations of circumstances (users, actions, values) need to be checked?  


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
