### PR TITLE
VACMS-14550: Makes ContentReleaseStatusControllerTest D10-compatible.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
+++ b/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
@@ -123,7 +123,7 @@ class ContentReleaseStatusController extends ControllerBase {
    */
   public function getLastReleaseTimestamp(): int {
     /** @var \Psr\Http\Message\ResponseInterface $response */
-    $response = $this->httpClient->request('GET', 'https://www.va.gov/BUILD.txt');
+    $response = $this->httpClient->get('https://www.va.gov/BUILD.txt');
     if (preg_match('/BUILDTIME=([0-9]*)/', $response->getBody(), $matches)) {
       return $matches[1];
     }

--- a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
+++ b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
@@ -92,7 +92,7 @@ class ContentReleaseStatusControllerTest extends VaGovUnitTestBase {
     $responseProphecy = $this->prophesize(Response::CLASS);
     $responseProphecy->getBody()->willReturn($responseBody);
 
-    $prophecy->request(Argument::type('string'), Argument::type('string'))->willReturn($responseProphecy->reveal());
+    $prophecy->get(Argument::type('string'))->willReturn($responseProphecy->reveal());
 
     return $prophecy->reveal();
   }


### PR DESCRIPTION
Closes #14550.

I will test this on the D10 branch.

@edmund-dunn I've cherry-picked this into the D10 branch, fixed the merge conflicts, and I can push when you approve this, or you can merge it separately.

```
nathan.douglas@va-gov-cms-web:/var/www/html$ git diff
diff --git a/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php b/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
index 23570e0b3..22059417f 100644
--- a/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
+++ b/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
@@ -125,8 +125,7 @@ public function getLastReleaseResponse(array $status): HtmlResponse {
    *   If the build file could not be parsed.
    */
   public function getLastReleaseTimestamp(): int {
-    $client = new Client();
-    $response = $client->get('https://www.va.gov/BUILD.txt');
+    $response = $this->httpClient->get('https://www.va.gov/BUILD.txt');
     if (preg_match('/BUILDTIME=([0-9]*)/', $response->getBody(), $matches)) {
       return $matches[1];
     }
diff --git a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
index 0104797f2..4ce752dc9 100644
--- a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
+++ b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
@@ -91,8 +91,9 @@ protected function getMockHttpClient(string $responseBody): ClientInterface {
 
     $responseProphecy = $this->prophesize(Response::CLASS);
     $responseProphecy->getBody()->willReturn($responseBody);
+    $response = $responseProphecy->reveal();
 
-    $prophecy->request(Argument::type('string'), Argument::type('string'))->willReturn($responseProphecy->reveal());
+    $prophecy->get(Argument::type('string'))->willReturn($response);
 
     return $prophecy->reveal();
   }
nathan.douglas@va-gov-cms-web:/var/www/html$ phpunit tests/phpunit/Controller/ContentReleaseStatusControllerTest.php 
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

Testing tests\phpunit\Controller\ContentReleaseStatusControllerTest
...................                                               19 / 19 (100%)

Time: 00:00.155, Memory: 38.50 MB

OK (19 tests, 57 assertions)
```
