### PR TITLE
VACMS-12800: Resolves PHP warning about missing #type

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -523,7 +523,9 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
  */
 function va_gov_backend_field_group_form_process_build_alter(array &$form, FormStateInterface $form_state, &$element) {
   // Toggle group Q&A component visibility.
-  $form['group_q_a_page_components']['#states']['visible']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+  if (!empty($form['group_q_a_page_components'])) {
+    $form['group_q_a_page_components']['#states']['visible']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

Relates to #12800
Relates to #13122

## Testing done
Manual

## QA steps
The warning can be created by editing any node (and not making any changes). In staging and prod, the warnings are not displayed, but are present in the Drupal log.

Example warning that should no longer be thrown:
```php
Warning: Undefined array key "#type" in Drupal\Core\Form\FormHelper::processStates() (line 211 of /var/www/cms/docroot/core/lib/Drupal/Core/Form/FormHelper.php) #0 /var/www/cms/docroot/core/includes/bootstrap.inc(347): _drupal_error_handler_real(2, 'Undefined array...', '/var/www/cms/do...', 211) #1 /var/www/cms/docroot/core/lib/Drupal/Core/Form/FormHelper.php(211): _drupal_error_handler(2, 'Undefined array...', '/var/www/cms/do...', 211) #2 /var/www/cms/docroot/core/lib/Drupal/Core/Render/Renderer.php(400): Drupal\Core\Form\FormHelper::processStates(Array) #3 /var/www/cms/docroot/core/lib/Drupal/Core/Render/Renderer.php(446): Drupal\Core\Render\Renderer->doRender(Array) #4 /var/www/cms/docroot/core/lib/Drupal/Core/Render/Renderer.php(204): Drupal\Core\Render\Renderer->doRender(Array, false) #5 /var/www/cms/docroot/core/lib/Drupal/Core/Template/TwigExtension.php(479): Drupal\Core\Render\Renderer->render(Array) #6 /var/www/cms/docroot/sites/default/files/php/twig/642cb4f52d449_node-edit-form.html.twig_5RM9tYqQKjofrkk9vIdJLoBUA/m5MtKuhoNsR1QL3PMBAaMaYbAal1iX3iuQRsUGRiNlU.php(48): Drupal\Core\Template\TwigExtension->escapeFilter(Object(Drupal\Core\Template\TwigEnvironment), Array, 'html', NULL, true) #7 /var/www/cms/docroot/vendor/twig/twig/src/Template.php(405):
```

As a content admin
1. Visit /admin/reports/dblog
2. Clear the log by clicking the 'reset' link
3. Visit /node/add
4. Then select any node
5. Make no changes and do not save the node
6. Visit /admin/reports/dblog?type%5B%5D=php&severity%5B%5D=4
   - [ ] Ensure there is no entry in the log

### Select Team for PR review
- [x] `Public websites`
