### PR TITLE
VACMS-13592: Update Vet Center editor login redirect for outdated content

### DIFF
--- a/docroot/modules/custom/va_gov_user/va_gov_user.module
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.module
@@ -17,13 +17,17 @@ function va_gov_user_user_login($account) {
   $route_name = \Drupal::routeMatch()->getRouteName();
   if (count($sections) === 1 && $route_name === 'user.login') {
     $alias_manager = \Drupal::service('path_alias.manager');
+    $request = \Drupal::request();
+    $path = $request->getPathInfo();
     $alias = $alias_manager->getAliasByPath('/taxonomy/term/' . key($sections));
+    if ($path === '/admin/content/outdated_content') {
+      $alias = $path;
+    }
     $response = new RedirectResponse($alias);
     // Save the session so login works.
     // Refactor the redirect code out of hook_user_login().
     // See https://www.drupal.org/node/2023537 and
     // https://www.drupal.org/node/3006306.
-    $request = \Drupal::request();
     $request->getSession()->save();
     $response->prepare($request);
     // Make sure to trigger kernel events.

--- a/docroot/modules/custom/va_gov_user/va_gov_user.module
+++ b/docroot/modules/custom/va_gov_user/va_gov_user.module
@@ -19,9 +19,9 @@ function va_gov_user_user_login($account) {
     $alias_manager = \Drupal::service('path_alias.manager');
     $request = \Drupal::request();
     $path = $request->getPathInfo();
-    $alias = $alias_manager->getAliasByPath('/taxonomy/term/' . key($sections));
-    if ($path === '/admin/content/outdated_content') {
-      $alias = $path;
+    $alias = $path;
+    if ($path === '/') {
+      $alias = $alias_manager->getAliasByPath('/taxonomy/term/' . key($sections));
     }
     $response = new RedirectResponse($alias);
     // Save the session so login works.


### PR DESCRIPTION
## Description
Close #13592.

## Testing done
Tested locally with an vet center editor and a vamc editor. Both redirected from a front page login to the dashboard. 

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

Engineer 
Please review the code.

Functional review.
As a vet center editor before logging in attempt to navigate to `/admin/content/outdated_content`. 
1. Log in
   - [ ] Validate that  you are taken to the outdated content tool. 
2. Then log out and go to the front page. Log in again.
   - [ ] Validate that you are taken to the dashboard.
3. Then repeat for a VAMC editor. 
   - [ ] Validate the same things occur. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
