### PR TITLE
VACMS-13362: Adds migration for NCA Facilities API data.

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_facility_nca.yml
+++ b/config/sync/migrate_plus.migration.va_node_facility_nca.yml
@@ -1,7 +1,10 @@
 uuid: 4a2758e4-e615-4669-a307-292cf0569231
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - tzfield
 id: va_node_facility_nca
 class: null
 field_plugin_method: null
@@ -27,7 +30,8 @@ source:
   ids:
     id:
       type: string
-  constants: null
+  constants:
+    country_code: US
   fields:
     -
       name: facility_type
@@ -45,6 +49,74 @@ source:
       name: classification
       label: classification
       selector: properties/classification
+    -
+      name: website
+      label: website
+      selector: properties/website
+    -
+      name: time_zone
+      label: time_zone
+      selector: properties/time_zone
+    -
+      name: mailing_city
+      label: mailing_city
+      selector: properties/address/mailing/city
+    -
+      name: mailing_state
+      label: mailing_state
+      selector: properties/address/mailing/state
+    -
+      name: mailing_zip
+      label: mailing_zip
+      selector: properties/address/mailing/zip
+    -
+      name: mailing_address1
+      label: mailing_address1
+      selector: properties/address/mailing/address_1
+    -
+      name: mailing_address2
+      label: mailing_address2
+      selector: properties/address/mailing/address_2
+    -
+      name: mailing_address3
+      label: mailing_address3
+      selector: properties/address/mailing/address_3
+    -
+      name: physical_city
+      label: physical_city
+      selector: properties/address/physical/city
+    -
+      name: physical_state
+      label: physical_state
+      selector: properties/address/physical/state
+    -
+      name: physical_zip
+      label: physical_zip
+      selector: properties/address/physical/zip
+    -
+      name: physical_address1
+      label: physical_address1
+      selector: properties/address/physical/address_1
+    -
+      name: physical_address2
+      label: physical_address2
+      selector: properties/address/physical/address_2
+    -
+      name: physical_address3
+      label: physical_address3
+      selector: properties/address/physical/address_3
+    -
+      name: fax
+      label: fax
+      selector: properties/phone/fax
+    -
+      name: phone
+      label: phone
+      selector: properties/phone/main
+    -
+      name: hours
+      label: hours
+      selector: properties/hours
     -
       name: coordinates
       label: coordinates
@@ -73,6 +145,134 @@ process:
     method: row
     source: id
     message: 'Skipped: Source API ID is empty, must have it.'
+  field_nca_classification:
+    -
+      plugin: static_map
+      source: classification
+      map:
+        'Confederate Cemetery': 1
+        'Government Lots': 2
+        'Monument Sites': 3
+        'National Cemetery': 4
+        'Post Cemetery': 5
+        Rural: 6
+        'Soldiers Lot': 7
+  field_link/uri:
+    -
+      plugin: str_replace
+      source: website
+      search: 'NULL'
+      replace: ''
+  field_link/title:
+    -
+      plugin: str_replace
+      source: name
+      search: 'NULL'
+      replace: ''
+  field_timezone: time_zone
+  field_mailing_address/langcode:
+    plugin: default_value
+    default_value: en
+  field_mailing_address/address_line1:
+    plugin: callback
+    callable: trim
+    source: mailing_address1
+  field_mailing_address/address_line2:
+    -
+      plugin: get
+      source:
+        - mailing_address2
+        - mailing_address3
+    -
+      plugin: callback
+      callable: array_filter
+    -
+      plugin: multiple_values
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ', '
+  field_mailing_address/locality: mailing_city
+  field_mailing_address/administrative_area: mailing_state
+  field_mailing_address/postal_code: mailing_zip
+  field_mailing_address/country_code:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: mailing_zip
+    -
+      plugin: get
+      source: constants/country_code
+  field_address/langcode:
+    plugin: default_value
+    default_value: en
+  field_address/address_line1:
+    plugin: callback
+    callable: trim
+    source: physical_address1
+  field_address/address_line2:
+    -
+      plugin: get
+      source:
+        - physical_address2
+        - physical_address3
+    -
+      plugin: callback
+      callable: array_filter
+    -
+      plugin: multiple_values
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ', '
+  field_address/locality: physical_city
+  field_address/administrative_area: physical_state
+  field_address/postal_code: physical_zip
+  field_address/country_code:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: physical_zip
+    -
+      plugin: get
+      source: constants/country_code
+  field_fax_number:
+    -
+      plugin: str_replace
+      source: fax
+      search: Ext.
+      replace: x
+    -
+      plugin: explode
+      delimiter: x
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ' x'
+  field_phone_number:
+    -
+      plugin: str_replace
+      source: phone
+      search: Ext.
+      replace: x
+    -
+      plugin: explode
+      delimiter: x
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ' x'
+  field_office_hours:
+    plugin: va_field_office_hours
+    source: hours
   field_administration:
     plugin: default_value
     default_value: 192
