### PR TITLE
VACMS-15809 Temporary disable VAMC Banner test.

### DIFF
--- a/tests/cypress/integration/features/content_type/full_width_banner_alert.feature
+++ b/tests/cypress/integration/features/content_type/full_width_banner_alert.feature
@@ -20,12 +20,13 @@ Scenario: Log in and create VAMC Full Width Banner Alert
   And I save the node
   Then the primary tab "Edit" should exist
   And the primary tab "Revisions" should exist
-  Given I click the edit tab
-  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message unpublish."
-  And I uncheck the "Published" checkbox within "#edit-status-wrapper"
-  And I save the node
-  Then the primary tab "Edit" should not exist
-  And the primary tab "Revisions" should exist
-  And I should see "it can no longer be edited."
-  Given I reload the page
-  Then I should see "it can no longer be edited."
+# -- The test fails from this point forward if there is an existing VA Boston banner.
+#  Given I click the edit tab
+#  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message unpublish."
+#  And I uncheck the "Published" checkbox within "#edit-status-wrapper"
+#  And I save the node
+#  Then the primary tab "Edit" should not exist
+#  And the primary tab "Revisions" should exist
+#  And I should see "it can no longer be edited."
+#  Given I reload the page
+#  Then I should see "it can no longer be edited."


### PR DESCRIPTION
## Description

Relates to #15809
This is to unblock an automated test that is failing due to a content condition.  This is an immediate fix to get CI working again, but will need to have a round of improving this test so it can not collide with existing content.


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
