### PR TITLE
VACMS-13854: Create Response Strategy plugin system.

### DIFF
--- a/docroot/modules/custom/va_gov_content_release/src/Annotation/ContentReleaseStrategy.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Annotation/ContentReleaseStrategy.php
@@ -23,7 +23,7 @@ class ContentReleaseStrategy extends Plugin {
   public $id;
 
   /**
-   * The human-readable name of the environemnt.
+   * The human-readable name of the strategy.
    *
    * @var \Drupal\Core\Annotation\Translation
    */

--- a/docroot/modules/custom/va_gov_content_release/src/Annotation/EntityEventStrategy.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Annotation/EntityEventStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\va_gov_content_release\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines the annotation object for entity event strategy plugins.
+ *
+ * @see plugin_api
+ * @see \Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginInterface
+ * @see \Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginManager
+ *
+ * @Annotation
+ */
+class EntityEventStrategy extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the entity event strategy.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $label;
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginBase.php
+++ b/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginBase.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class used for Entity Event Strategy plugins.
+ *
+ * These plugins are used to determine if a content release should be triggered
+ * based on the environment and the entity event.
+ */
+abstract class StrategyPluginBase extends PluginBase implements StrategyPluginInterface, ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    TranslationInterface $stringTranslation
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('string_translation')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  abstract public function shouldTriggerContentRelease(VaNodeInterface $node) : bool;
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginInterface.php
+++ b/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+
+/**
+ * An interface for Entity Event Strategy plugins.
+ *
+ * These plugins are used to determine if a content release should be triggered
+ * based on the environment and the entity event.
+ */
+interface StrategyPluginInterface extends PluginInspectionInterface {
+
+  /**
+   * Determine whether we should trigger a content release.
+   *
+   * @param \Drupal\va_gov_content_types\Entity\VaNodeInterface $node
+   *   The node that triggered the event.
+   *
+   * @return bool
+   *   TRUE if we should trigger a content release, FALSE otherwise.
+   */
+  public function shouldTriggerContentRelease(VaNodeInterface $node) : bool;
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginManager.php
+++ b/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginManager.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\va_gov_content_release\Annotation\EntityEventStrategy;
+use Drupal\va_gov_content_release\Exception\UnknownStrategyException;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+
+/**
+ * Manages the Entity Event Strategy plugins.
+ */
+class StrategyPluginManager extends DefaultPluginManager implements StrategyPluginManagerInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler
+  ) {
+    parent::__construct(
+      'Plugin/EntityEventStrategy',
+      $namespaces,
+      $module_handler,
+      StrategyPluginInterface::class,
+      EntityEventStrategy::class
+    );
+    $this->alterInfo('va_gov_content_release_entity_event_strategy');
+    $this->setCacheBackend($cache_backend, 'va_gov_content_release_entity_event_strategy');
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getStrategy(string $id) : StrategyPluginInterface {
+    try {
+      return $this->createInstance($id);
+    }
+    catch (PluginException) {
+      throw new UnknownStrategyException("Unknown strategy: $id");
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function shouldTriggerContentRelease(string $id, VaNodeInterface $node) : bool {
+    return $this->getStrategy($id)->shouldTriggerContentRelease($node);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginManagerInterface.php
+++ b/docroot/modules/custom/va_gov_content_release/src/EntityEvent/Strategy/Plugin/StrategyPluginManagerInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin;
+
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+
+/**
+ * An interface for the entity event strategy plugin manager.
+ */
+interface StrategyPluginManagerInterface {
+
+  /**
+   * Get the strategy plugin.
+   *
+   * @param string $id
+   *   The plugin ID.
+   *
+   * @return \Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginInterface
+   *   The strategy plugin.
+   *
+   * @throws \Drupal\va_gov_content_release\Exception\StrategyErrorException
+   *   If the strategy cannot be found.
+   */
+  public function getStrategy(string $id) : StrategyPluginInterface;
+
+  /**
+   * Determine whether we should trigger a content release.
+   *
+   * @param string $id
+   *   The plugin ID.
+   * @param \Drupal\va_gov_content_types\Entity\VaNodeInterface $node
+   *   The node that triggered the event.
+   *
+   * @throws \Drupal\va_gov_content_release\Exception\UnknownStrategyException
+   *   If the strategy cannot be found.
+   * @throws \Drupal\va_gov_content_release\Exception\StrategyErrorException
+   *   If the strategy encounters an error.
+   */
+  public function shouldTriggerContentRelease(string $id, VaNodeInterface $node) : bool;
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/ExceptionTest.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/ExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\va_gov_content_release\Plugin\EntityEventStrategy;
+
+use Drupal\va_gov_content_release\Exception\StrategyErrorException;
+use Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginBase;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+
+/**
+ * Exception test strategy.
+ *
+ * This always throws an exception.
+ *
+ * @EntityEventStrategy(
+ *   id = "test_exception",
+ *   label = @Translation("Exception Test")
+ * )
+ */
+class ExceptionTest extends StrategyPluginBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function shouldTriggerContentRelease(VaNodeInterface $node) : bool {
+    throw new StrategyErrorException('This is a test exception.');
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/FalseTest.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/FalseTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\va_gov_content_release\Plugin\EntityEventStrategy;
+
+use Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginBase;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+
+/**
+ * FALSE test strategy.
+ *
+ * This always returns FALSE.
+ *
+ * @EntityEventStrategy(
+ *   id = "test_false",
+ *   label = @Translation("FALSE Test")
+ * )
+ */
+class FalseTest extends StrategyPluginBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function shouldTriggerContentRelease(VaNodeInterface $node) : bool {
+    return FALSE;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/OnDemand.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/OnDemand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\va_gov_content_release\Plugin\EntityEventStrategy;
+
+use Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginBase;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+
+/**
+ * On-Demand strategy.
+ *
+ * This returns TRUE based on the nature of the changes to the content in
+ * question.
+ *
+ * @EntityEventStrategy(
+ *   id = "on_demand",
+ *   label = @Translation("On-Demand")
+ * )
+ */
+class OnDemand extends StrategyPluginBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function shouldTriggerContentRelease(VaNodeInterface $node) : bool {
+    return $node->shouldTriggerContentRelease();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/TrueTest.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Plugin/EntityEventStrategy/TrueTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\va_gov_content_release\Plugin\EntityEventStrategy;
+
+use Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginBase;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+
+/**
+ * TRUE test strategy.
+ *
+ * This always returns TRUE.
+ *
+ * @EntityEventStrategy(
+ *   id = "test_true",
+ *   label = @Translation("TRUE Test")
+ * )
+ */
+class TrueTest extends StrategyPluginBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function shouldTriggerContentRelease(VaNodeInterface $node) : bool {
+    return TRUE;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/va_gov_content_release.services.yml
+++ b/docroot/modules/custom/va_gov_content_release/va_gov_content_release.services.yml
@@ -17,6 +17,9 @@ services:
   plugin.manager.va_gov_content_release.strategy:
     class: Drupal\va_gov_content_release\Strategy\Plugin\StrategyPluginManager
     parent: default_plugin_manager
+  plugin.manager.va_gov_content_release.entity_event_strategy:
+    class: Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginManager
+    parent: default_plugin_manager
   va_gov_content_release.form_route_subscriber:
     class: Drupal\va_gov_content_release\EventSubscriber\FormRouteSubscriber
     arguments: ['@va_gov_content_release.form_resolver']

--- a/tests/phpunit/FrontendBuild/EntityEventSubscriberTest.php
+++ b/tests/phpunit/FrontendBuild/EntityEventSubscriberTest.php
@@ -131,10 +131,6 @@ class EntityEventSubscriberTest extends VaGovUnitTestBase {
         foreach ($triggerable_state as $key => $val) {
           $description .= $key . ': ' . $val . '; ';
         }
-        print json_encode([
-          'description' => $description,
-          'should_build' => $should_build,
-        ]);
         yield $description => [
           'enabled',
           $node,

--- a/tests/phpunit/va_gov_content_release/functional/EntityEvent/Strategy/Plugin/StrategyPluginManagerTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/EntityEvent/Strategy/Plugin/StrategyPluginManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_content_release\functional\Strategy\Plugin;
+namespace tests\phpunit\va_gov_content_release\functional\EntityEvent\Strategy\Plugin;
 
 use Drupal\va_gov_content_release\Exception\StrategyErrorException;
 use Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginInterface;

--- a/tests/phpunit/va_gov_content_release/functional/EntityEvent/Strategy/Plugin/StrategyPluginManagerTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/EntityEvent/Strategy/Plugin/StrategyPluginManagerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace tests\phpunit\va_gov_content_release\functional\Strategy\Plugin;
+
+use Drupal\va_gov_content_release\Exception\StrategyErrorException;
+use Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginInterface;
+use Drupal\va_gov_content_types\Entity\VaNodeInterface;
+use Tests\Support\Classes\VaGovExistingSiteBase;
+
+/**
+ * Functional test of the Strategy Plugin Manager service.
+ *
+ * @group functional
+ * @group all
+ *
+ * @coversDefaultClass \Drupal\va_gov_content_release\EntityEvent\Strategy\Plugin\StrategyPluginManager
+ */
+class StrategyPluginManagerTest extends VaGovExistingSiteBase {
+
+  /**
+   * Test that the Strategy Plugin Manager service is available.
+   *
+   * @covers ::__construct
+   * @covers ::getDefinitions
+   */
+  public function testGetDefinitions() {
+    $definitions = $this->container->get('plugin.manager.va_gov_content_release.entity_event_strategy')->getDefinitions();
+    $this->assertNotEmpty($definitions);
+  }
+
+  /**
+   * Test that the Strategy Plugin Manager service can execute a strategy.
+   *
+   * @covers ::shouldTriggerContentRelease
+   * @covers ::getStrategy
+   */
+  public function testShouldTriggerContentReleaseTrue() {
+    $nodeProphecy = $this->prophesize(VaNodeInterface::class);
+    $node = $nodeProphecy->reveal();
+    $result = $this->container->get('plugin.manager.va_gov_content_release.entity_event_strategy')->shouldTriggerContentRelease('test_true', $node);
+    $this->assertEquals(TRUE, $result);
+  }
+
+  /**
+   * Test that the Strategy Plugin Manager service can execute a strategy.
+   *
+   * @covers ::shouldTriggerContentRelease
+   * @covers ::getStrategy
+   */
+  public function testShouldTriggerContentReleaseFalse() {
+    $nodeProphecy = $this->prophesize(VaNodeInterface::class);
+    $node = $nodeProphecy->reveal();
+    $result = $this->container->get('plugin.manager.va_gov_content_release.entity_event_strategy')->shouldTriggerContentRelease('test_false', $node);
+    $this->assertEquals(FALSE, $result);
+  }
+
+  /**
+   * Test that the Strategy Plugin Manager propagates exceptions.
+   *
+   * @covers ::triggerContentRelease
+   * @covers ::getStrategy
+   */
+  public function testTriggerContentReleaseException() {
+    $nodeProphecy = $this->prophesize(VaNodeInterface::class);
+    $node = $nodeProphecy->reveal();
+    $this->expectException(StrategyErrorException::class);
+    $this->container->get('plugin.manager.va_gov_content_release.entity_event_strategy')->shouldTriggerContentRelease('test_exception', $node);
+  }
+
+  /**
+   * Test that the Strategy Plugin Manager's on-demand strategy works.
+   *
+   * @param bool $shouldTrigger
+   *   Whether the node should trigger a content release.
+   *
+   * @covers ::triggerContentRelease
+   * @covers ::getStrategy
+   * @dataProvider triggerContentReleaseOnDemandDataProvider
+   */
+  public function testTriggerContentReleaseOnDemand($shouldTrigger) {
+    $nodeProphecy = $this->prophesize(VaNodeInterface::class);
+    $nodeProphecy->shouldTriggerContentRelease()->willReturn($shouldTrigger)->shouldBeCalled();
+    $node = $nodeProphecy->reveal();
+    $actual = $this->container->get('plugin.manager.va_gov_content_release.entity_event_strategy')->shouldTriggerContentRelease('on_demand', $node);
+    $this->assertEquals($shouldTrigger, $actual);
+  }
+
+  /**
+   * Data provider for testTriggerContentReleaseOnDemand().
+   *
+   * @return array
+   *   An array of booleans.
+   */
+  public function triggerContentReleaseOnDemandDataProvider() {
+    return [
+      [TRUE],
+      [FALSE],
+    ];
+  }
+
+  /**
+   * Test that we can instantiate the necessary plugins.
+   *
+   * @param string $pluginId
+   *   A strategy plugin ID to retrieve.
+   *
+   * @dataProvider getStrategyDataProvider
+   */
+  public function testGetStrategy(string $pluginId) {
+    $plugin = \Drupal::service('plugin.manager.va_gov_content_release.entity_event_strategy')->getStrategy($pluginId);
+    $this->assertInstanceOf(StrategyPluginInterface::class, $plugin);
+  }
+
+  /**
+   * Data provider for testGetStrategy().
+   *
+   * @return array
+   *   An array of plugin IDs.
+   */
+  public function getStrategyDataProvider() {
+    return [
+      ['test_true'],
+      ['test_false'],
+      ['test_exception'],
+      ['on_demand'],
+    ];
+  }
+
+}

--- a/tests/phpunit/va_gov_content_release/functional/Strategy/Plugin/StrategyPluginManagerTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/Strategy/Plugin/StrategyPluginManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_content_release\functional\Plugin\Strategy;
+namespace tests\phpunit\va_gov_content_release\functional\Strategy\Plugin;
 
 use Drupal\va_gov_content_release\Exception\StrategyErrorException;
 use Drupal\va_gov_content_release\Strategy\Plugin\StrategyPluginInterface;


### PR DESCRIPTION
## Description

Closes #13854.

This (again) exists independently alongside the content release system within the CMS, and should not affect it yet.

## QA Steps
- [ ] Automated tests pass.