### PR TITLE
VACMS-15529 Remove duplicative field menu item.

### DIFF
--- a/config/sync/views.view.content_model_fields.yml
+++ b/config/sync/views.view.content_model_fields.yml
@@ -2,8 +2,6 @@ uuid: 9cce4e26-7273-40be-99c0-9fb19a6823c3
 langcode: en
 status: true
 dependencies:
-  config:
-    - system.menu.admin
   module:
     - config_views
     - content_model_documentation
@@ -1093,7 +1091,7 @@ display:
           enabled: false
       path: admin/reports/content-model/fields
       menu:
-        type: normal
+        type: none
         title: Fields
         description: 'Displays field settings of the content model.'
         weight: 0


### PR DESCRIPTION
## Description

closes #15529

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As an admin (they are the only users who can see this)
1. [login to the site](https://pr15530-aajkwumdnteo2u1jgy3dgwvtkg5nv9hx.ci.cms.va.gov/)
2. Pull down the reports menu.
   - [x] Validate that the `Reports > Fields` no longer exists as a menu item
   - [x] Validate that `Reports > Content model > Content model fields` does exist
   
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/35e0aa5f-4dc6-4768-a77c-1940dd7710c2)
 
