### PR TITLE
VACMS-13317: Fix saving taxonomy terms, other things.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
 
 use Drupal\Component\Utility\Html;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\TextValidatorTrait;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -12,53 +13,13 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class PreventAbsoluteCmsLinksValidator extends ConstraintValidator {
 
+  use TextValidatorTrait;
   use ValidatorContextAccessTrait;
-
-  /**
-   * Add a violation message.
-   *
-   * @param int $delta
-   *   The field delta.
-   * @param string $message
-   *   The violation message.
-   * @param array $params
-   *   Message parameters.
-   */
-  public function addViolation(int $delta, string $message, array $params = []) {
-    $this->getContext()
-      ->buildViolation($message, $params)
-      ->atPath((string) $delta . '.value')
-      ->addViolation();
-  }
 
   /**
    * {@inheritdoc}
    */
-  public function validate($items, Constraint $constraint) {
-    foreach ($items as $delta => $item) {
-      $type = $item->getFieldDefinition()->getType();
-      $fieldValue = $item->getValue();
-      /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint */
-      if ($type === 'text_long' && $fieldValue['format'] !== 'plain_text') {
-        $this->validateHtml($fieldValue['value'], $constraint, $delta);
-      }
-      else {
-        $this->validateText($fieldValue['value'], $constraint, $delta);
-      }
-    }
-  }
-
-  /**
-   * Validates plain text.
-   *
-   * @param string $text
-   *   A plain text string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
-   */
-  public function validateText(string $text, PreventAbsoluteCmsLinks $constraint, int $delta) {
+  public function validateText(string $text, Constraint $constraint, int $delta) {
     if (strpos($text, 'cms.va.gov') === FALSE) {
       return;
     }
@@ -71,16 +32,10 @@ class PreventAbsoluteCmsLinksValidator extends ConstraintValidator {
   }
 
   /**
-   * Validates HTML.
-   *
-   * @param string $html
-   *   An HTML string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
+   * {@inheritdoc}
    */
-  public function validateHtml(string $html, PreventAbsoluteCmsLinks $constraint, int $delta) {
+  public function validateHtml(string $html, Constraint $constraint, int $delta) {
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteCmsLinks $constraint */
     if (strpos($html, 'cms.va.gov') === FALSE) {
       return;
     }

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteUrlsAsPathsInLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteUrlsAsPathsInLinksValidator.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
 
 use Drupal\Component\Utility\Html;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\TextValidatorTrait;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -12,53 +13,13 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class PreventAbsoluteUrlsAsPathsInLinksValidator extends ConstraintValidator {
 
+  use TextValidatorTrait;
   use ValidatorContextAccessTrait;
-
-  /**
-   * Add a violation message.
-   *
-   * @param int $delta
-   *   The field delta.
-   * @param string $message
-   *   The violation message.
-   * @param array $params
-   *   Message parameters.
-   */
-  public function addViolation(int $delta, string $message, array $params = []) {
-    $this->getContext()
-      ->buildViolation($message, $params)
-      ->atPath((string) $delta . '.value')
-      ->addViolation();
-  }
 
   /**
    * {@inheritdoc}
    */
-  public function validate($items, Constraint $constraint) {
-    foreach ($items as $delta => $item) {
-      $type = $item->getFieldDefinition()->getType();
-      $fieldValue = $item->getValue();
-      /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteUrlsAsPathsInLinks $constraint */
-      if ($type === 'text_long' && $fieldValue['format'] !== 'plain_text') {
-        $this->validateHtml($fieldValue['value'], $constraint, $delta);
-      }
-      else {
-        $this->validateText($fieldValue['value'], $constraint, $delta);
-      }
-    }
-  }
-
-  /**
-   * Validates plain text.
-   *
-   * @param string $text
-   *   A plain text string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteUrlsAsPathsInLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
-   */
-  public function validateText(string $text, PreventAbsoluteUrlsAsPathsInLinks $constraint, int $delta) {
+  public function validateText(string $text, Constraint $constraint, int $delta) {
     /*
      * Regular expression explanation:
      *
@@ -76,6 +37,7 @@ class PreventAbsoluteUrlsAsPathsInLinksValidator extends ConstraintValidator {
      * In other words, we look for a string that looks like a valid URL but is
      * immediately preceded by a forward slash.
      */
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteUrlsAsPathsInLinks $constraint */
     if (preg_match('#(/https?://[^\s]+)#', $text, $matches)) {
       $this->addViolation($delta, $constraint->plainTextMessage, [
         ':url' => $matches[1],
@@ -84,16 +46,10 @@ class PreventAbsoluteUrlsAsPathsInLinksValidator extends ConstraintValidator {
   }
 
   /**
-   * Validates HTML.
-   *
-   * @param string $html
-   *   An HTML string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteUrlsAsPathsInLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
+   * {@inheritdoc}
    */
-  public function validateHtml(string $html, PreventAbsoluteUrlsAsPathsInLinks $constraint, int $delta) {
+  public function validateHtml(string $html, Constraint $constraint, int $delta) {
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventAbsoluteUrlsAsPathsInLinks $constraint */
     $dom = Html::load($html);
     $xpath = new \DOMXPath($dom);
     foreach ($xpath->query('//a[starts-with(@href, "/http")]') as $element) {

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventDomainsAsPathsInLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventDomainsAsPathsInLinksValidator.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
 
 use Drupal\Component\Utility\Html;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\TextValidatorTrait;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -12,53 +13,13 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class PreventDomainsAsPathsInLinksValidator extends ConstraintValidator {
 
+  use TextValidatorTrait;
   use ValidatorContextAccessTrait;
-
-  /**
-   * Add a violation message.
-   *
-   * @param int $delta
-   *   The field delta.
-   * @param string $message
-   *   The violation message.
-   * @param array $params
-   *   Message parameters.
-   */
-  public function addViolation(int $delta, string $message, array $params = []) {
-    $this->getContext()
-      ->buildViolation($message, $params)
-      ->atPath((string) $delta . '.value')
-      ->addViolation();
-  }
 
   /**
    * {@inheritdoc}
    */
-  public function validate($items, Constraint $constraint) {
-    foreach ($items as $delta => $item) {
-      $type = $item->getFieldDefinition()->getType();
-      $fieldValue = $item->getValue();
-      /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint */
-      if ($type === 'text_long' && $fieldValue['format'] !== 'plain_text') {
-        $this->validateHtml($fieldValue['value'], $constraint, $delta);
-      }
-      else {
-        $this->validateText($fieldValue['value'], $constraint, $delta);
-      }
-    }
-  }
-
-  /**
-   * Validates plain text.
-   *
-   * @param string $text
-   *   A plain text string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
-   */
-  public function validateText(string $text, PreventDomainsAsPathsInLinks $constraint, int $delta) {
+  public function validateText(string $text, Constraint $constraint, int $delta) {
     /*
      * Regular expression explanation:
      *
@@ -76,6 +37,7 @@ class PreventDomainsAsPathsInLinksValidator extends ConstraintValidator {
      * `/www.whitehouse.gov/something-else`, but not a path with a domain-name
      * beyond the first level, like `/some-path/www.example.com/`.
      */
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint */
     if (preg_match('#[\s"\'](/www\.[^\s"\']+)#', $text, $matches)) {
       $this->addViolation($delta, $constraint->plainTextMessage, [
         ':url' => $matches[1],
@@ -84,16 +46,10 @@ class PreventDomainsAsPathsInLinksValidator extends ConstraintValidator {
   }
 
   /**
-   * Validates HTML.
-   *
-   * @param string $html
-   *   An HTML string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
+   * {@inheritdoc}
    */
-  public function validateHtml(string $html, PreventDomainsAsPathsInLinks $constraint, int $delta) {
+  public function validateHtml(string $html, Constraint $constraint, int $delta) {
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventDomainsAsPathsInLinks $constraint */
     $dom = Html::load($html);
     $xpath = new \DOMXPath($dom);
     foreach ($xpath->query('//a[starts-with(@href, "/www.")]') as $element) {

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventProtocolRelativeLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventProtocolRelativeLinksValidator.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
 
 use Drupal\Component\Utility\Html;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\TextValidatorTrait;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -12,53 +13,13 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class PreventProtocolRelativeLinksValidator extends ConstraintValidator {
 
+  use TextValidatorTrait;
   use ValidatorContextAccessTrait;
-
-  /**
-   * Add a violation message.
-   *
-   * @param int $delta
-   *   The field delta.
-   * @param string $message
-   *   The violation message.
-   * @param array $params
-   *   Message parameters.
-   */
-  public function addViolation(int $delta, string $message, array $params = []) {
-    $this->getContext()
-      ->buildViolation($message, $params)
-      ->atPath((string) $delta . '.value')
-      ->addViolation();
-  }
 
   /**
    * {@inheritdoc}
    */
-  public function validate($items, Constraint $constraint) {
-    foreach ($items as $delta => $item) {
-      $type = $item->getFieldDefinition()->getType();
-      $fieldValue = $item->getValue();
-      /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinks $constraint */
-      if ($type === 'text_long' && $fieldValue['format'] !== 'plain_text') {
-        $this->validateHtml($fieldValue['value'], $constraint, $delta);
-      }
-      else {
-        $this->validateText($fieldValue['value'], $constraint, $delta);
-      }
-    }
-  }
-
-  /**
-   * Validates plain text.
-   *
-   * @param string $text
-   *   A plain text string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
-   */
-  public function validateText(string $text, PreventProtocolRelativeLinks $constraint, int $delta) {
+  public function validateText(string $text, Constraint $constraint, int $delta) {
     /*
      * Regular expression explanation:
      *
@@ -96,6 +57,7 @@ class PreventProtocolRelativeLinksValidator extends ConstraintValidator {
      * - contains at least two "words" separated by dots
      * - may contain arbitrary non-whitespace characters after that.
      */
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinks $constraint */
     if (preg_match('#([^(\w+:)]//[^/]+\w+(\.\w+)+\S*)#', $text, $matches)) {
       $this->addViolation($delta, $constraint->plainTextMessage, [
         ':url' => $matches[1],
@@ -104,16 +66,10 @@ class PreventProtocolRelativeLinksValidator extends ConstraintValidator {
   }
 
   /**
-   * Validates HTML.
-   *
-   * @param string $html
-   *   An HTML string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
+   * {@inheritdoc}
    */
-  public function validateHtml(string $html, PreventProtocolRelativeLinks $constraint, int $delta) {
+  public function validateHtml(string $html, Constraint $constraint, int $delta) {
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinks $constraint */
     $dom = Html::load($html);
     $xpath = new \DOMXPath($dom);
     foreach ($xpath->query('//a[starts-with(@href, "//")]') as $element) {

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventVaGovDomainsAsPathsInLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventVaGovDomainsAsPathsInLinksValidator.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
 
 use Drupal\Component\Utility\Html;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\TextValidatorTrait;
 use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -12,53 +13,13 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class PreventVaGovDomainsAsPathsInLinksValidator extends ConstraintValidator {
 
+  use TextValidatorTrait;
   use ValidatorContextAccessTrait;
-
-  /**
-   * Add a violation message.
-   *
-   * @param int $delta
-   *   The field delta.
-   * @param string $message
-   *   The violation message.
-   * @param array $params
-   *   Message parameters.
-   */
-  public function addViolation(int $delta, string $message, array $params = []) {
-    $this->getContext()
-      ->buildViolation($message, $params)
-      ->atPath((string) $delta . '.value')
-      ->addViolation();
-  }
 
   /**
    * {@inheritdoc}
    */
-  public function validate($items, Constraint $constraint) {
-    foreach ($items as $delta => $item) {
-      $type = $item->getFieldDefinition()->getType();
-      $fieldValue = $item->getValue();
-      /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventVaGovDomainsAsPathsInLinks $constraint */
-      if ($type === 'text_long' && $fieldValue['format'] !== 'plain_text') {
-        $this->validateHtml($fieldValue['value'], $constraint, $delta);
-      }
-      else {
-        $this->validateText($fieldValue['value'], $constraint, $delta);
-      }
-    }
-  }
-
-  /**
-   * Validates plain text.
-   *
-   * @param string $text
-   *   A plain text string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventVaGovDomainsAsPathsInLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
-   */
-  public function validateText(string $text, PreventVaGovDomainsAsPathsInLinks $constraint, int $delta) {
+  public function validateText(string $text, Constraint $constraint, int $delta) {
     /*
      * Regular expression explanation:
      *
@@ -81,6 +42,7 @@ class PreventVaGovDomainsAsPathsInLinksValidator extends ConstraintValidator {
      * In other words, we look for a string like `/va.gov/something` or
      * `/www.va.gov/something-else`.
      */
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventVaGovDomainsAsPathsInLinks $constraint */
     if (preg_match('#[\s"\']/([^\s/]*va\.gov[^\s]*)#', $text, $matches)) {
       $this->addViolation($delta, $constraint->plainTextMessage, [
         ':url' => $matches[1],
@@ -89,16 +51,10 @@ class PreventVaGovDomainsAsPathsInLinksValidator extends ConstraintValidator {
   }
 
   /**
-   * Validates HTML.
-   *
-   * @param string $html
-   *   An HTML string to validate.
-   * @param \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventVaGovDomainsAsPathsInLinks $constraint
-   *   The constraint we're validating.
-   * @param int $delta
-   *   The field item delta.
+   * {@inheritdoc}
    */
-  public function validateHtml(string $html, PreventVaGovDomainsAsPathsInLinks $constraint, int $delta) {
+  public function validateHtml(string $html, Constraint $constraint, int $delta) {
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventVaGovDomainsAsPathsInLinks $constraint */
     $dom = Html::load($html);
     $xpath = new \DOMXPath($dom);
     foreach ($xpath->query('//a[starts-with(@href, "/") and contains(@href, "va.gov")]') as $element) {

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/Traits/TextValidatorTrait.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/Traits/TextValidatorTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validates string and long_text fields according to text type.
+ */
+trait TextValidatorTrait {
+
+  /**
+   * Add a violation message.
+   *
+   * @param int $delta
+   *   The field delta.
+   * @param string $message
+   *   The violation message.
+   * @param array $params
+   *   Message parameters.
+   */
+  public function addViolation(int $delta, string $message, array $params = []) {
+    $this->getContext()
+      ->buildViolation($message, $params)
+      ->atPath((string) $delta . '.value')
+      ->addViolation();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($items, Constraint $constraint) {
+    foreach ($items as $delta => $item) {
+      $type = $item->getFieldDefinition()->getType();
+      $fieldValue = $item->getValue();
+      $stringValue = $fieldValue['value'] ?? '';
+      if (empty($stringValue)) {
+        continue;
+      }
+      elseif ($type === 'text_long' && $fieldValue['format'] !== 'plain_text') {
+        $this->validateHtml($stringValue, $constraint, $delta);
+      }
+      else {
+        $this->validateText($stringValue, $constraint, $delta);
+      }
+    }
+  }
+
+  /**
+   * Validates plain text.
+   *
+   * @param string $text
+   *   A plain text string to validate.
+   * @param \Symfony\Component\Validator\Constraint $constraint
+   *   The constraint we're validating.
+   * @param int $delta
+   *   The field item delta.
+   */
+  abstract public function validateText(string $text, Constraint $constraint, int $delta);
+
+  /**
+   * Validates HTML.
+   *
+   * @param string $html
+   *   An HTML string to validate.
+   * @param \Symfony\Component\Validator\Constraint $constraint
+   *   The constraint we're validating.
+   * @param int $delta
+   *   The field item delta.
+   */
+  abstract public function validateHtml(string $html, Constraint $constraint, int $delta);
+
+}


### PR DESCRIPTION
## Description

Closes #13317.

I used this as an opportunity to perform an overdue refactoring of some common functionality into a trait dedicated to validation of string and text fields.

## Testing done
Manual testing, existing automated tests.

## Screenshots
![Screenshot 2023-04-18 at 11 10 29 AM](https://user-images.githubusercontent.com/1318579/232821415-4620e08c-3e14-4910-a8bc-319d78794f94.png)

## QA steps

1. Go [here](https://cms-20ujuleyrfct0fofkmda2u7afgnuqrct.ci.cms.va.gov/taxonomy/term/2/edit)
2. Attempt to save the term.
3. Verify that the term is saved successfully.

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
