### PR TITLE
VACMS-11001: Updates custom module va_gov_db to be D10-compliant

### DIFF
--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -25,13 +25,6 @@ use Psr\Log\LogLevel;
  * @return string
  *   A message about what requested modules were uninstalled.
  *
- * @deprecated in va_gov_db:9.1.1 and is removed from va_gov_db:15.1.1 This is
- *   no longer needed for simple module disables,  It is still appropriate when
- *   order matters, if multiple uninstalls have a weighting problem. So may
- *   never be fully removed.
- *
- * @see https://github.com/department-of-veterans-affairs/va.gov-cms/pull/10650#issuecomment-1240819457
- *
  * @throws Drupal\Core\Utility\UpdateException
  */
 function _va_gov_db_uninstall_modules(array $modules, $uninstall_dependents = TRUE) {

--- a/docroot/modules/custom/va_gov_db/va_gov_db.install
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.install
@@ -25,6 +25,12 @@ use Psr\Log\LogLevel;
  * @return string
  *   A message about what requested modules were uninstalled.
  *
+ *   This is no longer needed for simple module disables. It is still
+ *   appropriate when order matters, if multiple uninstalls have a weighting
+ *   problem. So may never be fully removed.
+ *
+ * @see https://github.com/department-of-veterans-affairs/va.gov-cms/pull/10650#issuecomment-1240819457
+ *
  * @throws Drupal\Core\Utility\UpdateException
  */
 function _va_gov_db_uninstall_modules(array $modules, $uninstall_dependents = TRUE) {


### PR DESCRIPTION
## Description

Updates the `va_gov_db` module to be d10-compliant.

Relates to #11001


## QA steps

What needs to be checked to prove this works?

The upgrade status tool will not report any issues or warnings for the `va_gov_db` module.



### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

