### PR TITLE
VACMS-9919: Fixes visual focus styles on node edit form unlock button

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_buttons.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_buttons.scss
@@ -37,6 +37,11 @@
     border: 2px solid var(--va-blue-darker);
     color: var(--va-blue-darker);
   }
+
+  &:focus {
+    box-shadow: var(--focus-box-shadow);
+    outline: var(--focus-outline);
+  }
 }
 
 .button--outline.action-link {


### PR DESCRIPTION
## Description

Adds a11y-friendly visual indication styles to the "Unlock" button located on node edit forms.

Relates to #9919 


## Screenshots

![20230927_2022--visual-focus-style-on-node-edit-form-unlock-button](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/40986acf-0b44-47ed-ae67-c0ba48a8b84d)


## QA steps

- Proceed to https://pr15441-vjmcjb0adr0lmbaxa5vgno54ekn04mw6.ci.cms.va.gov/admin/content and click on the 'Edit' link of any content entry
- Scroll near the bottom of the screen
- Click on the 'Revision log message' form input
- Press the tab button 6 times
- [x] The 'Unlock' button should have visual focus -- a green border surrounding the button as shown in the screenshot above. 


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

