### PR TITLE
VACMS-15088: Removes the covid_url from payload

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -255,7 +255,6 @@ class PostFacilityStatus extends PostFacilityBase implements PostServiceInterfac
         $payload['system'] = [
           'name' => $systemNode->get('title')->value,
           'url' => 'https://www.va.gov' . $systemUrl,
-          'covid_url' => "https://www.va.gov{$systemUrl}/programs/covid-19-vaccines",
           'va_health_connect_phone' => $systemNode->get('field_va_health_connect_phone')->value,
         ];
       }


### PR DESCRIPTION
## Description

Relates to #15088 

## Testing done
Manually

## Screenshots
### Comparison of current output and PR output
<img width="2056" alt="Screenshot 2023-09-29 at 9 47 45 AM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/d5396930-e5e6-4259-9a52-8e2e1f8a7429">

## QA steps
### Clear the queue
- [x] In [terminal](https://tugboat.vfs.va.gov/tush/6516e4b32d3036648d94c9ff), run `drush queue:delete post_api_queue`
- [x] Run `drush queue:list`
- [x] Confirm that the post_api_queue is empty

### CMS QA
- [ ] As Ryan S, change a [facility's](https://pr15466-sz6f9gncwaoqrohquvrtrbuhjsggaa2m.ci.cms.va.gov/node/1708/edit) operating status
- [ ] In a separate browser, as an admin, [check the Post API Queue](https://pr15466-sz6f9gncwaoqrohquvrtrbuhjsggaa2m.ci.cms.va.gov/admin/config/post-api/queue)
- [ ] Confirm that `covid_url` is not in the payload

### LIghthouse QA
- [ ] Coordinate with Lighthouse to validate that the record to be sent in the test environment is ingested without error
- [ ] Process the [queue](https://pr15466-sz6f9gncwaoqrohquvrtrbuhjsggaa2m.ci.cms.va.gov/admin/config/post-api/queue)
- [ ] Confirm with Lighthouse that 1 record was sent and ingested without error

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`


