### PR TITLE
Add new Editors to beta per VHA DM

### DIFF
--- a/docroot/modules/custom/va_gov_events/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_events/src/EventSubscriber/EntityEventSubscriber.php
@@ -66,6 +66,18 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     1583,
     3610,
     2927,
+    2955,
+    3314,
+    2957,
+    3420,
+    2962,
+    2719,
+    4356,
+    1448,
+    2574,
+    1444,
+    2906,
+    31,
   ];
 
   /**


### PR DESCRIPTION
## Description

Relates to #13529

Somewhere wires got crossed between Facilities PO discussion with VHA DM, list of users that was provided to Public Websites, and list of Editors that VHA DM notified to try the new feature. This diff represents users who were notified by VHA DM, but not in our list, so do not currently have access to the feature. Adding them so they do and can test. 