### PR TITLE
VACMS-14247 Add published filter to VAMC System banner View

### DIFF
--- a/config/sync/views.view.vamc_alerts_and_operating_statuses.yml
+++ b/config/sync/views.view.vamc_alerts_and_operating_statuses.yml
@@ -750,6 +750,62 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+              translation_manager: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         field_administration_target_id:
           id: field_administration_target_id
           table: node__field_administration
@@ -849,6 +905,10 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:

--- a/config/sync/views.view.vamc_alerts_and_operating_statuses.yml
+++ b/config/sync/views.view.vamc_alerts_and_operating_statuses.yml
@@ -577,23 +577,7 @@ display:
         type: tag
         options: {  }
       empty: {  }
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          order: DESC
-          expose:
-            label: ''
-            field_identifier: created
-          exposed: false
-          granularity: second
+      sorts: {  }
       arguments: {  }
       filters:
         field_alert_type_value:
@@ -923,8 +907,8 @@ display:
             field_administration: field_administration
             created: created
             changed: changed
-            moderation_state: moderation_state
-          default: '-1'
+            status: status
+          default: changed
           info:
             title:
               sortable: true
@@ -968,12 +952,12 @@ display:
               responsive: ''
             changed:
               sortable: true
-              default_sort_order: asc
+              default_sort_order: desc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-            moderation_state:
+            status:
               sortable: true
               default_sort_order: asc
               align: ''
@@ -984,7 +968,7 @@ display:
           sticky: false
           summary: ''
           empty_table: false
-          caption: ''
+          caption: 'Results of VAMC System banner alerts and Operating status pages.'
           description: ''
       row:
         type: fields
@@ -1046,7 +1030,9 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/content/vamc-alerts-and-statuses
       menu:
         type: normal


### PR DESCRIPTION
## Description
Closes #14247

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

As and admin 
1. Go to /admin/content/vamc-alerts-and-statuses
   - [ ]  Validate that you can filter by published.   (not moderation state)


