### PR TITLE
VACMS-0000: A small change to the CD metrics script.

### DIFF
--- a/scripts/cd_metrics/time_to_restore.lib.js
+++ b/scripts/cd_metrics/time_to_restore.lib.js
@@ -120,7 +120,7 @@ export async function calculateAccruedTimeInFailure(sha) {
     repo,
     previousSha
   );
-  if (previousStatus !== "failure") {
+  if (previousStatus === "success") {
     // This would seem to be the first failing commit, so there is no accrued time in
     // failure.
     return 0;

--- a/scripts/cd_metrics/time_to_restore.lib.js
+++ b/scripts/cd_metrics/time_to_restore.lib.js
@@ -74,12 +74,16 @@ export async function shouldSubmitMetrics(testsFailed) {
   if (testsFailed) {
     return false;
   }
-  const previousSha = getParentCommitSha("HEAD");
-  const previousStatus = await getCombinedStatusForCommit(
+  let previousSha = getParentCommitSha("HEAD");
+  let previousStatus = await getCombinedStatusForCommit(
     owner,
     repo,
     previousSha
   );
+  while (previousStatus === "pending") {
+    previousSha = getParentCommitSha(previousSha);
+    previousStatus = await getCombinedStatusForCommit(owner, repo, previousSha);
+  }
   return previousStatus === "failure";
 }
 

--- a/scripts/cd_metrics/time_to_restore.lib.js
+++ b/scripts/cd_metrics/time_to_restore.lib.js
@@ -80,9 +80,11 @@ export async function shouldSubmitMetrics(testsFailed) {
     repo,
     previousSha
   );
-  while (previousStatus === "pending") {
+  let limit = 25;
+  while (previousStatus === "pending" && limit > 0) {
     previousSha = getParentCommitSha(previousSha);
     previousStatus = await getCombinedStatusForCommit(owner, repo, previousSha);
+    limit -= 1;
   }
   return previousStatus === "failure";
 }

--- a/scripts/cd_metrics/time_to_restore.test.js
+++ b/scripts/cd_metrics/time_to_restore.test.js
@@ -547,6 +547,60 @@ describe("time_to_restore.lib.js", () => {
       expect(result).toEqual(expectedOutput);
     });
   
+    it("should calculate the time to restore service correctly when there are pending commits", async () => {
+      jest.unstable_mockModule("./common.js", () => {
+        return {
+          ...actualCommon,
+          getCommitTimestamp: jest.fn().mockImplementation((sha) => {
+            if (sha === "HEAD") {
+              return 4000;
+            }
+            if (sha === "pending-sha-2") {
+              return 3000;
+            }
+            if (sha === "failing-sha-1") {
+              return 2000;
+            }
+            if (sha === "passing-sha") {
+              return 1000;
+            }
+            throw new Error("Unexpected sha");
+          }),
+          getParentCommitSha: jest.fn().mockImplementation((sha) => {
+            if (sha === "HEAD") {
+              return "pending-sha-2";
+            }
+            if (sha === "pending-sha-2") {
+              return "failing-sha-1";
+            }
+            if (sha === "failing-sha-1") {
+              return "passing-sha";
+            }
+            if (sha === "passing-sha") {
+              return "some-sha";
+            }
+            throw new Error("Unexpected sha");
+          }),
+          getCombinedStatusForCommit: jest.fn().mockImplementation(async (owner, repo, sha) => {
+            if (sha.startsWith("failing-sha")) {
+              return "failure";
+            }
+            if (sha.startsWith("passing-sha") || sha === "HEAD") {
+              return "success";
+            }
+            if (sha.startsWith("pending-sha")) {
+              return "pending";
+            }
+          }),
+        };
+      });
+  
+      const { calculateTimeToRestore } = await import("./time_to_restore.lib.js");
+      const result = await calculateTimeToRestore();
+      const expectedOutput = 2000;
+      expect(result).toEqual(expectedOutput);
+    });
+    
     it("should calculate the time to restore service correctly when there is no accrued failure time", async () => {
       jest.unstable_mockModule("./common.js", () => {
         return {


### PR DESCRIPTION
This script alters the Time-to-Restore calculation algorithm.

Previously, we assumed we had been in a failure condition if and only if the previous commit's combined status was `"failure"`.

However, this breaks under cases like the following:

![Screenshot 2023-06-22 at 11 26 03 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/1318579/b03a8f35-f358-4594-9d06-baf1a81387d9)

Here, we enter failure mode at commit `9ab040a`. The following commit (`055b532`) only changes documentation, and therefore no tests are run. Then `7d51500` runs tests and they succeed.

The correct failure period was `9ab040a..7d51500`, but this failure period is never reported.

This PR updates this logic to loop through previous commits until a non-pending commit is found.

I'm slightly concerned that there might be a pathological state where GitHub indicates _all_ commits have a status of "pending". As a result, I've added some logic to escape the loop after 25 "pending" statuses. This shouldn't happen normally, but I have in the past created large queues of commits changing only documentation.
