### PR TITLE
update easy_breadcrumb settings to remove dupe crumb on cms pages

### DIFF
--- a/config/sync/easy_breadcrumb.settings.yml
+++ b/config/sync/easy_breadcrumb.settings.yml
@@ -41,5 +41,5 @@ segment_display_limit: 0
 truncator_mode: false
 truncator_length: 100
 truncator_dots: true
-remove_repeated_segments_text_only: 0
+remove_repeated_segments_text_only: 1
 home_segment_validation_skip: 0


### PR DESCRIPTION
## Description
Closes #15842.

## Testing done
Visited various nodes as an admin and poked around sub-tabs (edit, revisions, etc) and noticed that breadcrumbs were no longer visually duplicated. The node view and edit tabs do render different breadcrumbs at the top of the page, because the routes are different (`/actual/path/to/content` vs `/node/{nid}/edit`. The breadcrumbs seen on the node view page are the correct breadcrumbs for the purpose of checking FE.

I built the web environment on this tugboat to ensure that no unexpected changes happen there either (this should be a cms-only change).

You may see erroneous breadcrumbs printing in the node view when checking certain routes! This is fixed separately in: #15858.

## Screenshots
Example Node View tab:
![Screenshot 2023-10-25 at 2 13 36 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/11279744/dff97c1f-b2b1-4bcc-b0ce-8cb0bbc3b694)
Example Node Edit tab:
![Screenshot 2023-10-25 at 2 13 50 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/11279744/7fd08628-be25-4ea8-9e9f-d87d77606904)


## QA steps
Links to example pages from each affected content type. Unless noted, what should be checked is the breadcrumb.
Note that what we are checking here is CMS pages + Content Build output. 

**Events**

Specifically check that the 'See more events' link works
* https://www.va.gov/lovell-federal-health-care-tricare/events/55993/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/lovell-federal-health-care-tricare/events/55993/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/lovell-federal-health-care-va/events/55993

**FAQ**

* https://www.va.gov/resources/ask-va-replaces-iris-and-the-gi-bill-help-portal/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/ask-va-replaces-iris-and-the-gi-bill-help-portal/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/ask-va-replaces-iris-and-the-gi-bill-help-portal

**VAMC Facility**

* https://www.va.gov/chicago-health-care/locations/lakeside-va-clinic/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/chicago-health-care/locations/lakeside-va-clinic/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/chicago-health-care/locations/lakeside-va-clinic

**Story**

* https://www.va.gov/chicago-health-care/stories/jesse-brown-will-be-hosting-a-food-drive-313-317-during-national-nutrition-month/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/chicago-health-care/stories/jesse-brown-will-be-hosting-a-food-drive-313-317-during-national-nutrition-month/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/chicago-health-care/stories/jesse-brown-will-be-hosting-a-food-drive-313-317-during-national-nutrition-month

**Staff Profile**

* https://www.va.gov/chicago-health-care/staff-profiles/jacqueline-neal/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/chicago-health-care/staff-profiles/jacqueline-neal/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/chicago-health-care/staff-profiles/jacqueline-neal

**Press Release**

Check both breadcrumb and 'See all press releases' link.

* https://www.va.gov/providence-health-care/news-releases/expanded-mental-health-benefits-aim-to-lower-veteran-suicide-rates/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/providence-health-care/news-releases/expanded-mental-health-benefits-aim-to-lower-veteran-suicide-rates/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/providence-health-care/news-releases/expanded-mental-health-benefits-aim-to-lower-veteran-suicide-rates

**Q & A**

* https://www.va.gov/resources/what-if-i-cant-sign-in-to-vagov-because-my-password-doesnt-work/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/what-if-i-cant-sign-in-to-vagov-because-my-password-doesnt-work/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/what-if-i-cant-sign-in-to-vagov-because-my-password-doesnt-work

**Step by Step**

* https://www.va.gov/resources/how-to-file-a-va-travel-reimbursement-claim-online/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/how-to-file-a-va-travel-reimbursement-claim-online/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/how-to-file-a-va-travel-reimbursement-claim-online

**Resources and Support Detail Page**

* https://www.va.gov/resources/about-our-va-community-care-network-and-covered-services/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/about-our-va-community-care-network-and-covered-services/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/resources/about-our-va-community-care-network-and-covered-services

**VA Form**

* https://www.va.gov/find-forms/about-form-21p-534/
* https://web-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/find-forms/about-form-21p-534/
* https://pr15853-ba9uklwvqjurjer3tdqgoqydldh0ajlg.ci.cms.va.gov/find-forms/about-form-21p-534

## Acceptance criteria

- [x] All pages listed have identical breadcrumbs and if indicated other links
### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
