### PR TITLE
VACMS-13769 Fix non page facilities urls pushed to lighthouse

### DIFF
--- a/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
+++ b/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
@@ -56,6 +56,19 @@ class FacilityOps {
    *   TRUE if it is a facility with status info. FALSE otherwise.
    */
   public static function isFacilityWithStatus(NodeInterface $node) : bool {
+    return self::isBundleFacilityWithStatus($node->bundle());
+  }
+
+  /**
+   * Checks if the entity is a facility node with status info.
+   *
+   * @param string $type
+   *   The bundle id to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility bundle with status info. FALSE otherwise.
+   */
+  public static function isBundleFacilityWithStatus(string $type) : bool {
     $facilities_with_status = [
       'health_care_local_facility',
       'nca_facility',
@@ -63,11 +76,12 @@ class FacilityOps {
       'vet_center_outstation',
       'vet_center',
     ];
-    return in_array($node->bundle(), $facilities_with_status);
+
+    return in_array($type, $facilities_with_status);
   }
 
   /**
-   * Checks if the entity is a facility is a product that has launched.
+   * Check if the entity is a facility is a product that has launched.
    *
    * @param \Drupal\node\NodeInterface $node
    *   The node to evaluate.

--- a/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
+++ b/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
@@ -10,6 +10,24 @@ use Drupal\node\NodeInterface;
 class FacilityOps {
 
   /**
+   * Get facility types.
+   *
+   * @return array
+   *   Array of facility types.
+   */
+  public static function getFacilityTypes() : array {
+    return [
+      'health_care_local_facility',
+      'nca_facility',
+      'vba_facility',
+      'vet_center_cap',
+      'vet_center_mobile_vet_center',
+      'vet_center_outstation',
+      'vet_center',
+    ];
+  }
+
+  /**
    * Checks if the node is a facility.
    *
    * @param \Drupal\node\NodeInterface $node
@@ -19,16 +37,19 @@ class FacilityOps {
    *   TRUE if it is a facility. FALSE otherwise.
    */
   public static function isFacility(NodeInterface $node) : bool {
-    $facilities = [
-      'health_care_local_facility',
-      'nca_facility',
-      'vba_facility',
-      'vet_center_cap',
+    return in_array($node->bundle(), self::getFacilityTypes());
+  }
+
+  /**
+   * Get facility types without status info.
+   *
+   * @return array
+   *   Facility types that have no status.
+   */
+  public static function getFacilityTypesWithoutStatus() : array {
+    return [
       'vet_center_mobile_vet_center',
-      'vet_center_outstation',
-      'vet_center',
     ];
-    return in_array($node->bundle(), $facilities);
   }
 
   /**
@@ -41,10 +62,7 @@ class FacilityOps {
    *   TRUE if it is a facility with status info. FALSE otherwise.
    */
   public static function isFacilityWithoutStatus(NodeInterface $node) : bool {
-    $facilities_without_status = [
-      'vet_center_mobile_vet_center',
-    ];
-    return in_array($node->bundle(), $facilities_without_status);
+    return in_array($node->bundle(), self::getFacilityTypesWithoutStatus());
   }
 
   /**
@@ -61,6 +79,23 @@ class FacilityOps {
   }
 
   /**
+   * Get facilty types that have status info.
+   *
+   * @return array
+   *   An array of facility types that have status.
+   */
+  public static function getFacilityTypesWithStatus() : array {
+    return [
+      'health_care_local_facility',
+      'nca_facility',
+      'vba_facility',
+      'vet_center_cap',
+      'vet_center_outstation',
+      'vet_center',
+    ];
+  }
+
+  /**
    * Checks if a bundle type has status info.
    *
    * @param string $type
@@ -70,16 +105,7 @@ class FacilityOps {
    *   TRUE if it is a facility bundle with status info. FALSE otherwise.
    */
   public static function isBundleFacilityWithStatus(string $type) : bool {
-    $facilities_with_status = [
-      'health_care_local_facility',
-      'nca_facility',
-      'vba_facility',
-      'vet_center_cap',
-      'vet_center_outstation',
-      'vet_center',
-    ];
-
-    return in_array($type, $facilities_with_status);
+    return in_array($type, self::getFacilityTypesWithStatus());
   }
 
   /**

--- a/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
+++ b/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\va_gov_facilities;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Wrapper class of largely static helper functions related to Facilities.
+ */
+class FacilityOps {
+
+  /**
+   * Checks if the entity is a facility.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility with status info. FALSE otherwise.
+   */
+  public static function isFacility(NodeInterface $node) : bool {
+    $facilities_with_status = [
+      'health_care_local_facility',
+      'nca_facility',
+      'vba_facility',
+      'vet_center_mobile_vet_center',
+      'vet_center_outstation',
+      'vet_center',
+    ];
+    return in_array($node->bundle(), $facilities_with_status);
+  }
+
+  /**
+   * Checks if the entity is a facility node with status info.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility with status info. FALSE otherwise.
+   */
+  public static function isFacilityWithoutStatus(NodeInterface $node) : bool {
+    $facilities_without_status = [
+      'vet_center_mobile_vet_center',
+    ];
+    return in_array($node->bundle(), $facilities_without_status);
+  }
+
+  /**
+   * Checks if the entity is a facility node with status info.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility with status info. FALSE otherwise.
+   */
+  public static function isFacilityWithStatus(NodeInterface $node) : bool {
+    $facilities_with_status = [
+      'health_care_local_facility',
+      'nca_facility',
+      'vba_facility',
+      'vet_center_outstation',
+      'vet_center',
+    ];
+    return in_array($node->bundle(), $facilities_with_status);
+  }
+
+  /**
+   * Checks if the entity is a facility is a product that has launched.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility is launched. FALSE otherwise.
+   */
+  public static function isFacilityLaunched(NodeInterface $node) : bool {
+    $facilities_not_launched = [
+      'nca_facility',
+      'vba_facility',
+    ];
+    return !in_array($node->bundle(), $facilities_not_launched);
+  }
+
+  /**
+   * Checks if the entity is a facility that has a FE page.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility ha a FE page. FALSE otherwise.
+   */
+  public static function facilityHasFePage(NodeInterface $node) : bool {
+    $facilities_with_no_fe_page = [
+      'vet_center_mobile_vet_center',
+      'vet_center_outstation',
+    ];
+    return !in_array($node->bundle(), $facilities_with_no_fe_page);
+  }
+
+  /**
+   * Get the parent-like field name.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to evaluate.
+   *
+   * @return string|null
+   *   The machine name of the field that connects to parent, NULL otherwise.
+   */
+  public static function getFacilityParentFieldName(NodeInterface $node) : string | null {
+    $parent = $node->hasField('field_office') ? 'field_office' : NULL;
+    $system = $node->hasField('field_region_page') ? 'field_region_page' : NULL;
+    return $system ?? $parent ?? NULL;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
+++ b/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
@@ -60,7 +60,7 @@ class FacilityOps {
   }
 
   /**
-   * Checks if the entity is a facility node with status info.
+   * Checks if a bundle type has status info.
    *
    * @param string $type
    *   The bundle id to evaluate.
@@ -81,13 +81,13 @@ class FacilityOps {
   }
 
   /**
-   * Check if the entity is a facility is a product that has launched.
+   * Check if the entity is a facility of a product that has launched.
    *
    * @param \Drupal\node\NodeInterface $node
    *   The node to evaluate.
    *
    * @return bool
-   *   TRUE if it is a facility is launched. FALSE otherwise.
+   *   TRUE if it is a facility of a product that has launched. FALSE otherwise.
    */
   public static function isFacilityLaunched(NodeInterface $node) : bool {
     $facilities_not_launched = [
@@ -104,7 +104,7 @@ class FacilityOps {
    *   The node to evaluate.
    *
    * @return bool
-   *   TRUE if it is a facility ha a FE page. FALSE otherwise.
+   *   TRUE if it is a facility that has a FE page. FALSE otherwise.
    */
   public static function facilityHasFePage(NodeInterface $node) : bool {
     $facilities_with_no_fe_page = [

--- a/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
+++ b/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
@@ -10,24 +10,25 @@ use Drupal\node\NodeInterface;
 class FacilityOps {
 
   /**
-   * Checks if the entity is a facility.
+   * Checks if the node is a facility.
    *
    * @param \Drupal\node\NodeInterface $node
    *   The node to evaluate.
    *
    * @return bool
-   *   TRUE if it is a facility with status info. FALSE otherwise.
+   *   TRUE if it is a facility. FALSE otherwise.
    */
   public static function isFacility(NodeInterface $node) : bool {
-    $facilities_with_status = [
+    $facilities = [
       'health_care_local_facility',
       'nca_facility',
       'vba_facility',
+      'vet_center_cap',
       'vet_center_mobile_vet_center',
       'vet_center_outstation',
       'vet_center',
     ];
-    return in_array($node->bundle(), $facilities_with_status);
+    return in_array($node->bundle(), $facilities);
   }
 
   /**
@@ -73,11 +74,29 @@ class FacilityOps {
       'health_care_local_facility',
       'nca_facility',
       'vba_facility',
+      'vet_center_cap',
       'vet_center_outstation',
       'vet_center',
     ];
 
     return in_array($type, $facilities_with_status);
+  }
+
+  /**
+   * Checks if the entity is a facility node with supplemental status.
+   *
+   * @param string $type
+   *   The bundle id to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility bundle with status info. FALSE otherwise.
+   */
+  public static function isBundleFacilityWithSupplementalStatus(string $type) : bool {
+    $facilities_with_supplemental_status = [
+      'health_care_local_facility',
+    ];
+
+    return in_array($type, $facilities_with_supplemental_status);
   }
 
   /**
@@ -108,6 +127,7 @@ class FacilityOps {
    */
   public static function facilityHasFePage(NodeInterface $node) : bool {
     $facilities_with_no_fe_page = [
+      'vet_center_cap',
       'vet_center_mobile_vet_center',
       'vet_center_outstation',
     ];

--- a/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
+++ b/docroot/modules/custom/va_gov_lovell/src/LovellOps.php
@@ -168,4 +168,20 @@ class LovellOps {
     return $is;
   }
 
+  /**
+   * Checks if the entity is within the Lovell Tricare section.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity to check.
+   *
+   * @return bool
+   *   TRUE if entity is within Lovell Tricare section. FALSE otherwise.
+   */
+  public static function isLovellTricareSection(NodeInterface $node) : bool {
+    if ($node->hasField('field_administration') && ($node->get('field_administration')->target_id == self::TRICARE_ID)) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
@@ -447,7 +447,7 @@ abstract class PostFacilityBase {
     foreach ($field_names as $field_name) {
       if ($current_revision->hasField($field_name)) {
         if (in_array($current_revision->get($field_name)->getFieldDefinition()->getType(), $field_reference_types)) {
-          // Tt is a reference we need to get the target.
+          // It is a reference; we need to get the target.
           $current_revision_values[$field_name] = ($current_revision->hasField($field_name)) ? $current_revision->get($field_name)->target_id : NULL;
           $default_revision_values[$field_name] = ($default_revision->hasField($field_name)) ? $default_revision->get($field_name)->target_id : NULL;
         }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
@@ -80,6 +80,16 @@ abstract class PostFacilityBase {
   }
 
   /**
+   * Checks to see if the data checks should be bypassed.
+   *
+   * @return bool
+   *   TRUE if bypass, FALSE if no bypass.
+   */
+  protected function shouldBypass() : bool {
+    return !empty($this->configFactory->get('va_gov_post_api.settings')->get('bypass_data_check'));
+  }
+
+  /**
    * Checks to see if the post queueing should dedupe.
    *
    * @return bool

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
@@ -3,6 +3,7 @@
 namespace Drupal\va_gov_post_api\Service;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\va_gov_lovell\LovellOps;
 
 /**
  * Class PostFacilityService posts specific service info to Lighthouse.
@@ -89,7 +90,7 @@ class PostFacilityService extends PostFacilityBase {
           $this->postQueue->addToQueue($data, $this->shouldDedupe());
           // @todo When this is expanded to more than just COVID we may want
           // to remove the messenger as it will be too noisy.
-          $message = t('The facility service data for %service_name is being sent to the Facility Locator.', ['%service_name' => $this->facilityService->getTitle()]);
+          $message = $this->t('The facility service data for %service_name is being sent to the Facility Locator.', ['%service_name' => $this->facilityService->getTitle()]);
           $this->messenger->addStatus($message);
           return 1;
         }
@@ -346,7 +347,7 @@ class PostFacilityService extends PostFacilityBase {
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
-      case $this->isLovellTricareSection($entity):
+      case LovellOps::isLovellTricareSection($entity):
         // Node is part of the Lovell-Tricare section, do not push.
         $push = FALSE;
         break;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -308,14 +308,17 @@ class PostFacilityStatus extends PostFacilityBase {
     $isNew = $this->facilityNode->isNew();
     $defaultRevisionIsPublished = $defaultRevision->isPublished();
 
-    $fields_to_detect = [
-      'title',
-      FacilityOps::getFacilityParentFieldName($this->facilityNode),
-      'field_operating_status_facility',
-      'field_operating_status_more_info',
-      'field_supplemental_status',
-    ];
-    $somethingChanged = $this->fieldsHaveChanges($this->facilityNode, $defaultRevision, $fields_to_detect);
+    // $fields_to_detect = [
+    // title',
+    // FacilityOps::getFacilityParentFieldName($this->facilityNode),
+    // 'field_operating_status_facility',
+    // 'field_operating_status_more_info',
+    // 'field_supplemental_status',
+    // ];
+    // Shortcircuiting this for now.  To revisit with a different testing model.
+    // $somethingChanged = $this->fieldsHaveChanges($this->facilityNode,
+    // $defaultRevision, $fields_to_detect); .
+    $somethingChanged = TRUE;
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -53,8 +53,10 @@ class PostFacilityStatus extends PostFacilityBase {
    */
   public function queueFacilityStatus(EntityInterface $entity, bool $forcePush = FALSE) {
     $queued_count = 0;
+    // Vet Center CAPs are excluded from this push and will have their own.
+    $is_vet_center_cap = $entity->bundle() === 'vet_center_cap';
 
-    if ($entity instanceof NodeInterface && FacilityOps::isFacilityWithStatus($entity)) {
+    if ($entity instanceof NodeInterface && FacilityOps::isFacilityWithStatus($entity) && !$is_vet_center_cap) {
       /** @var \Drupal\node\NodeInterface $entity*/
       $this->facilityNode = $entity;
       $facility_id = $entity->hasField('field_facility_locator_api_id') ? $entity->get('field_facility_locator_api_id')->value : NULL;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -305,19 +305,15 @@ class PostFacilityStatus extends PostFacilityBase {
     $defaultRevision = $this->getDefaultRevision($this->facilityNode);
     $isNew = $this->facilityNode->isNew();
     $defaultRevisionIsPublished = $defaultRevision->isPublished();
-    $statusChanged = $this->changedValue($this->facilityNode, $defaultRevision, 'field_operating_status_facility');
-    $statusInfoChanged = $this->changedValue($this->facilityNode, $defaultRevision, 'field_operating_status_more_info');
-    $supStatusChanged = $this->changedTarget($this->facilityNode, $defaultRevision, 'field_supplemental_status');
-    // Since we are also sending a url, we need to detect change to the url.
-    $titleChanged = $this->changedValue($this->facilityNode, $defaultRevision, 'title');
-    if ($field_name = FacilityOps::getFacilityParentFieldName($this->facilityNode)) {
-      $parentChanged = $this->changedTarget($this->facilityNode, $defaultRevision, $field_name);
-    }
-    else {
-      $parentChanged = FALSE;
-    }
 
-    $somethingChanged = $statusChanged || $statusInfoChanged || $supStatusChanged || $titleChanged || $parentChanged;
+    $fields_to_detect = [
+      'title',
+      FacilityOps::getFacilityParentFieldName($this->facilityNode),
+      'field_operating_status_facility',
+      'field_operating_status_more_info',
+      'field_supplemental_status',
+    ];
+    $somethingChanged = $this->fieldsHaveChanges($this->facilityNode, $defaultRevision, $fields_to_detect);
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
@@ -377,9 +373,12 @@ class PostFacilityStatus extends PostFacilityBase {
     $moderationState = $entity->get('moderation_state')->value;
     $thisRevisionIsPublished = $entity->isPublished();
     $defaultRevision = $this->getDefaultRevision($entity);
-    $nameChanged = $this->changedValue($entity, $defaultRevision, 'title');
-    $phoneChanged = $this->changedValue($entity, $defaultRevision, 'field_va_health_connect_phone');
-    $somethingChanged = $nameChanged || $phoneChanged;
+
+    $fields_to_detect = [
+      'title',
+      'field_va_health_connect_phone',
+    ];
+    $somethingChanged = $this->fieldsHaveChanges($this->facilityNode, $defaultRevision, $fields_to_detect);
     $push = FALSE;
     if ($thisRevisionIsPublished && $somethingChanged && $moderationState === self::STATE_PUBLISHED) {
       $push = TRUE;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
@@ -195,11 +195,11 @@ class PostFacilityWithoutStatus extends PostFacilityBase {
     $defaultRevisionIsPublished = $defaultRevision->isPublished();
     // We only care if the url changes, so title and parent are the only
     // things that affect the url other than published state.
-    $fields_to_detect = [
-      'title',
-      'field_office',
-    ];
-    $somethingChanged = $this->fieldsHaveChanges($this->facilityNode, $defaultRevision, $fields_to_detect);
+    // $fields_to_detect = [ 'title', 'field_office']; .
+    // Shortcircuiting this for now.  To revisit with a different testing model.
+    // $somethingChanged = $this->fieldsHaveChanges($this->facilityNode,
+    // $defaultRevision, $fields_to_detect); .
+    $somethingChanged = TRUE;
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
@@ -9,7 +9,7 @@ use Drupal\va_gov_facilities\FacilityOps;
 /**
  * Class PostFacilityService posts facility status info to Lighthouse.
  */
-class PostFacilityWithoutStatus extends PostFacilityBase {
+class PostFacilityWithoutStatus extends PostFacilityBase implements PostServiceInterface {
 
   /**
    * A array of any errors in prepping the data.
@@ -122,7 +122,7 @@ class PostFacilityWithoutStatus extends PostFacilityBase {
     $this->statusToPush = 'NORMAL';
     $this->additionalInfoToPush = NULL;
 
-    if ($this->shouldPush($forcePush)) {
+    if (self::shouldPush($this->facilityNode, $forcePush)) {
       $payload = [
         'core' => [
           'facility_url' => $this->getFacilityUrl(),
@@ -177,42 +177,67 @@ class PostFacilityWithoutStatus extends PostFacilityBase {
   }
 
   /**
+   * Determines if the entity is such that it is covered by this service.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity (usually a node, but not required).
+   *
+   * @return bool
+   *   TRUE if a pushable entity, FALSE otherwise.
+   */
+  public static function isPushAble(EntityInterface $entity): bool {
+    if ($entity instanceof NodeInterface && FacilityOps::isFacilityWithoutStatus($entity)) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Determines if the data says a payload should be assembled and pushed.
    *
+   * Potentially alters the pushed data based on what it evaluates.  This is
+   * beyond its concern but can not be separated cleanly.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity - A node in this case.
    * @param bool $forcePush
    *   Force processing of facility status if true.
    *
    * @return bool
    *   TRUE if should be pushed, FALSE otherwise.
    */
-  protected function shouldPush(bool $forcePush = FALSE) {
+  public static function shouldPush(EntityInterface $entity, bool $forcePush = FALSE) {
+    if (!self::isPushable($entity)) {
+      // This is not covered by this service.
+      return FALSE;
+    }
+    else {
+      // If it made it this far it is a node.
+      /**@var \Drupal\node\NodeInterface $nodeFacility */
+      $nodeFacility = $entity;
+    }
     // Moderation state of what is being saved.
-    $moderationState = $this->facilityNode->get('moderation_state')->value;
+    $moderationState = $nodeFacility->get('moderation_state')->value;
     $isArchived = ($moderationState === self::STATE_ARCHIVED) ? TRUE : FALSE;
-    $thisRevisionIsPublished = $this->facilityNode->isPublished();
-    $defaultRevision = $this->getDefaultRevision($this->facilityNode);
-    $isNew = $this->facilityNode->isNew();
+    $thisRevisionIsPublished = $nodeFacility->isPublished();
+    $defaultRevision = self::getDefaultRevision($nodeFacility);
+    $isNew = $nodeFacility->isNew();
     $defaultRevisionIsPublished = $defaultRevision->isPublished();
-    // We only care if the url changes, so title and parent are the only
-    // things that affect the url other than published state.
-    // $fields_to_detect = [ 'title', 'field_office']; .
-    // Shortcircuiting this for now.  To revisit with a different testing model.
-    // $somethingChanged = $this->fieldsHaveChanges($this->facilityNode,
-    // $defaultRevision, $fields_to_detect); .
-    $somethingChanged = TRUE;
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {
-
+      case $isArchived && $isNew:
+        // Essentially an impossible combination. New and archived
+        // But if it did occur, no harm in pushing.
       case $forcePush && $thisRevisionIsPublished:
         // Forced push from updates to referenced entity.
       case $isNew:
         // A new node, should be pushed to initiate the value.
-      case $thisRevisionIsPublished && $somethingChanged && $moderationState === self::STATE_PUBLISHED:
-        // This revision is published and had a change, should be pushed.
+      case $thisRevisionIsPublished && $moderationState === self::STATE_PUBLISHED:
+        // This revision is published and should be pushed.
       case $isArchived:
         // This node has been archived, got to push to remove it.
-      case (!$defaultRevisionIsPublished && !$thisRevisionIsPublished && $somethingChanged):
+      case (!$defaultRevisionIsPublished && !$thisRevisionIsPublished):
         // Draft on an unpublished node, should be pushed.
       case ($thisRevisionIsPublished && !$defaultRevisionIsPublished):
         // To be the source of truth for urls, we need to push url on newly
@@ -223,13 +248,6 @@ class PostFacilityWithoutStatus extends PostFacilityBase {
       case ($defaultRevisionIsPublished && !$thisRevisionIsPublished && $moderationState === self::STATE_DRAFT):
         // Draft revision on published node, should not push, even w/bypass.
         $push = FALSE;
-        break;
-
-      case ($this->shouldBypass()):
-        // Bypass is activated.
-        // If it is on bypass this is a bulk push, which will be the default rev
-        // so there is no risk of a draft status overriding published status.
-        $push = TRUE;
         break;
 
       default:

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
@@ -193,11 +193,13 @@ class PostFacilityWithoutStatus extends PostFacilityBase {
     $defaultRevision = $this->getDefaultRevision($this->facilityNode);
     $isNew = $this->facilityNode->isNew();
     $defaultRevisionIsPublished = $defaultRevision->isPublished();
-    $titleChanged = $this->changedValue($this->facilityNode, $defaultRevision, 'title');
-    $parentChanged = $this->changedTarget($this->facilityNode, $defaultRevision, 'field_office');
     // We only care if the url changes, so title and parent are the only
     // things that affect the url other than published state.
-    $somethingChanged = $titleChanged || $parentChanged;
+    $fields_to_detect = [
+      'title',
+      'field_office',
+    ];
+    $somethingChanged = $this->fieldsHaveChanges($this->facilityNode, $defaultRevision, $fields_to_detect);
 
     // Case race. First to evaluate to TRUE wins.
     switch (TRUE) {

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityWithoutStatus.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Drupal\va_gov_post_api\Service;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
+use Drupal\va_gov_facilities\FacilityOps;
+
+/**
+ * Class PostFacilityService posts facility status info to Lighthouse.
+ */
+class PostFacilityWithoutStatus extends PostFacilityBase {
+
+  /**
+   * A array of any errors in prepping the data.
+   *
+   * @var array
+   */
+  protected $errors = [];
+
+  /**
+   * The facility node.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $facilityNode;
+
+  /**
+   * Temp storage of the status that should be pushed.
+   *
+   * @var string
+   */
+  protected $statusToPush;
+
+  /**
+   * Temp storage of the status additional info that should be pushed.
+   *
+   * @var string
+   */
+  protected $additionalInfoToPush;
+
+  /**
+   * Adds facility service data to Post API queue.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   * @param bool $forcePush
+   *   Force processing of facility status if true.
+   *
+   * @return int
+   *   The count of the number of items queued (1,0).
+   */
+  public function queueFacility(EntityInterface $entity, bool $forcePush = FALSE) {
+    $queued_count = 0;
+
+    if ($entity instanceof NodeInterface && FacilityOps::isFacilityWithoutStatus($entity)) {
+      /** @var \Drupal\node\NodeInterface $entity*/
+      $this->facilityNode = $entity;
+      $facility_id = $entity->hasField('field_facility_locator_api_id') ? $entity->get('field_facility_locator_api_id')->value : NULL;
+      $data['nid'] = $entity->id();
+      // Queue item's Unique ID.
+      $data['uid'] = $facility_id ? "facility_status_{$facility_id}" : NULL;
+
+      // Set a key based on which the endpoint will be
+      // defined during queue execution.
+      $data['endpoint_path'] = ($facility_id) ? "/services/va_facilities/v0/facilities/{$facility_id}/cms-overlay" : NULL;
+
+      // Set payload. Default payload provided by this module is empty.
+      // See README.md
+      // Entity fields (updated and original) can be compared and processed in
+      // order to structure the payload array.
+      $data['payload'] = $this->getPayload($forcePush);
+
+      // Only add to queue if payload is not empty.
+      // If its empty, it means that there is no new information to send to
+      // endpoint.
+      if (!empty($data['payload']) && $facility_id) {
+        $this->postQueue->addToQueue($data, $this->shouldDedupe());
+        $queued_count = 1;
+        $message = $this->t('The facility info for %content_type: %facility_name is being sent to the Facility Locator.', $this->getMessageVars());
+        $this->messenger->addStatus($message);
+      }
+      elseif (empty($facility_id)) {
+        // Log error on empty Facility Locator API ID.
+        $message = $this->t('Post API: attempted to add an item with NID %nid to queue, but it had no Facility API ID.', $this->getMessageVars());
+        $this->loggerChannelFactory->get('va_gov_post_api')->error($message);
+      }
+    }
+    $this->nuke();
+    return $queued_count;
+  }
+
+  /**
+   * Get the message variables and values.
+   *
+   * @return array
+   *   An array of message values keyed by repacement token.
+   */
+  protected function getMessageVars(): array {
+    return [
+      '%content_type' => $this->facilityNode->get('type')->entity->label(),
+      '%facility_name' => $this->facilityNode->getTitle(),
+      '%nid' => $this->facilityNode->id(),
+    ];
+  }
+
+  /**
+   * Compose and return payload array for facility status.
+   *
+   * @param bool $forcePush
+   *   Force processing of facility status if true.
+   *
+   * @return array
+   *   Payload array.
+   */
+  protected function getPayload(bool $forcePush = FALSE): array {
+    // Default payload is an empty array.
+    $payload = [];
+
+    // Facilities without status, have no status, but Lighthouse requires.
+    // So we need to hard set the values to normal status.
+    $this->statusToPush = 'NORMAL';
+    $this->additionalInfoToPush = NULL;
+
+    if ($this->shouldPush($forcePush)) {
+      $payload = [
+        'core' => [
+          'facility_url' => $this->getFacilityUrl(),
+        ],
+        'operating_status' => [
+          'code' => strtoupper($this->statusToPush),
+          'additional_info' => $this->additionalInfoToPush,
+        ],
+      ];
+
+    }
+
+    return $payload;
+  }
+
+  /**
+   * Builds the appropriate url for a facility.
+   *
+   * @return string|null
+   *   A facility locator detail page if the node is not published.
+   *   A html page URL if the node is published.
+   *   Null if something completely went wrong.
+   */
+  protected function getFacilityUrl(): string | null {
+    $facility_url = NULL;
+
+    if ($this->facilityNode->isPublished()) {
+      if (!FacilityOps::facilityHasFePage($this->facilityNode)) {
+        // This facility is published, but has no page of its own.
+        $facility_url = $this->getParentLocationsPageUrl($this->facilityNode);
+      }
+      else {
+        // The node is published, so use the FE URL of the page.
+        $facility_url = "https://www.va.gov{$this->facilityNode->toUrl()->toString()}/";
+      }
+
+    }
+    else {
+      // The page is not published.
+      $facility_id = $this->facilityNode->hasField('field_facility_locator_api_id') ? $this->facilityNode->get('field_facility_locator_api_id')->value : NULL;
+      if (FacilityOps::isFacilityLaunched()) {
+        // This hasn't launched, and is not published, so we don't know the url.
+        // Lighthouse will have to use their url csv to figure it out.
+        $facility_url = NULL;
+      }
+      elseif ($facility_id) {
+        // Has launched but the page does not exist yet so send locator detail.
+        $facility_url = "https://www.va.gov/find-locations/facility/{$facility_id}";
+      }
+    }
+    return $facility_url;
+  }
+
+  /**
+   * Determines if the data says a payload should be assembled and pushed.
+   *
+   * @param bool $forcePush
+   *   Force processing of facility status if true.
+   *
+   * @return bool
+   *   TRUE if should be pushed, FALSE otherwise.
+   */
+  protected function shouldPush(bool $forcePush = FALSE) {
+    // Moderation state of what is being saved.
+    $moderationState = $this->facilityNode->get('moderation_state')->value;
+    $isArchived = ($moderationState === self::STATE_ARCHIVED) ? TRUE : FALSE;
+    $thisRevisionIsPublished = $this->facilityNode->isPublished();
+    $defaultRevision = $this->getDefaultRevision($this->facilityNode);
+    $isNew = $this->facilityNode->isNew();
+    $defaultRevisionIsPublished = $defaultRevision->isPublished();
+    $titleChanged = $this->changedValue($this->facilityNode, $defaultRevision, 'title');
+    $parentChanged = $this->changedTarget($this->facilityNode, $defaultRevision, 'field_office');
+    // We only care if the url changes, so title and parent are the only
+    // things that affect the url other than published state.
+    $somethingChanged = $titleChanged || $parentChanged;
+
+    // Case race. First to evaluate to TRUE wins.
+    switch (TRUE) {
+
+      case $forcePush && $thisRevisionIsPublished:
+        // Forced push from updates to referenced entity.
+      case $isNew:
+        // A new node, should be pushed to initiate the value.
+      case $thisRevisionIsPublished && $somethingChanged && $moderationState === self::STATE_PUBLISHED:
+        // This revision is published and had a change, should be pushed.
+      case $isArchived:
+        // This node has been archived, got to push to remove it.
+      case (!$defaultRevisionIsPublished && !$thisRevisionIsPublished && $somethingChanged):
+        // Draft on an unpublished node, should be pushed.
+      case ($thisRevisionIsPublished && !$defaultRevisionIsPublished):
+        // To be the source of truth for urls, we need to push url on newly
+        // published, because we use different urls.
+        $push = TRUE;
+        break;
+
+      case ($defaultRevisionIsPublished && !$thisRevisionIsPublished && $moderationState === self::STATE_DRAFT):
+        // Draft revision on published node, should not push, even w/bypass.
+        $push = FALSE;
+        break;
+
+      case ($this->shouldBypass()):
+        // Bypass is activated.
+        // If it is on bypass this is a bulk push, which will be the default rev
+        // so there is no risk of a draft status overriding published status.
+        $push = TRUE;
+        break;
+
+      default:
+        // Anything that makes it this far should not be pushed.
+        $push = FALSE;
+        break;
+    }
+
+    return $push;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostServiceInterface.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostServiceInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\va_gov_post_api\Service;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Defines a common interface va gov post api push services.
+ */
+interface PostServiceInterface {
+
+  /**
+   * Determines if the entity is such that it is covered by the push.
+   *
+   * Usually this is a content type covered by the push.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity (usually a node, but not required).
+   *
+   * @return bool
+   *   TRUE if a pushable entity, FALSE otherwise.
+   */
+  public static function isPushAble(EntityInterface $entity);
+
+  /**
+   * Determines if the entity is such should be assembled and pushed.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity (usually a node, but not required).
+   * @param bool $forcePush
+   *   Process due to referenced entity updates.
+   *
+   * @return bool
+   *   TRUE if should be pushed, FALSE otherwise.
+   */
+  public static function shouldPush(EntityInterface $entity, bool $forcePush = FALSE);
+
+}

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.info.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:post_api
   - drupal:slack
+  - drupal:va_gov_facilities

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -61,7 +61,7 @@ function _va_gov_post_api_add_facility_to_queue(NodeInterface $node) {
  * Adds facility service data to Post API queue to update Lighthouse.
  *
  * @param \Drupal\node\NodeInterface $node
- *   Entity.
+ *   Node.
  *
  * @return int
  *   The count of the number of items queued.

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -6,16 +6,19 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
+use Drupal\va_gov_facilities\FacilityOps;
 
 /**
  * Implements hook_entity_insert().
  *
  * Queues new items for sync.
  */
-function post_api_entity_insert(EntityInterface $entity) {
-  _post_api_add_facility_status_to_queue($entity);
-  _post_api_add_facility_service_to_queue($entity);
-
+function va_gov_post_api_entity_insert(EntityInterface $entity) {
+  if ($entity instanceof NodeInterface) {
+    _va_gov_post_api_add_facility_to_queue($entity);
+    _va_gov_post_api_add_facility_service_to_queue($entity);
+  }
 }
 
 /**
@@ -23,33 +26,32 @@ function post_api_entity_insert(EntityInterface $entity) {
  *
  * Queues updated items for sync.
  */
-function post_api_entity_update(EntityInterface $entity) {
-  _post_api_add_facility_status_to_queue($entity);
-  _post_api_add_facility_service_to_queue($entity);
+function va_gov_post_api_entity_update(EntityInterface $entity) {
+  if ($entity instanceof NodeInterface) {
+    _va_gov_post_api_add_facility_to_queue($entity);
+    _va_gov_post_api_add_facility_service_to_queue($entity);
+  }
 }
 
 /**
  * Adds facility data to Post API queue.
  *
- * @param \Drupal\Core\Entity\EntityInterface $entity
+ * @param \Drupal\node\NodeInterface $node
  *   Entity.
  *
  * @return int
  *   The count of the number of items queued.
  */
-function _post_api_add_facility_status_to_queue(EntityInterface $entity) {
-  $facilitiesWithStatus = [
-    'health_care_local_facility',
-    'nca_facility',
-    'vba_facility',
-    'vet_center',
-    'vet_center_outstation',
-  ];
-  if (in_array($entity->bundle(), $facilitiesWithStatus)) {
-    return Drupal::service('va_gov_post_api.queue_facility_status_updates')->queueFacilityStatus($entity);
+function _va_gov_post_api_add_facility_to_queue(NodeInterface $node) {
+  if (FacilityOps::isFacilityWithStatus($node)) {
+    return Drupal::service('va_gov_post_api.queue_facility_status_updates')->queueFacilityStatus($node);
   }
-  elseif ($entity->bundle() === 'health_care_region_page') {
-    return Drupal::service('va_gov_post_api.queue_facility_status_updates')->queueSystemRelatedFacilities($entity);
+  elseif (FacilityOps::isFacilityWithoutStatus($node)) {
+    // These don't have editable status, but we also need to push.
+    return Drupal::service('va_gov_post_api.queue_facility_without_status_updates')->queueFacility($node);
+  }
+  elseif ($node->bundle() === 'health_care_region_page') {
+    return Drupal::service('va_gov_post_api.queue_facility_status_updates')->queueSystemRelatedFacilities($node);
   }
 
   return 0;
@@ -58,21 +60,21 @@ function _post_api_add_facility_status_to_queue(EntityInterface $entity) {
 /**
  * Adds facility service data to Post API queue to update Lighthouse.
  *
- * @param \Drupal\Core\Entity\EntityInterface $entity
+ * @param \Drupal\node\NodeInterface $node
  *   Entity.
  *
  * @return int
  *   The count of the number of items queued.
  */
-function _post_api_add_facility_service_to_queue(EntityInterface $entity) {
-  if ($entity->bundle() === 'health_care_local_health_service') {
-    return Drupal::service('va_gov_post_api.queue_service_updates')->queueFacilityService($entity);
+function _va_gov_post_api_add_facility_service_to_queue(NodeInterface $node) {
+  if ($node->bundle() === 'health_care_local_health_service') {
+    return Drupal::service('va_gov_post_api.queue_service_updates')->queueFacilityService($node);
   }
-  elseif ($entity->bundle() === 'health_care_service_taxonomy') {
-    return Drupal::service('va_gov_post_api.queue_service_updates')->queueServiceTermRelatedServices($entity);
+  elseif ($node->bundle() === 'health_care_service_taxonomy') {
+    return Drupal::service('va_gov_post_api.queue_service_updates')->queueServiceTermRelatedServices($node);
   }
-  elseif ($entity->bundle() === 'regional_health_care_service_des') {
-    return Drupal::service('va_gov_post_api.queue_service_updates')->queueSystemRelatedServices($entity);
+  elseif ($node->bundle() === 'regional_health_care_service_des') {
+    return Drupal::service('va_gov_post_api.queue_service_updates')->queueSystemRelatedServices($node);
   }
 
   return 0;

--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.services.yml
@@ -16,3 +16,6 @@ services:
   va_gov_post_api.queue_facility_status_updates:
     class: '\Drupal\va_gov_post_api\Service\PostFacilityStatus'
     arguments: ['@config.factory', '@entity_type.manager', '@logger.factory', '@messenger', '@post_api.add_to_queue']
+  va_gov_post_api.queue_facility_without_status_updates:
+    class: '\Drupal\va_gov_post_api\Service\PostFacilityWithoutStatus'
+    arguments: ['@config.factory', '@entity_type.manager', '@logger.factory', '@messenger', '@post_api.add_to_queue']


### PR DESCRIPTION
## Description

Closes #13769

Summary:  

- Adding url pushes needs to make sure we push when the url would change.
- Adding pushes for Vet Center mobile, which we never pushed before because they have no status.
- Reducing the number of testing permutations while adding more data fields that need to be monitored for change.
- Significant refactoring to allow for different status vs non-status push classes, some shared functions that can be used across them, both in a base class and in a static FacilityOps class.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user admin.
Test an edit of an existing node for one of each facility content types. Changing data is not needed.
1.  PUBLISH a save to  '[health_care_local_facility](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/1816/edit)',
- [x] Validate that a message appears saying ut was queued for push to facility locator
- [x] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that the payload for this node entry appears with a link to the va.gov facility page
2. Save a DRAFT of an '[nca_facility](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/56017/edit)',
- [x] Validate that a message appears saying it was queued for push to facility locator
- [x] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that the payload for this node entry appears with a link URL with a value of NULL
3. Save a DRAFT if a '[vba_facility](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/48912/edit)',
- [x] Validate that a message appears saying it was queued for push to facility locator
- [x] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that the payload for this node entry appears with a link a link URL with a value of NULL
4. Save a DRAFT and a PUBLISH '[vet_center_cap](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/35952/edit)',
- [x]  validate that NO message appears saying it was queued for push to facility locator
- [x] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that there is NO item queued for the CAP, because Caps are not being pushed.
5.  Save and PUBLISH a published '[vet_center_mobile_vet_center](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/17518/edit)',
- [x] Validate that a message appears saying it was queued for push to facility locator
- [ ] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that the payload for this node entry appears with a link to the facility locations page with a hash(fragment) link down to the heading for this facility.
6. save a and PUBLISH a published '[vet_center_outstation](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/17529/edit)',
- [x] Validate that a message appears saying it was queued for push to facility locator
- [x] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that the payload for this node entry appears with a link to the facility locations page with a hash link down to the heading for this facility.
7. save a and PUBLISH a published '[vet_center](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/3718/edit)',
- [x] Validate that a message appears saying ut was queued for push to facility locator
- [x] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that the payload for this node entry appears with a link to the va.gov facility page
1.  save a draft ato a NEW   '[health_care_local_facility](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/node/50479/edit)' that has not been published
- [x] Validate that a message appears saying it was queued for push to facility locator
- [x] Go to [the queue](https://pr13814-03njwdfrcsvv97vua1ehc5mq1nutbus1.ci.cms.va.gov/admin/config/post-api/queue) and validate that the payload for this node entry appears with a link to the Facility Locator page page



