### PR TITLE
VACMS-15447: fixed php error in orphans report

### DIFF
--- a/config/sync/views.view.orphaned_paragraphs.yml
+++ b/config/sync/views.view.orphaned_paragraphs.yml
@@ -482,7 +482,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 2500
+          items_per_page: 20
           total_pages: null
           id: 0
           tags:
@@ -499,6 +499,7 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
+          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/OrphansReportViewsEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/OrphansReportViewsEventSubscriber.php
@@ -152,7 +152,8 @@ class OrphansReportViewsEventSubscriber implements EventSubscriberInterface {
       foreach ($view->result as $key => $value) {
         /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
         $paragraph = $value->_entity;
-        $top_parent = va_gov_backend_get_top_parent_entity($paragraph);
+        $tree = [];
+        $top_parent = va_gov_backend_get_top_parent_entity($paragraph, $tree);
         $used = $this->purger->isUsed($paragraph);
         if (!$used && !$top_parent) {
           $link = $this->getTopParentEntityLink($paragraph);


### PR DESCRIPTION
## Description

Closes #15447

## Testing done
Tested locally. Report displays with no erros. 

## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

1. Log in and navigate to /admin/reports/orphaned-paragraphs
   - [x] Validate that report appears
2. Then navigate to /admin/reports/dblog
   - [x] Validate that there are no new errors

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
