### PR TITLE
VACMS-13534: Installs `memcached` extension on Tugboat.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -124,9 +124,10 @@ services:
         - echo "apc.enable=1" >> /usr/local/etc/php/conf.d/php-cli.ini
         - echo "apc.enable_cli=1" >> /usr/local/etc/php/conf.d/php-cli.ini
 
-        # Install memcache extension
-        - pecl install memcache-8.0
-        - docker-php-ext-enable memcache
+        # Install memcached extension
+        - apt-get install libmemcached-dev
+        - yes '' | pecl install -f memcached
+        - docker-php-ext-enable memcached
 
         # Install node and npm.
         - ./scripts/install-nvm.sh

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -243,7 +243,7 @@ if (!empty($webhost_on_cli)) {
 $settings['container_yamls'][] = __DIR__ . '/services/services.monolog.yml';
 
 // Memcache-specific settings
-if (extension_loaded('memcache') && !empty($settings['memcache']['servers'])) {
+if (extension_loaded('memcached') && !empty($settings['memcache']['servers'])) {
   $settings['cache']['default'] = 'cache.backend.memcache';
   $settings['memcache']['bins'] = [
     'default' => 'default',

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -243,7 +243,7 @@ if (!empty($webhost_on_cli)) {
 $settings['container_yamls'][] = __DIR__ . '/services/services.monolog.yml';
 
 // Memcache-specific settings
-if (extension_loaded('memcached') && !empty($settings['memcache']['servers'])) {
+if ((extension_loaded('memcache') || extension_loaded('memcached')) && !empty($settings['memcache']['servers'])) {
   $settings['cache']['default'] = 'cache.backend.memcache';
   $settings['memcache']['bins'] = [
     'default' => 'default',

--- a/docroot/sites/default/settings/settings.local.php
+++ b/docroot/sites/default/settings/settings.local.php
@@ -41,7 +41,7 @@ $settings['va_gov_app_root'] = getenv('DDEV_APPROOT');
 $settings['va_gov_web_root'] = getenv('DDEV_APPROOT') . '/web';
 
 $settings['memcache']['servers'] = [
-  'memcache:11211' => 'default',
+  'memcached:11211' => 'default',
 ];
 
 $settings['cms_datadog_api_key'] = getenv('CMS_DATADOG_API_KEY');


### PR DESCRIPTION
## Description

Closes #13534.

Base preview build log [here](https://tugboat.vfs.va.gov/log/644ab4b19a752fdd164b74be).

The following code exists just to annoy the TIC and prevent a PR preview environment from building:

```php
file_get_contents()
```

![Screenshot 2023-04-27 at 2 43 46 PM](https://user-images.githubusercontent.com/1318579/234961410-edbc9416-8ea4-4deb-921e-41622f4320c9.png)

*sigh*

## QA Steps

- [x] Tests pass
- [x] Memcache statistics [page](https://pr13537-fv2uyxsnbhihvejq7pq2b99pru94hoji.ci.cms.va.gov/admin/reports/memcache) shows that `memcached` extension is in use
![Screenshot 2023-04-27 at 2 50 32 PM](https://user-images.githubusercontent.com/1318579/234963238-077dd5a3-2ea6-4fc2-9c76-39d44cddb1de.png)
