### PR TITLE
VACMS-14618: Fix a couple of returnless functions in prevent_select_duplicates.js

### DIFF
--- a/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.es6.js
+++ b/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.es6.js
@@ -77,9 +77,9 @@
     attach(context) {
       if (servicesFieldset) {
         // When drags, edits, deletions, or additions happen, fire the winnower.
-        servicesFieldset.addEventListener("change", winnower(context));
+        servicesFieldset.addEventListener("change", () => winnower(context));
         // Run the alpha sort.
-        context.addEventListener("load", alphaSortRows(context));
+        context.addEventListener("load", () => alphaSortRows(context));
       }
     },
   };

--- a/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.es6.js
+++ b/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.es6.js
@@ -76,10 +76,8 @@
   Drupal.behaviors.vaGovPreventSelectDuplicates = {
     attach(context) {
       if (servicesFieldset) {
-        // When drags, edits, deletions, or additions happen, fire the winnower.
-        servicesFieldset.addEventListener("change", () => winnower(context));
-        // Run the alpha sort.
-        context.addEventListener("load", () => alphaSortRows(context));
+        winnower(context);
+        alphaSortRows(context);
       }
     },
   };

--- a/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.js
+++ b/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.js
@@ -57,14 +57,7 @@
     attach: function attach(context) {
       if (servicesFieldset) {
         winnower(context);
-        servicesFieldset.addEventListener("change", function onChange() {
-          winnower(context);
-        });
-
         alphaSortRows(context);
-        context.addEventListener("load", function onLoad() {
-          alphaSortRows(context);
-        });
       }
     }
   };

--- a/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.js
+++ b/docroot/modules/custom/va_gov_vet_center/js/prevent_select_duplicates.js
@@ -56,9 +56,15 @@
   Drupal.behaviors.vaGovPreventSelectDuplicates = {
     attach: function attach(context) {
       if (servicesFieldset) {
-        servicesFieldset.addEventListener("change", winnower(context));
+        winnower(context);
+        servicesFieldset.addEventListener("change", function onChange() {
+          winnower(context);
+        });
 
-        context.addEventListener("load", alphaSortRows(context));
+        alphaSortRows(context);
+        context.addEventListener("load", function onLoad() {
+          alphaSortRows(context);
+        });
       }
     }
   };


### PR DESCRIPTION
Closes #14618.
Closes #14620.

This code, as written, does not seem to behave as intended:

```javascript
  var winnower = function winnower(context) {
    ....
  };

  var alphaSortRows = function alphaSortRows(context) {
    ....
  };

  Drupal.behaviors.vaGovPreventSelectDuplicates = {
    attach: function attach(context) {
      if (servicesFieldset) {
        servicesFieldset.addEventListener("change", winnower(context));

        context.addEventListener("load", alphaSortRows(context));
      }
    }
  };
```

This code is attached to an Inline Entity Form. 

The event listeners added are the results of evaluating the `winnower(context)` and `alphaSortRows(context)` calls, not references to those functions. 

Since the functions return void, there aren't actually any functions attached and listening to events.

The form works correctly at present, but this is because the form is built around an Inline Entity Form, and it seems that changes to form state, ajax requests, etc trigger the Drupal behavior to re-attach, which executes `winnow(context)` and `alphaSortRows(context)`. This can be observed by adding a breakpoint inside the attach function.

I changed this as follows:
```javascript
  Drupal.behaviors.vaGovPreventSelectDuplicates = {
    attach: function attach(context) {
      if (servicesFieldset) {
        winnower(context);
        alphaSortRows(context);
      }
    }
  };
```

Because of the `attach()` call firing on every IEF action, this appears to behave as intended. It's possible that I'm missing something, though.

## QA Steps

- [x] Edit [this node](https://cms-ouoc2cv77thjq0fqgc3hnxni4dzmmryv.ci.cms.va.gov/node/3786/edit)
- [ ] Scroll down to Services and verify the following:
  - [x] The existing items are sorted alphabetically in two groups (Required and Optional)
  - [x] When you click "Add new service", the form appears.
  - [x] The "Service name" dropdown should have an alphabetized list of _only_ the services not present in the above table.
  - [x] A service can be added, and the service list re-sorts alphabetically, by Required and Optional.
  - [x] The "Service name" dropdown no longer shows the service name you just added.
  - [x] A service can be removed, and the service list re-sorts alphabetically, by Required and Optional.
  - [x] The "Service name" dropdown once more shows the service name you just removed from the list.
  