### PR TITLE
VACMS-15629: Aligns va_gov_build_trigger and va_gov_content_release frontend version keys.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildRequester.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Service/BuildRequester.php
@@ -11,7 +11,7 @@ use Drupal\Core\State\StateInterface;
  */
 class BuildRequester implements BuildRequesterInterface {
 
-  public const VA_GOV_FRONTEND_VERSION = 'va_gov_build_trigger.frontend_version';
+  public const VA_GOV_FRONTEND_VERSION = 'va_gov_content_release.frontend_version';
 
   /**
    * The content release queue entity.


### PR DESCRIPTION
Closes #15629.

## QA Steps

- [x] Verify that switching a content-build branch builds and clones from the correct version.