### PR TITLE
VACMS-13156 Fix Tricare aliases pattern.

### DIFF
--- a/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_lovell/src/EventSubscriber/LovellEventSubscriber.php
@@ -337,7 +337,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
       if (!array_key_exists($section_id, LovellOps::LOVELL_SECTIONS)) {
         return;
       }
-      if ($entity->id() === '15007'  || LovellOps::isLovellBothListingPage($entity)) {
+      if ($entity->id() === LovellOps::LOVELL_FEDERAL_SYSTEM_ID  || LovellOps::isLovellBothListingPage($entity)) {
         // Special case of Lovell Federal system,
         // or listing pages that are in both systems but not rendered.
         return;
@@ -382,9 +382,14 @@ class LovellEventSubscriber implements EventSubscriberInterface {
     $url_pieces = explode('/', $new_url);
     $new_aliases = [];
     foreach ($prefixes as $prefix) {
+      // Replace the first segment and use the rest.
+      $url = "/{$prefix}/" . implode('/', array_slice($url_pieces, 2));
+      // Remove trailing -0 from using the menu parent for VAMC detail pages.
+      // This also applies to leadership pages.
+      $url = preg_replace('/-0$/', '', $url);
       $new_alias = PathAlias::Create([
-        'path' => '/node/' . $node->id(),
-        'alias' => '/' . $prefix . '/' . implode('/', array_slice($url_pieces, 2)),
+        'path' => "/node/{$node->id()}",
+        'alias' => $url,
         'langcode' => $node->language()->getId(),
       ]);
       $new_aliases[] = $new_alias;
@@ -407,7 +412,7 @@ class LovellEventSubscriber implements EventSubscriberInterface {
     $path_alias_manager = $this->entityTypeManager->getStorage('path_alias');
     $existing_aliases = $path_alias_manager->loadByProperties([
       'path'     => $path,
-      'langcode' => 'en',
+      'langcode' => $node->language()->getId(),
     ]);
 
     return $existing_aliases;

--- a/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
+++ b/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
@@ -22,6 +22,7 @@ class LovellOps {
   const VA_PATH = 'lovell-federal-health-care-va';
   const VA_VALUE = 'va';
   const LOVELL_MENU_ID = 'lovell-federal-health-care';
+  const LOVELL_FEDERAL_SYSTEM_ID = '15007';
   const LOVELL_SECTIONS = [
     self::VA_ID => self::VA_VALUE,
     self::TRICARE_ID => self::TRICARE_VALUE,
@@ -130,7 +131,7 @@ class LovellOps {
       LovellOps::VA_ID => LovellOps::VA_PATH,
     ];
 
-    // If section is not both remove invalid prefixes.
+    // If section is not both, remove invalid prefixes.
     if ($section_id !== LovellOps::BOTH_ID) {
       $valid_prefixes = array_intersect_key($valid_prefixes, [$section_id => 'keep']);
     }


### PR DESCRIPTION
## Description

Closes #13156 

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As an admin
1. Go to https://pr13225-yn0tf6reviz1tvty38wwgotfkyyzkypj.ci.cms.va.gov/node/55028/edit (which is one of the tricare detail pages nodes that has a -0 problem)
2. Add a revison log and publish and save the node.
   - [x] Validate that the url does not end in -0
   - [x] validate the alias is https://pr13225-yn0tf6reviz1tvty38wwgotfkyyzkypj.ci.cms.va.gov/lovell-federal-health-care-tricare/programs/chaplain-services
3. Go to /node/55022/edit (the VA equivalent of that page) /lovell-federal-health-care-va/programs/chaplain-services
4. Publish and save the node
   - [x] Validate that there is no -0 at the end
   - [x] validate the url is /lovell-federal-health-care-va/programs/chaplain-services
5. Go to a Lovell Federal detail page (appears at two urls) https://pr13225-yn0tf6reviz1tvty38wwgotfkyyzkypj.ci.cms.va.gov/node/36317/edit
6. Make a change to the node and publish and save.
   - [x] Validate that the url is /lovell-federal-health-care-va/work-with-us/volunteer-or-donate
7. Go to /lovell-federal-health-care-tricare/work-with-us/volunteer-or-donate
   - [x] validate that the request rewrites to /lovell-federal-health-care-va/work-with-us/volunteer-or-donate (the va is the canonical)





### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
