### PR TITLE
VACMS-10356 Add content validator for Preview URL links (#10356)

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinks.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinks.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that the text does not use any preview URLs as paths.
+ *
+ * In other words, we want to avoid things like this:
+ *
+ * `<a href="/https://www.va.gov/">VA.gov</a>`
+ *
+ * @Constraint(
+ *   id = "PreventPreviewUrlsAsPathsInLinks",
+ *   label = @Translation("Prevent Preview URLs as Paths in Links", context = "Validation"),
+ *   type = { "string_long", "text_long" }
+ * )
+ */
+class PreventPreviewUrlsAsPathsInLinks extends Constraint {
+
+  /**
+   * The error message for plain text fields.
+   *
+   * @var string
+   * @see \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinksValidator
+   */
+  public $plainTextMessage = 'Remove the preview link ":url" and replace it with a public production URL.';
+
+  /**
+   * The error message for rich text fields.
+   *
+   * @var string
+   * @see \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinksValidator
+   */
+  public $richTextMessage = 'Review the linked text ":link" (:url) and update the preview URL with a public production URL.';
+
+}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinks.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinks.php
@@ -25,7 +25,7 @@ class PreventPreviewUrlsAsPathsInLinks extends Constraint {
    * @var string
    * @see \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinksValidator
    */
-  public $plainTextMessage = 'Remove the preview link ":url" and replace it with a public production URL.';
+  public $plainTextMessage = 'Replace the preview link ":url" with a public URL.';
 
   /**
    * The error message for rich text fields.
@@ -33,6 +33,6 @@ class PreventPreviewUrlsAsPathsInLinks extends Constraint {
    * @var string
    * @see \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinksValidator
    */
-  public $richTextMessage = 'Review the linked text ":link" (:url) and update the preview URL with a public production URL.';
+  public $richTextMessage = 'Review the linked text ":link" (:url) and replace the preview URL with a public URL.';
 
 }

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinksValidator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\va_gov_backend\Plugin\Validation\Constraint;
+
+use Drupal\Component\Utility\Html;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\TextValidatorTrait;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the PreventPreviewUrlsAsPathsInLinks constraint.
+ */
+class PreventPreviewUrlsAsPathsInLinksValidator extends ConstraintValidator {
+
+  use TextValidatorTrait;
+  use ValidatorContextAccessTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateText(string $text, Constraint $constraint, int $delta) {
+    /*
+     * Regular expression explanation:
+     *
+     * #                Begin delimiter (replace '/', since we're mucking about
+     *                  with URLs, which contain slashes.)
+     *   (              Open capture group.  We capture the entire URL so that
+     *                  we can refer to it in the error message.
+     *     https?       Match either 'http' or 'https' ...
+     *     ://          ... followed by a colon and two slashes ...
+     *     preview-(staging|prod)
+     *     .vfs.va.gov  ... followed by a preview servers for prod|staging ...
+     *     [^\s]+       ... and any non-whitespace characters that follow.
+     *   )              Close capture group.
+     * #                End delimiter (replace '/')
+     *
+     * In other words, we look for a string that looks like a preview URL.
+     */
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinks $constraint */
+    if (preg_match('#(https?://preview-(staging|prod).vfs.va.gov[^\s]+)#', $text, $matches)) {
+      $this->addViolation($delta, $constraint->plainTextMessage, [
+        ':url' => $matches[1],
+      ]);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateHtml(string $html, Constraint $constraint, int $delta) {
+    /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinks $constraint */
+    $dom = Html::load($html);
+    $xpath = new \DOMXPath($dom);
+    foreach ($xpath->query('//a[starts-with(@href, "preview-staging.vfs.va.gov")] | //a[starts-with(@href, "preview-prod.vfs.va.gov")]') as $element) {
+      $url = $element->getAttribute('href');
+      $firstChild = $element->hasChildNodes() ? $element->childNodes[0] : NULL;
+      $link = $element->ownerDocument->saveHTML($firstChild ?? $element);
+      $this->getContext()
+        ->buildViolation($constraint->richTextMessage, [
+          ':link' => $link,
+          ':url' => $url,
+        ])
+        ->atPath((string) $delta . '.value')
+        ->addViolation();
+      return;
+    }
+  }
+
+}

--- a/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinksValidator.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventPreviewUrlsAsPathsInLinksValidator.php
@@ -52,7 +52,11 @@ class PreventPreviewUrlsAsPathsInLinksValidator extends ConstraintValidator {
     /** @var \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinks $constraint */
     $dom = Html::load($html);
     $xpath = new \DOMXPath($dom);
-    foreach ($xpath->query('//a[starts-with(@href, "preview-staging.vfs.va.gov")] | //a[starts-with(@href, "preview-prod.vfs.va.gov")]') as $element) {
+    foreach ($xpath->query('//a[contains(@href, "preview-staging.vfs.va.gov") or contains(@href, "preview-prod.vfs.va.gov")]') as $element) {
+      // Ignore non-element nodes.
+      if (!($element instanceof \DOMElement)) {
+        continue;
+      }
       $url = $element->getAttribute('href');
       $firstChild = $element->hasChildNodes() ? $element->childNodes[0] : NULL;
       $link = $element->ownerDocument->saveHTML($firstChild ?? $element);

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1323,6 +1323,7 @@ function va_gov_backend_entity_bundle_field_info_alter(&$fields, EntityTypeInter
       $field->addConstraint('PreventAbsoluteUrlsAsPathsInLinks');
       $field->addConstraint('PreventVaGovDomainsAsPathsInLinks');
       $field->addConstraint('PreventDomainsAsPathsInLinks');
+      $field->addConstraint('PreventPreviewUrlsAsPathsInLinks');
     }
     elseif ($field->getType() === 'text_long') {
       $field->addConstraint('PreventAbsoluteCmsLinks');
@@ -1332,6 +1333,7 @@ function va_gov_backend_entity_bundle_field_info_alter(&$fields, EntityTypeInter
       $field->addConstraint('PreventAbsoluteUrlsAsPathsInLinks');
       $field->addConstraint('PreventVaGovDomainsAsPathsInLinks');
       $field->addConstraint('PreventDomainsAsPathsInLinks');
+      $field->addConstraint('PreventPreviewUrlsAsPathsInLinks');
     }
   }
   // Add paragraph checks on clp panels.

--- a/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
@@ -10,7 +10,7 @@ use Tests\Support\Traits\ValidatorTestTrait;
 /**
  * A test to confirm the proper functioning of this validator.
  *
- * @group functional
+ * @group unit
  * @group all
  * @group validation
  *

--- a/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
@@ -69,7 +69,7 @@ class PreventPreviewUrlsAsPathsInLinksValidatorTest extends VaGovUnitTestBase {
   public function validateDataProvider() {
     return [
       [
-        TRUE,
+        FALSE,
         'Normal string_long text should not fail validation.',
       ],
       [

--- a/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace tests\phpunit\Content;
+
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinks;
+use Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventPreviewUrlsAsPathsInLinksValidator;
+use Tests\Support\Classes\VaGovUnitTestBase;
+use Tests\Support\Traits\ValidatorTestTrait;
+
+/**
+ * A test to confirm the proper functioning of this validator.
+ *
+ * @group functional
+ * @group all
+ * @group validation
+ *
+ * @coversDefaultClass \Drupal\va_gov_backend\Plugin\Validation\Constraint\PreventProtocolRelativeLinksValidator
+ */
+class PreventPreviewUrlsAsPathsInLinksValidatorTest extends VaGovUnitTestBase {
+
+  use ValidatorTestTrait;
+
+  /**
+   * Test ::addViolation().
+   *
+   * @covers ::addViolation
+   */
+  public function testAddViolation() {
+    $validator = new PreventPreviewUrlsAsPathsInLinksValidator();
+    $this->prepareValidator($validator, FALSE);
+    $validator->addViolation(3, 'Test violation');
+  }
+
+  /**
+   * Test ::validate().
+   *
+   * @param bool $willValidate
+   *   TRUE if the test string should validate, otherwise FALSE.
+   * @param string $testString
+   *   Some test string to attempt to validate.
+   * @param string $fieldType
+   *   The type of the text field, e.g. 'text_long' or 'string_long'.
+   * @param string $format
+   *   An optional format, like 'plain_text' or 'rich_text'.
+   *
+   * @covers validate
+   * @covers validateText
+   * @covers validateHtml
+   * @dataProvider validateDataProvider
+   */
+  public function testValidate(bool $willValidate, string $testString, string $fieldType = 'string_long', string $format = NULL) {
+    $value = [
+      'value' => $testString,
+    ];
+    if ($fieldType !== 'string_long') {
+      $value['format'] = $format;
+    }
+    $items = $this->getFieldItemList([
+      $this->getFieldItem($value, $fieldType),
+    ]);
+    $validator = new PreventPreviewUrlsAsPathsInLinksValidator();
+    $this->prepareValidator($validator, $willValidate);
+    $validator->validate($items, new PreventPreviewUrlsAsPathsInLinks());
+  }
+
+  /**
+   * Data provider.
+   */
+  public function validateDataProvider() {
+    return [
+      [
+        TRUE,
+        'Normal string_long text should not fail validation.',
+      ],
+      [
+        TRUE,
+        'Normal string_long text with the occasional // scattered throughout should not // fail validation.',
+      ],
+      [
+        FALSE,
+        'However, string_long text with http://preview-staging.vfs.va.gov/path/to/content a path that consists of an Preview URL should fail validation.',
+      ],
+      [
+        FALSE,
+        'However, string_long text with http://preview-prod.vfs.va.gov/path/to/content a path that consists of an Preview URL should fail validation.',
+      ],
+      [
+        TRUE,
+        'Normal text_long text should not fail validation.',
+        'text_long',
+      ],
+      [
+        FALSE,
+        'Something with a http://preview-staging.vfs.va.gov/path/to/content looks like it contains an Preview URL and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        FALSE,
+        'Something with a https://preview-prod.vfs.va.gov/path/to/content looks like it contains an Preview URL and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        FALSE,
+        'This contains a <a href="https://preview-staging.vfs.va.gov/path/to/content">path consisting of an Preview URL</a> inside a tag and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        FALSE,
+        'This contains a <a href="https://preview-prod.vfs.va.gov/path/to/content">path consisting of an Preview URL</a> inside a tag and should fail.',
+        'text_long',
+        'plain_text',
+      ],
+      [
+        TRUE,
+        'http://preview-staging.vfs.va.gov/path/to/content outside of <a href="https://www.example.org/">anchor tags</a> should not trigger the validator.',
+        'text_long',
+        'rich_text',
+      ],
+      [
+        TRUE,
+        'http://preview-prod.vfs.va.gov/path/to/content outside of <a href="https://www.example.org/">anchor tags</a> should not trigger the validator.',
+        'text_long',
+        'rich_text',
+      ],
+    ];
+  }
+
+}

--- a/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
+++ b/tests/phpunit/Content/PreventPreviewUrlsAsPathsInLinksValidatorTest.php
@@ -69,7 +69,7 @@ class PreventPreviewUrlsAsPathsInLinksValidatorTest extends VaGovUnitTestBase {
   public function validateDataProvider() {
     return [
       [
-        FALSE,
+        TRUE,
         'Normal string_long text should not fail validation.',
       ],
       [


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10356.

## Testing done

- Added unit tests for validator
- Tested functionality locally

## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user with ability to edit content:
1. Edit any node/page with rich text field, e.g. the VAMC system service description of a System Health Service.
2. Insert a link to a preview URL, e.g. `<a href="https://preview-staging.vfs.va.gov/example/path">Example Link!</a>`
3. Try to save the document and be blocked by errors and validate that:
   - [ ] An error appears at the top of the page:
   <img width="485" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/ffdcef63-a18a-4a6f-b18a-98f0251c0c4a">

   - [ ] The field title is highlighted red to indicate error:
   <img width="707" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/3eb165ce-5626-488d-9a7e-09ae1ccd4b0e">

   - [ ] An error appears at the bottom of the field:
   <img width="853" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/c6aa98aa-80d9-48f9-90d3-daae26e114c9">

4. Edit any node/item with plain text field, e.g. description of a media image.
5. Add a link to a preview URL, e.g. `https://preview-staging.vfs.va.gov/example/path`
6. Try to save the document and be blocked by errors and validate that:
   - [ ] An error appears at the top of the page:
   <img width="320" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/308cb38a-e6f6-4e44-aed7-3bee5dc5d0eb">

   - [ ] The field title is highlighted red to indicate error:
   <img width="948" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/7217b394-d6e3-4152-bae3-966458c56370"> 

   - [ ] An error appears at the bottom of the field:
   <img width="564" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/f3ddc2ad-f091-4ae0-b2bf-1c736d416a64">

7. Then validate Acceptance Criteria from issue
   - [ ]  A link created to the preview server url will fail form validation and prevent save.
   - [ ] Validator is covered by unit tests.

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
