### PR TITLE
VACMS-13649: Multi-time pattern passthrough

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
@@ -58,11 +58,12 @@ class VAFieldOfficeHours extends ProcessPluginBase {
       $hour = remove_leading_zeroes($hour);
       $low_day = strtolower($day);
       // Second, we parse the data.
-      if (parse_as_hour($hour)) {
-        // We have one start and one end time.
+      if (has_one_set_of_hours($hour)) {
         // Strip hour before the "to" for starthours.
         $start_time = strstr($hour, 'to', TRUE);
         // Strip hour after the "to" for endhours.
+        // Possible risk that there are comments after the hours
+        // that won't be captured. (None in the data on 2023-06-09, though.)
         $end_time = strstr($hour, 'to');
         $hours_clean[$low_day]['start_time'] = clean_time($start_time);
         $hours_clean[$low_day]['end_time'] = clean_time($end_time);
@@ -153,7 +154,7 @@ function remove_leading_zeroes($hour_range) {
  * @return bool
  *   TRUE if it has one opening and one closing time.
  */
-function parse_as_hour($hour_range) {
+function has_one_set_of_hours($hour_range) {
   // No hours.
   if (preg_match('(a.m.|p.m.)', $hour_range) === 0) {
     return FALSE;

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
@@ -53,20 +53,23 @@ class VAFieldOfficeHours extends ProcessPluginBase {
     ];
 
     foreach ($hours as $day => $hour) {
-
+      // First, we normalize the data.
       $hour = normalize_hour_characters($hour);
       $hour = remove_leading_zeroes($hour);
       $low_day = strtolower($day);
+      // Second, we parse the data.
       if (parse_as_hour($hour)) {
         // We have one start and one end time.
-        // Strip hour before the - for starthours.
+        // Strip hour before the "to" for starthours.
         $start_time = strstr($hour, 'to', TRUE);
-        // Strip hour after the - for endhours.
+        // Strip hour after the "to" for endhours.
         $end_time = strstr($hour, 'to');
         $hours_clean[$low_day]['start_time'] = clean_time($start_time);
         $hours_clean[$low_day]['end_time'] = clean_time($end_time);
       }
       else {
+        // We have something other than one start and one end time.
+        // Make it a comment.
         $hours_clean[$low_day]['comment'] = $hour;
       }
     }

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
@@ -53,8 +53,7 @@ class VAFieldOfficeHours extends ProcessPluginBase {
     ];
 
     foreach ($hours as $day => $hour) {
-      // Test $hour for non-contiguous entries,
-      // separated by semi-colons or comma.
+
       $hour = normalize_hour_characters($hour);
       $hour = remove_leading_zeroes($hour);
       $low_day = strtolower($day);
@@ -174,10 +173,10 @@ function parse_as_hour($hour_range) {
  */
 function clean_time($times) {
   $time = preg_replace("/[^0-9]/", "", $times);
-  $period = preg_replace("/[^a-zA-Z]/", "", $times);
+  $period = preg_replace("/[^(a\.m\.)|(p\.m\.)]/", "", $times);
 
-  // If period is PM then perform the following time conversion.
-  if ($period === "PM") {
+  // If period is p.m. then perform the following time conversion.
+  if ($period === "p.m.") {
     $time_mil = substr_replace($time, ':', -2, -2);
     $time_mil_clean = date("H:i", strtotime($time_mil . " " . $period));
     $h = substr($time_mil_clean, 0, -3);

--- a/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/process/VAFieldOfficeHours.php
@@ -53,8 +53,10 @@ class VAFieldOfficeHours extends ProcessPluginBase {
     ];
 
     foreach ($hours as $day => $hour) {
-      // Test $hour for non-contiguous entries, separated by semi-colons.
-      if (preg_match('(\;)', $hour) === 0) {
+      // Test $hour for non-contiguous entries,
+      // separated by semi-colons or comma.
+      if ((preg_match('(\;)', $hour) === 0)
+        && (preg_match('/(,\s\d)/', $hour) === 0)) {
         $hour = normalize_hours($hour);
       }
       // Strip hour before the - for starthours.
@@ -62,7 +64,11 @@ class VAFieldOfficeHours extends ProcessPluginBase {
       // Strip hour after the - for endhours.
       $end_time = strstr($hour, '-');
       $low_day = strtolower($day);
-      if (preg_match('(AM|PM)', $hour) === 0) {
+      if (preg_match('/(,\s\d)/', $hour) === 1) {
+        // If it has 2 sets of hours, treat it as a comment.
+        $hours_clean[$low_day]['comment'] = $hour;
+      }
+      elseif (preg_match('(AM|PM)', $hour) === 0) {
         // It is not hours, treat it as a comment.
         $hours_clean[$low_day]['comment'] = $hour;
       }
@@ -70,7 +76,6 @@ class VAFieldOfficeHours extends ProcessPluginBase {
         $hours_clean[$low_day]['start_time'] = clean_time($start_time);
         $hours_clean[$low_day]['end_time'] = clean_time($end_time);
       }
-
     }
     if (empty($hours_clean)) {
       $return = NULL;


### PR DESCRIPTION
## Description

Closes #13649 

## Testing done
Manually

## Screenshots
### Hours being parsed as hours
<img width="1441" alt="Screen Shot 2023-06-08 at 2 15 05 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/cf5912a7-d7c5-4404-87b6-70157f081446">

### Hours being parsed as comments
<img width="1375" alt="Screen Shot 2023-06-08 at 2 20 11 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/1f813424-13b7-4895-a3ac-1a5dc1b98022">



## QA steps
As user an admin user
- Run the [VBA migration](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/admin/structure/migrate/manage/facility/migrations/va_node_facility_vba/execute)
- Open the terminal in the Tugboat environment
- Run the following:
  - `drush migrate:import va_node_facility_nca --update --idlist=nca_800`
  -  `drush migrate:import va_node_health_care_local_facility --update --idlist=vha_557`
- Validate that the following have been formatted and put into comments:
  - [x] [vba_339](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4168/edit)
  - [x] [vba_339b](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4170/edit)
  - [x] [vba_339c](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/48912/edit)
- Validate that the following have not regressed (compared to the Lighthouse api)
  - [x] [vha_557](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/1484/edit): "24/7"
  - [x] [vba_307](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/3955/edit): "By appointment only"
  - [x] [vba_307b](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/3957/edit): No space after start time and "a.m."
  - [x] [vba_311a](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/42635/edit): Multi-range hours
  - [x] [vba_316](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4014/edit): No period after "a.m"
  - [x] [vba_317](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4029/edit): No space after "a.m."
  - [x] [vba_320a](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4073/edit): Includes "12:00 p.m." in end date (check that it's not midnight)
  - [x] [vba_327](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4115/edit): Includes "12:00 p.m." in start date (check that it's not midnight)
  - [x] [vba_347](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4233/edit): Uppercase "AM" and "PM"
  - [x] [vba_348](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4237/edit): No space before "am" or "pm"
  - [x] [vba_348a](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4238/edit): Odd data that should be put into a comment
  - [x] [vba_349u](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4267/edit): Has "to" instead of "-"
  - [x] [vba_442](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4338/edit): Inconsistent am/pm and spacing
  - [x] [vba_463c](https://pr14035-vwdcgeagk6rx8oojgcesb0qcb24tym6j.ci.cms.va.gov/node/4355/edit): Bad range character and leading zero


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
