### PR TITLE
VACMS-15098: Q&A Content text changes

### DIFF
--- a/config/sync/node.type.q_a.yml
+++ b/config/sync/node.type.q_a.yml
@@ -18,9 +18,9 @@ third_party_settings:
   node_title_help_text:
     title_help: 'Add a page title in a form of a question with sentence case capitalization. (<a href="https://design.va.gov/content-style-guide/capitalization" target="_blank">See further guidelines</a>)'
   menu_force:
-    menu_force: 0
-    menu_force_parent: 0
-name: 'Q&A - single'
+    menu_force: false
+    menu_force_parent: false
+name: 'Reusable Q&A'
 type: q_a
 description: 'Reusable content that answers a single question from Veterans or other beneficiaries. A Q&A may appear on its own or as part of an FAQ page.'
 help: 'Single Question and Answer.'

--- a/config/sync/paragraphs.paragraphs_type.q_a.yml
+++ b/config/sync/paragraphs.paragraphs_type.q_a.yml
@@ -1,14 +1,10 @@
 uuid: 525c8535-c6fa-4e64-8824-82c889785a6a
 langcode: en
 status: true
-dependencies:
-  module:
-    - paragraphs_browser
-third_party_settings:
-  paragraphs_browser:
-    description: 'For content formatted as a series of questions and answers. Use this (instead of Paragraph) for better accessibility and easy rearranging.'
+dependencies: {  }
 id: q_a
-label: 'Q&A'
+label: 'Page-Specific Q&A'
 icon_uuid: null
-description: 'Question and Answer'
+icon_default: null
+description: 'Page-specific (non-reusable) content formatted as a question and answer.'
 behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.q_a_group.yml
+++ b/config/sync/paragraphs.paragraphs_type.q_a_group.yml
@@ -8,8 +8,8 @@ third_party_settings:
   paragraphs_browser:
     image_path: themes/custom/vagovclaro/images/screenshots/q-a-section.jpg
 id: q_a_group
-label: 'Q&A group'
+label: 'Reusable Q&A Group'
 icon_uuid: null
 icon_default: null
-description: 'Create a new group of existing Q&As. Use this (instead of Rich text) for better accessibility and easy rearranging.'
+description: 'Create a group using stored Q&As in the CMS. Use this for better accessibility and easy rearranging. '
 behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.q_a_section.yml
+++ b/config/sync/paragraphs.paragraphs_type.q_a_section.yml
@@ -6,11 +6,10 @@ dependencies:
     - paragraphs_browser
 third_party_settings:
   paragraphs_browser:
-    description: 'For content formatted as a series of questions and answers. Use this (instead of Rich text) for better accessibility and easy rearranging.'
     image_path: themes/custom/vagovclaro/images/screenshots/q-a-section.jpg
 id: q_a_section
-label: 'Q&A Section'
+label: 'Page-Specific Q&A Group'
 icon_uuid: null
 icon_default: null
-description: 'For content formatted as a series of questions and answers. Use this (instead of Rich text) for better accessibility and easy rearranging.'
+description: 'Create a group of custom Q&As that provide information specific to the page content. Use this for better accessibility and easy rearranging.'
 behavior_plugins: {  }

--- a/config/sync/paragraphs_browser.paragraphs_browser_type.content.yml
+++ b/config/sync/paragraphs_browser.paragraphs_browser_type.content.yml
@@ -31,7 +31,6 @@ groups:
     weight: '9'
 map:
   wysiwyg: most_commonly_used
-  q_a_section: most_commonly_used
   expandable_text: collapsible_elements
   spanish_translation_summary: collapsible_elements
   process: other
@@ -54,3 +53,5 @@ map:
   three_column_layout: layout
   lists_of_links: other
   centralized_content_descriptor: advanced
+  q_a_section: most_commonly_used
+  q_a_group: most_commonly_used

--- a/tests/cypress/integration/features/content_type/campaign_landing_page/faq.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/faq.feature
@@ -7,7 +7,7 @@ Feature: Content Type: Campaign Landing Page
     And I click to collapse "Hero banner"
     And I click to expand "FAQs"
     And I enable the page segment
-    And I click the "Add Q&A" button
+    And I click the "Add Page-Specific Q&A" button
     Then I can fill in "Question" field with fake text
     And I can fill in "Text" field with fake text
     And I should see "Add a link to more FAQs"


### PR DESCRIPTION
## Description

Makes changes to the way we refer to reusable vs. non-resuable Question and Answer content. This PR changes various help text and labels in accordance with the mockup and the ticket.

Relates to #15098 

## Testing done
Functional, locally.

## Screenshots
![Screenshot 2023-09-19 at 8 07 37 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/625988d2-a73e-4d8c-bafe-9ed8fde4412a)
![Screenshot 2023-09-19 at 8 08 57 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/7d92987f-6354-4472-9e47-a3c788f8a3b3)
![Screenshot 2023-09-19 at 8 08 50 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/68abc4af-6a80-4ede-812b-55fca24797eb)
![Screenshot 2023-09-19 at 8 08 20 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/a8a5f3f8-9831-4fb9-a20e-6a55fe713e4f)
![Screenshot 2023-09-19 at 8 07 58 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/22a61f22-5ec3-435c-84be-aad3ab8f6dea)
![Screenshot 2023-09-19 at 8 34 57 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/a628f383-b902-46ef-a15c-afb5b45fa853)



## QA steps
As any user:
- Go to add a Benefit Detail page (/node/add/page). 
- [x] Scroll down to "Featured content" and ensure that there is a button that says "Add Page-Specific Q&A" and not "Add Q&A".
- Further down, click on the "Add main content" button and then click on "Most Commonly used".
- [x] The two that come up should be called Reusable Q&A and Page-Specific Q&A
- [x] Help text for Reusable Q&A should say "Create a group using stored Q&As in the CMS. Use this for better accessibility and easy rearranging."
- [x] Help text for Page-Specific Q&A should say "Create a group of custom Q&As that provide information specific to the page content. Use this for better accessibility and easy rearranging."

Go to add a Reusable Q&A content (node/add/q_a).
- [x] Make sure it's called Reusable Q&A

(This will behave the same way on Resources and Support.)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
