### PR TITLE
VACMS-15059: Fix issues with PHPUnit tests for D10.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
+++ b/docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
@@ -3,7 +3,7 @@
 namespace Drupal\va_gov_backend\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\HttpFoundation\Response;
+use Drupal\Core\Render\HtmlResponse;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -67,10 +67,10 @@ class ContentReleaseStatusController extends ControllerBase {
   /**
    * Get last release status response.
    *
-   * @return \Symfony\Component\HttpFoundation\Response
+   * @return \Drupal\Core\Render\HtmlResponse
    *   Return release status response.
    */
-  public function getDefault(): Response {
+  public function getDefault(): HtmlResponse {
     $renderArray = $this->getLastReleaseStatus();
     return $this->getLastReleaseResponse($renderArray);
   }
@@ -102,12 +102,12 @@ class ContentReleaseStatusController extends ControllerBase {
    * @param array $status
    *   The last release status render array.
    *
-   * @return \Symfony\Component\HttpFoundation\Response
+   * @return \Drupal\Core\Render\HtmlResponse
    *   A response encapsulating the last release status message.
    */
-  public function getLastReleaseResponse(array $status): Response {
+  public function getLastReleaseResponse(array $status): HtmlResponse {
     $output = $this->renderer->renderPlain($status);
-    $response = Response::create($output);
+    $response = new HtmlResponse($output);
     $response->setCache(['max_age' => 60]);
     return $response;
   }

--- a/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
+++ b/tests/phpunit/Controller/ContentReleaseStatusControllerTest.php
@@ -11,6 +11,7 @@ use Drupal\va_gov_backend\Controller\ContentReleaseStatusController;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Tests\Support\Classes\VaGovUnitTestBase;
@@ -90,7 +91,7 @@ class ContentReleaseStatusControllerTest extends VaGovUnitTestBase {
     $prophecy = $this->prophesize(Client::CLASS);
 
     $responseProphecy = $this->prophesize(Response::CLASS);
-    $responseProphecy->getBody()->willReturn($responseBody);
+    $responseProphecy->getBody()->willReturn(Utils::streamFor($responseBody));
 
     $prophecy->get(Argument::type('string'))->willReturn($responseProphecy->reveal());
 

--- a/tests/phpunit/Deploy/DeployServiceTest.php
+++ b/tests/phpunit/Deploy/DeployServiceTest.php
@@ -49,7 +49,7 @@ class DeployServiceTest extends VaGovUnitTestBase {
     DeployService::create($orig_settings);
 
     $settings = Settings::getAll();
-    $this->assertArrayEquals(
+    $this->assertEquals(
       $orig_settings,
       $settings,
       'Deploy Serviced initiated Settings correctly.'

--- a/tests/phpunit/Support/Traits/RawGitHubApiClientTrait.php
+++ b/tests/phpunit/Support/Traits/RawGitHubApiClientTrait.php
@@ -6,7 +6,7 @@ use Github\Client;
 use Github\HttpClient\Builder;
 use Github\HttpClient\Plugin\Authentication;
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Utils;
 use Http\Client\Common\HttpMethodsClientInterface;
 use Psr\Http\Client\ClientInterface;
 
@@ -150,7 +150,7 @@ trait RawGitHubApiClientTrait {
     return new Response(
       200,
       ['Content-Type' => 'application/json'],
-      stream_for(json_encode($value))
+      Utils::streamFor(json_encode($value))
     );
   }
 

--- a/tests/phpunit/va_gov_content_release/unit/Plugin/EntityEventStrategy/OnDemandTest.php
+++ b/tests/phpunit/va_gov_content_release/unit/Plugin/EntityEventStrategy/OnDemandTest.php
@@ -30,7 +30,7 @@ class OnDemandTest extends VaGovUnitTestBase {
     $containerProphecy->get('string_translation')->willReturn($stringTranslation);
 
     $loggerProphecy = $this->prophesize(LoggerInterface::class);
-    $loggerProphecy->info(Argument::cetera())->willReturn(NULL);
+    $loggerProphecy->info(Argument::cetera());
     $logger = $loggerProphecy->reveal();
     $loggerChannelFactoryProphecy = $this->prophesize(LoggerChannelFactoryInterface::class);
     $loggerChannelFactoryProphecy->get('va_gov_content_release')->willReturn($logger);

--- a/tests/phpunit/va_gov_content_release/unit/Plugin/EntityEventStrategy/VerboseFalseTest.php
+++ b/tests/phpunit/va_gov_content_release/unit/Plugin/EntityEventStrategy/VerboseFalseTest.php
@@ -33,7 +33,7 @@ class VerboseFalseTest extends VaGovUnitTestBase {
     $containerProphecy->get('string_translation')->willReturn($stringTranslation);
 
     $loggerProphecy = $this->prophesize(LoggerInterface::class);
-    $loggerProphecy->info(Argument::cetera())->willReturn(NULL);
+    $loggerProphecy->info(Argument::cetera());
     $logger = $loggerProphecy->reveal();
     $loggerChannelFactoryProphecy = $this->prophesize(LoggerChannelFactoryInterface::class);
     $loggerChannelFactoryProphecy->get('va_gov_content_release')->willReturn($logger);

--- a/tests/phpunit/va_gov_content_release/unit/Reporter/ReporterTest.php
+++ b/tests/phpunit/va_gov_content_release/unit/Reporter/ReporterTest.php
@@ -48,7 +48,7 @@ class ReporterTest extends VaGovUnitTestBase {
     $messengerProphecy->addError('message')->shouldBeCalled();
     $messenger = $messengerProphecy->reveal();
     $loggerProphecy = $this->prophesize(LoggerInterface::class);
-    $loggerProphecy->error('message')->shouldBeCalled();
+    $loggerProphecy->error('message', Argument::cetera())->shouldBeCalled();
     $loggerProphecy->log(Argument::cetera())->shouldBeCalled();
     $logger = $loggerProphecy->reveal();
     $stringTranslationProphecy = $this->prophesize(TranslationInterface::class);
@@ -78,7 +78,7 @@ class ReporterTest extends VaGovUnitTestBase {
     $messengerProphecy->addStatus('message')->shouldBeCalled();
     $messenger = $messengerProphecy->reveal();
     $loggerProphecy = $this->prophesize(LoggerInterface::class);
-    $loggerProphecy->info('message')->shouldBeCalled();
+    $loggerProphecy->info('message', Argument::cetera())->shouldBeCalled();
     $logger = $loggerProphecy->reveal();
     $loggerChannelFactoryProphecy = $this->prophesize(LoggerChannelFactoryInterface::class);
     $loggerChannelFactoryProphecy->get('va_gov_content_release')->willReturn($logger);


### PR DESCRIPTION
Closes #15059.

From D10 Tugboat:

```
root@php:/var/lib/tugboat# bin/phpunit           --group unit           --exclude-group disabled           --coverage-text           tests/phpunit
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Warning:       No code coverage driver available

Testing /var/lib/tugboat/tests/phpunit
...............................................................  63 / 689 (  9%)
............................................................... 126 / 689 ( 18%)
............................................................... 189 / 689 ( 27%)
............................................................... 252 / 689 ( 36%)
............................................................... 315 / 689 ( 45%)
............................................................... 378 / 689 ( 54%)
............................................................... 441 / 689 ( 64%)
............................................................... 504 / 689 ( 73%)
............................................................... 567 / 689 ( 82%)
............................................................... 630 / 689 ( 91%)
...........................................................     689 / 689 (100%)

Time: 00:47.692, Memory: 34.00 MB

OK (689 tests, 859 assertions)
```

## Acceptance Criteria
- [ ] Automated tests pass.