@@ -141,6 +341,14 @@ destination:
   default_bundle: nca_facility
   overwrite_properties:
     - field_geolocation
+    - field_nca_classification
+    - field_link
+    - field_timezone
+    - field_mailing_address
+    - field_address
+    - field_fax_number
+    - field_phone_number
+    - field_office_hours
     - changed
     - new_revision
     - revision_default

--- a/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
+++ b/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
@@ -79,7 +79,7 @@ class FacilityOps {
   }
 
   /**
-   * Get facilty types that have status info.
+   * Get facility types that have status info.
    *
    * @return array
    *   An array of facility types that have status.
@@ -123,6 +123,36 @@ class FacilityOps {
     ];
 
     return in_array($type, $facilities_with_supplemental_status);
+  }
+
+  /**
+   * Checks if the entity is a facility node that should be auto-archived.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility to be auto-archived. FALSE otherwise.
+   */
+  public static function isAutoArchiveFacility(NodeInterface $node) : bool {
+    return self::isBundleFacilityToAutoArchive($node->bundle());
+  }
+
+  /**
+   * Checks if the entity is a facility to be auto-archived.
+   *
+   * @param string $type
+   *   The bundle id to evaluate.
+   *
+   * @return bool
+   *   TRUE if it is a facility bundle to be auto-archived. FALSE otherwise.
+   */
+  public static function isBundleFacilityToAutoArchive(string $type) : bool {
+    $facilities_to_auto_archive = [
+      'nca_facility',
+    ];
+
+    return in_array($type, $facilities_to_auto_archive);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_nca.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_nca.yml
@@ -1,6 +1,9 @@
 # Migration meta data.
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - tzfield
 id: va_node_facility_nca
 class: null
 field_plugin_method: null
@@ -32,6 +35,7 @@ source:
       type: string
   # Define any constants that are needed to pass in as data.
   constants:
+    country_code: 'US'
   # All the fields that are used from the source.
   fields:
     -
@@ -50,6 +54,74 @@ source:
       name: classification
       label: classification
       selector: properties/classification
+    -
+      name: website
+      label: website
+      selector: properties/website
+    -
+      name: time_zone
+      label: time_zone
+      selector: properties/time_zone
+    -
+      name: mailing_city
+      label: mailing_city
+      selector: properties/address/mailing/city
+    -
+      name: mailing_state
+      label: mailing_state
+      selector: properties/address/mailing/state
+    -
+      name: mailing_zip
+      label: mailing_zip
+      selector: properties/address/mailing/zip
+    -
+      name: mailing_address1
+      label: mailing_address1
+      selector: properties/address/mailing/address_1
+    -
+      name: mailing_address2
+      label: mailing_address2
+      selector: properties/address/mailing/address_2
+    -
+      name: mailing_address3
+      label: mailing_address3
+      selector: properties/address/mailing/address_3
+    -
+      name: physical_city
+      label: physical_city
+      selector: properties/address/physical/city
+    -
+      name: physical_state
+      label: physical_state
+      selector: properties/address/physical/state
+    -
+      name: physical_zip
+      label: physical_zip
+      selector: properties/address/physical/zip
+    -
+      name: physical_address1
+      label: physical_address1
+      selector: properties/address/physical/address_1
+    -
+      name: physical_address2
+      label: physical_address2
+      selector: properties/address/physical/address_2
+    -
+      name: physical_address3
+      label: physical_address3
+      selector: properties/address/physical/address_3
+    -
+      name: fax
+      label: fax
+      selector: properties/phone/fax
+    -
+      name: phone
+      label: phone
+      selector: properties/phone/main
+    -
+      name: hours
+      label: hours
+      selector: properties/hours
     -
       name: coordinates
       label: coordinates
@@ -82,6 +154,138 @@ process:
     method: row
     source: id
     message: 'Skipped: Source API ID is empty, must have it.'
+  field_nca_classification:
+    -
+      plugin: static_map
+      source: classification
+      map:
+        'Confederate Cemetery': 1
+        'Government Lots': 2
+        'Monument Sites': 3
+        'National Cemetery': 4
+        'Post Cemetery': 5
+        Rural: 6
+        'Soldiers Lot': 7
+  field_link/uri:
+    -
+      plugin: str_replace
+      source: website
+      search: 'NULL'
+      replace: ''
+  field_link/title:
+    -
+      plugin: str_replace
+      source: name
+      search: 'NULL'
+      replace: ''
+  field_timezone: time_zone
+  field_mailing_address/langcode:
+    plugin: default_value
+    default_value: en
+  field_mailing_address/address_line1:
+    plugin: callback
+    callable: trim
+    source: mailing_address1
+  # We have two lines that have to become one.
+  field_mailing_address/address_line2:
+    -
+      plugin: get
+      source:
+        - mailing_address2
+        - mailing_address3
+    -
+      # This gets rid of any empty elements.
+      plugin: callback
+      callable: array_filter
+    -
+      plugin: multiple_values
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ', '
+  field_mailing_address/locality: mailing_city
+  field_mailing_address/administrative_area: mailing_state
+  field_mailing_address/postal_code: mailing_zip
+  field_mailing_address/country_code:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: mailing_zip
+    -
+      plugin: get
+      source: 'constants/country_code'
+  field_address/langcode:
+    plugin: default_value
+    default_value: en
+  field_address/address_line1:
+    plugin: callback
+    callable: trim
+    source: physical_address1
+  # We have two lines that have to become one.
+  field_address/address_line2:
+    -
+      plugin: get
+      source:
+        - physical_address2
+        - physical_address3
+    -
+      # This gets rid of any empty elements.
+      plugin: callback
+      callable: array_filter
+    -
+      plugin: multiple_values
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ', '
+  field_address/locality: physical_city
+  field_address/administrative_area: physical_state
+  field_address/postal_code: physical_zip
+  field_address/country_code:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: physical_zip
+    -
+      plugin: get
+      source: 'constants/country_code'
+  field_fax_number:
+    -
+      plugin: str_replace
+      source: fax
+      search: Ext.
+      replace: x
+    -
+      plugin: explode
+      delimiter: x
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ' x'
+  field_phone_number:
+    -
+      plugin: str_replace
+      source: phone
+      search: Ext.
+      replace: x
+    -
+      plugin: explode
+      delimiter: x
+    -
+      plugin: callback
+      callable: trim
+    -
+      plugin: concat
+      delimiter: ' x'
+  field_office_hours:
+    plugin: va_field_office_hours
+    source: hours
   field_administration:
     plugin: default_value
     # Set the value for "NCA Facilities" which is 192.
@@ -155,6 +359,14 @@ destination:
   # Only these fields will be overwritten if the content changes in the API.
   overwrite_properties:
     - 'field_geolocation'
+    - field_nca_classification
+    - field_link
+    - field_timezone
+    - field_mailing_address
+    - field_address
+    - field_fax_number
+    - field_phone_number
+    - field_office_hours
     - changed
     - new_revision
     - revision_default

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -219,7 +219,7 @@ class Commands extends DrushCommands {
     $facility->setRevisionLogMessage('Archived due to removal from Facility API.');
     $facility->setNewRevision(TRUE);
     $facility->setUnpublished();
-    Assign to CMS Migrator user.
+    // Assign to CMS Migrator user.
     $facility->setRevisionUserId(1317);
     // Prevents some other actions.
     $facility->setSyncing(TRUE);

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -163,7 +163,7 @@ class Commands extends DrushCommands {
       $facility_nodes_to_flag = $this->entityTypeManager->getStorage('node')->loadMultiple(array_values($facilities_to_flag));
       foreach ($facility_nodes_to_flag as $facility_node_to_flag) {
         // Get bundle type.
-        $bundle_type = $facility_node_to_flag->type->entity->id();
+        $bundle_type = $facility_node_to_flag->bundle();
         if (!in_array($bundle_type, $facility_bundles_to_archive)) {
           $this->addNodeRevision($facility_node_to_flag);
           $this->flagger->setFlag('removed_from_source', $facility_node_to_flag);

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -217,6 +217,15 @@ class Commands extends DrushCommands {
   protected function archiveRemovedFacility(NodeInterface $facility) {
     $facility->set('moderation_state', 'archived');
     $facility->setRevisionLogMessage('Archived due to removal from Facility API.');
+    $facility->setNewRevision(TRUE);
+    $facility->setUnpublished();
+    Assign to CMS Migrator user.
+    $facility->setRevisionUserId(1317);
+    // Prevents some other actions.
+    $facility->setSyncing(TRUE);
+    $facility->setChangedTime(time());
+    $facility->isDefaultRevision(TRUE);
+    $facility->setRevisionCreationTime(time());
     $facility->save();
   }
 

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -164,7 +164,7 @@ class Commands extends DrushCommands {
       foreach ($facility_nodes_to_flag as $facility_node_to_flag) {
         // Get bundle type.
         $bundle_type = $facility_node_to_flag->type->entity->id();
-        if (!in_array($bundle_type, $facilities_to_archive)) {
+        if (!in_array($bundle_type, $facility_bundles_to_archive)) {
           $this->addNodeRevision($facility_node_to_flag);
           $this->flagger->setFlag('removed_from_source', $facility_node_to_flag);
           // Send email to CMS Help Desk for follow-up steps.

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -155,7 +155,7 @@ class Commands extends DrushCommands {
       $this->migrateChannelLogger->log(LogLevel::WARNING, 'The facility API returned %count facilities, which seems suspicious. Flagging aborted.', $vars);
       return;
     }
-    $facilities_to_archive = ['nca_facility'];
+    $facility_bundles_to_archive = ['nca_facility'];
     $facilities_to_flag = $this->getFacilitiesToFlag($facilities_in_fapi);
     $count_flagged = count($facilities_to_flag);
     $count_archived = 0;

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -184,26 +184,18 @@ class Commands extends DrushCommands {
       ];
 
       if ($vars['%count_flagged'] > 0) {
-        $facility_string = ngettext("facility", "facilities", $count_flagged);
-        $vars['@facility_string'] = $facility_string;
-        $msg = 'Flagged %count_flagged @facility_string as removed from Facility API.';
+        $msg = 'Flagged %count_flagged facilities as removed from Facility API.';
         $this->migrateChannelLogger->log(LogLevel::INFO, $msg, $vars);
         // Create drush output.
         // @phpstan-ignore-next-line
-        $this->logger->success("Flagged {$count_flagged} {$facility_string} as removed from Facility API.",
-          ['@facility_string' => $facility_string]
-          );
+        $this->logger->success("Flagged {$count_flagged} facilities as removed from Facility API.");
       }
       if ($vars['%count_archived'] > 0) {
-        $facility_string = ngettext("facility", "facilities", $count_archived);
-        $vars['@facility_string'] = $facility_string;
-        $msg = 'Archived %count_archived @facility_string due to removal from Facility API.';
+        $msg = 'Archived %count_archived facilities due to removal from Facility API.';
         $this->migrateChannelLogger->log(LogLevel::INFO, $msg, $vars);
         // Create drush output.
         // @phpstan-ignore-next-line
-        $this->logger->success("Archived {$count_archived} {$facility_string} due to removal from Facility API.",
-          ['@facility_string' => $facility_string]
-          );
+        $this->logger->success("Archived {$count_archived} facilities due to removal from Facility API.");
       }
     }
   }


### PR DESCRIPTION
## Description

Closes #13362 

## Testing done
Manually

## Screenshots
<img width="1840" alt="Screen Shot 2023-05-31 at 7 46 10 AM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/830b5f2b-fad5-47fd-a982-e600e7cf3451">
<img width="1840" alt="Screen Shot 2023-05-31 at 7 46 49 AM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/42b5db5d-9f63-41fa-824c-556ed68e64ab">



## QA steps
### Test migration
- As an admin, go to [National Cemetery of the Alleghenies](https://pr13858-nlnnnfn5vedzn3oopc5rv5gxwhsm2mmz.ci.cms.va.gov/node/4595/edit) and note what data exists currently
- In a separate window, go to [Baxter Springs City Soldiers' Lot](https://pr13858-nlnnnfn5vedzn3oopc5rv5gxwhsm2mmz.ci.cms.va.gov/node/4432/edit) and note what data exists currently
- In a separate window, go to [Benicia Arsenal Post Cemetery](https://pr13858-nlnnnfn5vedzn3oopc5rv5gxwhsm2mmz.ci.cms.va.gov/node/27552/edit) and note what data exists currently
- In a separate window, run the [NCA migration](https://pr13858-nlnnnfn5vedzn3oopc5rv5gxwhsm2mmz.ci.cms.va.gov/admin/structure/migrate/manage/facility/migrations/va_node_facility_nca/execute) (making sure to have Update checked).
- [ ] Validate that the data in the NCA facilities in the open windows are now updated.

### Test archiving
- Open a PHP terminal in the PR Tugboat instance 
- Run the `drush` command: `drush va_gov_migrate:flag-missing-facilities`
- Does it only archive NCA facilities?
  - [ ] Validate that [Test Cemetery 1](https://pr13858-nlnnnfn5vedzn3oopc5rv5gxwhsm2mmz.ci.cms.va.gov/nca-facilities/locations/test-cemetery-1) was archived
  - [ ] Validate that the revision log message is associated with CMS Migrator
  - [ ] Validate that the revision log message is accurate
  - [ ] Validate that [Test Cemetery 2](https://pr13858-nlnnnfn5vedzn3oopc5rv5gxwhsm2mmz.ci.cms.va.gov/nca-facilities/locations/test-cemetery-2) was archived
  - [ ] Validate that the revision log message is associated with CMS Migrator
  - [ ] Validate that the revision log message is accurate
- Does it flag non-NCA facilities?
  - [ ] Validate that [Test VBA 1](https://pr13858-nlnnnfn5vedzn3oopc5rv5gxwhsm2mmz.ci.cms.va.gov/continental/locations/test-vba-1) was flagged 
  - [ ] Validate that the revision log message is associated with CMS Migrator
  - [ ] Validate that the revision log message is accurate


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`



