### PR TITLE
VACMS-15212: Prevent `composer.lock` files-changed check from running on fork PRs.

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -158,7 +158,7 @@ jobs:
   # Warn strongly if the `composer.lock` lines changed exceed a threshold.
   check-composer-lock-changes:
     name: Check composer.lock changes
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #15212.

## Acceptance Criteria

- [ ] Automated tests pass.