### PR TITLE
VACMS-15242: Make Revision log message requirement more inclusive

### DIFF
--- a/config/sync/core.entity_form_display.block_content.promo.default.yml
+++ b/config/sync/core.entity_form_display.block_content.promo.default.yml
@@ -10,8 +10,28 @@ dependencies:
     - workflows.workflow.editorial
   module:
     - content_moderation
+    - field_group
     - inline_entity_form
     - media_library
+third_party_settings:
+  field_group:
+    group_section_settings:
+      children:
+        - moderation_state
+        - field_owner
+        - revision_log
+      label: 'Section settings'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
+        description_display: after
 id: block_content.promo.default
 targetEntityType: block_content
 bundle: promo

--- a/config/sync/core.entity_form_display.block_content.promo.default.yml
+++ b/config/sync/core.entity_form_display.block_content.promo.default.yml
@@ -17,8 +17,8 @@ third_party_settings:
   field_group:
     group_section_settings:
       children:
-        - moderation_state
         - field_owner
+        - moderation_state
         - revision_log
       label: 'Section settings'
       region: content
@@ -65,7 +65,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 3
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -277,9 +277,6 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    // Disable the checkbox functionality.
-    unset($form['revision_log']['#states']);
-
     // Hide the checkbox that lets you opt into making a revision.
     // Promo blocks have a different form structure.
     if ($entity->bundle() === 'promo') {

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -264,31 +264,15 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    * @param string $form_id
    *   The form id.
    */
-  public function requireRevisionMessage(array &$form, FormStateInterface &$form_state, $form_id): void {
-    // Hide the checkbox that lets user opt into making a revision.
-    $formObject = $form_state->getFormObject();
-    if ($formObject instanceof EntityFormInterface) {
-      $entity = $formObject->getEntity();
-      if ($entity->bundle() === 'promo') {
-        // Hide revision checkbox on Promo blocks.
-        $form["revision_information"]["#access"] = TRUE;
-        unset($form['revision_log']['#states']);
-        $form["revision"]["#access"] = FALSE;
-        $form["revision_log"]["#access"] = TRUE;
-      }
-      else {
-        // Hide revision checkbox on all other custom blocks.
-        $form["revision_information"]["#attributes"]['class'][] = 'visually-hidden';
-        $this->bypassRevisionLogValidationOnIef($form, $form_state);
-      }
-    }
-
-    // Make revision log required.
+  public function requireRevisionMessage(array &$form, FormStateInterface &$form_state, $form_id) {
     $form['revision_log']['#required'] = TRUE;
     $form['revision_log']['widget']['#required'] = TRUE;
     $form['revision_log']['widget'][0]['#required'] = TRUE;
     $form['revision_log']['widget'][0]['value']['#required'] = TRUE;
     $form['#validate'][] = '_va_gov_workflow_validate_required_revision_message';
+    // Hide the checkbox that lets you opt into making a revision.
+    $form["revision_information"]["#attributes"]['class'][] = 'visually-hidden';
+    $this->bypassRevisionLogValidationOnIef($form, $form_state);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -271,7 +271,6 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     if (!$formObject instanceof EntityFormInterface) {
       return;
     }
-
     $entity = $formObject->getEntity();
     if (!$entity instanceof BlockContentInterface) {
       return;
@@ -279,8 +278,11 @@ class EntityEventSubscriber implements EventSubscriberInterface {
 
     // Hide the checkbox that lets you opt into making a revision.
     // Promo blocks have a different form structure.
-    if ($entity->bundle() === 'promo') {
-      $form['revision']['#access'] = FALSE;
+    if (in_array($entity->bundle(), ['promo', 'cms_announcement'])) {
+      $form["revision_information"]["#access"] = TRUE;
+      unset($form['revision_log']['#states']);
+      $form["revision"]["#access"] = FALSE;
+      $form["revision_log"]["#access"] = TRUE;
     }
     else {
       $form["revision_information"]["#attributes"]['class'][] = 'visually-hidden';

--- a/tests/cypress/support/main_content_blocks.js
+++ b/tests/cypress/support/main_content_blocks.js
@@ -49,5 +49,4 @@ Cypress.Commands.add("addMainContentBlockWithFile", (type) => {
     `[Test Data] ${faker.lorem.sentence()}`,
     { force: true }
   );
-  // cy.get("form.node-form").find("input#edit-submit").click();
 });

--- a/tests/cypress/support/main_content_blocks.js
+++ b/tests/cypress/support/main_content_blocks.js
@@ -1,10 +1,9 @@
 import { faker } from "@faker-js/faker";
 
 Cypress.Commands.add("addMainContentBlockWithRichText", (text) => {
-  cy.get("#edit-field-content-block-add-more-browse")
-    .scrollIntoView()
-    .should("be.visible")
-    .click();
+  cy.get("#edit-field-content-block-add-more-browse").scrollIntoView();
+  cy.get("#edit-field-content-block-add-more-browse").should("be.visible");
+  cy.get("#edit-field-content-block-add-more-browse").click();
   cy.wait(1000);
   cy.get("div#drupal-modal").within(() => {
     cy.wait(1000);
@@ -18,10 +17,9 @@ Cypress.Commands.add("addMainContentBlockWithRichText", (text) => {
 });
 
 Cypress.Commands.add("addMainContentBlockWithFile", (type) => {
-  cy.get("#edit-field-content-block-add-more-browse")
-    .scrollIntoView()
-    .should("be.visible")
-    .click();
+  cy.get("#edit-field-content-block-add-more-browse").scrollIntoView();
+  cy.get("#edit-field-content-block-add-more-browse").should("be.visible");
+  cy.get("#edit-field-content-block-add-more-browse").click();
   cy.wait(1000);
   cy.get("div#drupal-modal").within(() => {
     cy.wait(1000);

--- a/tests/cypress/support/main_content_blocks.js
+++ b/tests/cypress/support/main_content_blocks.js
@@ -51,5 +51,5 @@ Cypress.Commands.add("addMainContentBlockWithFile", (type) => {
     `[Test Data] ${faker.lorem.sentence()}`,
     { force: true }
   );
-  cy.get("form.node-form").find("input#edit-submit").click();
+  // cy.get("form.node-form").find("input#edit-submit").click();
 });


### PR DESCRIPTION
## Description

Relates to #15242 
#15187 

~~Revises the workflow module to hide the revision checkbox on promo block types as well as the other custom block types, without unintentionally hiding the required revision log message field on that type.~~

Updates the promo block architecture to match the other custom block types by adding a field set for section settings and moving revision_log, section and workflow state into it.

## Testing done
local functional

## Screenshots
![Screenshot 2023-09-27 at 1 20 01 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/152ab1d0-7806-416f-8c1f-c2264b82ee50)

## QA steps

As a user with any role, check both promo and non-promo blocks that a) revision log message works, is required and the checkbox is hidden.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
