### PR TITLE
VACMS-14271: Creates `FrontendVersion` service.

### DIFF
--- a/docroot/modules/custom/va_gov_content_release/drush.services.yml
+++ b/docroot/modules/custom/va_gov_content_release/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  va_gov_content_release.content_release_commands:
+    class: \Drupal\va_gov_content_release\Commands\FrontendVersionCommands
+    arguments:
+      - '@va_gov_content_release.frontend_version'
+    tags:
+      - { name: drush.command }

--- a/docroot/modules/custom/va_gov_content_release/src/Commands/FrontendVersionCommands.php
+++ b/docroot/modules/custom/va_gov_content_release/src/Commands/FrontendVersionCommands.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\va_gov_content_release\Commands;
+
+use Drupal\va_gov_content_release\FrontendVersion\FrontendVersionInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush interface to the frontend version service.
+ */
+class FrontendVersionCommands extends DrushCommands {
+
+  /**
+   * The Frontend Version service.
+   *
+   * @var \Drupal\va_gov_content_release\FrontendVersion\FrontendVersionInterface
+   */
+  protected $frontendVersion;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\va_gov_content_release\FrontendVersion\FrontendVersionInterface $frontendVersion
+   *   The frontend version service.
+   */
+  public function __construct(
+    FrontendVersionInterface $frontendVersion
+  ) {
+    $this->frontendVersion = $frontendVersion;
+  }
+
+  /**
+   * Get the frontend version.
+   *
+   * @command va-gov-content-release:frontend-version:get
+   * @aliases va-gov-content-release-frontend-version-get
+   */
+  public function get() {
+    $value = $this->frontendVersion->get();
+    $this->io()->write($value);
+  }
+
+  /**
+   * Reset the frontend version.
+   *
+   * @command va-gov-content-release:frontend-version:reset
+   * @aliases va-gov-content-release-frontend-version-reset
+   */
+  public function reset() {
+    $this->frontendVersion->reset();
+    $this->io()->success('Frontend version reset.');
+  }
+
+  /**
+   * Set the frontend version.
+   *
+   * @command va-gov-content-release:frontend-version:set
+   * @aliases va-gov-content-release-frontend-version-set
+   */
+  public function set($version) {
+    $this->frontendVersion->set($version);
+    $this->io()->success('Frontend version set to ' . $version);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/FrontendVersion/FrontendVersion.php
+++ b/docroot/modules/custom/va_gov_content_release/src/FrontendVersion/FrontendVersion.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\va_gov_content_release\FrontendVersion;
+
+use Drupal\Core\State\StateInterface;
+
+/**
+ * The FrontendVersion service.
+ *
+ * This service allows (in some environments) control over the version of the
+ * frontend that is used to perform content releases.
+ */
+class FrontendVersion implements FrontendVersionInterface {
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   */
+  public function __construct(StateInterface $state) {
+    $this->state = $state;
+  }
+
+  /**
+   * Get the current version of the frontend.
+   *
+   * @return string
+   *   The current version of the frontend.
+   */
+  public function get() : string {
+    return $this->state->get(FrontendVersionInterface::FRONTEND_VERSION, FrontendVersionInterface::FRONTEND_VERSION_DEFAULT);
+  }
+
+  /**
+   * Set the current version of the frontend.
+   *
+   * @param string $version
+   *   The version to set.
+   */
+  public function set(string $version) : void {
+    $this->state->set(FrontendVersionInterface::FRONTEND_VERSION, $version);
+  }
+
+  /**
+   * Reset the current version of the frontend.
+   */
+  public function reset() : void {
+    $this->state->delete(FrontendVersionInterface::FRONTEND_VERSION);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_release/src/FrontendVersion/FrontendVersionInterface.php
+++ b/docroot/modules/custom/va_gov_content_release/src/FrontendVersion/FrontendVersionInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\va_gov_content_release\FrontendVersion;
+
+/**
+ * An interface for the FrontendVersion service.
+ *
+ * This service allows (in some environments) control over the version of the
+ * frontend that is used to perform content releases.
+ */
+interface FrontendVersionInterface {
+
+  const FRONTEND_VERSION = 'va_gov_content_release.frontend_version';
+  const FRONTEND_VERSION_DEFAULT = '__default';
+
+  /**
+   * Get the current version of the frontend.
+   *
+   * @return string
+   *   The current version of the frontend.
+   */
+  public function get() : string;
+
+  /**
+   * Set the current version of the frontend.
+   *
+   * @param string $version
+   *   The version to set.
+   */
+  public function set(string $version) : void;
+
+  /**
+   * Reset the current version of the frontend.
+   */
+  public function reset() : void;
+
+}

--- a/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
+++ b/docroot/modules/custom/va_gov_content_release/va_gov_content_release.routing.yml
@@ -6,10 +6,10 @@ va_gov_content_release.form:
   requirements:
     _permission: "va gov deploy content build"
 
-va_gov_content_release.form.local:
-  path: "/admin/content/deploy/local"
+va_gov_content_release.form.local_dev:
+  path: "/admin/content/deploy/local_dev"
   defaults:
-    _title: '[TEST] Local manual content release'
+    _title: '[TEST] Local Dev manual content release'
     _form: '\Drupal\va_gov_build_trigger\Form\LocalBuildTriggerForm'
   requirements:
     _permission: "va gov deploy content build"

--- a/docroot/modules/custom/va_gov_content_release/va_gov_content_release.services.yml
+++ b/docroot/modules/custom/va_gov_content_release/va_gov_content_release.services.yml
@@ -31,3 +31,6 @@ services:
   va_gov_content_release.request:
     class: Drupal\va_gov_content_release\Request\Request
     arguments: ['@entity_type.manager']
+  va_gov_content_release.frontend_version:
+    class: Drupal\va_gov_content_release\FrontendVersion\FrontendVersion
+    arguments: ['@state']

--- a/tests/phpunit/va_gov_content_release/functional/EventSubscriber/FormRouteSubscriberTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/EventSubscriber/FormRouteSubscriberTest.php
@@ -72,7 +72,7 @@ class FormRouteSubscriberTest extends VaGovExistingSiteBase {
   public function formTestRoutesProvider() {
     return [
       ['brd', BrdBuildTriggerForm::class],
-      ['local', LocalBuildTriggerForm::class],
+      ['local_dev', LocalBuildTriggerForm::class],
       ['tugboat', TugboatBuildTriggerForm::class],
     ];
   }

--- a/tests/phpunit/va_gov_content_release/functional/FrontendVersion/FrontendVersionTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/FrontendVersion/FrontendVersionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace tests\phpunit\va_gov_content_release\functional\FrontendVersion;
+
+use Drupal\va_gov_content_release\FrontendVersion\FrontendVersion;
+use Tests\Support\Classes\VaGovExistingSiteBase;
+
+/**
+ * Functional test of the Frontend Version service.
+ *
+ * @group functional
+ * @group all
+ *
+ * @coversDefaultClass \Drupal\va_gov_content_release\FrontendVersion\FrontendVersion
+ */
+class FrontendVersionTest extends VaGovExistingSiteBase {
+
+  /**
+   * Test that the service is available.
+   *
+   * @covers ::__construct
+   */
+  public function testConstruct() {
+    $frontendVersion = \Drupal::service('va_gov_content_release.frontend_version');
+    $this->assertInstanceOf(FrontendVersion::class, $frontendVersion);
+  }
+
+}

--- a/tests/phpunit/va_gov_content_release/unit/FrontendVersion/FrontendVersionTest.php
+++ b/tests/phpunit/va_gov_content_release/unit/FrontendVersion/FrontendVersionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace tests\phpunit\va_gov_environment\unit\FrontendVersion;
+
+use Drupal\Core\State\State;
+use Drupal\Core\KeyValueStore\KeyValueMemoryFactory;
+use Drupal\va_gov_content_release\FrontendVersion\FrontendVersion;
+use Drupal\va_gov_content_release\FrontendVersion\FrontendVersionInterface;
+use Tests\Support\Classes\VaGovUnitTestBase;
+
+/**
+ * Unit test of the Frontend Version service.
+ *
+ * @group unit
+ * @group all
+ *
+ * @coversDefaultClass \Drupal\va_gov_content_release\FrontendVersion\FrontendVersion
+ */
+class FrontendVersionTest extends VaGovUnitTestBase {
+
+  /**
+   * Test that the service works as expected.
+   *
+   * @covers ::__construct
+   * @covers ::get
+   * @covers ::set
+   * @covers ::reset
+   */
+  public function testGetSetReset() : void {
+    $state = new State(new KeyValueMemoryFactory());
+    $frontendVersion = new FrontendVersion($state);
+    $this->assertEquals(FrontendVersionInterface::FRONTEND_VERSION_DEFAULT, $frontendVersion->get());
+    $frontendVersion->set('1.2.3');
+    $this->assertEquals('1.2.3', $frontendVersion->get());
+    $frontendVersion->reset();
+    $this->assertEquals(FrontendVersionInterface::FRONTEND_VERSION_DEFAULT, $frontendVersion->get());
+  }
+
+}


### PR DESCRIPTION
## Description

Closes #14271.

This does not yet interact with the current content release system, so risk should be minimal.

## QA steps

- [x] On tugboat (`tugboat shell 64b5594f2d3036648deac203`):
  - [x] `drush va-gov-content-release:frontend-version:get` should return `__default`.
  - [x] `drush va-gov-content-release:frontend-version:reset` should say that the frontend version was reset.
  - [x] `drush va-gov-content-release:frontend-version:set test` should say that the frontend version was set to `test`.
  - [x] `drush va-gov-content-release:frontend-version:reset` and then `drush va-gov-content-release:frontend-version:get` should indicate that the frontend version was reset as expected.
- [x] Automated tests pass.