### PR TITLE
VACMS-15222: Unlock benefit taxonomy fields to content admins

### DIFF
--- a/tests/cypress/integration/features/taxonomy_type/va_benefit_taxonomy.feature
+++ b/tests/cypress/integration/features/taxonomy_type/va_benefit_taxonomy.feature
@@ -6,8 +6,8 @@ Feature: Taxonomy: VA Benefits
     When I am at "admin/structure/taxonomy/manage/va_benefits_taxonomy/add"
     Then I should see "Official Benefit name"
     And I should see "The full name of the benefit."
-    And an element with the selector "#edit-name-0-value" should be disabled
-    And an element with the selector "#edit-field-va-benefit-api-id-0-value" should not exist
+    And an element with the selector "#edit-name-0-value" should not be disabled
+    And an element with the selector "#edit-field-va-benefit-api-id-0-value" should exist
     And an element with the selector "#edit-relations" should not exist
 
   Scenario: Log in and create a va benefit.


### PR DESCRIPTION
## Description

Relates to #15222 

Releases the lock down of the Benefit Name and ID fields for during the staging process of that content.

Note: Non-admins do not right now have access to this form but I structured the code so that it will be easier to lock down in the future as well as ensure that those fields aren't exposed to non-admins should access be granted to them.

## Testing done
Functional.

## Screenshots
<img width="735" alt="Screenshot 2023-09-15 at 7 05 13 AM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/4b23e3bd-aaf5-41e1-bfc2-21316797980f">

## QA steps

1. Log in as a testcontentadmin and got to admin/structure/taxonomy/manage/va_benefits_taxonomy/add
2. - [ ] Make sure the Name field is editable
3. - [ ] Make sure the ID field is editable

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
