### PR TITLE
VACMS-14761 Restore queue of facility services if service term changes

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
+++ b/docroot/modules/custom/va_gov_post_api/va_gov_post_api.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
 use Drupal\va_gov_facilities\FacilityOps;
 
 /**
@@ -18,6 +19,9 @@ function va_gov_post_api_entity_insert(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
     _va_gov_post_api_add_facility_to_queue($entity);
     _va_gov_post_api_add_facility_service_to_queue($entity);
+  }
+  elseif ($entity instanceof TermInterface) {
+    _va_gov_post_api_add_facility_service_to_queue_due_to_term_change($entity);
   }
 }
 
@@ -31,13 +35,17 @@ function va_gov_post_api_entity_update(EntityInterface $entity) {
     _va_gov_post_api_add_facility_to_queue($entity);
     _va_gov_post_api_add_facility_service_to_queue($entity);
   }
+  elseif ($entity instanceof TermInterface) {
+    _va_gov_post_api_add_facility_service_to_queue_due_to_term_change($entity);
+  }
+
 }
 
 /**
  * Adds facility data to Post API queue.
  *
  * @param \Drupal\node\NodeInterface $node
- *   Entity.
+ *   Node entity.
  *
  * @return int
  *   The count of the number of items queued.
@@ -61,7 +69,7 @@ function _va_gov_post_api_add_facility_to_queue(NodeInterface $node) {
  * Adds facility service data to Post API queue to update Lighthouse.
  *
  * @param \Drupal\node\NodeInterface $node
- *   Node.
+ *   Node entity.
  *
  * @return int
  *   The count of the number of items queued.
@@ -70,11 +78,25 @@ function _va_gov_post_api_add_facility_service_to_queue(NodeInterface $node) {
   if ($node->bundle() === 'health_care_local_health_service') {
     return Drupal::service('va_gov_post_api.queue_service_updates')->queueFacilityService($node);
   }
-  elseif ($node->bundle() === 'health_care_service_taxonomy') {
-    return Drupal::service('va_gov_post_api.queue_service_updates')->queueServiceTermRelatedServices($node);
-  }
   elseif ($node->bundle() === 'regional_health_care_service_des') {
     return Drupal::service('va_gov_post_api.queue_service_updates')->queueSystemRelatedServices($node);
+  }
+
+  return 0;
+}
+
+/**
+ * Adds facility service data to Post API queue if service term changes.
+ *
+ * @param \Drupal\taxonomy\TermInterface $term
+ *   Term entity.
+ *
+ * @return int
+ *   The count of the number of items queued.
+ */
+function _va_gov_post_api_add_facility_service_to_queue_due_to_term_change(TermInterface $term):int {
+  if ($term->bundle() === 'health_care_service_taxonomy') {
+    return Drupal::service('va_gov_post_api.queue_service_updates')->queueServiceTermRelatedServices($term);
   }
 
   return 0;


### PR DESCRIPTION

## Description

Relates to #14761

## Testing done
## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As an admin
1. Go to the [covid 19 vaccine service term](https://pr14762-ftm3uxhmzjsgdhwrgzuus0riu2scvvmt.ci.cms.va.gov/taxonomy/term/321/edit).
2. make a change to the VAMC desciption.  
3. Save the term as published
   - [x] Validate that after a delay, you see a list of 100's of services listed as being queued
   
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/de7d0ac1-e6a3-4ea3-b5f3-42738f18a181)

4. Then go [to watchdog](https://pr14762-ftm3uxhmzjsgdhwrgzuus0riu2scvvmt.ci.cms.va.gov/admin/reports/dblog?type%5B%5D=va_gov_post_api) and validate that you see multiple entries showing a batches of services being queued.
   - [x] Validate that
   
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/8cae0087-7bd7-4e21-aeee-c1268f25c09a)

5. Go to the post_API queue https://pr14762-ftm3uxhmzjsgdhwrgzuus0riu2scvvmt.ci.cms.va.gov/admin/config/post-api/queue
   - [x] validate that there are ~300 items in the queue.   DO NOT PROCESS THE QUEUE
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/d6548c07-65ed-4611-bae5-111b3a10bf3d)


