### PR TITLE
VACMS-13850: Creates `FormRouteSubscriber` service.

### DIFF
--- a/docroot/modules/custom/va_gov_content_release/src/EventSubscriber/FormRouteSubscriber.php
+++ b/docroot/modules/custom/va_gov_content_release/src/EventSubscriber/FormRouteSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\va_gov_content_release\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\va_gov_content_release\Form\Resolver\ResolverInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Sets the form class for the content release form based on the form resolver.
+ *
+ * This normally will be set per-environment, but we can override it for testing
+ * purposes.
+ */
+class FormRouteSubscriber extends RouteSubscriberBase implements FormRouteSubscriberInterface {
+
+  const ROUTE_NAME = 'va_gov_content_release.content_release_form';
+
+  /**
+   * Form Resolver service.
+   *
+   * @var \Drupal\va_gov_content_release\Form\ResolverInterface
+   */
+  protected $formResolver;
+
+  /**
+   * The constructor.
+   *
+   * @param \Drupal\va_gov_content_release\Form\ResolverInterface $formResolver
+   *   Form resolver service.
+   */
+  public function __construct(ResolverInterface $formResolver) {
+    $this->formResolver = $formResolver;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get(static::ROUTE_NAME)) {
+      $this->alterRoute($route);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoute(Route $route) {
+    $route->setDefault('_form', $this->formResolver->getFormClass());
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/EventSubscriber/FormRouteSubscriber.php
+++ b/docroot/modules/custom/va_gov_content_release/src/EventSubscriber/FormRouteSubscriber.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class FormRouteSubscriber extends RouteSubscriberBase implements FormRouteSubscriberInterface {
 
-  const ROUTE_NAME = 'va_gov_content_release.content_release_form';
+  const ROUTE_NAME = 'va_gov_content_release.form';
 
   /**
    * Form Resolver service.

--- a/docroot/modules/custom/va_gov_content_release/src/EventSubscriber/FormRouteSubscriberInterface.php
+++ b/docroot/modules/custom/va_gov_content_release/src/EventSubscriber/FormRouteSubscriberInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\va_gov_content_release\EventSubscriber;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * Sets the form class for the content release form based on the form resolver.
+ *
+ * This normally will be set per-environment, but we can override it for testing
+ * purposes.
+ */
+interface FormRouteSubscriberInterface {
+
+  /**
+   * Alter the specified route accordingly.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route.
+   */
+  public function alterRoute(Route $route);
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/Form/Resolver/Resolver.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Form/Resolver/Resolver.php
@@ -6,7 +6,7 @@ use Drupal\va_gov_build_trigger\Form\BrdBuildTriggerForm;
 use Drupal\va_gov_build_trigger\Form\LocalBuildTriggerForm;
 use Drupal\va_gov_build_trigger\Form\TugboatBuildTriggerForm;
 use Drupal\va_gov_content_release\Exception\CouldNotDetermineFormException;
-use Drupal\va_gov_environment\Service\DiscoveryInterface;
+use Drupal\va_gov_environment\Discovery\DiscoveryInterface;
 
 /**
  * The form resolver service.
@@ -20,14 +20,14 @@ class Resolver implements ResolverInterface {
   /**
    * The environment discovery service.
    *
-   * @var \Drupal\va_gov_environment\Service\DiscoveryInterface
+   * @var \Drupal\va_gov_environment\Discovery\DiscoveryInterface
    */
   protected $environmentDiscovery;
 
   /**
    * Constructor.
    *
-   * @param \Drupal\va_gov_environment\Service\DiscoveryInterface $environmentDiscovery
+   * @param \Drupal\va_gov_environment\Discovery\DiscoveryInterface $environmentDiscovery
    *   The environment discovery service.
    */
   public function __construct(DiscoveryInterface $environmentDiscovery) {

--- a/docroot/modules/custom/va_gov_content_release/src/Strategy/Resolver/Resolver.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Strategy/Resolver/Resolver.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\va_gov_content_release\Strategy\Resolver;
 
-use Drupal\va_gov_environment\Service\DiscoveryInterface;
+use Drupal\va_gov_environment\Discovery\DiscoveryInterface;
 use Drupal\va_gov_content_release\Strategy\Plugin\StrategyPluginManagerInterface;
 use Drupal\va_gov_content_release\Exception\CouldNotDetermineStrategyException;
 
@@ -24,7 +24,7 @@ class Resolver implements ResolverInterface {
   /**
    * The environment discovery service.
    *
-   * @var \Drupal\va_gov_environment\Service\DiscoveryInterface
+   * @var \Drupal\va_gov_environment\Discovery\DiscoveryInterface
    */
   protected $environmentDiscovery;
 
@@ -33,7 +33,7 @@ class Resolver implements ResolverInterface {
    *
    * @param \Drupal\va_gov_content_release\Strategy\Plugin\StrategyPluginManagerInterface $strategyPluginManager
    *   The strategy plugin manager.
-   * @param \Drupal\va_gov_environment\Service\DiscoveryInterface $environmentDiscovery
+   * @param \Drupal\va_gov_environment\Discovery\DiscoveryInterface $environmentDiscovery
    *   The environment discovery service.
    */
   public function __construct(

--- a/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
+++ b/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
@@ -1,0 +1,31 @@
+va_gov_content_release.content_release_form:
+  path: "/admin/content/deploy"
+  defaults:
+    _title: 'Manual content release'
+    _form: '\Drupal\va_gov_build_trigger\Form\BuildTriggerForm'
+  requirements:
+    _permission: "va gov deploy content build"
+
+va_gov_content_release.content_release_form.local:
+  path: "/admin/content/deploy/local"
+  defaults:
+    _title: '[TEST] Local manual content release'
+    _form: '\Drupal\va_gov_build_trigger\Form\LocalBuildTriggerForm'
+  requirements:
+    _permission: "va gov deploy content build"
+
+va_gov_content_release.content_release_form.tugboat:
+  path: "/admin/content/deploy/tugboat"
+  defaults:
+    _title: '[TEST] Tugboat manual content release'
+    _form: '\Drupal\va_gov_build_trigger\Form\TugboatBuildTriggerForm'
+  requirements:
+    _permission: "va gov deploy content build"
+
+va_gov_content_release.content_release_form.brd:
+  path: "/admin/content/deploy/brd"
+  defaults:
+    _title: '[TEST] BRD manual content release'
+    _form: '\Drupal\va_gov_build_trigger\Form\BrdBuildTriggerForm'
+  requirements:
+    _permission: "va gov deploy content build"

--- a/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
+++ b/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
@@ -1,4 +1,4 @@
-va_gov_content_release.content_release_form:
+va_gov_content_release.form:
   path: "/admin/content/deploy/new"
   defaults:
     _title: 'Manual content release'
@@ -6,7 +6,7 @@ va_gov_content_release.content_release_form:
   requirements:
     _permission: "va gov deploy content build"
 
-va_gov_content_release.content_release_form.local:
+va_gov_content_release.form.local:
   path: "/admin/content/deploy/local"
   defaults:
     _title: '[TEST] Local manual content release'
@@ -14,7 +14,7 @@ va_gov_content_release.content_release_form.local:
   requirements:
     _permission: "va gov deploy content build"
 
-va_gov_content_release.content_release_form.tugboat:
+va_gov_content_release.form.tugboat:
   path: "/admin/content/deploy/tugboat"
   defaults:
     _title: '[TEST] Tugboat manual content release'
@@ -22,7 +22,7 @@ va_gov_content_release.content_release_form.tugboat:
   requirements:
     _permission: "va gov deploy content build"
 
-va_gov_content_release.content_release_form.brd:
+va_gov_content_release.form.brd:
   path: "/admin/content/deploy/brd"
   defaults:
     _title: '[TEST] BRD manual content release'

--- a/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
+++ b/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
@@ -1,5 +1,5 @@
 va_gov_content_release.content_release_form:
-  path: "/admin/content/deploy"
+  path: "/admin/content/deploy/new"
   defaults:
     _title: 'Manual content release'
     _form: '\Drupal\va_gov_build_trigger\Form\BuildTriggerForm'

--- a/docroot/modules/custom/va_gov_content_release/va_gov_content_release.services.yml
+++ b/docroot/modules/custom/va_gov_content_release/va_gov_content_release.services.yml
@@ -17,3 +17,8 @@ services:
   plugin.manager.va_gov_content_release.strategy:
     class: Drupal\va_gov_content_release\Strategy\Plugin\StrategyPluginManager
     parent: default_plugin_manager
+  va_gov_content_release.form_route_subscriber:
+    class: Drupal\va_gov_content_release\EventSubscriber\FormRouteSubscriber
+    arguments: ['@va_gov_content_release.form_resolver']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/va_gov_environment/src/Discovery/Discovery.php
+++ b/docroot/modules/custom/va_gov_environment/src/Discovery/Discovery.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\va_gov_environment\Service;
+namespace Drupal\va_gov_environment\Discovery;
 
 use Drupal\Core\Site\Settings;
 use Drupal\va_gov_environment\Environment\Environment;

--- a/docroot/modules/custom/va_gov_environment/src/Discovery/DiscoveryInterface.php
+++ b/docroot/modules/custom/va_gov_environment/src/Discovery/DiscoveryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\va_gov_environment\Service;
+namespace Drupal\va_gov_environment\Discovery;
 
 use Drupal\va_gov_environment\Environment\EnvironmentInterface;
 

--- a/docroot/modules/custom/va_gov_environment/va_gov_environment.services.yml
+++ b/docroot/modules/custom/va_gov_environment/va_gov_environment.services.yml
@@ -1,4 +1,4 @@
 services:
   va_gov_environment.discovery:
-    class: Drupal\va_gov_environment\Service\Discovery
+    class: Drupal\va_gov_environment\Discovery\Discovery
     arguments: [ '@settings' ]

--- a/tests/phpunit/va_gov_content_release/functional/EventSubscriber/FormRouteSubscriberTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/EventSubscriber/FormRouteSubscriberTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace tests\phpunit\va_gov_content_release\functional\Form\Resolver;
+
+use Drupal\va_gov_content_release\EventSubscriber\FormRouteSubscriber;
+use Tests\Support\Classes\VaGovExistingSiteBase;
+use Drupal\va_gov_build_trigger\Form\BuildTriggerForm;
+use Drupal\va_gov_build_trigger\Form\BrdBuildTriggerForm;
+use Drupal\va_gov_build_trigger\Form\LocalBuildTriggerForm;
+use Drupal\va_gov_build_trigger\Form\TugboatBuildTriggerForm;
+
+/**
+ * Functional test of the Form Route Subscriber service.
+ *
+ * @group functional
+ * @group all
+ *
+ * @coversDefaultClass \Drupal\va_gov_content_release\EventSubscriber\FormRouteSubscriber
+ */
+class FormRouteSubscriberTest extends VaGovExistingSiteBase {
+
+  /**
+   * Test that the service is available.
+   *
+   * @covers ::__construct
+   */
+  public function testConstruct() {
+    $formRouteSubscriber = \Drupal::service('va_gov_content_release.form_route_subscriber');
+    $this->assertInstanceOf(FormRouteSubscriber::class, $formRouteSubscriber);
+  }
+
+  /**
+   * Test that the route has been altered.
+   *
+   * The route is normally using the form base class, so if that is still the
+   * case, the route has not been altered and something's broken.
+   */
+  public function testAlterRoute() {
+    $route = $this->container->get('router.route_provider')->getRouteByName('va_gov_content_release.content_release_form');
+    $form = $route->getDefault('_form');
+    $this->assertNotEquals(BuildTriggerForm::class, $form);
+    $this->assertContains($form, [
+      BrdBuildTriggerForm::class,
+      LocalBuildTriggerForm::class,
+      TugboatBuildTriggerForm::class,
+    ]);
+  }
+
+  /**
+   * Test that our form test routes are in place.
+   *
+   * @param string $route
+   *   The route name.
+   * @param string $class
+   *   The form class.
+   *
+   * @dataProvider formTestRoutesProvider
+   */
+  public function testFormTestRoutes(string $route, string $class) {
+    $prefix = 'va_gov_content_release.content_release_form.';
+    $route = $this->container->get('router.route_provider')->getRouteByName("{$prefix}{$route}");
+    $form = $route->getDefault('_form');
+    $this->assertEquals("\\{$class}", $form);
+  }
+
+  /**
+   * Data provider for testFormTestRoutes.
+   *
+   * @return array
+   *   The data.
+   */
+  public function formTestRoutesProvider() {
+    return [
+      ['brd', BrdBuildTriggerForm::class],
+      ['local', LocalBuildTriggerForm::class],
+      ['tugboat', TugboatBuildTriggerForm::class],
+    ];
+  }
+
+}

--- a/tests/phpunit/va_gov_content_release/functional/EventSubscriber/FormRouteSubscriberTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/EventSubscriber/FormRouteSubscriberTest.php
@@ -36,7 +36,7 @@ class FormRouteSubscriberTest extends VaGovExistingSiteBase {
    * case, the route has not been altered and something's broken.
    */
   public function testAlterRoute() {
-    $route = $this->container->get('router.route_provider')->getRouteByName('va_gov_content_release.content_release_form');
+    $route = $this->container->get('router.route_provider')->getRouteByName('va_gov_content_release.form');
     $form = $route->getDefault('_form');
     $this->assertNotEquals(BuildTriggerForm::class, $form);
     $this->assertContains($form, [
@@ -57,7 +57,7 @@ class FormRouteSubscriberTest extends VaGovExistingSiteBase {
    * @dataProvider formTestRoutesProvider
    */
   public function testFormTestRoutes(string $route, string $class) {
-    $prefix = 'va_gov_content_release.content_release_form.';
+    $prefix = 'va_gov_content_release.form.';
     $route = $this->container->get('router.route_provider')->getRouteByName("{$prefix}{$route}");
     $form = $route->getDefault('_form');
     $this->assertEquals("\\{$class}", $form);

--- a/tests/phpunit/va_gov_content_release/unit/Form/Resolver/ResolverTest.php
+++ b/tests/phpunit/va_gov_content_release/unit/Form/Resolver/ResolverTest.php
@@ -7,7 +7,7 @@ use Drupal\va_gov_build_trigger\Form\LocalBuildTriggerForm;
 use Drupal\va_gov_build_trigger\Form\TugboatBuildTriggerForm;
 use Drupal\va_gov_content_release\Form\Resolver\Resolver;
 use Drupal\va_gov_environment\Environment\Environment;
-use Drupal\va_gov_environment\Service\DiscoveryInterface;
+use Drupal\va_gov_environment\Discovery\DiscoveryInterface;
 use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**

--- a/tests/phpunit/va_gov_content_release/unit/Strategy/Resolver/ResolverTest.php
+++ b/tests/phpunit/va_gov_content_release/unit/Strategy/Resolver/ResolverTest.php
@@ -6,7 +6,7 @@ use Drupal\va_gov_content_release\Strategy\Plugin\StrategyPluginManagerInterface
 use Drupal\va_gov_content_release\Strategy\Resolver\Resolver;
 use Drupal\va_gov_content_release\Strategy\Resolver\ResolverInterface;
 use Drupal\va_gov_environment\Environment\Environment;
-use Drupal\va_gov_environment\Service\DiscoveryInterface;
+use Drupal\va_gov_environment\Discovery\DiscoveryInterface;
 use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**

--- a/tests/phpunit/va_gov_environment/functional/Service/DiscoveryTest.php
+++ b/tests/phpunit/va_gov_environment/functional/Service/DiscoveryTest.php
@@ -10,7 +10,7 @@ use Tests\Support\Classes\VaGovExistingSiteBase;
  * @group functional
  * @group all
  *
- * @coversDefaultClass \Drupal\va_gov_environment\Service\Discovery
+ * @coversDefaultClass \Drupal\va_gov_environment\Discovery\Discovery
  */
 class DiscoveryTest extends VaGovExistingSiteBase {
 

--- a/tests/phpunit/va_gov_environment/unit/Environment/EnvironmentTest.php
+++ b/tests/phpunit/va_gov_environment/unit/Environment/EnvironmentTest.php
@@ -4,7 +4,7 @@ namespace tests\phpunit\va_gov_environment\unit\Environment;
 
 use Drupal\Core\Site\Settings;
 use Drupal\va_gov_environment\Environment\Environment;
-use Drupal\va_gov_environment\Service\Discovery;
+use Drupal\va_gov_environment\Discovery\Discovery;
 use Tests\Support\Classes\VaGovUnitTestBase;
 
 /**

--- a/tests/phpunit/va_gov_environment/unit/Service/DiscoveryTest.php
+++ b/tests/phpunit/va_gov_environment/unit/Service/DiscoveryTest.php
@@ -4,7 +4,7 @@ namespace tests\phpunit\va_gov_environment\unit\Service;
 
 use Drupal\Core\Site\Settings;
 use Drupal\va_gov_environment\Environment\Environment;
-use Drupal\va_gov_environment\Service\Discovery;
+use Drupal\va_gov_environment\Discovery\Discovery;
 use Drupal\va_gov_environment\Exception\InvalidEnvironmentException;
 use Tests\Support\Classes\VaGovUnitTestBase;
 
@@ -14,7 +14,7 @@ use Tests\Support\Classes\VaGovUnitTestBase;
  * @group unit
  * @group all
  *
- * @coversDefaultClass \Drupal\va_gov_environment\Service\Discovery
+ * @coversDefaultClass \Drupal\va_gov_environment\Discovery\Discovery
  */
 class DiscoveryTest extends VaGovUnitTestBase {
 


### PR DESCRIPTION
## Description

Closes #13850.

This does not yet replace the `va_gov_build_trigger` route subscriber; I have a separate issue for doing that, #14272.