### PR TITLE
VACMS-14274: Removes entityqueue permission that is no longer valid.

### DIFF
--- a/config/sync/user.role.content_admin.yml
+++ b/config/sync/user.role.content_admin.yml
@@ -137,7 +137,6 @@ permissions:
   - 'update any news_promo block content'
   - 'update any promo block content'
   - 'update content translations'
-  - 'update home_page_hub_list entityqueue'
   - 'update media'
   - 'use editorial transition approve'
   - 'use editorial transition archive'

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -184,7 +184,6 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
           'update any news_promo block content',
           'update any promo block content',
           'update content translations',
-          'update home_page_hub_list entityqueue',
           'update media',
           'use editorial transition approve',
           'use editorial transition archive',


### PR DESCRIPTION
## Description
Removes an invalid permission causing D10 php exception to be thrown any time role dependencies are calculated.

Relates to #14274

## Testing done
Unit

## QA steps
As a content admin:
1. Visit admin/config/content/formats/manage/rich_text
2. Click 'Save configuration'
   - [ ] Validate that there are no errors

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
