### PR TITLE
VACMS-000 Remove Pittsburgh VAMC as default value on VAMC operating status node

### DIFF
--- a/config/sync/field.field.node.vamc_operating_status_and_alerts.field_office.yml
+++ b/config/sync/field.field.node.vamc_operating_status_and_alerts.field_office.yml
@@ -16,9 +16,7 @@ label: 'VAMC system'
 description: 'To do: hide this field or disable it after node creation. '
 required: true
 translatable: false
-default_value:
-  -
-    target_uuid: 2bddb1a7-6fb1-4503-838d-9c2fcb51c46a
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: unpublished


### PR DESCRIPTION
## Description

Currently when a user goes to [create a new VAMC System Operating Status](https://prod.cms.va.gov/node/add/vamc_operating_status_and_alerts), the VAMC system field defaults to VA Pittsburgh. This is a legacy configuration from VAMC pilot. This should default to none. 

## Screenshots

![Screenshot 2023-09-28 172921](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/51967950/b2fc932d-5071-4009-a9d1-7e01981f7a7b)
