### PR TITLE
VACMS-15891: Fine tuning some things for Q&A Audit View

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -7820,7 +7820,7 @@ display:
               empty_column: false
               responsive: ''
             type:
-              sortable: false
+              sortable: true
               default_sort_order: asc
               align: ''
               separator: ''
@@ -7989,7 +7989,7 @@ display:
       display_extenders:
         jsonapi_views:
           enabled: true
-      path: admin/content/qa
+      path: admin/content/audit/qa
       menu:
         type: tab
         title: 'Page-specific Q&A'
@@ -7999,10 +7999,10 @@ display:
         menu_name: admin
         parent: system.admin_content
         context: '0'
-        as_local_task: false
-        local_task_link_title: ''
-        local_task_parent: 'views_view:view.centralized_content_paragraphs.centralized_content_paragraphs'
-        local_task_weight: 0
+        as_local_task: true
+        local_task_link_title: 'Page-specific Q&A'
+        local_task_parent: 'views_view:view.content.content_audit_page'
+        local_task_weight: -150
         local_task_custom_parent_route: ''
       tab_options:
         type: normal


### PR DESCRIPTION
## Description

Relates to #15891 
Addresses feedback in [previous PR](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/15896) that was saved for later.

## Testing done
local

## Screenshots
![Screenshot 2023-11-06 at 10 55 45 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/22764938/be165307-5174-4027-9c6b-c425d05cd9a2)


## QA steps
Used style-guide here:
https://prod.cms.va.gov/admin/structure/cm_document/note/124/views-style-guide

As a developer logged in as administrator, go to https://cms-kames06eozeafsydwadkbl4dlywf6edv.ci.cms.va.gov/admin/content/audit/qa

- [x] Display machine name, not `default`
- [x] URL [`/admin/content/audit/qa`]
- [x] Menu item setting: Is it where it belongs?
- [x] Limit to 25 per page, paginated (style guide says 25, but cypress tests for 25)
- [x] Show result count in header below any exposed filters. (`<p>Displaying @start - @end of @total</p>`)
- [x] Has table caption describing the table (and not changed the content view)
- [x] Columns
   - [x] Title (sortable)
   - [x] Edit button (not operations, no heading)
   - [x] Content type (sortable) (if applicable)
   - [x] Updated (date time and by user) (sortable, default sort, DESC)
   - [x] Moderation State
   - [x] Section (field_administration) (sortable)
   - [ ] Question (not sortable)
- [ ] Filters
   - [ ] Exposed
      - [x] "Title contains" (text search of title field)
      - [x] "Content type" (single value drop down or multivalue? should options be limited) (if applicable)
      - [x] "Moderation state"  - Must use the one for multiple workflows (single value drop down or multivalue?)
      - [x] "Section" (workbench access section; single select, show children)
      - [x] Order of filters matches order of columns
       - [x] Reset button exists
       - [x] Apply button says 'Filter'
- [x] Tab navigation is alpha sorted or intentionally grouped

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
