### PR TITLE
VACMS-12325: Replace placeholder with real help text

### DIFF
--- a/config/sync/field.field.node.landing_page.field_spokes.yml
+++ b/config/sync/field.field.node.landing_page.field_spokes.yml
@@ -13,7 +13,7 @@ field_name: field_spokes
 entity_type: node
 bundle: landing_page
 label: Spokes
-description: '[Help text goes here]'
+description: 'Add a list of link teasers that will provide additional information that relates to the page topic.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.landing_page.field_support_services.yml
+++ b/config/sync/field.field.node.landing_page.field_support_services.yml
@@ -11,7 +11,7 @@ field_name: field_support_services
 entity_type: node
 bundle: landing_page
 label: 'Support Services'
-description: '[Help text goes here]'
+description: 'Add services that will be useful to veterans such as Health Benefits Hotline, My HealtheVet Help Desk, etc.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.q_a_section.field_section_intro.yml
+++ b/config/sync/field.field.paragraph.q_a_section.field_section_intro.yml
@@ -10,7 +10,7 @@ field_name: field_section_intro
 entity_type: paragraph
 bundle: q_a_section
 label: 'Section Intro'
-description: '[Help text goes here]'
+description: 'An optional introduction that explains why these questions may be relevant to visitors.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
## Description

Closes #12325 

## Testing done
Will test in test environment; just text changes.

## Screenshots
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12325#issuecomment-1622287110

## QA steps

As any user, go to https://cms-rpxhcmnci1r58oqds0ktydpnxtmepxem.ci.cms.va.gov/node/add/page
1. - [ ] Click "Main content" > Add content block and search for Q&S Section and add. Section Intro help text should say "An optional introduction that explains why these questions may be relevant to visitors."
Go to https://cms-rpxhcmnci1r58oqds0ktydpnxtmepxem.ci.cms.va.gov/node/add/landing_page
3. - [ ] Spokes help text should say "Add a list of link teasers that will provide additional information that relates to the page topic."
4. - [ ] Support services help text should say "Add services that will be useful to veterans such as Health Benefits Hotline, My HealtheVet Help Desk, etc."

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
