### PR TITLE
VACMS-0000: Ensure `$clientPayload` is not NULL.

### DIFF
--- a/docroot/modules/custom/va_gov_consumers/src/GitHub/GitHubClient.php
+++ b/docroot/modules/custom/va_gov_consumers/src/GitHub/GitHubClient.php
@@ -145,7 +145,7 @@ class GitHubClient implements GitHubClientInterface {
     return $this->request('POST', "repos/{$this->repositoryPath}/dispatches", [
       'json' => [
         'event_type' => $eventType,
-        'client_payload' => $clientPayload,
+        'client_payload' => $clientPayload ?? new \stdClass(),
       ],
     ]);
   }


### PR DESCRIPTION
## Description

This prevents an error when attempting to invoke content releases from production.

Normally, the `$clientPayload` argument is unspecified and defaults to `NULL`, but it's an error to actually send `NULL` as a value to the GitHub API; it returns a 422 status code like [this](https://dsva.slack.com/archives/CJT90C0UT/p1685130321762009).



## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
