### PR TITLE
VACMS-13087: update outdated content notifications

### DIFF
--- a/READMES/drush.md
+++ b/READMES/drush.md
@@ -38,4 +38,5 @@ See [MetricsCommands.php](../docroot/modules/custom/va_gov_backend/src/Commands/
 See
 [OutdatedContent.php](..docroot/modules/custom/va_gov_notifications/src/Service/OutdatedContent.php
 ).
-- `drush php-eval "print_r(\Drupal::service('va_gov_notifications.outdated_content')->checkForOutdatedContent());"` -- Check for outdated content and queue notifications for any found.
+- `drush php-eval "print_r(\Drupal::service('va_gov_notifications.outdated_content')->checkForOutdatedVamcContent());"` -- Check for outdated VAMC content and queue notifications for any found.
+- `drush php-eval "print_r(\Drupal::service('va_gov_notifications.outdated_content')->checkForOutdatedVetCenterContent());"` -- Check for outdated Vet Center content and queue notifications for any found.

--- a/config/sync/advancedqueue.advancedqueue_queue.vamc_outdated_content.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.vamc_outdated_content.yml
@@ -1,9 +1,9 @@
-uuid: d4c1926a-e396-4277-9d5c-e73842926e09
+uuid: 72c80a8c-bd11-4916-a297-27b57da2fa67
 langcode: en
 status: true
 dependencies: {  }
-id: outdated_content_notification
-label: 'Outdated Content Notification'
+id: vamc_outdated_content
+label: 'VAMC Outdated Content'
 backend: database
 backend_configuration:
   lease_time: 30
@@ -11,6 +11,6 @@ processor: cron
 processing_time: 10
 locked: false
 threshold:
-  type: 1
-  limit: 100
+  type: 2
+  limit: 30
   state: all

--- a/config/sync/advancedqueue.advancedqueue_queue.vet_center_outdated_content.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.vet_center_outdated_content.yml
@@ -1,0 +1,16 @@
+uuid: 26a5409f-d82b-4389-bff5-501c22eb00b2
+langcode: en
+status: true
+dependencies: {  }
+id: vet_center_outdated_content
+label: 'Vet Center Outdated Content'
+backend: database
+backend_configuration:
+  lease_time: 30
+processor: cron
+processing_time: 10
+locked: false
+threshold:
+  type: 2
+  limit: 30
+  state: all

--- a/docroot/modules/custom/va_gov_notifications/src/Service/OutdatedContentInterface.php
+++ b/docroot/modules/custom/va_gov_notifications/src/Service/OutdatedContentInterface.php
@@ -8,8 +8,13 @@ namespace Drupal\va_gov_notifications\Service;
 interface OutdatedContentInterface {
 
   /**
-   * Checks if every editor has outdated content.
+   * Checks if VAMC editors have outdated content.
    */
-  public function checkForOutdatedContent();
+  public function checkForOutdatedVamcContent();
+
+  /**
+   * Checks if Vet Center editors have outdated content.
+   */
+  public function checkForOutdatedVetCenterContent();
 
 }

--- a/docroot/modules/custom/va_gov_notifications/va_gov_notifications.install
+++ b/docroot/modules/custom/va_gov_notifications/va_gov_notifications.install
@@ -6,7 +6,7 @@
  */
 
 /**
- * Ininstall messages stack.
+ * Install messages stack.
  */
 function va_gov_notifications_update_9001(&$sandbox) {
   \Drupal::moduleHandler()->loadInclude('va_gov_db', 'install');
@@ -21,4 +21,27 @@ function va_gov_notifications_update_9001(&$sandbox) {
   $messages = _va_gov_db_install_modules($modules);
 
   return $messages;
+}
+
+/**
+ * Assign a product to VAMCs and Vet Centers in the Section taxonomy.
+ */
+function va_gov_notifications_update_9002() {
+  $vid = 'administration';
+  // The parent term id for VAMC System.
+  $vamc_parent_tid = '8';
+  // The parent term id for Vet Center System.
+  $vet_center_parent_tid = '190';
+  $vamc_child_terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree($vid, $vamc_parent_tid, NULL, TRUE);
+  foreach ($vamc_child_terms as $term) {
+    // VAMCs are product 284.
+    $term->field_product->target_id = '284';
+    $term->save();
+  }
+  $vet_center_child_terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree($vid, $vet_center_parent_tid, NULL, TRUE);
+  foreach ($vet_center_child_terms as $term) {
+    // Vet Centers are product 289.
+    $term->field_product->target_id = '289';
+    $term->save();
+  }
 }


### PR DESCRIPTION
## Description

Closes #13047.
Closes #13048.

## Testing done
Tested locally. Queued notifications, verified in queue that notifications were queued. Ran cron, emails were sent and caught by mailhog. Also showed as successfully processed in `/admin/config/system/queues`

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

- [ ] Shell into tugboat
- [ ] Run `drush php-eval "print_r(\Drupal::service('va_gov_notifications.outdated_content')->checkForOutdatedVamcContent());"`
- [ ] Run `drush php-eval "print_r(\Drupal::service('va_gov_notifications.outdated_content')->checkForOutdatedVetCenterContent());"`
- [ ] Visit `/admin/config/system/queues` to verify jobs are queued
- [ ] Go to `/admin/config/system/cron` and run cron
- [ ] re-Visit `/admin/config/system/queues` to verify jobs processing successfully
- [ ] Check the Captured Mail section of the individual Tugboat to see if email were sent, and to see the actual emails

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
