### PR TITLE
VACMS-13639: Fixes content lock operation on Reusable Q&A Content Type

### DIFF
--- a/config/sync/core.entity_form_display.node.q_a.default.yml
+++ b/config/sync/core.entity_form_display.node.q_a.default.yml
@@ -30,7 +30,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
@@ -254,25 +253,20 @@ content:
       field_widget_replace: 0
       open: 0
       field_widget_display_settings: {  }
+      additional_fields:
+        options: null
     third_party_settings: {  }
   field_related_information:
-    type: paragraphs
+    type: entity_reference_paragraphs
     weight: 7
     region: content
     settings:
       title: 'Link teaser'
       title_plural: 'Link teasers'
       edit_mode: open
-      closed_mode: summary
-      autocollapse: none
-      closed_mode_threshold: 0
       add_mode: dropdown
       form_display_mode: default
       default_paragraph_type: link_teaser
-      features:
-        add_above: '0'
-        collapse_edit_all: collapse_edit_all
-        duplicate: '0'
     third_party_settings: {  }
   field_standalone_page:
     type: boolean_checkbox
@@ -316,8 +310,14 @@ content:
       maxlength: 70
       counter_position: after
       js_prevent_submit: true
+      count_only_mode: false
       count_html_characters: false
       textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   url_redirects:
     weight: 6

--- a/config/sync/core.entity_form_display.node.q_a.default.yml
+++ b/config/sync/core.entity_form_display.node.q_a.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       label: 'Editorial Workflow'
       region: content
       parent_name: ''


### PR DESCRIPTION
## Description

The root cause of the issue was the selected widget (`Paragraphs(stable)`) for the Related Information field. If no value is provided for this field, the form will be forced to re-render up to five times in an effort to resolve the field.  The content lock module, however WILL NOT render its messages, unlock button, etc. after the first render attempt. Q&A Records that have a Related Information record present will properly render on the first pass and therefore, not subject to this issue.

FYI - The warnings above the content lock system message are due to the state of the Related Information field for that record.

Closes #13639 

## Testing done

Performed manual testing on ~20 Q&A records w/o Related Information and ~20 Q&A records with it.  
Confirmed the `This content is now locked by...` system message near top of page, as well as the `Unlock` button near the bottom.
Also, confirmed proper operation -- clicking unlock redirects to Lock Release form.

## Screenshots

### 15637 (Missing Related Information)

![VACMS-13639--20231023--1141](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/1e273cdf-8e98-4949-ad7f-e035f474c8a5)
![VACMS-13639--20231023--1142](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/f6eb2e7c-9298-4e90-93b1-5f463c72215f)

### 47213 (Related Information Populated)
![VACMS-13639--20231023--114230](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/ee0c045a-a170-4419-bf55-399d77a63f0a)
![VACMS-13639--20231023--1143](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/ecce411c-2dc8-4515-95cb-8cdb5e1e1715)


## QA steps

What needs to be checked to prove this works?

Navigating to <tugboat_url>/node/NID/edit substituting NID with a value below should display similar to the screenshots above:

Q&A w/Related Information:
15710 15711 15713 15718 15805 15806 15807 15808 15809 15855 15857 15858 16009 16481 16583 16584 16585 16586

Q&A w/o Related Information:
15712 15715 15803 15804 15832 15856 16482 16483 20486 20488 23233 23245 23246 23248 23249 23250 23251 23252


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


