### PR TITLE
Set up UX languages changes for TMGMT.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -507,7 +507,7 @@
                 "3272128 - Calling a static method, or accessing a static property directly on a trait is deprecated": "https://www.drupal.org/files/issues/2022-04-27/deprecated-static-function-call-in-trait-3272128.patch"
             },
             "drupal/tmgmt": {
-                "3316264 - Empty lines on job overview": "https://www.drupal.org/files/issues/2022-10-19/tmgmt_empty_job_lines.patch"
+                "UX language updates for TMGMT": "patches/tmgmt_language_changes.patch"
             },
             "drupal/viewfield": {
                 "3252356 - Add option to display default view on node edit when always use default value selected": "https://www.drupal.org/files/issues/2023-02-07/viewfield-option-display-default-view-on-node-edit-3252356-5.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfaee9a7f47af86a3ff86a529667e6f8",
+    "content-hash": "abaecc73cea750754812aadd2325f9ee",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -12813,17 +12813,17 @@
         },
         {
             "name": "drupal/tmgmt",
-            "version": "1.14.0",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/tmgmt.git",
-                "reference": "8.x-1.14"
+                "reference": "8.x-1.15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/tmgmt-8.x-1.14.zip",
-                "reference": "8.x-1.14",
-                "shasum": "9c7a0ee0a9f8c180e485f5ac16c5e8efd74d63bc"
+                "url": "https://ftp.drupal.org/files/projects/tmgmt-8.x-1.15.zip",
+                "reference": "8.x-1.15",
+                "shasum": "07732ee85222927585ee59e42b40b07fca8ff8b0"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10"
@@ -12837,13 +12837,13 @@
                 "drupal/tmgmt_language_combination": "*",
                 "drupal/tmgmt_local": "*",
                 "drupal/tmgmt_locale": "*",
-                "drupal/webform": "5.x-dev || 6.x-dev"
+                "drupal/webform": "5.x-dev || 6.x-dev || 6.2.x-dev"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.14",
-                    "datestamp": "1657223863",
+                    "version": "8.x-1.15",
+                    "datestamp": "1680643412",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -254,6 +254,7 @@ module:
   va_gov_media: 0
   va_gov_menu_access: 0
   va_gov_migrate: 0
+  va_gov_multilingual_tmgmt: 0
   va_gov_notifications: 0
   va_gov_post_api: 0
   va_gov_preview: 0

--- a/docroot/design-system/components/alert/alert.scss
+++ b/docroot/design-system/components/alert/alert.scss
@@ -33,19 +33,6 @@
   word-break: break-all;
 }
 
