### PR TITLE
VACMS-13150 Remove path alias truncation in core.path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -388,7 +388,8 @@
                 "2975602 - Html::serialize() escapes backslash-r to &#13;": "https://www.drupal.org/files/issues/2018-05-27/2975602-2-html_serialize.patch",
                 "Claro claro_preprocess_input()": "patches/drupal-core-claro_preprocess_input.patch",
                 "1156338 - Fixed maximum number of field values, but use «add more» similar to when cardinality «unlimited» is used": "https://www.drupal.org/files/issues/2022-01-27/drupal-fix-limited-cardinality-fields-1156338-23.patch",
-                "2942404 - Contentinfo landmark" : "https://www.drupal.org/files/issues/2023-01-17/2942404-43.patch"
+                "2942404 - Contentinfo landmark" : "https://www.drupal.org/files/issues/2023-01-17/2942404-43.patch",
+                "3351638 - Remove truncation of path alias in table." : "https://www.drupal.org/files/issues/2023-04-03/3351638-8.patch"
             },
             "drupal/danse_content_moderation": {
                 "3309657 - Danse 2.2.7 compatibility": "https://www.drupal.org/files/issues/2022-09-14/3309657-danse-2-2-7-compatibility.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1dd9052a15dab2d0bf8f1abed0c8a379",
+    "content-hash": "7b843316d6d885f471fd7c0f6956b64b",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -14288,6 +14288,7 @@
                 "issues": "https://github.com/FriendsOfPHP/Goutte/issues",
                 "source": "https://github.com/FriendsOfPHP/Goutte/tree/v3.3.1"
             },
+            "abandoned": "symfony/browser-kit",
             "time": "2020-11-01T09:30:18+00:00"
         },
         {


### PR DESCRIPTION
## Description

Closes #13150 

## Screenshots
![image](https://user-images.githubusercontent.com/5752113/229263615-9eea06b7-2f97-4ab4-94e3-8558f874e08b.png)

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As an admin
1. Go to /admin/config/search/path?search=/lovell-federal-health-care-tricare/health-services/returning-service-member
   - [x] Validate that the alias data is not truncated and that you can see the difference in alias between the two results.
2. Go to https://www.drupal.org/project/drupal/issues/3351638 and leave a comment that you reviewed and tested it and that it works.





