### PR TITLE
VACMS-13863: Improve workflow for promo blocks

### DIFF
--- a/config/sync/core.base_field_override.block_content.benefit_promo.info.yml
+++ b/config/sync/core.base_field_override.block_content.benefit_promo.info.yml
@@ -9,7 +9,7 @@ field_name: info
 entity_type: block_content
 bundle: benefit_promo
 label: 'Block description'
-description: 'A brief description of your block.'
+description: 'This is used for identifying the block within the CMS. The description will not be shown on VA.gov.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/core.base_field_override.block_content.news_promo.info.yml
+++ b/config/sync/core.base_field_override.block_content.news_promo.info.yml
@@ -9,7 +9,7 @@ field_name: info
 entity_type: block_content
 bundle: news_promo
 label: 'Block description'
-description: 'A brief description of your block.'
+description: 'This is used for identifying the block within the CMS. The description will not be shown on VA.gov.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.block_content.benefit_promo.field_promo_headline.yml
+++ b/config/sync/field.field.block_content.benefit_promo.field_promo_headline.yml
@@ -16,7 +16,7 @@ field_name: field_promo_headline
 entity_type: block_content
 bundle: benefit_promo
 label: 'Promo Headline'
-description: 'Use this headline to make it clear to Veterans what the topic of this promo is and that it''s relevant to them.'
+description: 'Use this headline to make it clear to Veterans what the topic of this promo is and why it''s relevant to them.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.block_content.news_promo.field_link_label.yml
+++ b/config/sync/field.field.block_content.news_promo.field_link_label.yml
@@ -17,7 +17,7 @@ field_name: field_link_label
 entity_type: block_content
 bundle: news_promo
 label: 'Link Text'
-description: 'Use this text to tell Veterans what to do next. Note: For accessibility and cognitive clarity, link text must include the intended purpose of and keywords from the H1 page title of the destination page.'
+description: 'This text tells Veterans what to do next.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.block_content.news_promo.field_promo_headline.yml
+++ b/config/sync/field.field.block_content.news_promo.field_promo_headline.yml
@@ -16,7 +16,7 @@ field_name: field_promo_headline
 entity_type: block_content
 bundle: news_promo
 label: 'Promo Headline'
-description: 'Use this headline to make it clear to Veterans what the topic of this promo is and that it''s relevant to them.'
+description: 'Use this headline to make it clear to Veterans what the topic of this promo is and why it''s relevant to them.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/user.role.homepage_manager.yml
+++ b/config/sync/user.role.homepage_manager.yml
@@ -19,8 +19,6 @@ label: 'Homepage Manager'
 weight: 5
 is_admin: null
 permissions:
-  - 'access administration pages'
-  - 'administer menu'
   - 'create benefit_promo block content'
   - 'create cta_with_link block content'
   - 'create news_promo block content'
@@ -38,6 +36,7 @@ permissions:
   - 'update home_page_news_spotlight entityqueue'
   - 'update v2_home_page_create_account entityqueue'
   - 'use editorial transition approve'
+  - 'use editorial transition archive'
   - 'use editorial transition archived_published'
   - 'use editorial transition create_new_draft'
   - 'use editorial transition publish'

--- a/config/sync/user.role.homepage_manager.yml
+++ b/config/sync/user.role.homepage_manager.yml
@@ -19,6 +19,8 @@ label: 'Homepage Manager'
 weight: 5
 is_admin: null
 permissions:
+  - 'access administration pages'
+  - 'administer menu'
   - 'create benefit_promo block content'
   - 'create cta_with_link block content'
   - 'create news_promo block content'
@@ -36,7 +38,6 @@ permissions:
   - 'update home_page_news_spotlight entityqueue'
   - 'update v2_home_page_create_account entityqueue'
   - 'use editorial transition approve'
-  - 'use editorial transition archive'
   - 'use editorial transition archived_published'
   - 'use editorial transition create_new_draft'
   - 'use editorial transition publish'

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -140,6 +140,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $form_state = $event->getFormState();
     $form_id = $event->getFormId();
     $this->requireRevisionMessage($form, $form_state, $form_id);
+    $this->removeArchiveOption($event);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\va_gov_workflow\EventSubscriber;
 
+use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityDeleteEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
@@ -11,7 +12,6 @@ use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\NodeForm;
 use Drupal\node\NodeInterface;
 use Drupal\va_gov_notifications\Service\NotificationsManager;
 use Drupal\va_gov_user\Service\UserPermsService;
@@ -172,7 +172,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Removes archive option for non-admins on certain content types.
+   * Removes archive option for non-admins on certain entity types.
    *
    * @param \Drupal\core_event_dispatcher\Event\Form\FormBaseAlterEvent $event
    *   The event.
