### PR TITLE
VACMS-14565 bugfix make facilities deleteable

### DIFF
--- a/docroot/modules/custom/va_gov_content_types/src/Interfaces/GetOriginalInterface.php
+++ b/docroot/modules/custom/va_gov_content_types/src/Interfaces/GetOriginalInterface.php
@@ -35,10 +35,10 @@ interface GetOriginalInterface {
    * @param string $field_name
    *   The machine name of the field to get.
    *
-   * @return \Drupal\Core\Field\FieldItemListInterface
-   *   The value of the field.
+   * @return \Drupal\Core\Field\FieldItemListInterface|null
+   *   The fieldItemList of the field if it exists. NULL otherwise.
    */
-  public function getOriginalField(string $field_name): FieldItemListInterface;
+  public function getOriginalField(string $field_name): ?FieldItemListInterface;
 
   /**
    * Checks if the value of the field on the node changed.

--- a/docroot/modules/custom/va_gov_content_types/src/Interfaces/GetOriginalInterface.php
+++ b/docroot/modules/custom/va_gov_content_types/src/Interfaces/GetOriginalInterface.php
@@ -35,10 +35,13 @@ interface GetOriginalInterface {
    * @param string $field_name
    *   The machine name of the field to get.
    *
-   * @return \Drupal\Core\Field\FieldItemListInterface|null
+   * @return \Drupal\Core\Field\FieldItemListInterface
    *   The fieldItemList of the field if it exists. NULL otherwise.
+   *
+   * @throws \Drupal\va_gov_content_types\Exception\NoOriginalExistsException
+   *   Thrown when the node has no original version.
    */
-  public function getOriginalField(string $field_name): ?FieldItemListInterface;
+  public function getOriginalField(string $field_name): FieldItemListInterface;
 
   /**
    * Checks if the value of the field on the node changed.

--- a/docroot/modules/custom/va_gov_content_types/src/Traits/DidChangeOperatingStatusTrait.php
+++ b/docroot/modules/custom/va_gov_content_types/src/Traits/DidChangeOperatingStatusTrait.php
@@ -38,7 +38,8 @@ trait DidChangeOperatingStatusTrait {
     if (!$this->isFacility()) {
       throw new NonFacilityException('This node is not a facility.');
     }
-    if (!$this->hasField(DidChangeOperatingStatusInterface::STATUS_FIELD)) {
+    if (!$this->hasField(DidChangeOperatingStatusInterface::STATUS_FIELD) || !$this->hasOriginal()) {
+      // It lacks either the field or the Original node (create or delete).
       return FALSE;
     }
     return $this->didChangeField(DidChangeOperatingStatusInterface::STATUS_FIELD) || $this->didChangeField(DidChangeOperatingStatusInterface::STATUS_INFO_FIELD);

--- a/docroot/modules/custom/va_gov_content_types/src/Traits/GetOriginalTrait.php
+++ b/docroot/modules/custom/va_gov_content_types/src/Traits/GetOriginalTrait.php
@@ -83,8 +83,8 @@ trait GetOriginalTrait {
     $originalField = $this->getOriginalField($fieldName);
     $currentField = $this->get($fieldName);
     if (!$originalField) {
-      // Consider a new save (no original exists) to be a change of value.
-      return TRUE;
+      // Consider a new save (no original exists) to not be a change of value.
+      return FALSE;
     }
 
     return !$currentField->equals($originalField);

--- a/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
+++ b/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
@@ -74,17 +74,6 @@ class GetOriginalTraitTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test that the getOriginalField method throws an exception appropriately.
-   */
-  public function testGetOriginalFieldException() {
-    $node = $this->createNode([
-      'bundle' => 'page',
-    ]);
-    $this->expectException(NoOriginalExistsException::class);
-    $node->getOriginalField('title');
-  }
-
-  /**
    * Test that the didChangeField method works.
    *
    * @param string $oldValue

--- a/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
+++ b/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
@@ -69,8 +69,8 @@ class GetOriginalTraitTest extends VaGovExistingSiteBase {
     $node->save();
     $node->original = $revision;
     $original = $node->getOriginal();
-    $this->assertEquals($node->id(), $original->id());
-    $this->assertEquals($node->get('title')->value, $original->get('title')->value);
+    $this->assertEquals($node->getOriginalField('id')->value, $original->id());
+    $this->assertEquals($node->getOriginalField('title')->value, $original->get('title')->value);
   }
 
   /**

--- a/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
+++ b/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
@@ -74,6 +74,17 @@ class GetOriginalTraitTest extends VaGovExistingSiteBase {
   }
 
   /**
+   * Test that the getOriginalField method throws an exception appropriately.
+   */
+  public function testGetOriginalFieldException() {
+    $node = $this->createNode([
+      'bundle' => 'page',
+    ]);
+    $this->expectException(NoOriginalExistsException::class);
+    $node->getOriginalField('title');
+  }
+
+  /**
    * Test that the didChangeField method works.
    *
    * @param string $oldValue

--- a/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
+++ b/tests/phpunit/va_gov_content_types/functional/Traits/GetOriginalTraitTest.php
@@ -133,4 +133,19 @@ class GetOriginalTraitTest extends VaGovExistingSiteBase {
     ];
   }
 
+  /**
+   * Confirm didChangeField() should return FALSE if the node is new.
+   *
+   * @covers ::didChangeField
+   */
+  public function testDidChangeFieldNew() {
+    $node = $this->createNode([
+      'bundle' => 'page',
+    ]);
+    $node->setNewRevision(TRUE);
+    $node->setTitle('Original Title');
+    $node->save();
+    $this->assertFalse($node->didChangeField('title'));
+  }
+
 }


### PR DESCRIPTION
## Description

Relates to #14565

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As an admin
1. Go to a [Abilene Vet center facility](https://pr14567-obclexe1yea8ftut4va5uquxmd47gobi.ci.cms.va.gov/abilene-vet-center) and delete it.
   - [ ] Validate that it deletes.
2. Go to the migration and run it as an update migration (check the "update" check box)
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/0e0b349a-4b3a-4c26-8699-31e0f38b9c2d)  

   - [ ] validate that the vet center you deleted, was recreated by [going here](https://pr14567-obclexe1yea8ftut4va5uquxmd47gobi.ci.cms.va.gov/abilene-vet-center) 
   - [ ] Open a new tab for [dblog](https://pr14567-obclexe1yea8ftut4va5uquxmd47gobi.ci.cms.va.gov/admin/reports/dblog)  validate there are no related errors/warnings in watchdog
3. Edit a facility node and give it status and publish it.
   - [ ] validate in dblog that a content release should have been triggered.
4. Edit the same node but do not change its status. and publish and save the revision
   - [ ] validate in dblog that a content release should **not** have been triggered
5. Edit the same node and change the status, save and publish it.
   - [ ] Validate in dblog that a content release should have been triggered.


### Does this PR need review from a Product Owner

- [ ] `Needs PO review`
