### PR TITLE
VACMS-14806: Block VACMS-0+ branch names.

### DIFF
--- a/hooks/git/pre-commit
+++ b/hooks/git/pre-commit
@@ -2,8 +2,8 @@
 
 # Check a specified branch name against a list of allowed patterns.
 function check_branch_name() {
-  case $1 in 
-    VAGOV-TEAM-[0-9]* | VACMS-[0-9]* | dependabot/* | revert-* | "") return 0;;
+  case $1 in
+    VAGOV-TEAM-[1-9][0-9]* | VACMS-[1-9][0-9]* | dependabot/* | revert-* | "") return 0;;
     *) return 1;;
   esac
 }
@@ -21,12 +21,15 @@ function is_ddev_running() {
 function branch_name_error() {
   cat <<-EOF >&2
     Aborting commit. Your branch name must be prefixed with one of the following:
-      - a VAGOV-TEAM-* or VACMS-* Github issue number format, 
-        e.g. VAGOV-TEAM-123-issue-name or VACMS-123-issue-name. 
+      - a VAGOV-TEAM-* or VACMS-* Github issue number format,
+        e.g. VAGOV-TEAM-123-issue-name or VACMS-123-issue-name.
       - dependabot/* (for work on Dependabot PRs)
       - revert-* (for work on GitHub-initiated revert PRs)
 
-    Use e.g. \`git branch --move <VACMS-0000-new-name>\` to rename.
+    Do not use VACMS-0, VACMS-00, et cetera for new branches instead of creating
+    a new GitHub ticket.
+
+    Use e.g. \`git branch --move <VACMS-14806-new-name>\` to rename.
 EOF
   exit 1
 }


### PR DESCRIPTION
Closes #14806.

## Testing

```
$ git branch -a | awk -F/ '{ print $NF }' | while read -r branch; do     check_branch_name "${branch}" && echo "good name ${branch}" || echo "bad name ${branch}"; done
good name VACMS-14687-Remove-old-entity-subscriber-stuff
good name VACMS-14803-Switch-form-classes
# Too lazy to bother with the following misfire:
bad name * VACMS-14806-Block-VACMS-0000-branch-names
bad name main
bad name REVERT-VACMS-11064
bad name VACMS-00000-disable-flysystem
bad name VACMS-00000-fix-for-sitewide-alert
bad name VACMS-00000-remove-flysystem-modules
bad name VACMS-00000-remove-topfloor-remove-composer-vcs-dir
bad name VACMS-00000-update-simplasamlphp-auth
good name VACMS-10046-update-link-color-across-the-cms-to-meet-wcag-20-aaa-contrast-requirement
good name VACMS-10099-place-qa-modal-in-cms-not-available-with-keyboard
good name VACMS-10116-radio-button-labels-on-cms-revisions-page
good name VACMS-10132-select-feilds-missing-abes-in-cms
good name VACMS-10622-add-eslint-plugin-yml-package-to-=packacke-json
good name VACMS-10642-update-inline-alt-text-guidance-string-in-cms
good name VACMS-10643-php-81-related-issues
good name VACMS-10661-create-report-of-outdated-content-in-the-cms
good name VACMS-10766-inline-guidance-groundwork-and-setup
good name VACMS-10793-audit-tables-across-va-gov
good name VACMS-10793-enable-views-event-dispatcher-module
good name VACMS-10866-update-color-of-pending-url-text-in-cms
good name VACMS-10870-upgrade-to-php81
good name VACMS-10923-additonal-filters-outdated-content
good name VACMS-10950-drupal-core-critical-update-sa-core-2022-016
good name VACMS-11011-disable-vagovadmin-theme
good name VACMS-11045-inline-content-guidance-trigger-reloads-page
good name VACMS-11066-do-initial-setup-for-ga4
good name VACMS-11109-inlin-guidance-form-group-field-not-populating-with-existing-content
good name VACMS-11121-add-inline-guidance-into-existing-nodes
good name VACMS-11158-published-pdfs
good name VACMS-11289-add-upcoming-expiration-filters
good name VACMS-11397-update-help-text-color
good name VACMS-11415-orphaned-paragraphs
good name VACMS-11435-table-audit-cleanup
good name VACMS-11455-changef-field-label-text-color
good name VACMS-11471-fix-error-new-table-audit
good name VACMS-11495-conent-audit-space-force
good name VACMS-11505-add-last-saved-by-an-editor-field
good name VACMS-11506-uodate-outdated-content-tool
good name VACMS-11575-match-csv-columns-to-tool
good name VACMS-11655-make-edit-form-responsive
good name VACMS-11697-alt-text-inline-guidance-open
good name VACMS-11698-last-touched-by-an-editor-field-not-always-updating
good name VACMS-11744-linky-404-report
good name VACMS-11924-fix-main-content-title
good name VACMS-12035-last-saved-by-an-editor-block-rampaging-unchecked
good name VACMS-12250-drupal-9-5
good name VACMS-12378-update-char-limit-error-warning
good name VACMS-12446-graphql-v4
good name VACMS-12450-update-outdated-content-report
good name VACMS-12549-focus-state-admin-toolbar
good name VACMS-12650-outdated-content-notificaton-email
good name VACMS-12783-monthly-cron-for-notifications
good name VACMS-12870-change-node-install-to-nvm
good name VACMS-12928-update-dependencies-for-design-system
good name VACMS-12930-retool-vagovclaro-for-webpack
good name VACMS-13017-update-all-build-tools-to-npm
good name VACMS-13047-vamc-outdated-content-notifications
good name VACMS-13226-outdated-content-notifications-invalid-url
good name VACMS-13278-menu-links-imited-to-255
good name VACMS-13296-graphql-v3
good name VACMS-13366-update-drupal-core
good name VACMS-13467-vet-center-notifications
good name VACMS-13468-vamc-notification-update
good name VACMS-13478-contirb-moudles-for-d10
good name VACMS-13487-upgrade-storybook-to-v7
good name VACMS-13494-add-nvw-to-web-tools
good name VACMS-13538-unable-to-alter-values-by-vbo
good name VACMS-13592-vet-center-login-update-outdated-content
good name VACMS-14148-facility-migration-failing
good name VACMS-9396-fix-related-section-of-kb-theming
good name VACMS-9424-entity-usage-et
good name VACMS-9818-Linky-script
good name VACMS-9821-remove-hidden-edit-link-in-main-content-listing
good name VACMS-9920-update-main-cms-toolbar-to-meet-a11y-standards
good name VACMS-9992-dteremine-course-of-action-for-dependencies-blocking-php-8-update
bad name main
bad name VACMS-0-email-typo
bad name VACMS-0000-Add-ddev-providers-platform-file
bad name VACMS-0000-Add-git-safe-directory-to-allow-actions-to-work
bad name VACMS-0000-Allows-ddev-to-listen-to-lando-fqdn
bad name VACMS-0000-Attempt-to-make-content-editing-test-more-reliable
bad name VACMS-0000-CD-Metrics-fix
bad name VACMS-0000-Catch-an-uncaught-exception-in-anchor-links-js
bad name VACMS-0000-Claro-testing
bad name VACMS-0000-Clean-up-config
bad name VACMS-0000-Deconcurrentize-Cypress
bad name VACMS-0000-Deconcurrentize-behat
bad name VACMS-0000-Deconcurrentize-content-build-gql
bad name VACMS-0000-Deconcurrentize-phpunit
bad name VACMS-0000-Dependabot-alerts
bad name VACMS-0000-Disable-TrimNodeTitleWhitespaceTest-again
bad name VACMS-0000-Disable-a-few-tests
bad name VACMS-0000-Disable-failure-on-watchdog-messages
bad name VACMS-0000-Disable-sitewide_alerts-on-Tugboat
bad name VACMS-0000-Document-content-release-system
bad name VACMS-0000-Downgrade-Yarn-to-1.19.1
bad name VACMS-0000-Echo-task-output
bad name VACMS-0000-Fiddling-about
bad name VACMS-0000-Fix-periodic-tasks
bad name VACMS-0000-Ignore-AWS-SDK-patch-updates
bad name VACMS-0000-Ignore-image-crop-tests
bad name VACMS-0000-Ignore-module-and-core-updates-on-status-error-checks
bad name VACMS-0000-Look-whats-happened-to-Cypresss-baby
bad name VACMS-0000-Nate-plumbing-the-dreamlands-of-kadath
bad name VACMS-0000-Nug-doug-D10-2
bad name VACMS-0000-Patch-to-stop-Raven-from-exploding-and-killing-everyone
bad name VACMS-0000-Prevent-links-with-VA-domains-as-first-path-segment
bad name VACMS-0000-Prevents-Dependabot-from-attempting-Drupal-core-updates
bad name VACMS-0000-Remove-CodeQL-CI-test
bad name VACMS-0000-Remove-distracting-test-output
bad name VACMS-0000-Remove-extra-drush-in-flag-removed-facilities
bad name VACMS-0000-Remove-old-facilities
bad name VACMS-0000-Remove-reference-to-vertical-tabs-js
bad name VACMS-0000-Revert-drupal-hierarchy-manager-upgrade
bad name VACMS-0000-Run-backup-retention-only-on-main-repo
bad name VACMS-0000-Skip-set-tugboat-tests-pending-if-dependabot
bad name VACMS-0000-Some-improvements-to-user-login-test
bad name VACMS-0000-Sort-permissions-arrays-in-tests
bad name VACMS-0000-Temporarily-disable-three-accessibility-tests
bad name VACMS-0000-Truncate-strings-that-can-cause-issues-in-Cypress-tests
bad name VACMS-0000-Update-VA-root-certs
bad name VACMS-0000-Update-node-requirement
bad name VACMS-0000-Update-to-Drupal-9.2.13
bad name VACMS-0000-Update-vets-website
bad name VACMS-0000-Updates-Linkit
bad name VACMS-0000-Updates-caniuse-lite
bad name VACMS-0000-Updates-vets-web
bad name VACMS-0000-Use-ProphecyTrait
bad name VACMS-0000-Use-substring-of-generated-text-in-link-text-field
bad name VACMS-0000-Various-updates-to-NPM-packages
bad name VACMS-0000-Work-on-Cypress-support-for-iframes
bad name VACMS-0000-Zap-the-platform-overrides
bad name VACMS-0000-exclude-core-git-from-remove-git-dirs
bad name VACMS-0000-removes-core-git-repo-path
bad name VACMS-0000_test_ci_break_2
good name VACMS-10001-PHPStan-optimizations
good name VACMS-10049-Fix-failing-Cypress-test
good name VACMS-10249-Require-PHPSpec-Prophecy
good name VACMS-10249-Troubleshooting-content-build-gql-test
good name VACMS-10249-Upgrade-graphql-explorer-packages
good name VACMS-10290-Upgrade-Drupal-to-9.3.21
good name VACMS-10298-Create-report-of-modernized-and-unmodernized-urls
good name VACMS-10366-Remove-no-reply-from-update-manager-preferences
good name VACMS-10368-Checkout-WCAG21-lift
good name VACMS-10391-Add-timestamps-before-each-test
good name VACMS-10455-Fix-search-api-complaints
good name VACMS-10471-Fix-escaped-HTML-in-sitewide-alert
good name VACMS-10502-Add-composer-validate-GitHub-action
good name VACMS-10554-Move-set-tests-pending-to-GitHub-Action
good name VACMS-10570-Protect-content-build-gql-against-concurrent-content-builds
good name VACMS-10579-Add-content-validator
good name VACMS-10596-Move-check-cer-test-into-GitHub-Actions
good name VACMS-10619-Refactor-GitHub-Actions
good name VACMS-10649-Disable-update-manager-on-BRD-environments
good name VACMS-10689-Debug-race-conditions-in-tests
good name VACMS-10691-Add-validator-to-prevent-linking-to-media-pages
good name VACMS-10692-Disable-PHP-CodeSniffer-rule-that-doesnt-like-see-github-urls
good name VACMS-10722-Create-script-to-populate-repo-with-bad-files
good name VACMS-10787-Improve-Cypress-Axe-test-visibility
good name VACMS-10789-Update-PHPStan-packages
good name VACMS-10807-Confirm-that-prod-and-staging-services-yml-files-are-identical
good name VACMS-10921-Send-code-coverage-metrics-to-DataDog
good name VACMS-10947-Contextual-advice-action
good name VACMS-10974-Audit-GitHub-Actions
good name VACMS-10989-Adds-new-user-count-metrics
good name VACMS-10995-Disable-color-module
good name VACMS-10996-Removes-obsolete-permission-from-content_admin
good name VACMS-10997-Remove-better_field_descriptions-module
good name VACMS-11005-Updates-va_gov_post_api-for-compatibility-with-D10
good name VACMS-11010-Assure-Claro-theme-compatibility-with-Drupal-10
good name VACMS-11049-Fix-attributes-error
good name VACMS-11082-Investigate-gathering-line-count-metrics
good name VACMS-11257-Send-GitHub-metrics-to-DataDog
good name VACMS-11280-Patch-content-build-gql-to-add-timestamps
good name VACMS-11631-Create-and-save-media-entities-in-functional-tests
good name VACMS-11639-Fix-status-error-processing
good name VACMS-11669-Fix-warning-importing-configuration
good name VACMS-11724-Reënable-status-error-test
good name VACMS-11761-Delay-accessibility-tests-to-allow-CSS-transitions-to-finish
good name VACMS-11811-Shifts-PHP-Lint-into-GHA-action
good name VACMS-11834-Improve-password_policy-test
good name VACMS-11881-Change-order-of-file-permission-changes
good name VACMS-11884-PR-for-testing
good name VACMS-11884-Test-Bullseye-on-Tugboat
good name VACMS-11895-Adds-Cypress-support-for-watchdog
good name VACMS-11896-Make-contentreleasestatuscontroller-test-more-reliable
good name VACMS-11904-Undefined-array-key-href
good name VACMS-11905-Undefined-key-req_optional
good name VACMS-11906-Patch-taxonomy_entity_index-to-fix-error
good name VACMS-11961-Move-DownloadableFileTest-tests-into-Cypress
good name VACMS-12054-Dont-throw-error-on-undefined-array-key
good name VACMS-12180-Prevent-references-to-preview-links
good name VACMS-12189-Rollback-auto_entitylabel
good name VACMS-12231-Remove-old-db-tables
good name VACMS-12270-Upgrade-to-Drupal-9.4.10
good name VACMS-12396-Incorporate-heading-violation-check-into-tugboat-content-build
good name VACMS-12415-Fixes-field-validation-error-message-links
good name VACMS-12476-Intercept-GTM-requests-in-Cypress
good name VACMS-12500-Reformats-Cypress-files
good name VACMS-12614-Refactor-cypress-log-specific-code
good name VACMS-12621-Evaluate-cypress-parallel
good name VACMS-12627-Expand-metrics-for-header-violations
good name VACMS-12630-Test-READ-COMMITTED
good name VACMS-12679-Pass-arguments-to-behat
good name VACMS-12681-Pin-setup-node-action
good name VACMS-12734-Update-Cypress-to-recent-compatible-version
good name VACMS-12845-Export-outdated-content-metrics
good name VACMS-13317-Fix-saving-taxonomy-terms
good name VACMS-13489-Address-loadtest-vulnerability-alerts
good name VACMS-13852-Create-Entity-Event-Subscriber
good name VACMS-13855-Create-entity-event-strategy-resolver-service
good name VACMS-14386-Create-new-content-release-forms
good name VACMS-14550-Make-ContentReleaseStatusControllerTest-D10-compatible
good name VACMS-14687-Remove-old-entity-subscriber-stuff
good name VACMS-14803-Switch-form-classes
good name VACMS-1501-watchdog-success-record
good name VACMS-2406-hide-meta-tags-field
good name VACMS-2407-Hide-plain-language-certified-date
good name VACMS-2457-update-tablefield-caption-help-text
good name VACMS-2681-Changes-to-redirect_options-behavior
good name VACMS-2756-export-metatag-paths
good name VACMS-2756-metatag-entity-paths
good name VACMS-2788-performanceLoginTest-problems
good name VACMS-2912-force-editors-to-save-before-publishing
good name VACMS-3011-Optimize-composer-flags
good name VACMS-3124-Have-CMS-notify-Slack-if-content-release-fails
good name VACMS-3211-display-settings-for-new-rich-text-paragraph
good name VACMS-3223-user-role-dimension-for-google-analytics
good name VACMS-3270
good name VACMS-3378-save-and-select-button-fails
good name VACMS-3387-Schemata-entries-pollute-dblog
good name VACMS-3395-fix-moderation-control
good name VACMS-3436-Fix-failing-tests
good name VACMS-3436-link-experience-on-help-center-pages
good name VACMS-3436-link-experience-on-help-center-pages-cypress
good name VACMS-3449-paragraphs-should-be-forced-to-clone-on-node-clone
good name VACMS-3450-paragraphs-should-have-a-single-parent
good name VACMS-3451-make-url-field-required
good name VACMS-3468-collect-userid-via-ga-gtm
good name VACMS-3509-Video-embeds-for-CMS-help-center-pages
good name VACMS-3563-Add-alt-text-meta-tags
good name VACMS-3570-remove-obsolete-displays-in-right-sidebar-latest-revision
good name VACMS-3591-fix-parent-and-revision-ids-on-paragraphs
good name VACMS-3607-Disable-grid-view-in-media-library
good name VACMS-3608-Change-button-label-in-entity-clone-confirmation-form
good name VACMS-3680-Whats-new-in-the-CMS
good name VACMS-3693-userSections-GTM-Layer
good name VACMS-3694-Fixes-GTM-ContentOwner-Reporting
good name VACMS-3717-Change-event-default-timezone-to-America-New-York
good name VACMS-3772-Add-edited-flag
good name VACMS-3772-Create-flag-when-user-edits-node
good name VACMS-3810-Fixes-GTM-dataLayer-issues-and-adds-tests
good name VACMS-3826-Update-Drupal-Core-to-8.9.11
good name VACMS-3937-Replace-downloadable_file-tests
good name VACMS-3955-Get-Jenkins-API-Token-From-SSM
good name VACMS-3955-Revert-changes-to-Jenkins-API-thing
good name VACMS-3960-Updates-vagov-web
good name VACMS-3962-Update-to-Drupal-8.9.13
good name VACMS-3974-Changes-to-CMS-Announcements-Block-Paths
good name VACMS-4101-Just-output-the-stupid-node-uuid
good name VACMS-4105-Render-JSD-Widget-on-Access-Denied-Page
good name VACMS-4117-Tablefield-incorrectly-saves-values
good name VACMS-4133-Update-help-text-for-link-to-file-or-video
good name VACMS-4222-Better-tests-for-BRD-environment
good name VACMS-4222-Better-tests-for-BRD-environment-3
good name VACMS-4292-Remove-schemata-module
good name VACMS-4460-Install-and-enable-Memcache
good name VACMS-4499-Fix-count-warning
good name VACMS-4831-Make-va_gov_notifications-D9-compatible
good name VACMS-4871-Switch-from-Yaml-Tasks-to-Task
good name VACMS-4871-Switch-from-Yaml-Tasks-to-Task-2
good name VACMS-4919-Static-analysis-and-deprecated-code-checks
good name VACMS-4919-check-for-deprecated-code
good name VACMS-4927-Configure-Memcache-support-in-Tugboat
good name VACMS-4947-Add-workaround-repositories-for-certain-D8-only-modules
good name VACMS-4947-Add-workaround-repositories-for-certain-modules
good name VACMS-4954-Update-acquia-drupal-spec-tool-to-3_0
good name VACMS-4954-Upgrade-Acquia-Drupal-Spec-Tool
good name VACMS-4954-Upgrade-acquia-drupal-spec-tool-to-a-more-recent-version
good name VACMS-5083-Add-benchmark-scripts-and-documentation
good name VACMS-5376-Repair-incomplete-node-hrefs
good name VACMS-5430-Create-publish-now-button
good name VACMS-5596-Redirect-to-media-library-after-unlocking
good name VACMS-5650-test-changes
good name VACMS-5908-Test-tasks-should-return-an-exit-code-on-failure-depending-on-a-flag
good name VACMS-5922-Fix-help_center-test
good name VACMS-5926-Upgrade-to-Drupal-9.1.11
good name VACMS-6113-Automatically-fix-broken-links-to-email-addresses
good name VACMS-6172-Validator-and-constraint-to-fail-Drupal-URLs
good name VACMS-6257-Remove-Webform-module
good name VACMS-6331-validation-constraint-preventing-adjacent-links
good name VACMS-6334-Tweak-sentry-settings
good name VACMS-6353-Remove-calls-to-deprecated-render-function
good name VACMS-6457-Resolve-Dependabot-alerts
good name VACMS-6461-Create-Dockerfile
good name VACMS-6702-Send-CMS-logs-to-Datadog
good name VACMS-6738-Patch-Memcache-module-to-use-persistent-connections
good name VACMS-6902-Update-Drupal-core-9.2.7-9.2.8
good name VACMS-6948-Adds-patch-to-explicitly-set-menu-link-bundle
good name VACMS-6948-Debugging-menu-links
good name VACMS-6984-Remove-Drupal-Console
good name VACMS-7030-Fix-appearances-of-the-preview-button
good name VACMS-7377-Ensure-compatibility-with-Composer-2.2
good name VACMS-7459-Bump-Tugboat-Memcached-max-item-size
good name VACMS-7582-Update-local-dev-and-Tugboat-to-PHP-7.4
good name VACMS-7834-Defensive-coding-in-theme_suggestions_paragraph_alter-hooks
good name VACMS-8085-Removes-logspam-from-performance-tests
good name VACMS-8160-Install-Upgrade-Status
good name VACMS-8166-Upgrade-to-Drupal-9.4
good name VACMS-8168-Ameliorate-worst-accessibility-test-issues
good name VACMS-8518-Disable-nested-interactive-wcag2a-rule
good name VACMS-8518-Dont-perform-accessibility-tests-on-menu-parent-element
good name VACMS-8519-Test-coverage-for-file-upload
good name VACMS-8525-Fix-issues-deleting-revisions
good name VACMS-8662-Alternative-approach-for-Cypress
good name VACMS-8662-Fiddle-around-with-Cypress
good name VACMS-8662-Test-Branch
good name VACMS-8662-Test-Branch-3
good name VACMS-8671-Part-2
good name VACMS-8671-Replace-mock-HTTP-client-class-tests
good name VACMS-8672-Create-Cypress-step-definitions
good name VACMS-8675-Port-Behat-tests-to-Cypress
good name VACMS-8739-Removes-GITHUB_WORKSPACE-workaround-from-GitHub-Actions
good name VACMS-8790-Upgrades-Drupal-to-9.3.11
good name VACMS-8950-Remove-Vagovadmin-theme
good name VACMS-9319-Remove-content-announcement-block-placement-for-recurring-events
good name VACMS-9416-Rework-local-commands
good name VACMS-9513-Uninstall-site-alert-module
good name VACMS-9574-Update-Drupal-to-9.3.17
good name VACMS-9818-Linky-script
good name VACMS-9839-Debug-and-reenable-failing-phpunit-test
good name VACMS-9839-Temporarily-disable-PHPUnit-test
good name VACMS-9882-Draft-testing-qa-strategy-document
good name VACMS-9905-Remove-PHPUnit-performance-tests
good name VACMS-9905-Temporarily-increase-CreateMediaTest-timeout
good name VACMS-9996-Reevaluate-packages-with-composer-repository-overrides
bad name VAGOV-0-drupal-core-source
bad name VAGOV-000-menu-regression-test
bad name VAGOV-1229-devshop-yaml-tasks
bad name VAGOV-1229-status-links
bad name VAGOV-1738-remove-preview-button-et
bad name VAGOV-2215-more-documentation
bad name VAGOV-5244-roll-off-lightning
bad name VAGOV-5767-web-tests
bad name VAGOV-6257-computed-fields
bad name VAGOV-6290-deprecated-field-removal-et
bad name VAGOV-878-web-build
bad name VAMC-6571-health-service-migration
bad name add-v2-config-file
bad name aws-sdk-php-3.261.4
bad name site-process-4.2.1
bad name danse-2.2.7
bad name dropzonejs-2.8.0
bad name entity_embed-1.1.0
bad name fast_404-2.0.0-alpha5
bad name geocoder-3.31.0
bad name menu_breadcrumb-1.13.0
bad name metatag-1.22.0
bad name next-1.6.2
bad name redirect-1.6.0
bad name role_delegation-1.1.0
bad name search_api-1.28.0
bad name smart_date-3.6.1
bad name views_bulk_edit-2.8.0
bad name workbench_access-1.0.0-beta4
bad name workbench_menu_access-1.3.0
bad name email-link
bad name facility-alerts-poc
bad name kevwalsh-patch-1
bad name plain-language-linting-mvp
bad name main
bad name master
good name revert-754-vagov-6332-disable-staging-deploys
bad name tome-branch-b
bad name vagov-000-composer-nuke-clear-composer-cache
bad name vagov-6194-tome-sync-export
bad name VACMS-0000-AutoEntityLabel-test-branch
bad name VACMS-0000-Remove-set-tests-pending
good name VACMS-10870-test_code_on_74
good name VACMS-12252-drupal-10
good name VACMS-12291-lagoon-poc
good name VACMS-12453-samlauth-module
good name VACMS-12568-for-drupal-10
good name VACMS-13509-translation_docs
good name VACMS-13768-force-queue-vet-center-facilities
good name VACMS-14032-autoarchive-outstation-mobiles-clear-data
good name VACMS-14237-fix_str_replace-process-plugin
good name VACMS-14803-Switch-form-classes
good name VACMS-8017-vamc-service-data-push
good name VACMS-8662-Alternative-approach-for-Cypress
good name VACMS-9416-Rework-local-commands
bad name davidconlon-patch-4
bad name davidmpickett-runbook-labeling
bad name fast_404-3.1.0
bad name metatag-2.0.0
bad name migrate_tools-6.0.2
bad name tablefield-2.4.0
bad name textfield_counter-2.3.0
bad name integration-expanded-service-data-push
bad name jilladams-patch-1
bad name main
good name revert-14042-VACMS-13143-Magichead-with-depth-fields
bad name swirtSJW-patch-1
bad name teeshe-patch-1
bad name xiongjaneg-patch-1
bad name ElijahLynn-patch-1
bad name VACMS-000-502-test
bad name VACMS-000-502-test-1
bad name VACMS-000-502-test-10
bad name VACMS-000-502-test-11
bad name VACMS-000-502-test-12
bad name VACMS-000-502-test-13
bad name VACMS-000-502-test-14
bad name VACMS-000-502-test-15
bad name VACMS-000-502-test-16
bad name VACMS-000-502-test-2
bad name VACMS-000-502-test-3
bad name VACMS-000-502-test-4
bad name VACMS-000-502-test-5
bad name VACMS-000-502-test-6
bad name VACMS-000-502-test-7
bad name VACMS-000-502-test-8
bad name VACMS-000-502-test-9
bad name VACMS-0000-CMS-Test-fiddling
bad name VACMS-0000-Just-testing-stuff
bad name VACMS-0000-Simplest-stupidest-possible-way-of-parallelizing-Cypress-tests
bad name VACMS-0000-Testing-stuff-more
bad name VACMS-00000-remove-topfloor-remove-composer-vcs-dir
good name VACMS-10649-Disable-update-manager-on-BRD-environments
good name VACMS-10661-create-report-of-outdated-content-in-the-cms
good name VACMS-10870-upgrade-to-php81
good name VACMS-10870-upgrade-to-php81_rebased
good name VACMS-10947-Contextual-advice-action
good name VACMS-11315-disable-php-opcache-jit
good name VACMS-12291-lagoon-poc
good name VACMS-12870-change-node-install-to-nvm
good name VACMS-13152-Reenable-CodeQL
good name VACMS-13845-Creates-environment-discovery-service
good name VACMS-13948-Record-continuous-delivery-metrics
good name VACMS-1948-Upgrade-to-Drupal-9-1
good name VACMS-4695_sentry_no_staging
good name VACMS-4802-Disables-Password-Policy-on-lower-environments
good name VACMS-5908-Test-tasks-should-return-an-exit-code-on-failure-depending-on-a-flag
good name VACMS-6010_new_high_cap
good name VACMS-6334-Tweak-sentry-settings
good name VACMS-6702-Send-CMS-logs-to-Datadog
good name VACMS-7023-Forbid-PHPUnit-to-reuse-connections
good name VACMS-7377-Ensure-compatibility-with-Composer-2.2
good name VACMS-7552-theme-build-process
good name VACMS-8662-Fiddle-around-with-Cypress
good name VACMS-8675-Port-Behat-tests-to-Cypress
good name VACMS-8844-Install-and-configure-monolog
good name VACMS-9416-Rework-local-commands
bad name contributing-doc
bad name bumpalo-3.12.0
bad name openssl-0.10.48
bad name aws-sdk-php-3.236.0
bad name blazy-2.14.0
bad name coder-8.3.17
bad name config_split-2.0.0-rc4
bad name consumer_image_styles-4.0.8
bad name consumers-1.16.0
bad name content_model_documentation-1.0.0-alpha12
bad name content_model_documentation-1.0.1
bad name core-recommended-9.2.7
bad name ctools_block-4.0.1
bad name dropzonejs-2.8.0
bad name entity_browser_table-1.4.0
bad name entity_clone-2.0.0-beta2
bad name epp-1.3.0
bad name hierarchy_manager-3.3.2
bad name hook_event_dispatcher-3.3.2
bad name jsonapi_menu_items-1.2.4
bad name menu_link_attributes-1.3.0
bad name next-1.3.0
bad name node_revision_delete-1.0.0-rc5
bad name override_node_options-2.7.0
bad name password_policy-4.0.0
bad name path_redirect_import-2.0.5
bad name pathauto-1.11.0
bad name raven-4.0.13
bad name raven-4.0.14
bad name smart_date-3.6.1
bad name smart_date-3.7.2
bad name taxonomy_entity_index-1.12.0
bad name phpstan-1.10.4
bad name phpstan-1.10.9
bad name phpstan-deprecation-rules-1.1.2
bad name phpunit-9.5.25
bad name simplesamlphp-1.19.7
bad name simplesamlphp-1.19.8
bad name php_codesniffer-3.7.2
bad name content-build-0.0.3107
bad name drupal-test-traits-2.0.1
bad name json5-1.0.2
bad name luxon-1.28.1
bad name json5-1.0.2
bad name json5-and-babel-loader-2.2.3
bad name webpack-5.76.0
bad name json5-2.2.3
bad name json5-2.2.3
bad name el-actions-test
bad name lagoonize
bad name main
bad name master
bad name ndouglas-patch-1
bad name VACMS-0000-AutoEntityLabel-test-branch
bad name VACMS-0000-Remove-set-tests-pending
good name VACMS-10870-test_code_on_74
good name VACMS-12252-drupal-10
good name VACMS-12291-lagoon-poc
good name VACMS-12453-samlauth-module
good name VACMS-12568-for-drupal-10
good name VACMS-13509-translation_docs
good name VACMS-13768-force-queue-vet-center-facilities
good name VACMS-14032-autoarchive-outstation-mobiles-clear-data
good name VACMS-14237-fix_str_replace-process-plugin
good name VACMS-14803-Switch-form-classes
good name VACMS-8017-vamc-service-data-push
good name VACMS-8662-Alternative-approach-for-Cypress
good name VACMS-9416-Rework-local-commands
bad name davidconlon-patch-4
bad name davidmpickett-runbook-labeling
bad name fast_404-3.1.0
bad name metatag-2.0.0
bad name migrate_tools-6.0.2
bad name tablefield-2.4.0
bad name textfield_counter-2.3.0
bad name integration-expanded-service-data-push
bad name jilladams-patch-1
bad name main
good name revert-14042-VACMS-13143-Magichead-with-depth-fields
bad name swirtSJW-patch-1
bad name teeshe-patch-1
bad name xiongjaneg-patch-1
```

## QA Steps

- [ ] Run the same script I ran, or one of your own devising to check that this will block undesirable branch names and permit others.