### PR TITLE
VACMS-15199: Fixes Composer scaffolding.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -295,8 +295,8 @@
     "extra": {
         "drupal-scaffold": {
             "file-mapping": {
+                "[project-root]/.gitattributes": false,
                 "[web-root]/.editorconfig": false,
-                "[web-root]/.gitattributes": false,
                 "[web-root]/.htaccess": false,
                 "[web-root]/INSTALL.txt": false,
                 "[web-root]/README.txt": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c30355f410f191205d66a4a14e3481a5",
+    "content-hash": "60a26ea8840c1217afb070b19769dca6",
     "packages": [
         {
             "name": "alchemy/zippy",


### PR DESCRIPTION
Closes #15199.

## Acceptance Criteria

- [ ] Scaffolding does not overwrite `.gitattributes`.