### PR TITLE
[DNM] [AP] VACMS-000 simplify jsonapi response for news story nodes

### DIFF
--- a/config/sync/jsonapi_extras.jsonapi_resource_config.block_content--cms_announcement.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.block_content--cms_announcement.yml
@@ -1,0 +1,142 @@
+uuid: a77310ab-aa13-4576-801a-6cdc3fc1cc8b
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.cms_announcement
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: block_content--cms_announcement
+disabled: true
+path: block_content/cms_announcement
+resourceType: block_content--cms_announcement
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  revision_id:
+    disabled: false
+    fieldName: revision_id
+    publicName: revision_id
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_created:
+    disabled: false
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: false
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: false
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  info:
+    disabled: false
+    fieldName: info
+    publicName: info
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  reusable:
+    disabled: false
+    fieldName: reusable
+    publicName: reusable
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: false
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: false
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  moderation_state:
+    disabled: false
+    fieldName: moderation_state
+    publicName: moderation_state
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_announcement_type:
+    disabled: false
+    fieldName: field_announcement_type
+    publicName: field_announcement_type
+    enhancer:
+      id: ''
+  field_body:
+    disabled: false
+    fieldName: field_body
+    publicName: field_body
+    enhancer:
+      id: ''
+  field_submission_guidelines:
+    disabled: false
+    fieldName: field_submission_guidelines
+    publicName: field_submission_guidelines
+    enhancer:
+      id: ''
+  field_title:
+    disabled: false
+    fieldName: field_title
+    publicName: field_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.cm_document--cm_document.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.cm_document--cm_document.yml
@@ -1,0 +1,177 @@
+uuid: 9c85d7b9-f7bd-47ac-beb8-67de061afcd4
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_model_documentation
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: cm_document--cm_document
+disabled: true
+path: cm_document/cm_document
+resourceType: cm_document--cm_document
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: false
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  revision_created:
+    disabled: false
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: false
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log_message:
+    disabled: false
+    fieldName: revision_log_message
+    publicName: revision_log_message
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  user_id:
+    disabled: false
+    fieldName: user_id
+    publicName: user_id
+    enhancer:
+      id: ''
+  name:
+    disabled: false
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+  documented_entity:
+    disabled: false
+    fieldName: documented_entity
+    publicName: documented_entity
+    enhancer:
+      id: ''
+  notes:
+    disabled: false
+    fieldName: notes
+    publicName: notes
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: false
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: false
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_data_pulled_from:
+    disabled: false
+    fieldName: field_data_pulled_from
+    publicName: field_data_pulled_from
+    enhancer:
+      id: ''
+  field_data_pushed_to:
+    disabled: false
+    fieldName: field_data_pushed_to
+    publicName: field_data_pushed_to
+    enhancer:
+      id: ''
+  field_links_to_design:
+    disabled: false
+    fieldName: field_links_to_design
+    publicName: field_links_to_design
+    enhancer:
+      id: ''
+  field_links_to_research:
+    disabled: false
+    fieldName: field_links_to_research
+    publicName: field_links_to_research
+    enhancer:
+      id: ''
+  field_link_to_cms_design_system:
+    disabled: false
+    fieldName: field_link_to_cms_design_system
+    publicName: field_link_to_cms_design_system
+    enhancer:
+      id: ''
+  field_link_to_va_design_system:
+    disabled: false
+    fieldName: field_link_to_va_design_system
+    publicName: field_link_to_va_design_system
+    enhancer:
+      id: ''
+  field_other_links:
+    disabled: false
+    fieldName: field_other_links
+    publicName: field_other_links
+    enhancer:
+      id: ''
+  field_related_knowledgebase:
+    disabled: false
+    fieldName: field_related_knowledgebase
+    publicName: field_related_knowledgebase
+    enhancer:
+      id: ''
+  field_screenshots:
+    disabled: false
+    fieldName: field_screenshots
+    publicName: field_screenshots
+    enhancer:
+      id: ''
+  field_stakeholders:
+    disabled: false
+    fieldName: field_stakeholders
+    publicName: field_stakeholders
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.entity_view_display--entity_view_display.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.entity_view_display--entity_view_display.yml
@@ -1,0 +1,86 @@
+uuid: 75216906-1a2b-4b86-9c10-cff4855de485
+langcode: en
+status: true
+dependencies:
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: entity_view_display--entity_view_display
+disabled: true
+path: entity_view_display/entity_view_display
+resourceType: entity_view_display--entity_view_display
+resourceFields:
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  dependencies:
+    disabled: false
+    fieldName: dependencies
+    publicName: dependencies
+    enhancer:
+      id: ''
+  third_party_settings:
+    disabled: false
+    fieldName: third_party_settings
+    publicName: third_party_settings
+    enhancer:
+      id: ''
+  _core:
+    disabled: false
+    fieldName: _core
+    publicName: _core
+    enhancer:
+      id: ''
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  targetEntityType:
+    disabled: false
+    fieldName: targetEntityType
+    publicName: targetEntityType
+    enhancer:
+      id: ''
+  bundle:
+    disabled: false
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+  mode:
+    disabled: false
+    fieldName: mode
+    publicName: mode
+    enhancer:
+      id: ''
+  content:
+    disabled: false
+    fieldName: content
+    publicName: content
+    enhancer:
+      id: ''
+  hidden:
+    disabled: false
+    fieldName: hidden
+    publicName: hidden
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--awaiting_csv.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--awaiting_csv.yml
@@ -1,0 +1,76 @@
+uuid: 398fb5f1-ee66-4268-88b8-580bb461f779
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.awaiting_csv
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--awaiting_csv
+disabled: true
+path: flagging/awaiting_csv
+resourceType: flagging--awaiting_csv
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--awaiting_editor.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--awaiting_editor.yml
@@ -1,0 +1,76 @@
+uuid: 1bb00d45-deb6-42e3-a640-c772f95f94b9
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.awaiting_editor
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--awaiting_editor
+disabled: true
+path: flagging/awaiting_editor
+resourceType: flagging--awaiting_editor
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--awaiting_redirect.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--awaiting_redirect.yml
@@ -1,0 +1,76 @@
+uuid: 02dbaf34-e990-4dde-b5f9-4e39c2df4394
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.awaiting_redirect
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--awaiting_redirect
+disabled: true
+path: flagging/awaiting_redirect
+resourceType: flagging--awaiting_redirect
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--changed_filename.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--changed_filename.yml
@@ -1,0 +1,76 @@
+uuid: 67fa30ee-685b-42c5-b065-4fa22ebac5db
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.changed_filename
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--changed_filename
+disabled: true
+path: flagging/changed_filename
+resourceType: flagging--changed_filename
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--changed_name.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--changed_name.yml
@@ -1,0 +1,76 @@
+uuid: 7ed9e0e8-40d6-46d3-8940-590735c6f58b
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.changed_name
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--changed_name
+disabled: true
+path: flagging/changed_name
+resourceType: flagging--changed_name
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--changed_title.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--changed_title.yml
@@ -1,0 +1,76 @@
+uuid: 5f3e1f41-98de-45a0-aa6c-00a89886fcbe
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.changed_title
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--changed_title
+disabled: true
+path: flagging/changed_title
+resourceType: flagging--changed_title
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--deleted.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--deleted.yml
@@ -1,0 +1,76 @@
+uuid: a37b1414-2762-4130-9349-e142d7ffa2a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.deleted
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--deleted
+disabled: true
+path: flagging/deleted
+resourceType: flagging--deleted
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--edited.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--edited.yml
@@ -1,0 +1,76 @@
+uuid: eade87a0-1867-44a7-8104-8ffd5f0b7fc8
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.edited
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--edited
+disabled: true
+path: flagging/edited
+resourceType: flagging--edited
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--email_node.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--email_node.yml
@@ -1,0 +1,76 @@
+uuid: bfe098f2-7190-429b-9fdd-daebe2c917ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.email_node
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--email_node
+disabled: true
+path: flagging/email_node
+resourceType: flagging--email_node
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--email_term.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--email_term.yml
@@ -1,0 +1,76 @@
+uuid: b6a7a206-fa99-42af-81bf-4539d90b25a8
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.email_term
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--email_term
+disabled: true
+path: flagging/email_term
+resourceType: flagging--email_term
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--email_user.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--email_user.yml
@@ -1,0 +1,76 @@
+uuid: 97fdd0e8-500a-4354-a53d-2a2863a6a170
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.email_user
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--email_user
+disabled: true
+path: flagging/email_user
+resourceType: flagging--email_user
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--new.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--new.yml
@@ -1,0 +1,76 @@
+uuid: b7dbaf66-02af-42d2-9871-5a423e2bbf22
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.new
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--new
+disabled: true
+path: flagging/new
+resourceType: flagging--new
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--new_form.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--new_form.yml
@@ -1,0 +1,76 @@
+uuid: 93f7cff9-018b-4263-8a12-f802a52d98f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.new_form
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--new_form
+disabled: true
+path: flagging/new_form
+resourceType: flagging--new_form
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--removed_from_source.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--removed_from_source.yml
@@ -1,0 +1,76 @@
+uuid: 8936c6f7-b151-4eeb-8e3f-af1a93cdbebe
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.removed_from_source
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--removed_from_source
+disabled: true
+path: flagging/removed_from_source
+resourceType: flagging--removed_from_source
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--subscribe_node.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--subscribe_node.yml
@@ -1,0 +1,76 @@
+uuid: 0d277de6-fb1f-49c3-864d-a93be7081498
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.subscribe_node
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--subscribe_node
+disabled: true
+path: flagging/subscribe_node
+resourceType: flagging--subscribe_node
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--subscribe_term.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--subscribe_term.yml
@@ -1,0 +1,76 @@
+uuid: 9f537847-cf8b-45cf-9d16-cf72e35fe4d2
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.subscribe_term
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--subscribe_term
+disabled: true
+path: flagging/subscribe_term
+resourceType: flagging--subscribe_term
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--subscribe_user.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.flagging--subscribe_user.yml
@@ -1,0 +1,76 @@
+uuid: 8bfe611e-fdaf-490d-8f85-9d88e9b97cf1
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.subscribe_user
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: flagging--subscribe_user
+disabled: true
+path: flagging/subscribe_user
+resourceType: flagging--subscribe_user
+resourceFields:
+  id:
+    disabled: false
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  flag_id:
+    disabled: false
+    fieldName: flag_id
+    publicName: flag_id
+    enhancer:
+      id: ''
+  entity_type:
+    disabled: false
+    fieldName: entity_type
+    publicName: entity_type
+    enhancer:
+      id: ''
+  entity_id:
+    disabled: false
+    fieldName: entity_id
+    publicName: entity_id
+    enhancer:
+      id: ''
+  flagged_entity:
+    disabled: false
+    fieldName: flagged_entity
+    publicName: flagged_entity
+    enhancer:
+      id: ''
+  global:
+    disabled: false
+    fieldName: global
+    publicName: global
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  session_id:
+    disabled: false
+    fieldName: session_id
+    publicName: session_id
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.media--image.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.media--image.yml
@@ -1,0 +1,172 @@
+uuid: 95d170c4-4460-424e-8c39-aca4a04332ea
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: media--image
+disabled: false
+path: media/image
+resourceType: media--image
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: false
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  bundle:
+    disabled: false
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+  revision_created:
+    disabled: true
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: true
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log_message:
+    disabled: true
+    fieldName: revision_log_message
+    publicName: revision_log_message
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  name:
+    disabled: false
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+  thumbnail:
+    disabled: false
+    fieldName: thumbnail
+    publicName: thumbnail
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  metatag:
+    disabled: true
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: true
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: true
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  field_description:
+    disabled: false
+    fieldName: field_description
+    publicName: field_description
+    enhancer:
+      id: ''
+  field_media_in_library:
+    disabled: true
+    fieldName: field_media_in_library
+    publicName: field_media_in_library
+    enhancer:
+      id: ''
+  field_media_submission_guideline:
+    disabled: true
+    fieldName: field_media_submission_guideline
+    publicName: field_media_submission_guideline
+    enhancer:
+      id: ''
+  field_owner:
+    disabled: true
+    fieldName: field_owner
+    publicName: field_owner
+    enhancer:
+      id: ''
+  image:
+    disabled: false
+    fieldName: image
+    publicName: image
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_facility_new_facility.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_facility_new_facility.yml
@@ -1,0 +1,82 @@
+uuid: 1d584bb7-55bd-4c39-bdf0-f0609f6909a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_facility_new_facility
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_facility_new_facility
+disabled: true
+path: message/va_facility_new_facility
+resourceType: message--va_facility_new_facility
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_facility_removed_from_source.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_facility_removed_from_source.yml
@@ -1,0 +1,82 @@
+uuid: 5b1204e8-67ca-4bfc-b06a-45a2feaa7ed5
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_facility_removed_from_source
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_facility_removed_from_source
+disabled: true
+path: message/va_facility_removed_from_source
+resourceType: message--va_facility_removed_from_source
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_facility_title_change.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_facility_title_change.yml
@@ -1,0 +1,82 @@
+uuid: 90dbc990-5a79-4d7c-b9cb-b0a49be3540c
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_facility_title_change
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_facility_title_change
+disabled: true
+path: message/va_facility_title_change
+resourceType: message--va_facility_title_change
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_changed_title.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_changed_title.yml
@@ -1,0 +1,82 @@
+uuid: 8da3d16a-22cb-4d36-8533-60d8cd15ae06
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_form_changed_title
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_form_changed_title
+disabled: true
+path: message/va_form_changed_title
+resourceType: message--va_form_changed_title
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_changed_url.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_changed_url.yml
@@ -1,0 +1,82 @@
+uuid: 02d20ac3-50f2-43d6-ae25-4a4409047f5f
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_form_changed_url
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_form_changed_url
+disabled: true
+path: message/va_form_changed_url
+resourceType: message--va_form_changed_url
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_deleted.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_deleted.yml
@@ -1,0 +1,82 @@
+uuid: 4deee044-7ea6-4435-a74c-48a022004c7d
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_form_deleted
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_form_deleted
+disabled: true
+path: message/va_form_deleted
+resourceType: message--va_form_deleted
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_new_form.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_form_new_form.yml
@@ -1,0 +1,82 @@
+uuid: 886125c3-129b-44a5-8d38-86c7cfefc4b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_form_new_form
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_form_new_form
+disabled: true
+path: message/va_form_new_form
+resourceType: message--va_form_new_form
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_outdated_content.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--va_outdated_content.yml
@@ -1,0 +1,82 @@
+uuid: 91fd05b9-6c35-44b0-9b16-cdd8b9a8fa90
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.va_outdated_content
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--va_outdated_content
+disabled: true
+path: message/va_outdated_content
+resourceType: message--va_outdated_content
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_editor_username:
+    disabled: false
+    fieldName: field_editor_username
+    publicName: field_editor_username
+    enhancer:
+      id: ''
+  field_subject:
+    disabled: false
+    fieldName: field_subject
+    publicName: field_subject
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--vamc_outdated_content.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--vamc_outdated_content.yml
@@ -1,0 +1,82 @@
+uuid: c2496370-8d7d-4074-aa37-5c79667dc47d
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.vamc_outdated_content
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--vamc_outdated_content
+disabled: true
+path: message/vamc_outdated_content
+resourceType: message--vamc_outdated_content
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_editor_username:
+    disabled: false
+    fieldName: field_editor_username
+    publicName: field_editor_username
+    enhancer:
+      id: ''
+  field_subject:
+    disabled: false
+    fieldName: field_subject
+    publicName: field_subject
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--vet_center_official_name_change.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--vet_center_official_name_change.yml
@@ -1,0 +1,82 @@
+uuid: ae8a7858-0274-4f8b-8ad8-3f614f1adb9b
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.vet_center_official_name_change
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--vet_center_official_name_change
+disabled: true
+path: message/vet_center_official_name_change
+resourceType: message--vet_center_official_name_change
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_target_entity:
+    disabled: false
+    fieldName: field_target_entity
+    publicName: field_target_entity
+    enhancer:
+      id: ''
+  field_target_node_title:
+    disabled: false
+    fieldName: field_target_node_title
+    publicName: field_target_node_title
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message--vet_center_outdated_content.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message--vet_center_outdated_content.yml
@@ -1,0 +1,82 @@
+uuid: a5ee664e-304d-4768-81b0-a7f4a6353563
+langcode: en
+status: true
+dependencies:
+  config:
+    - message.template.vet_center_outdated_content
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message--vet_center_outdated_content
+disabled: true
+path: message/vet_center_outdated_content
+resourceType: message--vet_center_outdated_content
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  arguments:
+    disabled: false
+    fieldName: arguments
+    publicName: arguments
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  field_editor_username:
+    disabled: false
+    fieldName: field_editor_username
+    publicName: field_editor_username
+    enhancer:
+      id: ''
+  field_subject:
+    disabled: false
+    fieldName: field_subject
+    publicName: field_subject
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.message_template--message_template.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.message_template--message_template.yml
@@ -1,0 +1,81 @@
+uuid: b68370f8-e84d-463b-8797-8f66e47e4dec
+langcode: en
+status: true
+dependencies:
+  module:
+    - jsonapi_defaults
+    - message
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: message_template--message_template
+disabled: true
+path: message_template/message_template
+resourceType: message_template--message_template
+resourceFields:
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  dependencies:
+    disabled: false
+    fieldName: dependencies
+    publicName: dependencies
+    enhancer:
+      id: ''
+  third_party_settings:
+    disabled: false
+    fieldName: third_party_settings
+    publicName: third_party_settings
+    enhancer:
+      id: ''
+  _core:
+    disabled: false
+    fieldName: _core
+    publicName: _core
+    enhancer:
+      id: ''
+  template:
+    disabled: false
+    fieldName: template
+    publicName: template
+    enhancer:
+      id: ''
+  label:
+    disabled: false
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+  description:
+    disabled: false
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: ''
+  text:
+    disabled: false
+    fieldName: text
+    publicName: text
+    enhancer:
+      id: ''
+  settings:
+    disabled: false
+    fieldName: settings
+    publicName: settings
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--news_story.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--news_story.yml
@@ -1,0 +1,228 @@
+uuid: 526d7535-475f-4e63-b248-533f7cd134e5
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_story
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: node--news_story
+disabled: false
+path: node/news_story
+resourceType: node--news_story
+resourceFields:
+  nid:
+    disabled: false
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: true
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  title:
+    disabled: false
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  promote:
+    disabled: true
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  moderation_state:
+    disabled: false
+    fieldName: moderation_state
+    publicName: moderation_state
+    enhancer:
+      id: ''
+  metatag:
+    disabled: true
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  menu_link:
+    disabled: true
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: true
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: true
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  field_administration:
+    disabled: true
+    fieldName: field_administration
+    publicName: field_administration
+    enhancer:
+      id: ''
+  field_author:
+    disabled: false
+    fieldName: field_author
+    publicName: field_author
+    enhancer:
+      id: ''
+  field_featured:
+    disabled: false
+    fieldName: field_featured
+    publicName: field_featured
+    enhancer:
+      id: ''
+  field_full_story:
+    disabled: false
+    fieldName: field_full_story
+    publicName: field_full_story
+    enhancer:
+      id: nested
+      settings:
+        path: processed
+  field_image_caption:
+    disabled: false
+    fieldName: field_image_caption
+    publicName: field_image_caption
+    enhancer:
+      id: ''
+  field_intro_text:
+    disabled: false
+    fieldName: field_intro_text
+    publicName: field_intro_text
+    enhancer:
+      id: ''
+  field_last_saved_by_an_editor:
+    disabled: true
+    fieldName: field_last_saved_by_an_editor
+    publicName: field_last_saved_by_an_editor
+    enhancer:
+      id: ''
+  field_listing:
+    disabled: false
+    fieldName: field_listing
+    publicName: field_listing
+    enhancer:
+      id: ''
+  field_media:
+    disabled: false
+    fieldName: field_media
+    publicName: field_media
+    enhancer:
+      id: ''
+  field_meta_tags:
+    disabled: false
+    fieldName: field_meta_tags
+    publicName: field_meta_tags
+    enhancer:
+      id: ''
+  field_order:
+    disabled: false
+    fieldName: field_order
+    publicName: field_order
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--person_profile.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--person_profile.yml
@@ -1,0 +1,256 @@
+uuid: 36f95aea-fab3-42c7-9f42-52c86f0760dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.person_profile
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: node--person_profile
+disabled: false
+path: node/person_profile
+resourceType: node--person_profile
+resourceFields:
+  nid:
+    disabled: false
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: true
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  title:
+    disabled: false
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  promote:
+    disabled: true
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  moderation_state:
+    disabled: false
+    fieldName: moderation_state
+    publicName: moderation_state
+    enhancer:
+      id: ''
+  metatag:
+    disabled: true
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  menu_link:
+    disabled: true
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: true
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: true
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  field_administration:
+    disabled: true
+    fieldName: field_administration
+    publicName: field_administration
+    enhancer:
+      id: ''
+  field_body:
+    disabled: false
+    fieldName: field_body
+    publicName: field_body
+    enhancer:
+      id: ''
+  field_complete_biography:
+    disabled: false
+    fieldName: field_complete_biography
+    publicName: field_complete_biography
+    enhancer:
+      id: ''
+  field_complete_biography_create:
+    disabled: false
+    fieldName: field_complete_biography_create
+    publicName: field_complete_biography_create
+    enhancer:
+      id: ''
+  field_description:
+    disabled: false
+    fieldName: field_description
+    publicName: field_description
+    enhancer:
+      id: ''
+  field_email_address:
+    disabled: false
+    fieldName: field_email_address
+    publicName: field_email_address
+    enhancer:
+      id: ''
+  field_intro_text:
+    disabled: false
+    fieldName: field_intro_text
+    publicName: field_intro_text
+    enhancer:
+      id: ''
+  field_last_name:
+    disabled: false
+    fieldName: field_last_name
+    publicName: field_last_name
+    enhancer:
+      id: ''
+  field_last_saved_by_an_editor:
+    disabled: true
+    fieldName: field_last_saved_by_an_editor
+    publicName: field_last_saved_by_an_editor
+    enhancer:
+      id: ''
+  field_media:
+    disabled: false
+    fieldName: field_media
+    publicName: field_media
+    enhancer:
+      id: ''
+  field_meta_tags:
+    disabled: false
+    fieldName: field_meta_tags
+    publicName: field_meta_tags
+    enhancer:
+      id: ''
+  field_name_first:
+    disabled: false
+    fieldName: field_name_first
+    publicName: field_name_first
+    enhancer:
+      id: ''
+  field_office:
+    disabled: false
+    fieldName: field_office
+    publicName: field_office
+    enhancer:
+      id: ''
+  field_phone_number:
+    disabled: false
+    fieldName: field_phone_number
+    publicName: field_phone_number
+    enhancer:
+      id: ''
+  field_photo_allow_hires_download:
+    disabled: false
+    fieldName: field_photo_allow_hires_download
+    publicName: field_photo_allow_hires_download
+    enhancer:
+      id: ''
+  field_suffix:
+    disabled: false
+    fieldName: field_suffix
+    publicName: field_suffix
+    enhancer:
+      id: ''


### PR DESCRIPTION
## Description
Using this PR to generate a tugboat preview to help debug next-build issues. 

locally, i trimmed down what info is included in the jsonapi responses for:
`/jsonapi` (by disabling a bunch of cms-only things), `node/news_story`, `node/person_profile`, `/media/image` (by removing a bunch of included cms data we don't need to know about on the FE) 

this is the current time to build 2170 pages on next-build's tugboat's main preview (nothing trimmed down):
`├ ● /[[...slug]] (2849940 ms)`                                                            
locally, targeting this PR env with all 4 of the above trimmed down:
`├ ● /[[...slug]] (917521 ms)`

additional builds seemed even faster:
`├ ● /[[...slug]] (852600 ms)`

## Testing done


## Screenshots


## QA steps
What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [x] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
