### PR TITLE
VACMS-13079 Add workflow to Service Taxonomy.

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,9 +15,10 @@ jobs:
         run: ./tests/scripts/check-cer.sh
       - name: Check Revision Log fields
         # See also `composer va:test:check-node-revision-logs` in composer.json
-        run: ./tests/scripts/check-node-revision-logs.sh
         # See also `composer va:test:check-taxonomy-revision-logs` in composer.json
-        run: ./tests/scripts/check-taxonomy-revision-logs.sh
+        run: |
+          ./tests/scripts/check-node-revision-logs.sh
+          ./tests/scripts/check-taxonomy-revision-logs.sh
 
   # Validate that the `composer.lock` hash is up-to-date.
   composer-validate:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,8 +14,10 @@ jobs:
         # See also `composer va:test:check-cer` in composer.json
         run: ./tests/scripts/check-cer.sh
       - name: Check Revision Log fields
-        # See also `composer va:test:check-revision-logs` in composer.json
-        run: ./tests/scripts/check-revision-logs.sh
+        # See also `composer va:test:check-node-revision-logs` in composer.json
+        run: ./tests/scripts/check-node-revision-logs.sh
+        # See also `composer va:test:check-taxonomy-revision-logs` in composer.json
+        run: ./tests/scripts/check-taxonomy-revision-logs.sh
 
   # Validate that the `composer.lock` hash is up-to-date.
   composer-validate:
@@ -140,7 +142,7 @@ jobs:
         # https://github.com/actions/cache/releases/tag/v3.0.10
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Stylelint modules
-        # https://github.com/reviewdog/action-stylelint/releases/tag/v1.14.0 
+        # https://github.com/reviewdog/action-stylelint/releases/tag/v1.14.0
         # See also `composer va:test:stylelint-modules` in composer.json
         uses: reviewdog/action-stylelint@a45bf7c5a91efc6f9443ae59b9cf7387b7868492
         with:
@@ -151,7 +153,7 @@ jobs:
           stylelint_config: '.stylelintrc'
           stylelint_input: 'docroot/modules/custom/**/*.css'
       - name: Stylelint themes
-        # https://github.com/reviewdog/action-stylelint/releases/tag/v1.14.0 
+        # https://github.com/reviewdog/action-stylelint/releases/tag/v1.14.0
         # See also `composer va:test:stylelint-themes` in composer.json
         uses: reviewdog/action-stylelint@a45bf7c5a91efc6f9443ae59b9cf7387b7868492
         with:

--- a/composer.json
+++ b/composer.json
@@ -553,7 +553,8 @@
         "va:test:fast": "Runs the \"fast\" static analysis, linting, and unit tests.",
         "va:test:behat": "Run Behat tests.",
         "va:test:check-cer": "Check the Corresponding Entity References fields.",
-        "va:test:check-revision-logs": "Check the revision log fields.",
+        "va:test:check-node-revision-logs": "Check the node revision log fields.",
+        "va:test:check-taxonomy-revision-logs": "Check the taxonomy revision log fields.",
         "va:test:content-build-gql": "Run GraphQL export to test content-build.",
         "va:test:cypress": "Run Cypress tests.",
         "va:test:cypress-ci": "Run Cypress tests with CI-specific functionality.",
@@ -649,7 +650,8 @@
             "@composer validate",
             "@va:test:behat",
             "@va:test:check-cer",
-            "@va:test:check-revision-logs",
+            "@va:test:check-node-revision-logs",
+            "@va:test:check-taxonomy-revision-logs",
             "@va:test:content-build-gql",
             "@va:test:cypress",
             "@va:test:eslint",
@@ -666,7 +668,8 @@
             "# Runs the \"fast\" static analysis, linting, and unit tests.",
             "@composer validate",
             "@va:test:check-cer",
-            "@va:test:check-revision-logs",
+            "@va:test:check-node-revision-logs",
+            "@va:test:check-taxonomy-revision-logs",
             "@va:test:eslint",
             "@va:test:lint-php",
             "@va:test:php_codesniffer",
@@ -680,7 +683,8 @@
             "@composer validate || true",
             "@va:test:behat || true",
             "@va:test:check-cer || true",
-            "@va:test:check-revision-logs || true",
+            "@va:test:check-node-revision-logs || true",
+            "@va:test:check-taxonomy-revision-logs || true",
             "@va:test:content-build-gql || true",
             "@va:test:cypress || true",
             "@va:test:eslint || true",
