### PR TITLE
VACMS-13638: Increase Cypress smoke test timeout.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "stylelint-themes": "npx stylelint 'docroot/themes/custom/**/*.scss'",
     "stylelint": "npx stylelint",
     "test:cypress": "cypress run -e \"TAGS=$CYPRESS_TAGS\"",
+    "test:cypress:verify": "cypress verify",
     "test:cypress:interactive": "cypress open -e \"TAGS=not @ignore and not @piv,VAGOV_INTERACTIVE=true\""
   },
   "repository": {

--- a/tests/scripts/cypress-tests.sh
+++ b/tests/scripts/cypress-tests.sh
@@ -11,6 +11,9 @@ pushd "${repo_root}" > /dev/null
 
 ./node_modules/.bin/cypress install
 
+export CYPRESS_VERIFY_TIMEOUT=100000
+npm run test:cypress:verify
+
 npm run test:cypress -- "${@}"
 
 popd > /dev/null


### PR DESCRIPTION
## Description

Closes #13638.

Tested on CMS-Test; top test runs are those after this change, bottom test runs are those prior to the change.

![Screenshot 2023-05-10 at 11 35 48 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/1318579/ba1f9e74-45fb-4f73-8878-2736ff7926c8)
