### PR TITLE
VACMS-11365: Adds GHA workflow to repair PR titles.

### DIFF
--- a/.github/workflows/repair-pr-title.yml
+++ b/.github/workflows/repair-pr-title.yml
@@ -1,0 +1,45 @@
+name: "Repair PR Title"
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  repair_pr_title:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Repair PR title
+        run: |
+          PR_API_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
+
+          # Retrieve the PR object.
+          PR="$(curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "${PR_API_URL}")"
+          echo "PR: $PR"
+
+          # This will be a JSON-quoted string. We do _not_ strip the quotes.
+          # For instance (pathological example):
+          # "Bump drupal/coder from 8.3.17 to 8.3.18\" ' } \\\" ' 4"
+          ORIGINAL_TITLE="$(jq '.title' <<< "$PR")"
+          echo "ORIGINAL_TITLE: $ORIGINAL_TITLE"
+
+          # Fix the prefix. This should preserve everything else.
+          UPDATED_TITLE="$(echo "$ORIGINAL_TITLE" | sed -E 's/vacms ([0-9]+) /VACMS-\1: /I')"
+          echo "UPDATED_TITLE: $UPDATED_TITLE"
+
+          if [ "$ORIGINAL_TITLE" != "$UPDATED_TITLE" ]; then
+            echo "Updating PR title from $ORIGINAL_TITLE to $UPDATED_TITLE"
+
+            # $UPDATED_TITLE is already quoted, so we must not quote it again.
+            curl \
+              -X PATCH \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "${PR_API_URL}" \
+              -d "{\"title\":$UPDATED_TITLE}"
+          fi
+        shell: bash


### PR DESCRIPTION
## Description

Closes #11365.

## Testing done
See [this PR](https://github.com/department-of-veterans-affairs/va.gov-cms-test/pull/1354). I tested with a fairly pathological title.

![Screenshot 2023-05-30 at 3 51 26 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/1318579/bb5735c7-bd38-428e-8d08-290289547527)


## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing annoucement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
