### PR TITLE
VACMS-10154: Add role="presentation" to description field

### DIFF
--- a/docroot/themes/custom/vagovclaro/templates/field/field--node--field-description.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/field/field--node--field-description.html.twig
@@ -40,3 +40,7 @@
 {%
   extends "field--node--field-meta-title.html.twig"
 %}
+
+{% block a11y_role %}
+  role="presentation"
+{% endblock %}

--- a/docroot/themes/custom/vagovclaro/templates/field/field--node--field-meta-title.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/field/field--node--field-meta-title.html.twig
@@ -55,7 +55,7 @@
 {% set classes = classes|merge(['seo-alert']) %}
 {% endif %}
 
-<table>
+<table {% block a11y_role %}{% endblock %}>
   <tbody>
     <tr{{ attributes.addClass(classes) }}>
       <td{{ title_attributes.addClass(title_classes) }}><div>{{ label }}</div></td>


### PR DESCRIPTION
## Description

Relates to #10154 

Adds `role=presentation` to the table containing data from the description field.  

This field appears in the following content types/bundles:

- Landing Page
- Event
- Events List
- VAMC Facility
- VAMC Detail Page
- VAMC System
- Health Services List
- Benefits Hub Landing Page
- Leadership List
- VAMC Locations List
- Office
- Publication
- Benefits Detail Page
- Staff Profile
- News Releases List
- Publication Listing Page
- Stories List

## Testing done

WAVE Tests were performed to confirm no accessibility violations were introduced.

## Screenshots

![VACMS-10154--20230717--1145](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/497c238e-bfc6-4257-a2c1-7d8ad39ef2fb)

## QA steps

What needs to be checked to prove this works?  

- go to https://pr14392-huojvklm2al0d20mn7nwow0wzkpcszzh.ci.cms.va.gov/node/8296 or https://pr14392-huojvklm2al0d20mn7nwow0wzkpcszzh.ci.cms.va.gov/resources or any page of the types listed above
- inspect the "Meta description" element
-  confirm that the table element contains an attribute key named `role` with the value `presentation`

What needs to be checked to prove it didn't break any related things?  

This was a simple, scoped modification.  The likelihood that this change has broken anything, related or not, is negligable.

What variations of circumstances (users, actions, values) need to be checked?  

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements