### PR TITLE
VACMS-14175: updates to pdf report, fixes access for POs

### DIFF
--- a/config/sync/views.view.pdf_audit.yml
+++ b/config/sync/views.view.pdf_audit.yml
@@ -1291,11 +1291,11 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: custom
-          label: 'File Link'
+          label: 'Web Link'
           exclude: false
           alter:
             alter_text: true
-            text: "{% set public= 'public://' %}\r\n{% set prod= 'https://www.va.gov/files/' %} \r\n{% set local= '/' %} \r\n\r\nCMS: <a href=\"{{ uri|replace({ (public): local}) }}\">{{ uri|replace({ (public): local}) }}</a><br>\r\nWeb: <a href=\"{{ uri|replace({ (public): prod}) }}\">{{ uri|replace({ (public): prod}) }}</a>"
+            text: "{% set public= 'public://' %}\r\n{% set prod= 'https://www.va.gov/files/' %} \r\n{% set local= '/' %} \r\n <a href=\"{{ uri|replace({ (public): prod}) }}\">{{ uri|replace({ (public): prod}) }}</a>"
             make_link: false
             path: ''
             absolute: false
@@ -2439,11 +2439,11 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: custom
-          label: 'File Link'
+          label: 'Web Link'
           exclude: false
           alter:
             alter_text: true
-            text: "{% set public= 'public://' %}\r\n{% set prod= 'https://www.va.gov/files/' %} \r\n{% set local= '/' %} \r\n\r\nCMS: <a href=\"{{ uri|replace({ (public): local}) }}\">{{ uri|replace({ (public): local}) }}</a><br>\r\nWeb: <a href=\"{{ uri|replace({ (public): prod}) }}\">{{ uri|replace({ (public): prod}) }}</a>"
+            text: "{% set public= 'public://' %}\r\n{% set prod= 'https://www.va.gov/files/' %} \r\n{% set local= '/' %} \r\n <a href=\"{{ uri|replace({ (public): prod}) }}\">{{ uri|replace({ (public): prod}) }}</a>"
             make_link: false
             path: ''
             absolute: false
@@ -2675,6 +2675,73 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: reverse__node__field_pdf_version
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: 'field_pdf_version Published'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         view_node:
           id: view_node
           table: node_field_revision
@@ -2684,7 +2751,7 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: entity_link
-          label: 'Link to Content'
+          label: field_pdf_version
           exclude: false
           alter:
             alter_text: false
@@ -2728,6 +2795,73 @@ display:
           text: view
           output_url_as_text: true
           absolute: true
+        status_1:
+          id: status_1
+          table: node_field_data
+          field: status
+          relationship: reverse__node__field_media
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: 'field_media Published'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         view_node_1:
           id: view_node_1
           table: node_field_revision
@@ -2737,7 +2871,7 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: entity_link
-          label: 'Link to Content'
+          label: field_media
           exclude: false
           alter:
             alter_text: false
@@ -2781,6 +2915,73 @@ display:
           text: view
           output_url_as_text: true
           absolute: true
+        status_2:
+          id: status_2
+          table: node_field_data
+          field: status
+          relationship: reverse__node__field_press_release_downloads
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: 'field_press_release_downloads Published'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         view_node_2:
           id: view_node_2
           table: node_field_revision
@@ -2790,7 +2991,7 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: entity_link
-          label: 'Link to Content'
+          label: field_press_release_downloads
           exclude: false
           alter:
             alter_text: false

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/views/access/PdfAuditAccess.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/views/access/PdfAuditAccess.php
@@ -34,9 +34,12 @@ class PdfAuditAccess extends AccessPluginBase {
       '29',
       '80',
       '2046',
-      '4433', //erika washburn
-      '1203', //dave conlon
-      '1342' //michelle middaugh
+      // Erika washburn.
+      '4433',
+      // Dave conlon.
+      '1203',
+      // Michelle middaugh.
+      '1342',
     ];
     $account_roles = $account->getRoles();
     $account_id = $account->id();

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/views/access/PdfAuditAccess.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/views/access/PdfAuditAccess.php
@@ -34,6 +34,9 @@ class PdfAuditAccess extends AccessPluginBase {
       '29',
       '80',
       '2046',
+      '4433', //erika washburn
+      '1203', //dave conlon
+      '1342' //michelle middaugh
     ];
     $account_roles = $account->getRoles();
     $account_id = $account->id();

--- a/scripts/compile-theme.sh
+++ b/scripts/compile-theme.sh
@@ -17,6 +17,7 @@ export NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
 
 pushd ./docroot/core
+nvm install 16
 yarn install
 yarn build:css
 popd


### PR DESCRIPTION
## Description

Closes #14175.

## Testing done
Tested locally. CMS link removed because link to entity is already present in title field. CSV exprot now contains published column for each pdf column. 

## Screenshots


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  


1. Log into the CMS and navigate to `/admin/content/media/pdfs`
   - [x] Validate that Web Link column exists and contains a linkt ot eh file onteh front end.
2. Then click Download CSV
   - [x] Validate that field_pdf_version, field_media and field_press_release_downloads are present and are each preceded by a Published column.  
   - [x] Validate that the csv downloads.
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
