### PR TITLE
VACMS-13150 Update to more recent core truncation patch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -390,7 +390,7 @@
                 "Claro claro_preprocess_input()": "patches/drupal-core-claro_preprocess_input.patch",
                 "1156338 - Fixed maximum number of field values, but use «add more» similar to when cardinality «unlimited» is used": "https://www.drupal.org/files/issues/2022-01-27/drupal-fix-limited-cardinality-fields-1156338-23.patch",
                 "2942404 - Contentinfo landmark" : "https://www.drupal.org/files/issues/2023-01-17/2942404-43.patch",
-                "3351638 - Remove truncation of path alias in table." : "https://www.drupal.org/files/issues/2023-04-03/3351638-8.patch"
+                "3351638 - Remove truncation of path alias in table." : "https://www.drupal.org/files/issues/2023-04-05/3351638-23.patch"
             },
             "drupal/danse_content_moderation": {
                 "3309657 - Danse 2.2.7 compatibility": "https://www.drupal.org/files/issues/2022-09-14/3309657-danse-2-2-7-compatibility.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b26323ae238b17d48135aad70417011",
+    "content-hash": "21822fecdc730bddeffd9c41b599d883",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",


### PR DESCRIPTION
## Description

Relates #13150  (which has already been closed.)

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
As an admin
1. Go to https://pr13198-2w92pma8g4qbryqeftqbvjoubjiltr2r.ci.cms.va.gov/admin/config/search/path?search=/lovell-federal-health-care-tricare/health-services/returning-service-member
   - [x] Validate that the alias data is not truncated and that you can see the difference in alias between the two results.
2. Go to https://www.drupal.org/project/drupal/issues/3351638 and leave a comment that you reviewed and tested it, mark it as RTBC and that it works.



### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
