### PR TITLE
VACMS-11005: Updates `va_gov_post_api` for compatibility with D10.

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php
@@ -107,19 +107,28 @@ class VaGovFacilityForceQueueForm extends FormBase {
       ->condition('moderation_state', 'archived', '!=')
       ->execute();
 
-    $vet_center_outstation = \Drupal::entityQuery('node')
+    $vet_center_outstation = $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery()
       ->condition('type', 'vet_center_outstation')
       ->condition('moderation_state', 'archived', '!=')
+      ->accessCheck(FALSE)
       ->execute();
 
-    $vet_center_mobile_vet_center = \Drupal::entityQuery('node')
+    $vet_center_mobile_vet_center = $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery()
       ->condition('type', 'vet_center_mobile_vet_center')
       ->condition('moderation_state', 'archived', '!=')
+      ->accessCheck(FALSE)
       ->execute();
 
-    $vet_center_cap = \Drupal::entityQuery('node')
+    $vet_center_cap = $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery()
       ->condition('type', 'vet_center_cap')
       ->condition('moderation_state', 'archived', '!=')
+      ->accessCheck(FALSE)
       ->execute();
 
     $form['description'] = [


### PR DESCRIPTION
Closes #11005.

@omahane I noticed the following code:

```php
   ....

    $vet_center_cap = \Drupal::entityQuery('node')
      ->condition('type', 'vet_center_cap')
      ->condition('moderation_state', 'archived', '!=')
      ->execute();

    $form['description'] = [
      '#type' => 'markup',
      '#markup' => $this->t('This form queues ALL items of a selected type for sync to Lighthouse.'),
    ];

    $form['facility_type'] = [
      '#type' => 'radios',
      '#title' => $this->t('Content type'),
      '#description' => $this->t('Select a content type to queue.'),
      '#options' => [
        'health_care_local_facility' => $this->t('VAMC facilities') . ' (' . count($health_care_local_facility) . ')',
        'health_care_local_health_service' => ' - ' . $this->t('VAMC facility services') . ' (' . count($health_care_facility_service) . ')',
        'nca_facility' => $this->t('NCA facilities') . ' (' . count($nca_facility) . ')',
        'vba_facility' => $this->t('VBA facilities') . ' (' . count($vba_facility) . ')',
        'vet_center' => $this->t('Vet Centers') . ' (' . count($vet_center) . ')',
        'vet_center_outstation' => $this->t('Vet Center Outstations') . ' (' . count($vet_center_outstation) . ')',
        'vet_center_mobile_vet_center' => $this->t('Vet Center Mobile Vet Centers') . ' (' . count($vet_center_mobile_vet_center) . ')',
      ],
      '#required' => TRUE,
    ];

    $form['submit'] = [
      '#type' => 'submit',
      '#value' => $this->t('Force-Queue Selected Items'),
    ];

```

`$vet_center_cap` doesn't appear to be used after it is created. It doesn't appear in `$form['facility_type']['#options']`, for instance. Is this intended?

## QA Steps

- [x] Navigate to https://pr14638-ir7w6kzjsoifcfnwh4cffmp7malrliln.ci.cms.va.gov//admin/config/va-gov-post-api/facility-force-queue
   - [x] Validate that each of the items have counts that are not 0
- [x] Then select the option "Vet Center Outstations"
- [x] Click the "Force Queue Selected items" button
- [x] When the page returns scroll down the list of queued items
   - [x] Validate that the count of items queues matches the count of items processed 
- [x] Then select the option "Vet Center Mobile Vet Centers"
- [x] Click the "Force Queue Selected items" button
- [x] When the page returns scroll down the list of queued items
   - [x] Validate that the count of items queues matches the count of items processed 
- [x]  Go to the [post api queue](https://pr14638-ir7w6kzjsoifcfnwh4cffmp7malrliln.ci.cms.va.gov/admin/config/post-api/queue) and see that the number of items in the queues matches the amount claimed to be queued 