@@ -703,10 +707,15 @@
             "! ./scripts/should-run-directly.sh || ./tests/scripts/check-cer.sh",
             "./scripts/should-run-directly.sh || ddev composer va:test:check-cer --"
         ],
-        "va:test:check-revision-logs": [
-            "# Check the revision log fields.",
-            "! ./scripts/should-run-directly.sh || ./tests/scripts/check-revision-logs.sh",
-            "./scripts/should-run-directly.sh || ddev composer va:test:check-revision-logs --"
+        "va:test:check-node-revision-logs": [
+            "# Check the node revision log fields.",
+            "! ./scripts/should-run-directly.sh || ./tests/scripts/check-node-revision-logs.sh",
+            "./scripts/should-run-directly.sh || ddev composer va:test:check-node-revision-logs --"
+        ],
+        "va:test:check-taxonomy-revision-logs": [
+            "# Check the taxonomy revision log fields.",
+            "! ./scripts/should-run-directly.sh || ./tests/scripts/check-taxonomy-revision-logs.sh",
+            "./scripts/should-run-directly.sh || ddev composer va:test:check-taxonomy-revision-logs --"
         ],
         "va:test:content-build-gql": [
             "# Run GraphQL export to test content-build.",

--- a/composer.json
+++ b/composer.json
@@ -390,7 +390,8 @@
                 "Claro claro_preprocess_input()": "patches/drupal-core-claro_preprocess_input.patch",
                 "1156338 - Fixed maximum number of field values, but use «add more» similar to when cardinality «unlimited» is used": "https://www.drupal.org/files/issues/2022-01-27/drupal-fix-limited-cardinality-fields-1156338-23.patch",
                 "2942404 - Contentinfo landmark" : "https://www.drupal.org/files/issues/2023-01-17/2942404-43.patch",
-                "3351638 - Remove truncation of path alias in table." : "https://www.drupal.org/files/issues/2023-04-05/3351638-23.patch"
+                "3351638 - Remove truncation of path alias in table." : "https://www.drupal.org/files/issues/2023-04-05/3351638-23.patch",
+                "3047110 - Add workflow to taxonomy" : "https://www.drupal.org/files/issues/2023-04-14/3047110-45.patch"
             },
             "drupal/danse_content_moderation": {
                 "3309657 - Danse 2.2.7 compatibility": "https://www.drupal.org/files/issues/2022-09-14/3309657-danse-2-2-7-compatibility.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6e1ba2fb3a2d7407297507b859798d2",
+    "content-hash": "7667d81e2d6d46f961275b3b4b1bd8b7",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -864,7 +864,7 @@
             "version": "v4.1.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:fengyuanchen/cropper.git",
+                "url": "https://github.com/fengyuanchen/cropper.git",
                 "reference": "617d9bdb8688cc4edb3b03bc49a04b83c7facbe7"
             },
             "dist": {
@@ -7150,10 +7150,6 @@
                 {
                     "name": "mglaman",
                     "homepage": "https://www.drupal.org/user/2416470"
-                },
-                {
-                    "name": "pfaocle",
-                    "homepage": "https://www.drupal.org/user/9740"
                 },
                 {
                     "name": "roberto.rivera.ixis",

--- a/config/sync/core.entity_form_display.taxonomy_term.administration.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.administration.default.yml
@@ -24,19 +24,32 @@ third_party_settings:
         open: false
         required_fields: false
     group_email_updates:
-      children:
-        - field_email_updates_link_text
-        - field_email_updates_url
+      children: {  }
       label: 'Email updates'
       region: hidden
       parent_name: ''
-      weight: 5
+      weight: 9
       format_type: fieldset
       format_settings:
         classes: ''
         id: ''
         description: 'A link that leads someone to subscribe to email updates.'
         required_fields: true
+    group_workflow:
+      children:
+        - revision_log_message
+      label: 'Editorial workflow'
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.administration.default
 targetEntityType: taxonomy_term
 bundle: administration
@@ -68,5 +81,6 @@ hidden:
   description: true
   langcode: true
   layout_builder__layout: true
+  moderation_state: true
   path: true
   status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.audience_beneficiaries.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.audience_beneficiaries.default.yml
@@ -8,6 +8,23 @@ dependencies:
   module:
     - path
     - text
+third_party_settings:
+  field_group:
+    group_workflow:
+      children:
+        - revision_log_message
+      label: 'Editorial workflow'
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.audience_beneficiaries.default
 targetEntityType: taxonomy_term
 bundle: audience_beneficiaries
@@ -42,6 +59,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   langcode: true
+  moderation_state: true
   status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.audience_non_beneficiaries.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.audience_non_beneficiaries.default.yml
@@ -8,6 +8,23 @@ dependencies:
   module:
     - path
     - text
+third_party_settings:
+  field_group:
+    group_workflow:
+      children:
+        - revision_log_message
+      label: 'Editorial workflow'
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.audience_non_beneficiaries.default
 targetEntityType: taxonomy_term
 bundle: audience_non_beneficiaries
@@ -42,6 +59,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   langcode: true
+  moderation_state: true
   status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.external_data_source_destination.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.external_data_source_destination.default.yml
@@ -1,13 +1,11 @@
-uuid: 39aa50cd-863f-4399-ac03-22ef3d200535
+uuid: 740e1b98-4880-44f4-91a8-45562a1e394b
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.taxonomy_term.lc_categories.field_enforce_unique_value
-    - field.field.taxonomy_term.lc_categories.field_topic_id
-    - taxonomy.vocabulary.lc_categories
+    - taxonomy.vocabulary.external_data_source_destination
   module:
-    - allow_only_one
+    - field_group
     - path
     - text
 third_party_settings:
@@ -15,6 +13,7 @@ third_party_settings:
     group_workflow:
       children:
         - revision_log_message
+        - status
       label: 'Editorial workflow'
       region: content
       parent_name: ''
@@ -27,9 +26,9 @@ third_party_settings:
         description: ''
         required_fields: true
         description_display: after
-id: taxonomy_term.lc_categories.default
+id: taxonomy_term.external_data_source_destination.default
 targetEntityType: taxonomy_term
-bundle: lc_categories
+bundle: external_data_source_destination
 mode: default
 content:
   description:
@@ -40,20 +39,12 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-  field_enforce_unique_value:
-    type: allow_only_one_widget
-    weight: 3
+  langcode:
+    type: language_select
+    weight: 2
     region: content
     settings:
-      size: 1
-    third_party_settings: {  }
-  field_topic_id:
-    type: string_textfield
-    weight: 4
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
+      include_locked: true
     third_party_settings: {  }
   name:
     type: string_textfield
@@ -65,16 +56,16 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
-  translation:
-    weight: 5
+  status:
+    type: boolean_checkbox
+    weight: 4
     region: content
-    settings: {  }
+    settings:
+      display_label: true
     third_party_settings: {  }
 hidden:
-  langcode: true
   moderation_state: true
-  status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.facility_supplemental_status.default.yml
@@ -61,6 +61,21 @@ third_party_settings:
         id: ''
         description: 'Visible title of the status ie: Covid-Red'
         required_fields: true
+    group_workflow:
+      children:
+        - revision_log_message
+      label: 'Editorial workflow'
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.facility_supplemental_status.default
 targetEntityType: taxonomy_term
 bundle: facility_supplemental_status
@@ -132,5 +147,6 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  moderation_state: true
   path: true
   status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -24,8 +24,10 @@ dependencies:
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vet_center_type_of_care
     - field.field.taxonomy_term.health_care_service_taxonomy.field_vha_healthservice_stopcode
     - taxonomy.vocabulary.health_care_service_taxonomy
+    - workflows.workflow.editorial
   module:
     - allow_only_one
+    - content_moderation
     - field_group
     - path
     - text
@@ -37,7 +39,7 @@ third_party_settings:
       label: 'Section settings'
       region: hidden
       parent_name: ''
-      weight: 9
+      weight: 12
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -101,6 +103,21 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
+        description: ''
+        required_fields: true
+        description_display: after
+    group_workflow:
+      children:
+        - moderation_state
+      label: Workflow
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
         description: ''
         required_fields: true
         description_display: after
@@ -257,6 +274,12 @@ content:
     region: content
     settings:
       placeholder: ''
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 8
+    region: content
+    settings: {  }
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -109,7 +109,8 @@ third_party_settings:
     group_workflow:
       children:
         - moderation_state
-      label: Workflow
+        - revision_log_message
+      label: 'Editorial workflow'
       region: content
       parent_name: ''
       weight: 20

--- a/config/sync/core.entity_form_display.taxonomy_term.products.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.products.default.yml
@@ -8,6 +8,23 @@ dependencies:
   module:
     - path
     - text
+third_party_settings:
+  field_group:
+    group_workflow:
+      children:
+        - revision_log_message
+      label: 'Editorial workflow'
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.products.default
 targetEntityType: taxonomy_term
 bundle: products
@@ -45,6 +62,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  translation:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   langcode: true
+  moderation_state: true
   status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.topics.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.topics.default.yml
@@ -7,6 +7,23 @@ dependencies:
   module:
     - path
     - text
+third_party_settings:
+  field_group:
+    group_workflow:
+      children:
+        - revision_log_message
+      label: 'Editorial workflow'
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.topics.default
 targetEntityType: taxonomy_term
 bundle: topics
@@ -34,6 +51,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   langcode: true
+  moderation_state: true
   status: true

--- a/config/sync/core.entity_form_display.taxonomy_term.type_of_redirect.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.type_of_redirect.default.yml
@@ -7,6 +7,23 @@ dependencies:
   module:
     - path
     - text
+third_party_settings:
+  field_group:
+    group_workflow:
+      children:
+        - revision_log_message
+      label: 'Editorial workflow'
+      region: content
+      parent_name: ''
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: sections
+        description: ''
+        required_fields: true
+        description_display: after
 id: taxonomy_term.type_of_redirect.default
 targetEntityType: taxonomy_term
 bundle: type_of_redirect
@@ -36,4 +53,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  moderation_state: true
   status: true

--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -38,6 +38,11 @@ targetEntityType: taxonomy_term
 bundle: health_care_service_taxonomy
 mode: default
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   description:
     type: text_default
     label: above

--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -58,6 +58,7 @@ dependencies:
     - node.type.vet_center_mobile_vet_center
     - node.type.vet_center_outstation
     - node.type.vha_facility_nonclinical_service
+    - taxonomy.vocabulary.health_care_service_taxonomy
   module:
     - content_moderation
 _core:
@@ -197,4 +198,6 @@ type_settings:
       - vet_center_mobile_vet_center
       - vet_center_outstation
       - vha_facility_nonclinical_service
+    taxonomy_term:
+      - health_care_service_taxonomy
   default_moderation_state: draft

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\ContentEntityTypeInterface;
 
 /**
  * Implements hook_help().
@@ -36,5 +37,23 @@ function _va_gov_workflow_validate_required_revision_message(array $form, FormSt
   // Add revision log validation.
   if ($form_state->isValueEmpty(['revision_log', '0', 'value'])) {
     $form_state->setErrorByName('revision_log][0][value', t('Revision log message is required'));
+  }
+}
+
+/**
+ * Implements hook_entity_base_field_info_alter().
+ *
+ * {@inheritdoc}
+ */
+function va_gov_workflow_entity_base_field_info_alter(&$fields, ContentEntityTypeInterface $entity_type) {
+  // Display the revision_log_message field.
+  if ($entity_type->id() == 'taxonomy_term' && isset($fields['revision_log_message'])) {
+    // Grab the existing options so we don't stomp them without intent.
+    $form_options = $fields['revision_log_message']->getDisplayOptions('form');
+    // For some reason the field defaults to region = hidden.
+    $form_options['region'] = 'content';
+    $fields['revision_log_message']
+      ->setRequired(TRUE)
+      ->setDisplayOptions('form', $form_options);
   }
 }

--- a/tests/cypress/integration/common/i_create_a_taxonomy_term.js
+++ b/tests/cypress/integration/common/i_create_a_taxonomy_term.js
@@ -50,6 +50,10 @@ Given("I create a {string} taxonomy term", (vocabulary) => {
     `I do not know how to create ${vocabulary} taxonomy terms yet.  Please add a definition in ${__filename}.`
   );
   creator().then(() => {
+    cy.get("#edit-revision-log-message-0-value").type(
+      `[Test revision log 1]${faker.lorem.sentence()}`,
+      { force: true }
+    );
     cy.get("form.taxonomy-term-form").find("input#edit-submit").click();
     cy.getLastCreatedTaxonomyTerm().then((tidCommand) => {
       cy.log(tidCommand);

--- a/tests/cypress/integration/common/i_create_a_taxonomy_term.js
+++ b/tests/cypress/integration/common/i_create_a_taxonomy_term.js
@@ -39,6 +39,11 @@ const creators = {
       faker.datatype.number(),
       { force: true }
     );
+
+    cy.get("#edit-moderation-state-0-state").select("published", {
+      force: true,
+    });
+
     return cy.wait(1000);
   },
 };

--- a/tests/phpunit/Content/AliasesTest.php
+++ b/tests/phpunit/Content/AliasesTest.php
@@ -51,7 +51,7 @@ class AliasesTest extends VaGovExistingSiteBase {
       'description' => 'Test Services Description',
       'uid' => $author->id(),
     ]);
-    $vha_service_category_term->save();
+    $vha_service_category_term->setPublished()->save();
 
     // Create a VHA health care service term.
     $vha_service_term = $this->createTerm($vha_service_vocab, [
@@ -61,7 +61,7 @@ class AliasesTest extends VaGovExistingSiteBase {
       'parent' => $vha_service_category_term->id(),
       'uid' => $author->id(),
     ]);
-    $vha_service_term->save();
+    $vha_service_term->set('moderation_state', 'published')->setPublished()->save();
 
     // Create a VAMC regional health care service node.
     $service_node = $this->createNode([

--- a/tests/scripts/check-node-revision-logs.sh
+++ b/tests/scripts/check-node-revision-logs.sh
@@ -14,7 +14,7 @@ for filename in config/sync/core.entity_form_display.node.*.default.yml; do
 done
 
 if [ "${failure}" -eq 1 ]; then
-  echo "To fix this test, ensure that all content types with the moderation_state field"
+  echo "To fix this test, ensure that all node content types with the moderation_state field"
   echo "also have the revision_log field directly below it."
   exit 1
 fi

--- a/tests/scripts/check-taxonomy-revision-logs.sh
+++ b/tests/scripts/check-taxonomy-revision-logs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ex
+
+export failure=0
+
+
+for filename in config/sync/core.entity_form_display.taxonomy_term.*.default.yml; do
+  if ! grep --quiet '\- revision_log_message' "${filename}"; then
+    failure=1
+    echo "The revision_log_message field was not found in ${filename}."
+  fi
+done
+
+if [ "${failure}" -eq 1 ]; then
+  echo "To fix this test, ensure that all taxonomy_term types"
+  echo "have the revision_log_message present."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Description

Closes #13079 

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user admin
1. Go to https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/admin/config/workflow/workflows/manage/editorial
   - [x] Validate that "VA Services" is the only taxonomy enabled under 'Taxonomy term types'
2. Navigate to an existing VA Service term. Caregiver Support https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/48/edit
   - [x] Validate that it is defaulted to published moderation state because it was published.
   - [x] validate that draft, published and archived are available choices.
   - [x] validate that the published state and selector sit above the Revision log message field.
   - [x] Validate that the revision log message field is required and that a save can not occur if it is empty.
   - [x] Change the title to include the word "DRAFT" and save it as a draft with revision log message.  Validate that it saves
   - [x] Click on the Revisions tab and validate that your change shows as a revision.

3. Navigate to Advice nurse health term https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/104/edit
   - [x] Add the word "PUBLISHED" to the title. add a revision log message and save as published. Validate that it saved.
4. Trigger a content release https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/admin/content/deploy  

While waiting for the content release to complete
5.  Spot check other vocabularies to make sure they have required revision logs
   - [x] Audience - Beneficiaries https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/268/edit
   - [x] Audience - Non beneficiaries https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/308/edit
   - [x] External data https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/1112/edit
   - [x] Facility supplemental status https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/1036/edit
   - [x] Products https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/288/edit
   - [x] Resources and support https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/301/edit
   - [x] Sections https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/995/edit
   - [x] Topics https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/294/edit
   - [x] Type of Redirect https://pr13303-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/taxonomy/term/32/edit

--- later ---
10. After the content release is complete, Navigate to the FE version of the page. https://web-ic1jnjkygvuews05uoo3n7wbhyzv4tzk.ci.cms.va.gov/south-texas-health-care/health-services/
   - [x] validate that you see "PUBLISHED" in the Advice nurse listing.
   - [x] validate that you do NOT see "DRAFT"  by "Caregiver support" listing.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
