### PR TITLE
VACMS-14732 bump drupal/post_api to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
         "drupal/pathauto": "^1.6",
         "drupal/pathologic": "^2.0@alpha",
         "drupal/pfm": "^2.0",
-        "drupal/post_api": "^2.0.1",
+        "drupal/post_api": "^2.0.2",
         "drupal/prometheus_exporter": "^1.0@beta",
         "drupal/raven": "^4.0",
         "drupal/redirect": "^1.3",
@@ -475,9 +475,6 @@
             "drupal/pathauto": {
                 "3204586 - Update URL Alias action is only available for nodes + users and does not work with views_bulk_operations": "https://www.drupal.org/files/issues/2022-10-28/pathauto-add_deriver_for_alias_update_action-3204586-28_0.patch",
                 "3214658 - Omit nolink items from url path args and add token that uses parent url": "https://www.drupal.org/files/issues/2022-05-08/remove-nolink-args-use-parent-entity-url-3214658-18.patch"
-            },
-            "drupal/post_api": {
-                "3289117 - Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2022-08-22/post_api.2.x-dev.rector.patch"
             },
             "drupal/prometheus_exporter": {
                 "3214628 - Add published/unpublished node statistics to NodeCount.": "https://www.drupal.org/files/issues/2021-06-29/prometheus_exporter-add_status_metrics_to_node_count-3214628-3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b666233b363308338a511b5c1a0ea9ba",
+    "content-hash": "a810e0eeaf54953424d6126a3912ab92",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -10866,29 +10866,29 @@
         },
         {
             "name": "drupal/post_api",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/post_api.git",
-                "reference": "2.0.1"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/post_api-2.0.1.zip",
-                "reference": "2.0.1",
-                "shasum": "979e070a1ff7f192b5aaa628130eddfc9bd010a0"
+                "url": "https://ftp.drupal.org/files/projects/post_api-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "4075bc9c965f8bf5f30020b2699dbfd2c57a7d42"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^8 || ^9 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.1",
-                    "datestamp": "1590717054",
+                    "version": "2.0.2",
+                    "datestamp": "1691697591",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -10904,6 +10904,10 @@
                 {
                     "name": "oksana-c",
                     "homepage": "https://www.drupal.org/user/2916547"
+                },
+                {
+                    "name": "swirt",
+                    "homepage": "https://www.drupal.org/user/138230"
                 }
             ],
             "description": "Developer tools to support POST requests to external endpoints for any data queued via Queue API.",

--- a/tests/phpunit/API/PostApiQueueTest.php
+++ b/tests/phpunit/API/PostApiQueueTest.php
@@ -85,11 +85,11 @@ class PostApiQueueTest extends VaGovExistingSiteBase {
 
     $response = $this->processItem(NULL);
     // Payload is empty. Request should fail.
-    $this->assertEquals(404, $response, 'POST request is expected to fail with 404 due to incomplete endpoint URL.');
+    $this->assertEquals(404, $response->getStatusCode(), 'POST request is expected to fail with 404 due to incomplete endpoint URL.');
 
     $response = $this->processItem(self::$mockData);
     // Payload and credentials are available. POSt should return 200 OK.
-    $this->assertEquals(200, $response, 'POST request is successful.');
+    $this->assertEquals(200, $response->getStatusCode(), 'POST request is successful.');
 
     $queue->deleteQueue();
   }

--- a/tests/phpunit/API/PostApiQueueTest.php
+++ b/tests/phpunit/API/PostApiQueueTest.php
@@ -85,7 +85,8 @@ class PostApiQueueTest extends VaGovExistingSiteBase {
 
     $response = $this->processItem(NULL);
     // Payload is empty. Request should fail.
-    $this->assertEquals(404, $response->getStatusCode(), 'POST request is expected to fail with 404 due to incomplete endpoint URL.');
+    // A guzzle exception gets thrown which causes the response to be a code.
+    $this->assertEquals(404, $response, 'POST request is expected to fail with 404 due to incomplete endpoint URL.');
 
     $response = $this->processItem(self::$mockData);
     // Payload and credentials are available. POSt should return 200 OK.


### PR DESCRIPTION
## Description

Relates to #14732
## Testing done

Tested posting to facility API and altering the status code to look like an error.

![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/f0e02100-2d3a-4530-b4c1-c68634adb0d5)


## QA steps

Note: This was QA's locally because I could intercept request and make it fail.  Testing of the logging of fails can not be tested on tugboat.

Login as admin:
1. edit a facility https://pr14754-fpoqff2lxxpv6v5es6ouubwrwblhar7f.ci.cms.va.gov/node/2287/edit
2. change its status and publish.
3. Go to the queue. https://pr14754-fpoqff2lxxpv6v5es6ouubwrwblhar7f.ci.cms.va.gov/admin/config/post-api/queue
4. process the queue list
  - [x] Validate that the queue empties.
6. Visit dblog https://pr14754-fpoqff2lxxpv6v5es6ouubwrwblhar7f.ci.cms.va.gov/admin/reports/dblog
  - [x] validate that  there is no post_api failure. (the 2 failures in the screenshot are from automated testing entries that fail on send.
  - [x] validate the there is an entry that shows the queue processed successfully
  
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/fb61a7fa-ac1a-4770-8f9b-f7db3a027f3a)




