### PR TITLE
VACMS-15891: Assign weights to content audit views' menu local tasks so tabs appear alphabetically

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -7994,7 +7994,7 @@ display:
         type: tab
         title: 'Page-specific Q&A'
         description: ''
-        weight: -150
+        weight: 0
         expanded: false
         menu_name: admin
         parent: system.admin_content
@@ -8002,7 +8002,7 @@ display:
         as_local_task: true
         local_task_link_title: 'Page-specific Q&A'
         local_task_parent: 'views_view:view.content.content_audit_page'
-        local_task_weight: -150
+        local_task_weight: 400
         local_task_custom_parent_route: ''
       tab_options:
         type: normal

--- a/config/sync/views.view.facility_services.yml
+++ b/config/sync/views.view.facility_services.yml
@@ -11160,7 +11160,7 @@ display:
         as_local_task: true
         local_task_link_title: 'VAMC system banner image audit'
         local_task_parent: 'views_view:view.content.content_audit_page'
-        local_task_weight: 6
+        local_task_weight: 700
         local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1

--- a/config/sync/views.view.metatag_audit.yml
+++ b/config/sync/views.view.metatag_audit.yml
@@ -1385,7 +1385,7 @@ display:
         as_local_task: true
         local_task_link_title: Metatags
         local_task_parent: 'views_view:view.content.content_audit_page'
-        local_task_weight: 3
+        local_task_weight: 300
         local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1

--- a/config/sync/views.view.rich_text_field_audit.yml
+++ b/config/sync/views.view.rich_text_field_audit.yml
@@ -4567,7 +4567,7 @@ display:
         as_local_task: true
         local_task_link_title: 'Phone Numbers'
         local_task_parent: 'views_view:view.content.content_audit_page'
-        local_task_weight: 3
+        local_task_weight: 500
         local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -2111,6 +2111,7 @@ display:
       tags:
         - 'config:field.storage.media.field_owner'
         - 'config:search_api.index.content'
+        - 'search_api_list:content'
   content_search:
     id: content_search
     display_title: Search
@@ -2135,7 +2136,7 @@ display:
         as_local_task: true
         local_task_link_title: 'Content Search'
         local_task_parent: 'views_view:view.content.content_audit_page'
-        local_task_weight: 2
+        local_task_weight: 200
         local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1
@@ -2149,6 +2150,7 @@ display:
       tags:
         - 'config:field.storage.media.field_owner'
         - 'config:search_api.index.content'
+        - 'search_api_list:content'
   search_data_export:
     id: search_data_export
     display_title: 'Search data export'
@@ -3561,3 +3563,4 @@ display:
       tags:
         - 'config:field.storage.media.field_owner'
         - 'config:search_api.index.content'
+        - 'search_api_list:content'

--- a/config/sync/views.view.tables.yml
+++ b/config/sync/views.view.tables.yml
@@ -665,7 +665,7 @@ display:
         type: tab
         title: 'Content Audit - Tables'
         description: ''
-        weight: null
+        weight: 0
         expanded: false
         menu_name: main
         parent: ''
@@ -673,7 +673,7 @@ display:
         as_local_task: true
         local_task_link_title: Tables
         local_task_parent: 'views_view:view.content.content_audit_page'
-        local_task_weight: 4
+        local_task_weight: 600
         local_task_custom_parent_route: ''
     cache_metadata:
       max-age: -1


### PR DESCRIPTION
## Description
This is a quick follow up to #15891 to address the order of menu tabs (menu local tasks) for content audit Views.

Because the menu tab order is defined using weights, and the weights of existing Views didn't allow for placing the new 'Page-specific Q&A' View alphabetically, several Views had to be updated.

Relates to #15891

## Testing done
Manual.

## Screenshots
Before:
![Screenshot 2023-11-09 at 11 00 07 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/f95e9459-f754-40df-92be-830f62dbd865)

After:
![Screenshot 2023-11-09 at 10 59 11 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/936b0539-e9e5-445a-9a00-9ea14c3a5b4f)

## QA steps
As a content admin
1. Visit /admin/content/audit/qa
   - [ ] Validate that the tabs are listed in alphabetical order

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

