### PR TITLE
VACMS-11230: Follow up to remove debugging code

### DIFF
--- a/docroot/modules/custom/va_gov_block_types/va_gov_block_types.module
+++ b/docroot/modules/custom/va_gov_block_types/va_gov_block_types.module
@@ -24,7 +24,6 @@ function va_gov_block_types_preprocess_details__node_page_edit_form__field_alert
     return 'No field block status';
   }
   $status = $block->get('status')->value;
-  echo $status;
 
   // If block is not published, provide a custom class.
   if (intval($status) === 0) {


### PR DESCRIPTION
## Description

Relates to #11230 

Previous PR left a line of debugging code that prints an integer to the screen when the alert block is placed. It's very small and we didn't catch it during testing.

## Testing done
Local, functional.

## Screenshots
<img width="576" alt="Screenshot 2023-09-26 at 10 43 27 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/402e7474-16bd-4a54-8d71-c83bdf70a5ba">

## QA steps

As a user with any role, edit any benefit detail page and place an unpublished alert block. Ensure that an integer is not placed on the screen as shown in the screenshot.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
