### PR TITLE
VACMS-0000: Disable sitewide_alert alerts on Tugboat.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -189,6 +189,9 @@ services:
         # https://www.drush.org/latest/deploycommand/ (updatedb, cache:rebuild, config:import, deploy:hook)
         - drush deploy
 
+        # Disable sitewide alerts so as not to interfere with testing.
+        - drush sitewide-alert:disable
+
         # Prevent continuous releases from running on Tugboat, and reset to ready.
         - drush sset va_gov_build_trigger.continuous_release_enabled 0
         - drush sset va_gov_build_trigger.release_state ready


### PR DESCRIPTION
## Description

`sitewide_alert` alerts added to prod can propagate through the lower environments, but that's not ideal. The information they contain is generally not relevant. If it is relevant, we already know about it and are trying to fix the underlying issue. Either way, the alert can interfere with browser tests that expect certain elements to be visible. 

This can be somewhat difficult to predict, since some elements vary in length, and one that is a few characters too wide can be partially obscured by the JSD widget and thus not visible for test purposes.

This PR should disable all `sitewide_alert` alerts so that our tests run against a more predictable configuration.

![Screenshot 2023-07-05 at 8 55 09 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/1318579/4f9d3ab0-cd16-4ed8-b13d-249689b6d00d)

![Screenshot 2023-07-05 at 8 56 13 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/1318579/572f5f29-b7d2-4ff3-a26a-9a0bc4ed4214)
