### PR TITLE
VACMS-10368: Uses WCAG 2.1A and 2.1AA standards.

### DIFF
--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -17,7 +17,7 @@ const axeContext = {
 const axeRuntimeOptions = {
   runOnly: {
     type: "tag",
-    values: ["wcag2a", "wcag2aa"],
+    values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
   },
 };
 


### PR DESCRIPTION
## Description

Closes #10368.

If tests pass, this should be good to merge.