### PR TITLE
VACMS-15721: added description field for alert blocks view and browser

### DIFF
--- a/config/sync/views.view.custom_block_entity_browsers.yml
+++ b/config/sync/views.view.custom_block_entity_browsers.yml
@@ -837,6 +837,71 @@ display:
           empty_zero: false
           hide_alter_empty: true
           use_field_cardinality: true
+        info:
+          id: info
+          table: block_content_field_data
+          field: info
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: info
+          plugin_id: field
+          label: Description
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         status:
           id: status
           table: block_content_field_data

--- a/config/sync/views.view.va_blocks_admin.yml
+++ b/config/sync/views.view.va_blocks_admin.yml
@@ -1353,8 +1353,8 @@ display:
           entity_type: block_content
           entity_field: info
           plugin_id: field
-          label: ''
-          exclude: true
+          label: Description
+          exclude: false
           alter:
             alter_text: false
             text: ''


### PR DESCRIPTION
## Description

Closes #15721.

## Testing done
Tested localy. Description field now displayed as first column on both the /admin/content/alerts page in the in the entity browser for adding alerts. 

## Screenshots
![CleanShot2023-10-31at12 12 14](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/109987005/5c31ce19-103c-4f09-9de1-e41a1d73c87f)
![CleanShot2023-10-31at12 11 41](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/109987005/808df794-1095-4187-a599-a7d320c7f957)


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

1. Navigate to /admin/content/alerts
   - [x] Validate that the description column is the first column and is populated
2. Then add a Benefits Details page, scroll down to the Include Alert section and click Place Alert
   - [x] Validate that the Description column is present and populated


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
