### PR TITLE
VACMS-8141 Prevent re-use of VAMC banner alerts.

### DIFF
--- a/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
+++ b/docroot/modules/custom/va_gov_facilities/src/FacilityOps.php
@@ -28,6 +28,26 @@ class FacilityOps {
   }
 
   /**
+   * Returns the section for the requested facility type.
+   *
+   * @param string $section
+   *   Values: vamc, vet center, vba, nca.
+   *
+   * @return int
+   *   The section id of the facility type, or 0.
+   */
+  public static function getFacilityTypeSectionId($section) {
+    $sections = [
+      'vamc' => 8,
+      'vet center' => 190,
+      'vba' => 191,
+      'nca' => 192,
+    ];
+
+    return $sections[$section] ?? 0;
+  }
+
+  /**
    * Checks if the node is a facility.
    *
    * @param \Drupal\node\NodeInterface $node

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityPreventReuse.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityPreventReuse.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Drupal\va_gov_vamc\EventSubscriber;
+
+use Drupal\core_event_dispatcher\EntityHookEvents;
+use Drupal\core_event_dispatcher\Event\Entity\EntityAccessEvent;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\va_gov_facilities\FacilityOps;
+use Drupal\va_gov_user\Service\UserPermsService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * VA.gov VAMC Entity Event Subscriber.
+ */
+class VAMCEntityPreventReuse implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  private $database;
+
+  /**
+   * The Drupal Messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   *  The Drupal Messenger.
+   */
+  protected $messenger;
+
+  /**
+   * The User Perms Service.
+   *
+   * @var \Drupal\va_gov_user\Service\UserPermsService
+   */
+  protected $userPermsService;
+
+  /**
+   * Constructs the EventSubscriber object.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The current user.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
+   * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
+   *   The user perms service.
+   */
+  public function __construct(
+    Connection $database,
+    MessengerInterface $messenger,
+    UserPermsService $user_perms_service,
+  ) {
+    $this->database = $database;
+    $this->messenger = $messenger;
+    $this->userPermsService = $user_perms_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      EntityHookEvents::ENTITY_ACCESS => 'entityAccess',
+    ];
+  }
+
+  /**
+   * Alteration to entity view pages.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityAccessEvent $event
+   *   The entity view alter service.
+   */
+  public function entityAccess(EntityAccessEvent $event) {
+    $node = $event->getEntity();
+    $op = $event->getOperation();
+    if ($node instanceof NodeInterface && $this->isRestricted($node, $op)) {
+      $tokens = ['@content_type' => $node->type->entity->label()];
+      $reason_message = (string) $this->t('This @content_type has already been unpublished, it can no longer be edited.', $tokens);
+      $this->messenger->addWarning($reason_message);
+      // Like other perms in Drupal, grants are additive, so we have to pull
+      // this one grant out explicitly to operate only on the basis of
+      // restricting to this grant.
+      $result = AccessResult::forbidden($reason_message);
+      $result->addCacheTags(['tag_from_' . __FUNCTION__]);
+      $result->cachePerUser();
+      // Cache for a week.  This value should not change often.
+      $result->setCacheMaxAge(604800);
+      $event->setAccessResult($result);
+    }
+  }
+
+  /**
+   * Checks to see if the node moved from published to unpublished.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   *
+   * @return bool
+   *   TRUE if the node moved from published to unpublished. FALSE otherwise.
+   */
+  public static function isAnUnpublishEvent(NodeInterface $node): bool {
+    $new_state = $node->isPublished();
+    $previous_state = (!empty($node->original)) ? $node->original->isPublished() : 0;
+    if (!$new_state && $previous_state) {
+      // This was published on the previous revision, but is no longer.
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Checks to see if there are previously published revisions for the node.
+   *
+   * This is a heavier check. Use isAnUnpublishEvent() first, it's lighter.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   A node to check for published revisions.
+   *
+   * @return bool
+   *   TRUE if it had previously published revisions. False otherwise.
+   */
+  public static function hasPublishedRevisions($node): bool {
+    if ($node->isPublished()) {
+      // This is still published so no need to look for previous publishes.
+      return FALSE;
+    }
+    $storage = \Drupal::entityTypeManager()
+      ->getStorage('node');
+
+    $count = $storage->getQuery()
+      ->condition('nid', $node->id())
+      ->condition('status', 1)
+      ->allRevisions()
+      ->count()
+      ->execute();
+    // This has a published revision.
+    return $count >= 1;
+  }
+
+  /**
+   * Checks to see if the node is restricted by specific access grant.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   A node to check for restriction.
+   * @param string $op
+   *   The operation view, update, delete.
+   *
+   * @return bool
+   *   TRUE if the node operation is restricted by node access grant,
+   *   FALSE otherwise.
+   */
+  public function isRestricted(NodeInterface $node, $op): bool {
+    $is_restricted = FALSE;
+    $restricted_ops = [
+      'clone',
+      'delete',
+      'update',
+    ];
+    if (in_array($op, $restricted_ops) && $node->bundle() === 'full_width_banner_alert') {
+      // Check the node for an existing access grant of this type.
+      $select = $this->database
+        ->select('node_access', 'na')
+        ->fields('na', ['grant_view', 'grant_update', 'grant_delete'])
+        ->condition('na.realm', 'node_reuse_restrict', '=')
+        ->condition('na.gid', FacilityOps::getFacilityTypeSectionId('vamc'), '=')
+        ->condition('nid', $node->id());
+      $result = $select->execute()->fetchObject();
+      if (!empty($result) && empty($result->$op)) {
+        $is_restricted = TRUE;
+      }
+      elseif (!empty($result) && $op === 'clone') {
+        // Clone isn't covered by grants, we have to force based on grant exist.
+        $is_restricted = TRUE;
+      }
+    }
+
+    return $is_restricted;
+  }
+
+  /**
+   * Evaluates the node to see if should get locked for editing.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   A node to check for restriction.
+   *
+   * @return array
+   *   An array of grant data, or empty array.
+   */
+  public static function buildGrantForEditLock(NodeInterface $node): array {
+    $grants = [];
+    if (($node->bundle() === 'full_width_banner_alert')
+      && !$node->isPublished()
+      && (self::isAnUnpublishEvent($node) || self::hasPublishedRevisions($node))
+    ) {
+      // The node should be locked because it was published but is not anymore.
+      $grants[] = [
+        'langcode' => $node->get('langcode')->value,
+        'gid' => FacilityOps::getFacilityTypeSectionId('vamc'),
+        'realm' => 'node_reuse_restrict',
+        'grant_view' => 1,
+        'grant_update' => 0,
+        'grant_delete' => 0,
+      ];
+    }
+    return $grants;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
@@ -266,16 +266,6 @@ function va_gov_vamc_update_9006(&$sandbox) {
 }
 
 /**
- * Rebuild node_access table to include new node grants for VAMC Banners.
- */
-function va_gov_vamc_update_9007(&$sandbox) {
-  node_access_needs_rebuild(TRUE);
-  // Note for history.  Used of node_access_rebuild() yields faulty results
-  // so rebuild using the UI.
-  return 'Flagged that node_access need to be rebuilt in the UI.';
-}
-
-/**
  * Update the alert body field to only rich_text_limited.
  */
 function va_gov_vamc_update_9007() {

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
@@ -266,6 +266,15 @@ function va_gov_vamc_update_9006(&$sandbox) {
 }
 
 /**
+ * Rebuild node_access table to include new node grants for VAMC Banners.
+ */
+function va_gov_vamc_update_9007(&$sandbox) {
+  node_access_needs_rebuild(TRUE);
+  node_access_rebuild();
+  return 'Rebuilt all node_access grants. Approximately 49,000.';
+}
+
+/**
  * Update the alert body field to only rich_text_limited.
  */
 function va_gov_vamc_update_9007() {

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
@@ -270,8 +270,9 @@ function va_gov_vamc_update_9006(&$sandbox) {
  */
 function va_gov_vamc_update_9007(&$sandbox) {
   node_access_needs_rebuild(TRUE);
-  node_access_rebuild();
-  return 'Rebuilt all node_access grants. Approximately 49,000.';
+  // Note for history.  Used of node_access_rebuild() yields faulty results
+  // so rebuild using the UI.
+  return 'Flagged that node_access need to be rebuilt in the UI.';
 }
 
 /**

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
@@ -5,9 +5,13 @@
  * Contains va_gov_vamc.module.
  */
 
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+use Drupal\va_gov_facilities\FacilityOps;
+use Drupal\va_gov_vamc\EventSubscriber\VAMCEntityPreventReuse;
 
 /**
  * Implements hook_help().
@@ -46,6 +50,31 @@ function va_gov_vamc_form_alter(&$form, FormStateInterface $form_state, $form_id
       _va_gov_vamc_vbo_facility_status_form_ui($form, $form_state);
     }
   }
+}
+
+/**
+ * Implements hook_node_access_records().
+ */
+function va_gov_vamc_node_access_records(NodeInterface $node) {
+  $grants = VAMCEntityPreventReuse::buildGrantForEditLock($node);
+
+  return $grants;
+}
+
+/**
+ * Implements hook_node_grants().
+ */
+function va_gov_vamc_node_grants(AccountInterface $account, $operation) {
+  // This assigns access grants, to remove the edit tab/operation.
+  $grants = [];
+  /** @var Drupal\va_gov_user\Service\UserPermsService $va_perm_service */
+  $va_perm_service = Drupal::getContainer()->get('va_gov_user.user_perms');
+  if (!$va_perm_service->hasAdminRole(TRUE)) {
+    // This user is not admin, everyone else should be restricted from re-using
+    // if a reusing grant is set on the node.
+    $grants['node_reuse_restrict'] = [FacilityOps::getFacilityTypeSectionId('vamc')];
+  }
+  return $grants;
 }
 
 /**
@@ -113,13 +142,9 @@ function _va_gov_vamc_vbo_facility_status_form_ui(array &$form, FormStateInterfa
  *   The node form array.
  */
 function _va_gov_vamc_vamc_title_access(array &$form) {
-  $allowed_roles = [
-    'administrator',
-    'content_admin',
-  ];
-  $current_user_roles = \Drupal::currentUser()->getRoles();
-  $admin_role_count = count(array_intersect($allowed_roles, $current_user_roles));
-  if ($admin_role_count < 1) {
+  /** @var Drupal\va_gov_user\Service\UserPermsService  $va_permservice */
+  $va_permservice = Drupal::getContainer()->get('va_gov_user.user_perms');
+  if (!$va_permservice->hasAdminRole()) {
     $form['title']['#disabled'] = 'disabled';
   }
 }

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
@@ -10,6 +10,14 @@ services:
       - '@va_gov_notifications.notifications_manager'
     tags:
       - { name: event_subscriber }
+  va_gov_vamc.entity_prevent_reuse:
+    class: Drupal\va_gov_vamc\EventSubscriber\VAMCEntityPreventReuse
+    arguments:
+      - '@database'
+      - '@messenger'
+      - '@va_gov_user.user_perms'
+    tags:
+      - { name: event_subscriber }
   va_gov_vamc.content_hardening_deduper:
     class: Drupal\va_gov_vamc\Service\ContentHardeningDeduper
     arguments: ['@current_user', '@entity_type.manager', '@logger.factory', '@messenger']

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
@@ -15,6 +15,7 @@ services:
     arguments:
       - '@database'
       - '@messenger'
+      - '@current_route_match'
       - '@va_gov_user.user_perms'
     tags:
       - { name: event_subscriber }

--- a/tests/cypress/integration/common/i_check_the_checkbox.js
+++ b/tests/cypress/integration/common/i_check_the_checkbox.js
@@ -7,3 +7,15 @@ Given(`I check the {string} checkbox`, (text) => {
 Given(`I uncheck the {string} checkbox`, (text) => {
   cy.contains(text).parent().find("input").uncheck({ force: true });
 });
+
+Given(`I check the {string} checkbox within {string}`, (text, selector) => {
+  cy.get(selector).contains(text).parent().find("input").check({ force: true });
+});
+
+Given(`I uncheck the {string} checkbox within {string}`, (text, selector) => {
+  cy.get(selector)
+    .contains(text)
+    .parent()
+    .find("input")
+    .uncheck({ force: true });
+});

--- a/tests/cypress/integration/common/should_exist.js
+++ b/tests/cypress/integration/common/should_exist.js
@@ -35,10 +35,10 @@ Then("an image with the selector {string} should exist", (selector) => {
     });
 });
 
-Then("the {string} tab should exist", (text) =>
+Then("the primary tab {string} should exist", (text) =>
   cy.get(".tabs__tab a").contains(text).should("exist")
 );
 
-Then("the {string} tab should not exist", (text) =>
-  cy.get(".tabs__tab a").contains(text).should("not exist")
+Then("the primary tab {string} should not exist", (text) =>
+  cy.get(".tabs__tab a").contains(text).should("not.exist")
 );

--- a/tests/cypress/integration/common/should_exist.js
+++ b/tests/cypress/integration/common/should_exist.js
@@ -34,3 +34,11 @@ Then("an image with the selector {string} should exist", (selector) => {
       expect($img[0].naturalHeight).to.be.greaterThan(0);
     });
 });
+
+Then("the {string} tab should exist", (text) =>
+  cy.get(".tabs__tab a").contains(text).should("exist")
+);
+
+Then("the {string} tab should not exist", (text) =>
+  cy.get(".tabs__tab a").contains(text).should("not exist")
+);

--- a/tests/cypress/integration/content_editing_vamc_banner_reuse.feature
+++ b/tests/cypress/integration/content_editing_vamc_banner_reuse.feature
@@ -1,0 +1,28 @@
+@content_editing_vamc_banner_reuse
+Feature: VAMC full_width_banner_alert editors should not be able to reuse banners.
+
+Scenario: Log in and create VAMC Full Width Banner Alert
+  When I am logged in as a user with the roles "vamc_content_creator, content_publisher"
+  And my workbench access sections are set to "205"
+  And I am at "/node/add/full_width_banner_alert"
+  And I select option "---VA Boston health care" from dropdown "Section"
+#  And I check the "VA Boston health care" checkbox
+  And I select option "Information" from dropdown "Alert type"
+  And I fill in "Title" with "[Test Data] Banner alert title"
+  And I fill in ckeditor "field-body-0-value" with "[Test Data] Banner alert Body"
+  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
+  And I save the node
+  And I wait "10" seconds
+  Then the "Edit" tab should exist
+  Given I click the edit tab
+  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message publish."
+  And I check the Published checkbox
+  And I save the node
+  And I wait "10" seconds
+  Then the "Edit" tab should exist
+  Given I click the edit tab
+  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message unpublish."
+  And I uncheck the Published checkbox
+  And I save the node
+  And I wait "10" seconds
+  Then the "Edit" tab should not exist

--- a/tests/cypress/integration/content_editing_vamc_banner_reuse.feature
+++ b/tests/cypress/integration/content_editing_vamc_banner_reuse.feature
@@ -6,23 +6,26 @@ Scenario: Log in and create VAMC Full Width Banner Alert
   And my workbench access sections are set to "205"
   And I am at "/node/add/full_width_banner_alert"
   And I select option "---VA Boston health care" from dropdown "Section"
-#  And I check the "VA Boston health care" checkbox
+  And I check the "VA Boston health care" checkbox within "#edit-field-banner-alert-vamcs--wrapper"
   And I select option "Information" from dropdown "Alert type"
   And I fill in "Title" with "[Test Data] Banner alert title"
   And I fill in ckeditor "field-body-0-value" with "[Test Data] Banner alert Body"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I save the node
-  And I wait "10" seconds
-  Then the "Edit" tab should exist
+  Then the primary tab "Edit" should exist
+  And the primary tab "Revisions" should exist
   Given I click the edit tab
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message publish."
-  And I check the Published checkbox
+  And I check the "Published" checkbox within "#edit-status-wrapper"
   And I save the node
-  And I wait "10" seconds
-  Then the "Edit" tab should exist
+  Then the primary tab "Edit" should exist
+  And the primary tab "Revisions" should exist
   Given I click the edit tab
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message unpublish."
-  And I uncheck the Published checkbox
+  And I uncheck the "Published" checkbox within "#edit-status-wrapper"
   And I save the node
-  And I wait "10" seconds
-  Then the "Edit" tab should not exist
+  Then the primary tab "Edit" should not exist
+  And the primary tab "Revisions" should exist
+  And I should see "it can no longer be edited."
+  Given I reload the page
+  Then I should see "it can no longer be edited."


### PR DESCRIPTION
## Description

Closes #8141

## Testing done
## QA steps

Login as an admin
1 visit https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/admin/reports/status/rebuild  and rebuild the permissions (get a cup o coffee, this takes a while)


Login as user edgar.cruse  (an editor in chillicothe)
### Sections page
2. Go [here](https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/section/vha/vamc-facilities/va-chillicothe-health-care) and filter the page for content type = "VAMC System Banner Alert with Situation Updates"
   - [ ] Validate that some have edit buttons and others do not (indicating that some have already been published and unpublished and are no longer available to edit)
 3. GO to the content page https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/admin/content?title=&type=full_width_banner_alert&moderation_state=All&owner=337
   - [ ] Validate that the list has some with edit buttons and some without.
 Go to content not  in your section (tampa health care) https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/admin/content?title=&type=full_width_banner_alert&moderation_state=All&owner=319
    - [ ] Validate that none have edit buttons (Edgar doesn't belong here)
### Edit an existing published
3. go to [this published banner](https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/va-chillicothe-health-care/vamc-banner-alert/2021-11-16/coronavirus)  
   - [ ] validate that you can see the edit and revisions tabs.
   - [ ] Click edit.  Make no changes to the node except for adding a revision log. Save the node.  Validate that you can again see an Edit and Revisions tab
5. Click edit.  Make and uncheck the Published box, add a revision log. Save the node.
   - [ ] Validate that you NOT see an Edit tab, but the Revisions tab is visible.
   - [ ] Validate that you see a warning (yellow) indicating the node has been unpublished and can't be re-used.
  
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/c64f5818-82d4-4adf-b578-8626fddca6cc)

6. Reload the page
   - [ ] Validate the warning persists and the edit tab is still not present.

### A banner that does not belong to you
1. Go to https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/va-tampa-health-care/vamc-banner-alert/2023-04-05/toxic-exposure-screening
   - [ ] Validate you have no access to edit or see revisions.
2. Visit an unpublished banner alert  https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/vamc-banner-alert/2021-06-22/website-coming-soon-not-the-official-va-tampa-health-care-website
   - [ ] Validate you have no way to edit and that you see a warning indicating it can't be edited.

### A new banner

1. Go to https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/node/add/full_width_banner_alert 
2. Fill out all required fields
3. Leave 'Published' unchecked.
4. Save the node
   - [ ] Validate that you still see an edit tab.
5. Edit the node and publish it.   
   - [ ] Validate that you still see an edit  and revisions tab. 
6. Edit the node, unpublish and save it
   - [ ] Validate that you do not, see an edit tab
   - [ ] Validate you do see a revisions tab
   - [ ] Validate you see a warning that says the node as been unpublished and is no longer editable.
 
Login as admin
### Sections page
2. Go [here](https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/section/vha/vamc-facilities/va-chillicothe-health-care) and filter the page for content type = "VAMC System Banner Alert with Situation Updates"
   - [ ] Validate that you see edit buttons on all the banners.
 3. go to this unpubleished previousley published banner https://pr14181-rfsw4ifjca4fum4i40ebyiux9avcuvkg.ci.cms.va.gov/va-chillicothe-health-care/vamc-banner-alert/2021-11-16/coronavirus
   - [ ] Validate that you can edit if you have to
   - [ ] Validate that you see a warning that you can not edit it.  (this is only going to appear once per cached version.) 
