### PR TITLE
VACMS-12559: Removes ability to sort on moderation_state on content view.

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -814,7 +814,7 @@ display:
               empty_column: false
               responsive: priority-low
             moderation_state:
-              sortable: true
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
@@ -4313,7 +4313,7 @@ display:
               empty_column: false
               responsive: ''
             moderation_state:
-              sortable: true
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''


### PR DESCRIPTION
## Description

Closes #12559.

I reviewed other views, but none of them with a sortable moderation_state field seemed to span the non-workflowed content types.

## Testing done


## Screenshots


## QA steps

- [x] Go [here](https://pr13945-n25nq2orzzzpvqv7o2rcs1ish1l2krtc.ci.cms.va.gov/admin/content) and verify that the table is not sortable by the Moderation State field.
- [x] Go [here](https://pr13945-n25nq2orzzzpvqv7o2rcs1ish1l2krtc.ci.cms.va.gov/admin/content/audit) and verify that the table is not sortable by the Moderation State field.
