### PR TITLE
VACMS-14289: Changes max depth to 2.

### DIFF
--- a/config/sync/field.field.taxonomy_term.va_benefits_taxonomy.field_va_benefit_eligibility_ov.yml
+++ b/config/sync/field.field.taxonomy_term.va_benefits_taxonomy.field_va_benefit_eligibility_ov.yml
@@ -164,5 +164,5 @@ settings:
       wysiwyg:
         weight: '90'
         enabled: 0
-  max_depth: 3
+  max_depth: 2
 field_type: magichead

--- a/tests/phpunit/va_gov_magichead/functional/Field/MaxDepthTest.php
+++ b/tests/phpunit/va_gov_magichead/functional/Field/MaxDepthTest.php
@@ -23,7 +23,7 @@ class MaxDepthTest extends VaGovExistingSiteBase {
     $this->assertSession()->pageTextContains('The maximum depth of a magichead item.');
     $elements = $this->cssSelect('#edit-settings-max-depth');
     $this->assertCount(1, $elements);
-    $this->assertSame($elements[0]->getValue(), '3');
+    $this->assertSame($elements[0]->getValue(), '2');
   }
 
 }


### PR DESCRIPTION
## Description
Simple config change for magihead max depth.

Relates to #14289

## Testing done
Tested using drag and drop and accessibliity (show row weights) modes.

## Screenshots
<img width="396" alt="Screenshot 2023-08-29 at 3 10 40 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/2c5e2550-3b0e-42a2-91f0-fcf99055998a">

## QA steps

As a content admin or administrator
1. Visit /admin/structure/taxonomy/manage/va_benefits_taxonomy/overview/fields/taxonomy_term.va_benefits_taxonomy.field_va_benefit_eligibility_ov
   - [x] Validate that the max depth is set to 2
 
### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
