### PR TITLE
VACMS-13220:  Remove inline Q&A editing

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.paragraph.q_a_group.field_section_header
     - paragraphs.paragraphs_type.q_a_group
   module:
+    - change_labels
     - entity_browser_table
     - limited_field_widgets
     - text
@@ -32,16 +33,19 @@ content:
     region: content
     settings:
       entity_browser: q_a_browser
-      field_widget_display: label
-      field_widget_edit: '1'
+      field_widget_display: linked_title
+      field_widget_display_settings:
+        target_blank: '1'
       field_widget_remove: '1'
       selection_mode: selection_append
+      field_widget_edit: 0
       field_widget_replace: 0
       open: 0
-      field_widget_display_settings: {  }
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
+      change_labels:
+        add_another: ''
   field_rich_wysiwyg:
     type: text_textarea
     weight: 1
@@ -63,6 +67,11 @@ content:
       js_prevent_submit: true
       count_html_characters: false
       textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -239,6 +239,7 @@ module:
   va_gov_clp: 0
   va_gov_dashboards: 0
   va_gov_db: 0
+  va_gov_entity_browser: 0
   va_gov_events: 0
   va_gov_facilities: 0
   va_gov_flags: 0

--- a/docroot/modules/custom/va_gov_entity_browser/src/Plugin/EntityBrowser/FieldWidgetDisplay/LinkedTitle.php
+++ b/docroot/modules/custom/va_gov_entity_browser/src/Plugin/EntityBrowser/FieldWidgetDisplay/LinkedTitle.php
@@ -26,7 +26,8 @@ class LinkedTitle extends EntityLabel {
     $config = $this->getConfiguration();
     $translation = $this->entityRepository->getTranslationFromContext($entity);
 
-    // Display a linked title if user has access to view the label and entity.
+    // Display a linked title only if user has access to view the label and
+    // entity.
     if ($translation->access('view label') && $translation->access('view') && $entity->hasLinkTemplate('canonical')) {
       $return = [
         '#title' => $entity->label(),

--- a/docroot/modules/custom/va_gov_entity_browser/src/Plugin/EntityBrowser/FieldWidgetDisplay/LinkedTitle.php
+++ b/docroot/modules/custom/va_gov_entity_browser/src/Plugin/EntityBrowser/FieldWidgetDisplay/LinkedTitle.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\va_gov_entity_browser\Plugin\EntityBrowser\FieldWidgetDisplay;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\entity_browser\Plugin\EntityBrowser\FieldWidgetDisplay\EntityLabel;
+
+/**
+ * Displays a link to the entity.
+ *
+ * @EntityBrowserFieldWidgetDisplay(
+ *   id = "linked_title",
+ *   label = @Translation("Linked title"),
+ *   description = @Translation("Displays entity with a link.")
+ * )
+ */
+class LinkedTitle extends EntityLabel {
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function view(EntityInterface $entity) {
+    $config = $this->getConfiguration();
+    $translation = $this->entityRepository->getTranslationFromContext($entity);
+
+    // Display a linked title if user has access to view the label and entity.
+    if ($translation->access('view label') && $translation->access('view') && $entity->hasLinkTemplate('canonical')) {
+      $return = [
+        '#title' => $entity->label(),
+        '#type' => 'link',
+        '#url' => $entity->toUrl(),
+      ];
+      if (!empty($config['target_blank'])) {
+        $return['#attributes'] = [
+          'target' => '_blank',
+          'rel' => 'noopener noreferrer',
+        ];
+      }
+      return $return;
+    }
+
+    return parent::view($entity);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $config = $this->getConfiguration();
+    $form['target_blank'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Open in new tab'),
+      '#default_value' => $config['target_blank'] ?: 0,
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'target_blank' => 1,
+    ] + parent::defaultConfiguration();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_entity_browser/va_gov_entity_browser.info.yml
+++ b/docroot/modules/custom/va_gov_entity_browser/va_gov_entity_browser.info.yml
@@ -1,0 +1,7 @@
+name: VA.gov Entity Browser
+type: module
+description: Provides customizations and enhancements to entity browser.
+package: Custom
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:entity_browser


### PR DESCRIPTION
## Description

Relates to #13220.

## Testing done
Manual

## Screenshots
![Screenshot 2023-04-18 at 9 14 54 AM](https://user-images.githubusercontent.com/221539/232839877-0707d381-56a7-46b3-92db-3cc2984134f1.png)

## QA steps

As a content admin
1. View this node /resources/ds-logon-faqs and click Edit to edit it.
   - [ ] Validate the 'Edit' button is NOT present for all Q&A's
   - [ ] Validate the title of the Q&A's are linked
   - [ ] Validate that each Q&A's, when clicked, open in a new tab

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