-.va-alert.messages--warning {
-  background-color: var(--va-gold-lightest);
-  border-color: var(--va-gold-med);
-
-  svg {
-    color: var(--va-gold-med);
-  }
-}
-
-.va-alert.messages--warning a {
-  background-color: var(--va-gold-lightest);
-}
-
 .va-alert.messages--success,
 .va-alert.messages--status {
   background-color: var(--va-green-lightest);
@@ -59,6 +46,19 @@
 .va-alert.messages--success a,
 .va-alert.messages--status a {
   background-color: var(--va-green-lightest);
+}
+
+.va-alert.messages--warning {
+  background-color: var(--va-gold-lightest);
+  border-color: var(--va-gold-med);
+
+  svg {
+    color: var(--va-gold-med);
+  }
+}
+
+.va-alert.messages--warning a {
+  background-color: var(--va-gold-lightest);
 }
 
 .va-alert.messages--error {

--- a/docroot/design-system/components/alert/alert.twig
+++ b/docroot/design-system/components/alert/alert.twig
@@ -28,6 +28,11 @@
 
 
 <div role="region" aria-label="Status message" {{ attributes.addClass(classes)|without('role', 'aria-label') }}>
+  {# attributes is not local to this template's scope, so the classes added above subsequently get passed back out. #}
+  {# This is a problem if multiple messages of different types are passed in. If we added messages--error here, #}
+  {# it will still be present when this template is called with a different type. Removing the classes here is cleanup. #}
+  {# See status-messages.html.twig and how it sends attributes to alert.twig. #}
+  {{ attributes.removeClass(classes) }}
   {% if type == 'error' %}
   {% set alert_icon = 'ban' %}
   <div role="alert">

--- a/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/src/EventSubscriber/FormEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/src/EventSubscriber/FormEventSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\va_gov_multilingual_tmgmt\EventSubscriber;
+
+use Drupal\Core\Link;
+use Drupal\Core\Messenger\Messenger;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\core_event_dispatcher\Event\Form\FormAlterEvent;
+use Drupal\core_event_dispatcher\FormHookEvents;
+use Drupal\tmgmt\Entity\JobItem;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * VA.gov home event subscriber.
+ */
+class FormEventSubscriber implements EventSubscriberInterface {
+
+  const CONFLICTING_ITEMS_MESSAGE_SINGLE = 'The translation for the following item is already in progress, so it will not be added to this job: @items.';
+  const CONFLICTING_ITEMS_MESSAGE_PLURAL = 'The translation for the following @count items is already in progress, so they will not be added to this job: @items.';
+
+  /**
+   * The translation manager.
+   *
+   * @var \Drupal\Core\StringTranslation\TranslationManager
+   */
+  protected TranslationManager $translationManager;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs event subscriber.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationManager $translation_manager
+   *   The translation manager.
+   * @param \Drupal\Core\Messenger\Messenger $messenger
+   *   THe messenger service.
+   */
+  public function __construct(TranslationManager $translation_manager, Messenger $messenger) {
+    $this->translationManager = $translation_manager;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * Form alters for va_gov_home.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Form\FormAlterEvent $event
+   *   The form event.
+   */
+  public function formAlter(FormAlterEvent $event) {
+    if ($event->getFormId() === 'tmgmt_job_edit_form') {
+      /** @var Drupal\tmgmt\Form\JobForm $form_object */
+      $form_object = $event->getFormState()->getFormObject();
+      $job = $form_object->getEntity();
+      $conflicting_items_by_item = $job->getConflictingItems();
+      $form = &$event->getForm();
+      $form['message'] = [];
+      if (count($conflicting_items_by_item)) {
+        // Make a list of links to the existing items causing the conflicts.
+        $conflicts = [];
+        $num_of_existing_items = 0;
+        foreach ($conflicting_items_by_item as $conflicting_items) {
+          $num_of_existing_items += count($conflicting_items);
+          foreach (JobItem::loadMultiple($conflicting_items) as $id => $conflicting_item) {
+            $conflicts[] = Link::createFromRoute($conflicting_item->label(), 'entity.tmgmt_job_item.canonical', ['tmgmt_job_item' => $id])->toString();
+          }
+        }
+        // Make the links usable in formatPlural().
+        $conflict_list = Markup::create(implode(', ', $conflicts));
+        $message = $this->translationManager
+          ->formatPlural($num_of_existing_items, $this::CONFLICTING_ITEMS_MESSAGE_SINGLE, $this::CONFLICTING_ITEMS_MESSAGE_PLURAL, ['@items' => $conflict_list]);
+        $this->messenger->addWarning($message);
+      }
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      FormHookEvents::FORM_ALTER => ['formAlter'],
+    ];
+  }
+
+}

--- a/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/src/EventSubscriber/FormEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/src/EventSubscriber/FormEventSubscriber.php
@@ -51,6 +51,27 @@ class FormEventSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\core_event_dispatcher\Event\Form\FormAlterEvent $event
    *   The form event.
+   *
+   *   What we are doing here is replacing TMGMT's version of the warning around
+   *   duplicate items being dropped from a new translation job. They use
+   *   alarming language, weird non-standard formatting, and place it
+   *   incorrectly for a warning message.
+   *
+   *   Everything we're doing in the form alter is to send the information to a
+   *   standard warning message. This itself presents a problem. Ideally we
+   *   would only want this message to show when the user is looking at the job
+   *   form. However, since we do this in formAlter, and since formAlter is
+   *   invoked prior to form build, which is called during the submission
+   *   process, we cannot prevent the message from showing on the success page
+   *   after form submission is complete.
+   *
+   *   I tried doing this in a #pre_render callback, with some success in terms
+   *   of when a message would show. However, #pre_render operates on a render
+   *   array, which means we don't have access to the form, form_state, or the
+   *   TMGMT job objects. We need the job object to construct the actual message
+   *   of the text.
+   *
+   *   See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13780.
    */
   public function formAlter(FormAlterEvent $event) {
     if ($event->getFormId() === 'tmgmt_job_edit_form') {

--- a/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/va_gov_multilingual_tmgmt.info.yml
+++ b/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/va_gov_multilingual_tmgmt.info.yml
@@ -1,0 +1,7 @@
+name: VA.gov multilingual TMGMT
+type: module
+description: Enhancements and modifications for translation management (TMGMT).
+package: Custom
+core_version_requirement: ^9 || ^10
+dependencies:
+  - tmgmt

--- a/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/va_gov_multilingual_tmgmt.services.yml
+++ b/docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/va_gov_multilingual_tmgmt.services.yml
@@ -1,0 +1,6 @@
+services:
+  va_gov_multilingual_tmgmt.event_subscriber:
+    class: Drupal\va_gov_multilingual_tmgmt\EventSubscriber\FormEventSubscriber
+    arguments: ['@string_translation', '@messenger']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/va_gov_multilingual/va_gov_multilingual.info.yml
+++ b/docroot/modules/custom/va_gov_multilingual/va_gov_multilingual.info.yml
@@ -1,0 +1,5 @@
+name: VA.gov multilingual
+type: module
+description: Functionality for delivering multilingual content to Veterans.
+package: Custom
+core_version_requirement: ^9 || ^10

--- a/patches/tmgmt_language_changes.patch
+++ b/patches/tmgmt_language_changes.patch
@@ -1,0 +1,33 @@
+diff --git a/src/Form/JobForm.php b/src/Form/JobForm.php
+index 8c9396ee..eb6d1beb 100644
+--- a/src/Form/JobForm.php
++++ b/src/Form/JobForm.php
+@@ -640,7 +640,7 @@ class JobForm extends TmgmtFormBase {
+       if ($existing_items_ids = $form_state->get('existing_item_ids')) {
+         $storage->delete($storage->loadMultiple($existing_items_ids));
+         $num_of_items = count($existing_items_ids);
+-        $this->messenger()->addWarning(\Drupal::translation()->formatPlural($num_of_items, '1 conflicting item has been dropped.', '@count conflicting items have been dropped.'));
++        $this->messenger()->addWarning(\Drupal::translation()->formatPlural($num_of_items, '1 item is already in translation and was not included in the job.', '@count items are already in translation and were not included in the job.'));
+       }
+
+       if ($form_state->getValue('submit_all')) {
+diff --git a/src/JobCheckoutManager.php b/src/JobCheckoutManager.php
+index dac0b255..d91c04c2 100644
+--- a/src/JobCheckoutManager.php
++++ b/src/JobCheckoutManager.php
+@@ -255,12 +255,13 @@ class JobCheckoutManager {
+     if ($existing_items_ids = $job->getConflictingItemIds()) {
+       $item_storage = $this->entityTypeManager->getStorage('tmgmt_job_item');
+       if (count($existing_items_ids) == $job->getItems()) {
+-        $this->messenger()->addStatus($this->t('All job items for job @label are conflicting, the job can not be submitted.', ['@label' => $job->label()]));
++        $this->messenger()->addStatus($this->t('All items for job @label are already being translated. This job cannot be submitted.
++', ['@label' => $job->label()]));
+         return;
+       }
+       $item_storage->delete($item_storage->loadMultiple($existing_items_ids));
+       $num_of_items = count($existing_items_ids);
+-      $this->messenger()->addWarning($this->getStringTranslation()->formatPlural($num_of_items, '1 conflicting item has been dropped for job @label.', '@count conflicting items have been dropped for job @label.', ['@label' => $job->label()]));
++      $this->messenger()->addWarning($this->getStringTranslation()->formatPlural($num_of_items, '1 item is already in translation and was not included in job @label.', '@count items are already in translation and were not included in job @label.', ['@label' => $job->label()]));
+     }
+
+     if ($template_job_id && $job_id != $template_job_id) {

--- a/patches/tmgmt_language_changes.patch
+++ b/patches/tmgmt_language_changes.patch
@@ -1,7 +1,16 @@
 diff --git a/src/Form/JobForm.php b/src/Form/JobForm.php
-index 8c9396ee..eb6d1beb 100644
+index 8c9396ee..1c32cbc9 100644
 --- a/src/Form/JobForm.php
 +++ b/src/Form/JobForm.php
+@@ -592,7 +592,7 @@ class JobForm extends TmgmtFormBase {
+       // If the amount of existing items is the same as the total job item count
+       // then the job can not be submitted.
+       if (count($job->getItems()) == count($existing_items_ids)) {
+-        $form_state->setErrorByName('target_language', $this->t('All job items are conflicting, the job can not be submitted.'));
++        $form_state->setErrorByName('target_language', $this->t('All items in this job are already being translated. This job cannot be submitted.'));
+       }
+     }
+   }
 @@ -640,7 +640,7 @@ class JobForm extends TmgmtFormBase {
        if ($existing_items_ids = $form_state->get('existing_item_ids')) {
          $storage->delete($storage->loadMultiple($existing_items_ids));


### PR DESCRIPTION
## Description

#13780 

## Testing done
Same as QA steps.

## QA steps

1. Log in as admin.
2. Visit https://pr13894-swyq1xt9wttom9yleleqcke7jeuka3rv.ci.cms.va.gov/admin/tmgmt/sources.
3. Select any two items, select 'Spanish' as the target language, and hit 'Request translation'.
4. On the next page, hit 'Submit to provider'. You'll be taken back to the Sources page.
  - [x] The items you selected in 3 should have blue hourglasses in the Spanish column on the right.
5. Select *one* of the two items from steps 3/4. as well as 1 or more additional 'fresh' items. Select 'Spanish' as the target language and hit 'Request translation'.
  - [x] On the next page, at the top, you should see a message 'The translation for the following item is already in progress, so it will not be added to this job: `already translated item`'
  - [x] The message should be formatted with the CMS-standard 'warning' style. 
6. Hit 'Submit to provider'. You'll be taken back to Sources page.
  - [x]  The warning message at top should include '1 item is already in translation and was not included in the job.'.
  - [x] Note: you will also see the message from the previous step. This is known and proving extremely difficult to prevent and a low impact non-blocking bug.
7. Repeat the process, but select *2 or more* items that have the blue hour glass on the right, in addition to fresh items. Hit 'Submit to provider'.
  - [x] The warning messages should include 'The translation for the following `number` items is already in progress, so they will not be added to this job: `items`' 
  - [x] After submission, the warning message should include "The translation for the following `number` items is already in progress, so they will not be added to this job: `items`'
8. Repeat the process, but this time select *only* items that are already in progress.
  - [x] When you hit 'Submit to provider', you should receive a form error: All items in this job are already being translated. This job cannot be submitted.


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
