### PR TITLE
VACMS-15206: Fix namespaces of some PHPUnit tests.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,8 +42,6 @@
 *.xml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.yml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 
-composer.lock linguist-generated=false
-
 # Define binary file attributes.
 # - Do not treat them as text.
 # - Include binary diff in patches instead of "binary files differ."

--- a/tests/phpunit/va_gov_content_release/functional/EventSubscriber/EntityEventSubscriberTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/EventSubscriber/EntityEventSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_content_release\functional\Form\Resolver;
+namespace tests\phpunit\va_gov_content_release\functional\Form\EventSubscriber;
 
 use Drupal\va_gov_content_release\EventSubscriber\EntityEventSubscriber;
 use Tests\Support\Classes\VaGovExistingSiteBase;

--- a/tests/phpunit/va_gov_content_release/functional/EventSubscriber/EntityEventSubscriberTest.php
+++ b/tests/phpunit/va_gov_content_release/functional/EventSubscriber/EntityEventSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_content_release\functional\Form\EventSubscriber;
+namespace tests\phpunit\va_gov_content_release\functional\EventSubscriber;
 
 use Drupal\va_gov_content_release\EventSubscriber\EntityEventSubscriber;
 use Tests\Support\Classes\VaGovExistingSiteBase;

--- a/tests/phpunit/va_gov_content_types/unit/ModuleTest.php
+++ b/tests/phpunit/va_gov_content_types/unit/ModuleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_content_types\unit\Traits;
+namespace tests\phpunit\va_gov_content_types\unit;
 
 use Drupal\Tests\Traits\Core\GeneratePermutationsTrait;
 use Drupal\va_gov_content_types\Entity\HealthCareLocalFacility;
@@ -10,7 +10,7 @@ use Tests\Support\Classes\VaGovUnitTestBase;
 require __DIR__ . '/../../../../docroot/modules/custom/va_gov_content_types/va_gov_content_types.module';
 
 /**
- * Unit test of the ContentReleaseTriggerTrait trait.
+ * Unit test of the va_gov_content_types module hooks.
  *
  * @group unit
  * @group all

--- a/tests/phpunit/va_gov_git/functional/BranchSearch/BranchSearchTest.php
+++ b/tests/phpunit/va_gov_git/functional/BranchSearch/BranchSearchTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_git\functional\BranchSearch\Factory;
+namespace tests\phpunit\va_gov_git\functional\BranchSearch;
 
 use Drupal\va_gov_git\BranchSearch\BranchSearch;
 use Tests\Support\Classes\VaGovExistingSiteBase;


### PR DESCRIPTION
Closes #15206.

## Acceptance Criteria

- [ ] No messages indicating incorrect namespacing are displayed in `composer install` output.