### PR TITLE
VACMS-0000: Fix a settings value that broke staging post-deploy tests

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -114,7 +114,7 @@ $settings['va_cms_bot_github_auth_token'] = getenv('CMS_GITHUB_VA_CMS_BOT_TOKEN'
 $settings['va_gov_composer_home'] = getenv('COMPOSER_HOME');
 $settings['va_gov_path_to_composer'] = '/usr/local/bin/composer';
 // The default BRD locations. These settings are currently only used on tugboat/local
-$settings['va_gov_web_root'] = '/var/www/cms/docroot/web';
+$settings['va_gov_web_root'] = '/var/www/cms/web';
 $settings['va_gov_app_root'] = '/var/www/cms';
 
 // Defaults (should only be local that doesn't set these), default to dev for config_split


### PR DESCRIPTION
Post-deploy tests failed [here](http://jenkins.vfs.va.gov/job/testing/job/cms-post-deploy-tests-staging/2172/consoleFull).

Verified on staging:

```
$ composer va:test:phpunit-functional
> # Run PHPUnit (functional) tests.
> ! ./scripts/should-run-directly.sh || bin/phpunit --group functional --exclude-group disabled tests/phpunit --
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

Testing /var/www/cms/tests/phpunit
..........................................S....................  63 / 274 ( 22%)
...........................................SSS................. 126 / 274 ( 45%)
............................................................... 189 / 274 ( 68%)
............................................................... 252 / 274 ( 91%)
......................                                          274 / 274 (100%)

Time: 06:40.516, Memory: 3.67 GB

OK, but incomplete, skipped, or risky tests!
Tests: 274, Assertions: 441, Skipped: 4.
> ./scripts/should-run-directly.sh || ddev composer va:test:phpunit-functional --
```