### PR TITLE
VACMS-0000: Enable syntax highlighting for *.module and *.install files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.module linguist-language=PHP
+*.install linguist-language=PHP


### PR DESCRIPTION
See [here](https://github.com/github-linguist/linguist/issues/1792).

Won't work immediately, [apparently](https://github.com/github-linguist/linguist/issues/1792#issuecomment-286418120).

@swirtSJW Any other extensions we need to add here? 🤔 