### PR TITLE
VACMS-15774: Stop exposing environment variables in Tugboat build logs.

### DIFF
--- a/tests/scripts/ci-wrapper.sh
+++ b/tests/scripts/ci-wrapper.sh
@@ -9,7 +9,9 @@ pushd "${repo_root}" > /dev/null
 : "${RETURN_EXIT_CODE:=0}"
 
 set -o allexport
+set +x
 source "${repo_root}/.env"
+set -x
 set +o allexport
 
 test_name="${1}"
@@ -23,7 +25,7 @@ echo "Status name: ${status_name}"
 time composer "${composer_name}" 2>&1
 exit_code=$?
 
-if [ -n "${GITHUB_TOKEN}" ]; then 
+if [ -n "${GITHUB_TOKEN}" ]; then
   if [ "${exit_code}" -eq 0 ]; then
     github-status-updater \
       -action=update_state \


### PR DESCRIPTION
Closes #15774.

```
+ pushd /var/lib/tugboat
+ : 0
+ set -o allexport
+ set +x
+ set +o allexport
+ test_name=status-error
```

## Acceptance Criteria

- [x] No environment variables are exposed in Tugboat build logs.