### PR TITLE
VACMS-10089: Putting cypress event form conditional test back in

### DIFF
--- a/tests/cypress/integration/features/content_type/event.feature
+++ b/tests/cypress/integration/features/content_type/event.feature
@@ -37,6 +37,65 @@ Feature: Content Type: Event
     When I select the "Online" radio button
     Then an element with the selector "#edit-field-url-of-an-online-event-0-uri" should be empty
 
+  Scenario: Confirm that the default time zone when creating an event is set explicitly to Eastern.
+    Given I am logged in as a user with the "content_admin" role
+    When I am at "node/add/event"
+    Then the element with selector "#edit-field-datetime-range-timezone-0-timezone" should contain "New York"
+
+  Scenario: Confirm that the event form conditional elements are shown or hidden appropriately
+    Given I am logged in as a user with the "content_admin" role
+    And I am at "node/add/event"
+
+    And I select the "At a VA facility" radio button
+    Then I should see "Facility location"
+    And I should see "Building, floor, or room"
+    And I should not see "Street address"
+    And I should not see an element with the selector "#edit-field-address-0-address-locality"
+    And I should not see an element with the selector "#edit-field-address-0-address-administrative-area"
+    And I should not see "Country"
+    And I should not see an element with the selector "#edit-field-url-of-an-online-event-0-uri"
+
+    When I select the "At a non-VA location" radio button
+    Then I should not see "Facility location"
+    And I should see "Building, floor, or room"
+    And I should see "Street address"
+    And I should see an element with the selector "#edit-field-address-0-address-locality"
+    And I should see an element with the selector "#edit-field-address-0-address-administrative-area"
+    And I should see "Country"
+    And I should not see an element with the selector "#edit-field-url-of-an-online-event-0-uri"
+
+    When I select the "Online" radio button
+    Then I should not see "Facility location"
+    And I should not see "Building, floor, or room"
+    And I should not see "Street address"
+    And I should not see an element with the selector "#edit-field-address-0-address-locality"
+    And I should not see an element with the selector "#edit-field-address-0-address-administrative-area"
+    And I should not see "Country"
+    And I should see an element with the selector "#edit-field-url-of-an-online-event-0-uri"
+
+    # Registration checkbox reveals conditional form elements
+    When I check the "Include registration information" checkbox
+    Then "Cost" should be visible
+    And I should see "Registration is required for this event"
+    And "Call to action" should be visible
+
+    When I select option "Register" from dropdown "Call to action"
+    Then I should see an element with the selector "#edit-field-link-0-uri"
+    And I select option "Apply" from dropdown "Call to action"
+    Then I should see an element with the selector "#edit-field-link-0-uri"
+    And I select option "RSVP" from dropdown "Call to action"
+    Then I should see an element with the selector "#edit-field-link-0-uri"
+    And I select option "More Details" from dropdown "Call to action"
+    Then I should see an element with the selector "#edit-field-link-0-uri"
+    And I select option "- None -" from dropdown "Call to action"
+    Then I should not see an element with the selector "#edit-field-link-0-uri"
+
+    When I uncheck the "Include registration information" checkbox
+    Then I should not see "Cost"
+    And I should not see "Registration is required for this event"
+    And I should not see "Call to action"
+    And I should not see an element with the selector "#edit-field-link-0-uri"
+
   Scenario: Users who can only publish to National Outreach Calendar do not see the "Publish to the National Outreach Calendar" checkbox
     Given I am logged in as a user with the "administrator" role
     When I set the "feature_event_outreach_checkbox" feature toggle to "on"


### PR DESCRIPTION
## Description

Relates to #15552 
We inadvertently removed some tests that should have stayed.

## Testing done
Local cypress test

## Screenshots
n/a

## QA steps
n/a

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