@@ -180,12 +180,13 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   private function removeArchiveOption(FormBaseAlterEvent $event) {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
-    if ($form_state->getFormObject() instanceof NodeForm) {
-      /** @var \Drupal\node\NodeInterface $node **/
-      $node = $form_state->getFormObject()->getEntity();
-      $bundle = $node->bundle();
+    if ($form_state->getFormObject() instanceof ContentEntityForm) {
+      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = $form_state->getFormObject()->getEntity();
+      $entity_type = $entity->getEntityType()->id();
+      $bundle = $entity->bundle();
       $is_admin = $this->userPermsService->hasAdminRole();
-      $is_archiveable = $this->workflowContentControl->isBundleArchiveableByNonAdmins($bundle);
+      $is_archiveable = $this->workflowContentControl->isBundleArchiveableByNonAdmins($bundle, $entity_type);
       if (!$is_admin && !$is_archiveable) {
         unset($form['moderation_state']['widget'][0]['state']['#options']['archived']);
       }

--- a/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
+++ b/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
@@ -29,40 +29,47 @@ class WorkflowContentControl {
   }
 
   /**
-   * An array of node bundles that only Admins can archive.
+   * An array of entity bundles that only Admins can archive.
    *
    * @return array
    *   The content type array.
    */
-  public function getBundlesArchiveableByAdmins() {
-    return [
-      'basic_landing_page',
-      'centralized_content',
-      'documentation_page',
-      'event_listing',
-      'health_care_local_facility',
-      'health_care_region_page',
-      'health_services_listing',
-      'landing_page',
-      'leadership_listing',
-      'locations_listing',
-      'nca_facility',
-      'office',
-      'page',
-      'press_releases_listing',
-      'publication_listing',
-      'story_listing',
-      'support_service',
-      'va_form',
-      'vamc_operating_status_and_alerts',
-      'vamc_system_policies_page',
-      'vamc_system_register_for_care',
-      'vamc_system_medical_records_offi',
-      'vamc_system_billing_insurance',
-      'vba_facility',
-      'vet_center',
-      'vet_center_locations_list',
+  public function getBundlesArchiveableByAdmins($entity_type = 'node'): array {
+    $bundles = [
+      'node' => [
+        'basic_landing_page',
+        'centralized_content',
+        'documentation_page',
+        'event_listing',
+        'health_care_local_facility',
+        'health_care_region_page',
+        'health_services_listing',
+        'landing_page',
+        'leadership_listing',
+        'locations_listing',
+        'nca_facility',
+        'office',
+        'page',
+        'press_releases_listing',
+        'publication_listing',
+        'story_listing',
+        'support_service',
+        'va_form',
+        'vamc_operating_status_and_alerts',
+        'vamc_system_policies_page',
+        'vamc_system_register_for_care',
+        'vamc_system_medical_records_offi',
+        'vamc_system_billing_insurance',
+        'vba_facility',
+        'vet_center',
+        'vet_center_locations_list',
+      ],
+      'block_content' => [
+        'benefit_promo',
+        'news_promo',
+      ],
     ];
+    return $bundles[$entity_type] ?? [];
   }
 
   /**
@@ -70,12 +77,14 @@ class WorkflowContentControl {
    *
    * @param string $bundle
    *   The entity bundle type.
+   * @param string $entity_type
+   *   The entity type.
    *
    * @return bool
    *   Returns true if non-admin can archive, false if non-admin can not.
    */
-  public function isBundleArchiveableByNonAdmins($bundle) {
-    return in_array($bundle, $this->getBundlesArchiveableByAdmins()) ? FALSE : TRUE;
+  public function isBundleArchiveableByNonAdmins(string $bundle, string $entity_type = 'node') {
+    return in_array($bundle, $this->getBundlesArchiveableByAdmins($entity_type)) ? FALSE : TRUE;
   }
 
 }


### PR DESCRIPTION
## Description

Closes #13863 

Updates text and workflow for promo blocks (news, benefit) according to [this figma mockup](https://www.figma.com/file/sOMpovTM82TgC08ugF0FxF/News-Promo-Block?type=design&node-id=0-1&mode=design&t=4HX5hbqW1RqCYoA5-0) and these concepts:

~~- Makes sure "Delete" option doesn't show up for non-admin users~~
~~- Ensures that user role "homepage manager" can't archive block~~
- Ensures that non-admins can archive block
- Updates news promo block help text: block description, link text, promo headline field
- Updates benefit promo block help text: block description, promo headline field

## Testing done
Functional testing for the promo blocks, non-promo blocks, nodes in the bundle and not in the bundle.


## Screenshots
TBD

## QA steps

As user `homepagemanager` with homepage manager role (or grant a user both homepage manager role and section `-- Office of Public and Intergovernmental Affairs` access:
- Go to [homepage news promo block edit form](https://cms-hwzr9sq9w6ph4nma2iqpmdgctt7odwpo.ci.cms.va.gov/block/209?destination=/admin/structure/block/block-content) directly; not in menu
- [x] Ensure that section settings "change to" options shows Draft and Publish and not Archive options.
- [x] Ensure that the save button at the bottom does not have "Delete" option next to it.
~~- [ ] Fill out test data in all required fields and click "Save". Ensure that there are no error messages.~~

Check the help text:
News Promo help text
- [x] Block description: _This is used for identifying the block within the CMS. The description will not be shown on VA.gov._
- [x] Link-related text: Link Text field on the News Promo. Text: _This text tells Veterans what to do next._
- [x] "Promo headline" field: _Use this headline to make it clear to Veterans what the topic of this promo is and why it's relevant to them._
 
Benefit Promo help text
- [x] Block description: _This is used for identifying the block within the CMS. The description will not be shown on VA.gov._
- [x] "Promo headline" field: _Use this headline to make it clear to Veterans what the topic of this promo is and why it's relevant to them._

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
