### PR TITLE
VACMS-15272: Remove old content release queue jobs.

### DIFF
--- a/config/sync/advancedqueue.advancedqueue_queue.content_release.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.content_release.yml
@@ -10,3 +10,7 @@ backend_configuration:
 processor: daemon
 processing_time: 0
 locked: false
+threshold:
+  type: 2
+  limit: 7
+  state: all


### PR DESCRIPTION
Closes #15272.

## QA Steps

- [x] Go [here](https://pr15285-ss22ynye1fnkssunwfl9dg4jjyjbucqg.ci.cms.va.gov/admin/config/system/queues).
- [x] Verify that Content Release queue no longer has 21K+ items.
- [x] Go [here](https://pr15285-ss22ynye1fnkssunwfl9dg4jjyjbucqg.ci.cms.va.gov/admin/config/system/queues/manage/content_release?destination=/admin/config/system/queues).
- [x] Verify the queue is configured to keep items in the queue for 7 days.
- [x] Verify the queue is configured to remove both succeeded and failed items.