### PR TITLE
VACMS-15187: Exposes revision log message on promo type blocks

### DIFF
--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -2,16 +2,17 @@
 
 namespace Drupal\va_gov_workflow\EventSubscriber;
 
+use Drupal\block_content\BlockContentInterface;
 use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityDeleteEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
 use Drupal\core_event_dispatcher\Event\Form\FormBaseAlterEvent;
-use Drupal\Core\Entity\EntityFormInterface;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 use Drupal\va_gov_notifications\Service\NotificationsManager;
 use Drupal\va_gov_user\Service\UserPermsService;
@@ -265,6 +266,17 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    *   The form id.
    */
   public function requireRevisionMessage(array &$form, FormStateInterface &$form_state, $form_id) {
+    // Check if the block-content form is of type promo and exit (#15187)
+    $formObject = $form_state->getFormObject();
+    if ($formObject instanceof EntityFormInterface) {
+      $entity = $formObject->getEntity();
+      if ($entity instanceof BlockContentInterface) {
+        if ($entity->bundle() === 'promo') {
+          return;
+        }
+      }
+    }
+
     $form['revision_log']['#required'] = TRUE;
     $form['revision_log']['widget']['#required'] = TRUE;
     $form['revision_log']['widget'][0]['#required'] = TRUE;


### PR DESCRIPTION
## Description

Quick fix connected to #15187 
Addresses #15242

Temporarily undoes the code that hides the checkbox to create revision log message on promo block types because it also hid the required field.
We will need to follow up on ticket #15187  with work to hide the checkbox again on promo block types or to adjust the promo block content-block forms to match the other block forms structure.

## Testing done
Functional, locally

## Screenshots
<img width="521" alt="Screenshot 2023-09-13 at 11 13 53 AM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/cadb31f9-b0e0-4956-ad75-8b9bc0876710">


## QA steps
- [ ] Log in as any user and go to /block/6
- [ ] Check that you can see the "require revision log" field.
- [ ] Check that you can make changes to the form and save.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
