### PR TITLE
VACMS:15279 utilize menu form alter in home module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -253,6 +253,7 @@ module:
   va_gov_github: 0
   va_gov_govdelivery: 0
   va_gov_graphql: 0
+  va_gov_header_footer: 0
   va_gov_help_center: 0
   va_gov_links: 0
   va_gov_live_field_migration: 0

--- a/docroot/modules/custom/va_gov_header_footer/src/EventSubscriber/FormEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_header_footer/src/EventSubscriber/FormEventSubscriber.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\va_gov_header_footer\EventSubscriber;
+
+use Drupal\core_event_dispatcher\Event\Form\FormAlterEvent;
+use Drupal\core_event_dispatcher\FormHookEvents;
+use Drupal\va_gov_header_footer\Traits\MenuFormAlter;
+use Drupal\va_gov_user\Service\UserPermsService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Va gov header footer event subscriber.
+ */
+class FormEventSubscriber implements EventSubscriberInterface {
+
+  use MenuFormAlter;
+
+  /**
+   * The VA user permission service.
+   *
+   * @var \Drupal\va_gov_user\Service\UserPermsService
+   */
+  protected UserPermsService $permsService;
+
+  /**
+   * List of menu form Ids to alter.
+   *
+   * @var array
+   */
+  private array $menus = [
+    'menu_link_content_va-gov-footer_form',
+    'menu_link_content_footer-bottom-rail_form',
+  ];
+
+  /**
+   * Constructs event subscriber.
+   *
+   * @param \Drupal\va_gov_user\Service\UserPermsService $permsService
+   *   The messenger.
+   */
+  public function __construct(UserPermsService $permsService) {
+    $this->permsService = $permsService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      FormHookEvents::FORM_ALTER => ['formAlter'],
+    ];
+  }
+
+  /**
+   * Form alters for va_gov_home.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Form\FormAlterEvent $event
+   *   The form event.
+   */
+  public function formAlter(FormAlterEvent $event): void {
+    $form = &$event->getForm();
+    $formId = $event->getFormId();
+    $admin = $this->permsService->hasAdminRole(TRUE);
+    if (in_array($formId, $this->menus) && !$admin) {
+      $this->hideMenuLinkDescriptionField($form);
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_header_footer/src/Traits/MenuFormAlter.php
+++ b/docroot/modules/custom/va_gov_header_footer/src/Traits/MenuFormAlter.php
@@ -17,4 +17,68 @@ trait MenuFormAlter {
     $form['description']['#access'] = FALSE;
   }
 
+  /**
+   * Hides the attributes form field for home page hub list link form.
+   *
+   * @param array $form
+   *   The form element array.
+   *
+   * @return $this
+   */
+  public function hubMenuHideAddtributes(array &$form): static {
+    if (!empty($form['options']['attributes'])) {
+      $form['options']['attributes']['#access'] = FALSE;
+    }
+    return $this;
+  }
+
+  /**
+   * Hides the expanded form field for home page hub list link form.
+   *
+   * @param array $form
+   *   The form element array.
+   *
+   * @return $this
+   */
+  public function hubMenuHideExpanded(array &$form): static {
+    if (!empty($form['expanded'])) {
+      $form['expanded']['#access'] = FALSE;
+    }
+    return $this;
+  }
+
+  /**
+   * Hides the view_mode form field for home page hub list link form.
+   *
+   * @param array $form
+   *   The form element array.
+   * @param bool $admin
+   *   TRUE if current user is an administrator.
+   *
+   * @return $this
+   */
+  public function hubMenuHideViewMode(array &$form, bool $admin): static {
+    if (!empty($form['view_mode'])) {
+      $form['view_mode']['#access'] = $admin;
+    }
+    return $this;
+  }
+
+  /**
+   * Hides the parent link form field for home page hub list link form.
+   *
+   * @param array $form
+   *   The form element array.
+   * @param bool $admin
+   *   TRUE if current user is an administrator.
+   *
+   * @return $this
+   */
+  public function hubMenuHideParentLink(array &$form, bool $admin): static {
+    if (!empty($form['menu_parent'])) {
+      $form['menu_parent']['#access'] = $admin;
+    }
+    return $this;
+  }
+
 }

--- a/docroot/modules/custom/va_gov_header_footer/src/Traits/MenuFormAlter.php
+++ b/docroot/modules/custom/va_gov_header_footer/src/Traits/MenuFormAlter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\va_gov_header_footer\Traits;
+
+/**
+ * Provides centralized menu form alter methods.
+ */
+trait MenuFormAlter {
+
+  /**
+   * Hides the description field on certain menu link forms.
+   *
+   * @param array $form
+   *   The form element array.
+   */
+  public function hideMenuLinkDescriptionField(array &$form): void {
+    $form['description']['#access'] = FALSE;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_header_footer/va_gov_header_footer.info.yml
+++ b/docroot/modules/custom/va_gov_header_footer/va_gov_header_footer.info.yml
@@ -1,0 +1,5 @@
+name: VA.gov Menus
+type: module
+description: Provides custom logic for menus.
+package: Custom
+core_version_requirement: ^9 || ^10

--- a/docroot/modules/custom/va_gov_header_footer/va_gov_header_footer.services.yml
+++ b/docroot/modules/custom/va_gov_header_footer/va_gov_header_footer.services.yml
@@ -1,0 +1,6 @@
+services:
+  va_gov_header_footer.event_subscriber:
+    class: Drupal\va_gov_header_footer\EventSubscriber\FormEventSubscriber
+    arguments: ['@va_gov_user.user_perms']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
@@ -35,12 +35,15 @@ class FormEventSubscriber implements EventSubscriberInterface {
    * @param \Drupal\core_event_dispatcher\Event\Form\FormAlterEvent $event
    *   The form event.
    */
-  public function formAlter(FormAlterEvent $event) {
+  public function formAlter(FormAlterEvent $event): void {
+    $form = &$event->getForm();
     if ($event->getFormId() === 'menu_link_content_home-page-hub-list_form') {
-      $form = &$event->getForm();
       $admin = $this->permsService->hasAdminRole(TRUE);
       $this->hubMenuFormAlter($form, $admin);
-    };
+    }
+    if ($event->getFormId() === 'menu_link_content_va-gov-footer_form' || $event->getFormId() === 'menu-link-content-footer-bottom-rail-form') {
+      $this->hideMenuLinkDescriptionField($form, $admin);
+    }
   }
 
   /**
@@ -51,7 +54,7 @@ class FormEventSubscriber implements EventSubscriberInterface {
    * @param bool $admin
    *   TRUE if current user is an admin.
    */
-  public function hubMenuFormAlter(array &$form, bool $admin) {
+  public function hubMenuFormAlter(array &$form, bool $admin): void {
     $this->hubMenuHideAddtributes($form)
       ->hubMenuHideExpanded($form)
       ->hubMenuHideViewMode($form, $admin)
@@ -120,6 +123,16 @@ class FormEventSubscriber implements EventSubscriberInterface {
       $form['menu_parent']['#access'] = $admin;
     }
     return $this;
+  }
+
+  /**
+   * Hides the description field on certain menu link forms.
+   *
+   * @param array $form
+   *   The form element array.
+   */
+  public function hideMenuLinkDescriptionField(array &$form): void {
+    $form['description']['#access'] = FALSE;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
@@ -41,8 +41,8 @@ class FormEventSubscriber implements EventSubscriberInterface {
       $admin = $this->permsService->hasAdminRole(TRUE);
       $this->hubMenuFormAlter($form, $admin);
     }
-    if ($event->getFormId() === 'menu_link_content_va-gov-footer_form' || $event->getFormId() === 'menu-link-content-footer-bottom-rail-form') {
-      $this->hideMenuLinkDescriptionField($form, $admin);
+    if ($event->getFormId() === 'menu_link_content_va-gov-footer_form' || $event->getFormId() === 'menu_link_content_footer-bottom-rail_form') {
+      $this->hideMenuLinkDescriptionField($form);
     }
   }
 

--- a/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
@@ -4,6 +4,7 @@ namespace Drupal\va_gov_home\EventSubscriber;
 
 use Drupal\core_event_dispatcher\Event\Form\FormAlterEvent;
 use Drupal\core_event_dispatcher\FormHookEvents;
+use Drupal\va_gov_header_footer\Traits\MenuFormAlter;
 use Drupal\va_gov_user\Service\UserPermsService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -11,6 +12,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * VA.gov home event subscriber.
  */
 class FormEventSubscriber implements EventSubscriberInterface {
+
+  use MenuFormAlter;
 
   /**
    * The VA user permission service.
@@ -27,6 +30,15 @@ class FormEventSubscriber implements EventSubscriberInterface {
    */
   public function __construct(UserPermsService $permsService) {
     $this->permsService = $permsService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      FormHookEvents::FORM_ALTER => ['formAlter'],
+    ];
   }
 
   /**
@@ -56,79 +68,6 @@ class FormEventSubscriber implements EventSubscriberInterface {
       ->hubMenuHideExpanded($form)
       ->hubMenuHideViewMode($form, $admin)
       ->hubMenuHideParentLink($form, $admin);
-  }
-
-  /**
-   * Hides the attributes form field for home page hub list link form.
-   *
-   * @param array $form
-   *   The form element array.
-   *
-   * @return $this
-   */
-  public function hubMenuHideAddtributes(array &$form): static {
-    if (!empty($form['options']['attributes'])) {
-      $form['options']['attributes']['#access'] = FALSE;
-    }
-    return $this;
-  }
-
-  /**
-   * Hides the expanded form field for home page hub list link form.
-   *
-   * @param array $form
-   *   The form element array.
-   *
-   * @return $this
-   */
-  public function hubMenuHideExpanded(array &$form): static {
-    if (!empty($form['expanded'])) {
-      $form['expanded']['#access'] = FALSE;
-    }
-    return $this;
-  }
-
-  /**
-   * Hides the view_mode form field for home page hub list link form.
-   *
-   * @param array $form
-   *   The form element array.
-   * @param bool $admin
-   *   TRUE if current user is an administrator.
-   *
-   * @return $this
-   */
-  public function hubMenuHideViewMode(array &$form, bool $admin): static {
-    if (!empty($form['view_mode'])) {
-      $form['view_mode']['#access'] = $admin;
-    }
-    return $this;
-  }
-
-  /**
-   * Hides the parent link form field for home page hub list link form.
-   *
-   * @param array $form
-   *   The form element array.
-   * @param bool $admin
-   *   TRUE if current user is an administrator.
-   *
-   * @return $this
-   */
-  public function hubMenuHideParentLink(array &$form, bool $admin): static {
-    if (!empty($form['menu_parent'])) {
-      $form['menu_parent']['#access'] = $admin;
-    }
-    return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getSubscribedEvents(): array {
-    return [
-      FormHookEvents::FORM_ALTER => ['formAlter'],
-    ];
   }
 
 }

--- a/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_home/src/EventSubscriber/FormEventSubscriber.php
@@ -41,9 +41,6 @@ class FormEventSubscriber implements EventSubscriberInterface {
       $admin = $this->permsService->hasAdminRole(TRUE);
       $this->hubMenuFormAlter($form, $admin);
     }
-    if ($event->getFormId() === 'menu_link_content_va-gov-footer_form' || $event->getFormId() === 'menu_link_content_footer-bottom-rail_form') {
-      $this->hideMenuLinkDescriptionField($form);
-    }
   }
 
   /**
@@ -123,16 +120,6 @@ class FormEventSubscriber implements EventSubscriberInterface {
       $form['menu_parent']['#access'] = $admin;
     }
     return $this;
-  }
-
-  /**
-   * Hides the description field on certain menu link forms.
-   *
-   * @param array $form
-   *   The form element array.
-   */
-  public function hideMenuLinkDescriptionField(array &$form): void {
-    $form['description']['#access'] = FALSE;
   }
 
   /**


### PR DESCRIPTION
## Description

Follow up for work on hiding the link descriptions in certain menu fields, we crated a new menu form alter trait that can't be utilized by other modules until it is implemented. This PR addresses the ticket to break up that work and follow an order of operations. This is not ready to merge until PR #15069 is deployed to prod.

Relates to #15279 
#14793 

## Engineering notes
This PR is in a state that just serves as a preview/reminder. It will need to be edited to show the base branch as "main".

## Testing done
TBD

## Screenshots
n/a

## QA steps

TBD

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
