### PR TITLE
VACMS-15702 Fix view mode notifications

### DIFF
--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -36,7 +36,6 @@ dependencies:
     - office_hours
     - options
     - telephone
-    - text
     - user
 third_party_settings:
   field_group:
@@ -229,6 +228,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -243,6 +243,7 @@ content:
         title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
@@ -219,6 +219,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -229,6 +230,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.nca_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.nca_facility.default.yml
@@ -149,6 +149,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -163,6 +164,7 @@ content:
         title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.nca_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.nca_facility.external_content.yml
@@ -125,6 +125,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -136,9 +137,10 @@ content:
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
       exceptions:
+        title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
-        title: 'Exception hours'
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
@@ -160,6 +160,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -174,6 +175,7 @@ content:
         title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.search_index.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.search_index.yml
@@ -133,6 +133,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -144,9 +145,10 @@ content:
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
       exceptions:
+        title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
-        title: 'Exception hours'
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:
@@ -178,6 +180,7 @@ content:
     weight: 0
     region: content
 hidden:
+  breadcrumbs: true
   content_moderation_control: true
   field_administration: true
   field_cc_above_top_of_page: true

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.teaser.yml
@@ -46,6 +46,7 @@ content:
     weight: 100
     region: content
 hidden:
+  breadcrumbs: true
   field_administration: true
   field_cc_above_top_of_page: true
   field_cc_bottom_of_page_content: true

--- a/config/sync/core.entity_view_display.node.vba_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.vba_facility.default.yml
@@ -401,6 +401,7 @@ content:
         title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vba_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vba_facility.external_content.yml
@@ -208,6 +208,7 @@ content:
         title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vba_facility.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.vba_facility.ief_table.yml
@@ -104,14 +104,14 @@ mode: ief_table
 content:
   field_address:
     type: address_default
-    label: hidden
+    label: above
     settings: {  }
     third_party_settings: {  }
     weight: 4
     region: content
   field_facility_locator_api_id:
     type: string
-    label: hidden
+    label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -119,7 +119,7 @@ content:
     region: content
   field_office_hours:
     type: office_hours
-    label: hidden
+    label: above
     settings:
       day_format: long
       time_format: g
@@ -152,21 +152,21 @@ content:
     region: content
   field_operating_status_facility:
     type: list_default
-    label: hidden
+    label: above
     settings: {  }
     third_party_settings: {  }
     weight: 2
     region: content
   field_operating_status_more_info:
     type: basic_string
-    label: hidden
+    label: above
     settings: {  }
     third_party_settings: {  }
     weight: 3
     region: content
   field_phone_number:
     type: telephone_link
-    label: hidden
+    label: above
     settings:
       title: ''
     third_party_settings: {  }
@@ -203,8 +203,6 @@ hidden:
   flag_changed_title: true
   flag_new: true
   flag_removed_from_source: true
-  label: true
   langcode: true
   links: true
   search_api_excerpt: true
-  status: true

--- a/config/sync/core.entity_view_display.node.vba_facility.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.vba_facility.ief_table.yml
@@ -104,14 +104,14 @@ mode: ief_table
 content:
   field_address:
     type: address_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 4
     region: content
   field_facility_locator_api_id:
     type: string
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -119,7 +119,7 @@ content:
     region: content
   field_office_hours:
     type: office_hours
-    label: above
+    label: hidden
     settings:
       day_format: long
       time_format: g
@@ -127,6 +127,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -141,6 +142,7 @@ content:
         title: 'Exception hours'
         restrict_exceptions_to_num_days: 7
         date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:
@@ -150,21 +152,21 @@ content:
     region: content
   field_operating_status_facility:
     type: list_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 2
     region: content
   field_operating_status_more_info:
     type: basic_string
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 3
     region: content
   field_phone_number:
     type: telephone_link
-    label: above
+    label: hidden
     settings:
       title: ''
     third_party_settings: {  }
@@ -201,6 +203,8 @@ hidden:
   flag_changed_title: true
   flag_new: true
   flag_removed_from_source: true
+  label: true
   langcode: true
   links: true
   search_api_excerpt: true
+  status: true

--- a/config/sync/core.entity_view_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.default.yml
@@ -264,6 +264,8 @@ content:
     settings:
       image_link: ''
       image_style: large
+      image_loading:
+        attribute: lazy
     third_party_settings: {  }
     weight: 11
     region: content
@@ -277,6 +279,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: ''
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -287,6 +290,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vet_center.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.external_content.yml
@@ -84,6 +84,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: ''
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -94,6 +95,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vet_center.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.ief_table.yml
@@ -58,6 +58,7 @@ content:
     weight: 0
     region: content
 hidden:
+  breadcrumbs: true
   content_moderation_control: true
   field_address: true
   field_administration: true

--- a/config/sync/core.entity_view_display.node.vet_center_cap.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_cap.default.yml
@@ -98,6 +98,8 @@ content:
     settings:
       image_link: ''
       image_style: crop_3_2
+      image_loading:
+        attribute: lazy
     third_party_settings: {  }
     weight: 3
     region: content
@@ -119,6 +121,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: ''
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -129,6 +132,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vet_center_mobile_vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_mobile_vet_center.default.yml
@@ -87,6 +87,8 @@ content:
     settings:
       image_link: ''
       image_style: 3_2_medium_thumbnail
+      image_loading:
+        attribute: lazy
     third_party_settings: {  }
     weight: 2
     region: content
@@ -108,6 +110,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: ''
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -118,6 +121,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vet_center_mobile_vet_center.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_mobile_vet_center.external_content.yml
@@ -76,6 +76,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: ''
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -86,6 +87,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.node.vet_center_outstation.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vet_center_outstation.external_content.yml
@@ -78,6 +78,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: ''
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -88,6 +89,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -114,6 +114,7 @@ content:
       grouped: false
       show_closed: all
       closed_format: Closed
+      all_day_format: 'All day open'
       separator:
         days: '<br />'
         grouped_days: ' - '
@@ -124,6 +125,11 @@ content:
         position: ''
         open_text: 'Currently open!'
         closed_text: 'Currently closed'
+      exceptions:
+        title: 'Exception hours'
+        restrict_exceptions_to_num_days: 7
+        date_format: long
+        all_day_format: 'All day open'
       timezone_field: ''
       office_hours_first_day: ''
       schema:


### PR DESCRIPTION
## Description

Relates to #15702

![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/854c6ddc-be3a-41df-87bc-84272ef29059)


## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As an admin
1. Flush the cache. (these messages often only appear on the first load of a page, why they appear after save).
2. Then visit the follow pages and validate that you see no notification about field office hours.
   - [x] Validate [VBA](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/vba-facilities/locations/va-regional-benefit-satellite-office-at-fort-smith-va-clinic)
   - [x] Validate [NCA](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/node/4481)
   - [x] Validate [VAMC](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/node/1941)
   - [x] Validate [Vet Center](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/node/3776)
   - [x] Validate [VC Mobile](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/henderson-vet-center/henderson-mobile-vet-center)
   - [x] Validate [VC Outstation](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/la-crosse-vet-center/wausau-vet-center-outstation)
   - [x] Validate [Billing and Insurance](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/eastern-kansas-health-care/billing-and-insurance)
   - [x] Validate [VC CAP](https://pr15863-eguzdu2tctxueapcxxmcktk80nnprx1v.ci.cms.va.gov/dubois-vet-center/community-access-point/dubois-vet-center-penn-state-dubois)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
