### PR TITLE
VACMS-15747 Feature toggle to launch nat outreach checkbox for all

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -5,3 +5,4 @@ features:
   feature_single_value_field_link: FEATURE_SINGLE_VALUE_FIELD_LINK
   feature_health_connect_number: FEATURE_HEALTH_CONNECT_NUMBER
   feature_event_outreach_checkbox: FEATURE_EVENT_OUTREACH_CHECKBOX
+  feature_event_outreach_checkbox_all: FEATURE_EVENT_OUTREACH_CHECKBOX_ALL

--- a/docroot/modules/custom/va_gov_events/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_events/src/EventSubscriber/EntityEventSubscriber.php
@@ -51,6 +51,11 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   const OUTREACH_CHECKBOX_FEATURE_NAME = 'feature_event_outreach_checkbox';
 
   /**
+   * The Feature toggle name that controls displaying the checkbox to all users.
+   */
+  const OUTREACH_CHECKBOX_ALL_NAME = 'feature_event_outreach_checkbox_all';
+
+  /**
    * The list of users allowed to view the outreach checkbox.
    */
   const OUTREACH_CHECKBOX_TEST_USERS = [
@@ -90,6 +95,13 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   private bool $outreachCheckboxFeatureEnabled;
 
   /**
+   * TRUE if the outreach checkbox feature toggle is enabled for all users.
+   *
+   * @var bool
+   */
+  private bool $outreachCheckboxAllFeatureEnabled;
+
+  /**
    * Constructs the EventSubscriber object.
    *
    * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
@@ -103,6 +115,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $this->userPermsService = $user_perms_service;
     $this->currentUser = $account_proxy->getAccount();
     $this->outreachCheckboxFeatureEnabled = $feature_status->getStatus(self::OUTREACH_CHECKBOX_FEATURE_NAME);
+    $this->outreachCheckboxAllFeatureEnabled = $feature_status->getStatus(self::OUTREACH_CHECKBOX_ALL_NAME);
   }
 
   /**
@@ -123,7 +136,13 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    *   TRUE if the outreach checkbox should be enabled.
    */
   protected function outreachCheckboxEnabled(): bool {
+    // If both feature toggles are on, display the checkbox to all users.
+    if ($this->outreachCheckboxFeatureEnabled && $this->outreachCheckboxAllFeatureEnabled) {
+      return TRUE;
+    }
     $admin = $this->userPermsService->hasAdminRole(TRUE);
+    // If only the primary outreach feature toggle is on, and the user is either
+    // an admin, or in the test user list, display the checkbox.
     return (
       $this->outreachCheckboxFeatureEnabled
       && (in_array($this->currentUser->id(), self::OUTREACH_CHECKBOX_TEST_USERS) || $admin)

--- a/tests/cypress/integration/features/content_type/event.feature
+++ b/tests/cypress/integration/features/content_type/event.feature
@@ -2,8 +2,9 @@
 Feature: Content Type: Event
 
   Scenario: Log in and create an event.
-    Given I am logged in as a user with the "administrator" role
+    Given I am logged in as a user with the "content_admin" role
     When I set the "feature_event_outreach_checkbox" feature toggle to "on"
+    And I set the "feature_event_outreach_checkbox_all" feature toggle to "on"
     Then I create a "event" node
 
   Scenario: Confirm that event form conditional fields are cleared out if parent options change


### PR DESCRIPTION
## Description

Relates to #15747

## Testing done
Manually tested with various user accounts and feature toggle states. Updated cypress test suite for events.

## Screenshots
![Screenshot 2023-10-31 at 3 21 00 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/2eb50f24-cafc-4bfc-aff3-55376a292d6c)

## QA steps
As an administrator
1. Visit the [feature toggle page](https://cms-d1o5mk1v7bc9puuz5ijun6eq7w7j52da.ci.cms.va.gov/admin/config/system/feature_toggle), and ensure that the `FEATURE_EVENT_OUTREACH_CHECKBOX_ALL` is OFF and the `FEATURE_EVENT_OUTREACH_CHECKBOX` is ON (this is the state we will launch in production).
2. Visit the [create Event node](https://cms-d1o5mk1v7bc9puuz5ijun6eq7w7j52da.ci.cms.va.gov/node/add/event) page
   - [x] Validate you see the 'Publish to the National Outreach Calendar' checkbox.
3. Fill out the event, ensuring to check the checkbox
4. Save the event
   - [x] On the subsequent view page, validate the 'Outreach events' event list is listed under 'Additional Listings'

As an Outreach Hub user (eg: triana.poindexter@va.gov)
5. Visit the [create Event node](https://cms-d1o5mk1v7bc9puuz5ijun6eq7w7j52da.ci.cms.va.gov/node/add/event) page
   - [x] Validate you DO NOT see the checkbox
7.  Fill out the event
8.  Save the event
   - [x] On the subsequent view page, validate you DO NOT see the 'Outreach events' event listed under 'Additional Listings'

As a content admin
9. Visit the [create Event node](https://cms-d1o5mk1v7bc9puuz5ijun6eq7w7j52da.ci.cms.va.gov/node/add/event) page
   - [x] Validate you DO NOT see the checkbox
10. Fill out the event
11. Save the event
   - [x] On the subsequent view page, validate you DO NOT see the 'Outreach events' event listed under 'Additional Listings'

As an administrator
12. Visit the [feature toggle page](https://cms-d1o5mk1v7bc9puuz5ijun6eq7w7j52da.ci.cms.va.gov/admin/config/system/feature_toggle).
13. Check the box for the `FEATURE_EVENT_OUTREACH_CHECKBOX_ALL` toggle, and save the form

As an Outreach Hub user (eg: triana.poindexter@va.gov)
14. Visit the [create Event node](https://cms-d1o5mk1v7bc9puuz5ijun6eq7w7j52da.ci.cms.va.gov/node/add/event) page
   - [x] Validate you DO see the checkbox
15. Fill out the event, ensuring the check the checkbox
16. Save the event
   - [x] On the subsequent view page, validate you DO  see the 'Outreach events' event listed under 'Additional Listings'

As a content admin
17. Visit the [create Event node](https://cms-d1o5mk1v7bc9puuz5ijun6eq7w7j52da.ci.cms.va.gov/node/add/event) page
   - [x] Validate you DO see the checkbox
18. Fill out the event, ensuring the check the checkbox
19. Save the event
   - [x] On the subsequent view page, validate you DO see the 'Outreach events' event listed under 'Additional Listings'

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review
- [x] `Public websites`