### PR TITLE
VACMS-15779: Set `rel="noopener"` in preview links.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1011,7 +1011,7 @@ function va_gov_backend_preprocess_page(&$variables) {
         $host = \Drupal::request()->getHost();
         $preview_form = new PreviewForm();
         $url = $preview_form->getEnvironment($host, $nid);
-        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" target="_blank" href="' . $url . '">Preview</a>';
+        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
         $variables['page']['sidebar_second']['#markup'] = $button;
       }
     }


### PR DESCRIPTION
Closes #15779.

![Screenshot 2023-10-24 at 10 17 11 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/1318579/6c0e06b7-6dcc-45b7-bc92-4bf2ae2b75cf)

## QA Steps

- [ ] Find a node view somewhere on the site that has a preview link
- [ ] Verify that the link contains a `rel="noopener"` attribute.