### PR TITLE
VACMS-15995: Adds reference to Service location in Service Region.

### DIFF
--- a/config/sync/field.field.node.service_region.field_service_location.yml
+++ b/config/sync/field.field.node.service_region.field_service_location.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_service_location
     - node.type.service_region
+    - paragraphs.paragraphs_type.service_location
   module:
     - entity_reference_revisions
 id: node.service_region.field_service_location
@@ -19,5 +20,144 @@ default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:paragraph'
-  handler_settings: {  }
+  handler_settings:
+    target_bundles:
+      service_location: service_location
+    negate: 0
+    target_bundles_drag_drop:
+      address:
+        weight: 46
+        enabled: false
+      alert:
+        weight: 47
+        enabled: false
+      alert_single:
+        weight: 48
+        enabled: false
+      audience_topics:
+        weight: 49
+        enabled: false
+      basic_accordion:
+        weight: 50
+        enabled: false
+      button:
+        weight: 51
+        enabled: false
+      centralized_content_descriptor:
+        weight: 52
+        enabled: false
+      checklist:
+        weight: 53
+        enabled: false
+      checklist_item:
+        weight: 54
+        enabled: false
+      collapsible_panel:
+        weight: 55
+        enabled: false
+      collapsible_panel_item:
+        weight: 56
+        enabled: false
+      contact_information:
+        weight: 57
+        enabled: false
+      downloadable_file:
+        weight: 58
+        enabled: false
+      email_contact:
+        weight: 59
+        enabled: false
+      embedded_video:
+        weight: 60
+        enabled: false
+      expandable_text:
+        weight: 61
+        enabled: false
+      featured_content:
+        weight: 62
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 63
+        enabled: false
+      link_teaser:
+        weight: 64
+        enabled: false
+      link_teaser_with_image:
+        weight: 65
+        enabled: false
+      list_of_link_teasers:
+        weight: 68
+        enabled: false
+      list_of_links:
+        weight: 67
+        enabled: false
+      lists_of_links:
+        weight: 66
+        enabled: false
+      magichead_group:
+        weight: 69
+        enabled: false
+      media:
+        weight: 70
+        enabled: false
+      media_list_images:
+        weight: 71
+        enabled: false
+      media_list_videos:
+        weight: 72
+        enabled: false
+      non_reusable_alert:
+        weight: 73
+        enabled: false
+      number_callout:
+        weight: 74
+        enabled: false
+      phone_number:
+        weight: 75
+        enabled: false
+      process:
+        weight: 76
+        enabled: false
+      q_a:
+        weight: 77
+        enabled: false
+      q_a_group:
+        weight: 78
+        enabled: false
+      q_a_section:
+        weight: 79
+        enabled: false
+      react_widget:
+        weight: 80
+        enabled: false
+      rich_text_char_limit_1000:
+        weight: 81
+        enabled: false
+      service_location:
+        weight: 82
+        enabled: true
+      service_location_address:
+        weight: 83
+        enabled: false
+      situation_update:
+        weight: 84
+        enabled: false
+      spanish_translation_summary:
+        weight: 85
+        enabled: false
+      staff_profile:
+        weight: 86
+        enabled: false
+      step:
+        weight: 87
+        enabled: false
+      step_by_step:
+        weight: 88
+        enabled: false
+      table:
+        weight: 89
+        enabled: false
+      wysiwyg:
+        weight: 90
+        enabled: false
 field_type: entity_reference_revisions


### PR DESCRIPTION
## Description

Relates to #15995

## Testing done
Manually

## Screenshots
### Service Region Content Relationship Diagram
![Screenshot 2023-11-03 at 1 21 26 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/0179db81-728f-4092-958b-7101fdeff1da)


### Service Region node:edit
![Screenshot 2023-11-03 at 1 19 14 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/42a6c12e-28e2-46e6-95c0-a387a3e2d7c7)


## QA steps
As an admin, create a [Service Region](https://pr15997-o8bugnlzbpvnl0zgtvniulcc1nnbbsxa.ci.cms.va.gov/node/add/service_region)
- [x] Confirm that it has a Service location

Edit the Service Region just created, adding another Service Location
- [x] Confirm that you can only add a Service location

As an admin, create an [entity relationship diagram](https://pr15997-o8bugnlzbpvnl0zgtvniulcc1nnbbsxa.ci.cms.va.gov/admin/reports/content-model/entity-diagram/node/service_region?max_depth=1) for Service Region
- [x] Confirm that it has a reference to Service location



### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
