### PR TITLE
VACMS-15953 Regenerate phpstan baselines

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,14 +1,79 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
 			count: 1
-			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PdfCheckValidator.php
+			path: docroot/modules/custom/va_gov_backend/src/Controller/ContentReleaseStatusController.php
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
 			count: 1
-			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/UniqueTitleValidator.php
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:setAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Filter/EmailLinkRepairFilter.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Filter/NodeLinkEnforcementFilter.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:setAttribute\\(\\)\\.$#"
+			count: 3
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Filter/NodeLinkEnforcementFilter.php
+
+		-
+			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\Query\\\\QueryInterface\\:\\:distinct\\(\\)\\.$#"
+			count: 2
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$plainTextMessage\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteCmsLinksValidator.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteUrlsAsPathsInLinksValidator.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventDomainsAsPathsInLinksValidator.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventLocalFileLinksValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$richTextMessage\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventMediaViewLinksValidator.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventMediaViewLinksValidator.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventProtocolRelativeLinksValidator.php
+
+		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventVaGovDomainsAsPathsInLinksValidator.php
 
 		-
 			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:head\\(\\)\\.$#"
@@ -41,14 +106,24 @@ parameters:
 			path: docroot/modules/custom/va_gov_backend/va_gov_backend.module
 
 		-
+			message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemListInterface\\<Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\>\\:\\:\\$caption\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/va_gov_backend.module
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemListInterface\\<Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\>\\:\\:\\$pathauto\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/va_gov_backend.module
+
+		-
+			message: "#^Undefined variable\\: \\$mime$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_backend/va_gov_backend.module
+
+		-
 			message: "#^Call to an undefined method Psr\\\\Log\\\\LoggerInterface\\:\\:success\\(\\)\\.$#"
 			count: 2
 			path: docroot/modules/custom/va_gov_build_trigger/src/Commands/SiteStatusCommands.php
-
-		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 3
-			path: docroot/modules/custom/va_gov_build_trigger/src/Form/PreviewForm.php
 
 		-
 			message: "#^Method Drupal\\\\va_gov_build_trigger\\\\Plugin\\\\AdvancedQueue\\\\JobType\\\\ReleaseDispatch\\:\\:process\\(\\) should return Drupal\\\\advancedqueue\\\\JobResult but return statement is missing\\.$#"
@@ -66,11 +141,6 @@ parameters:
 			path: docroot/modules/custom/va_gov_clone/src/CloneManager.php
 
 		-
-			message: "#^Access to an undefined property Drupal\\\\va_gov_consumers\\\\Git\\\\GithubFactory\\:\\:\\$logger\\.$#"
-			count: 1
-			path: docroot/modules/custom/va_gov_consumers/src/Git/GithubFactory.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$children\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
@@ -79,6 +149,16 @@ parameters:
 			message: "#^Call to an undefined method Drupal\\\\Core\\\\Form\\\\FormInterface\\:\\:getEntity\\(\\)\\.$#"
 			count: 3
 			path: docroot/modules/custom/va_gov_consumers/va_gov_consumers.module
+
+		-
+			message: "#^Variable \\$vc_node_fetch in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_dashboards/va_gov_dashboards.module
+
+		-
+			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\RevisionableInterface\\:\\:get\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_db/va_gov_db.install
 
 		-
 			message: "#^Call to an undefined method Drupal\\\\node\\\\Entity\\\\Node\\:\\:setRevisionAuthorId\\(\\)\\.$#"
@@ -91,9 +171,29 @@ parameters:
 			path: docroot/modules/custom/va_gov_db/va_gov_db.install
 
 		-
+			message: "#^Call to an undefined method Drupal\\\\node\\\\Entity\\\\Node\\:\\:setRevisionAuthorId\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_db/va_gov_db.post_update.php
+
+		-
 			message: "#^Variable \\$nids might not be defined\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_db/va_gov_db.post_update.php
+
+		-
+			message: "#^Static call to instance method Drupal\\\\smart_date_recur\\\\Entity\\\\SmartDateRule\\:\\:getMonthsLimit\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_events/src/Controller/Instances.php
+
+		-
+			message: "#^Variable \\$messages in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_events/src/Form/SmartDateOverrideForm.php
+
+		-
+			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_govdelivery/src/EventSubscriber/EntityEventSubscriber.php
 
 		-
 			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\ContentEntityInterface\\:\\:isPublished\\(\\)\\.$#"
@@ -106,7 +206,32 @@ parameters:
 			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
 
 		-
+			message: "#^Method Drupal\\\\va_gov_govdelivery\\\\Service\\\\ProcessStatusBulletin\\:\\:getVamcs\\(\\) has invalid return type Drupal\\\\va_gov_govdelivery\\\\Service\\\\vamcs\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
+
+		-
+			message: "#^PHPDoc tag @return with type array\\[Drupal\\\\va_gov_govdelivery\\\\Service\\\\vamcs\\] is not subtype of native type array\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
+
+		-
+			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
+
+		-
+			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
+
+		-
 			message: "#^Property Drupal\\\\va_gov_govdelivery\\\\Service\\\\ProcessStatusBulletin\\:\\:\\$renderer has unknown class Drupal\\\\va_gov_govdelivery\\\\Service\\\\Drupal\\\\Core\\\\Render\\\\RendererInterface as its type\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
+
+		-
+			message: "#^Variable \\$latest_situation_update in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
 
@@ -121,14 +246,34 @@ parameters:
 			path: docroot/modules/custom/va_gov_govdelivery/src/Service/ProcessStatusBulletin.php
 
 		-
+			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\RevisionableInterface\\:\\:isPublished\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
+
+		-
 			message: "#^Call to an undefined method Drupal\\\\Core\\\\Form\\\\FormInterface\\:\\:getEntity\\(\\)\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_govdelivery/va_gov_govdelivery.module
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\ConstraintViolationInterface\\:\\:\\$arrayPropertyPath\\.$#"
 			count: 1
-			path: docroot/modules/custom/va_gov_graphql/src/Routing/RouteSubscriber.php
+			path: docroot/modules/custom/va_gov_magichead/src/Plugin/Field/FieldWidget/MagicHeadParagraphsClassicWidget.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$maximumDepthErrorMessage\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_magichead/src/Plugin/Validation/Constraint/DepthFieldConstraintValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$negativeDepthErrorMessage\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_magichead/src/Plugin/Validation/Constraint/DepthFieldConstraintValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$skippedDepthErrorMessage\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_magichead/src/Plugin/Validation/Constraint/DepthFieldConstraintValidator.php
 
 		-
 			message: "#^Call to method getFormObject\\(\\) on an unknown class Drupal\\\\va_gov_menu_access\\\\Service\\\\Drupal\\\\Core\\\\Form\\\\FormStateInterface\\.$#"
@@ -146,21 +291,6 @@ parameters:
 			path: docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 3
-			path: docroot/modules/custom/va_gov_migrate/src/EventSubscriber/PostRowSave.php
-
-		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 4
-			path: docroot/modules/custom/va_gov_migrate/src/Form/MigrateConfigForm.php
-
-		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 1
-			path: docroot/modules/custom/va_gov_migrate/src/Obtainer/ObtainAlertBlockTitles.php
-
-		-
 			message: "#^Variable \\$anomalies might not be defined\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_migrate/src/Obtainer/ObtainAndTestBody.php
@@ -169,6 +299,21 @@ parameters:
 			message: "#^Method Drupal\\\\va_gov_migrate\\\\Paragraph\\\\CollapsiblePanel\\:\\:isParagraph\\(\\) should return bool but return statement is missing\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_migrate/src/Paragraph/CollapsiblePanel.php
+
+		-
+			message: "#^Variable \\$answer in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_migrate/src/Paragraph/QAAccordion.php
+
+		-
+			message: "#^Variable \\$answer in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_migrate/src/Paragraph/QASchema.php
+
+		-
+			message: "#^Variable \\$answerQuery in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_migrate/src/Paragraph/QAUnstructured.php
 
 		-
 			message: "#^Variable \\$error might not be defined\\.$#"
@@ -201,39 +346,39 @@ parameters:
 			path: docroot/modules/custom/va_gov_migrate/src/Paragraph/ReactWidget.php
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 5
-			path: docroot/modules/custom/va_gov_migrate/src/ParagraphMigrator.php
-
-		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 1
-			path: docroot/modules/custom/va_gov_migrate/src/ParagraphType.php
-
-		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 1
-			path: docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/AlertBlockSource.php
-
-		-
 			message: "#^Cannot access property \\$data on object\\|false\\.$#"
-			count: 2
-			path: docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/MetalsmithSource.php
-
-		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 3
-			path: docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/MetalsmithSource.php
-
-		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
-			path: docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/SupportService.php
+			path: docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/MetalsmithSource.php
+
+		-
+			message: "#^Variable \\$response in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_migrate/src/Plugin/migrate/source/MetalsmithSource.php
 
 		-
 			message: "#^Undefined variable\\: \\$source_id$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_migrate/va_gov_migrate.install
+
+		-
+			message: "#^Call to method getEntity\\(\\) on an unknown class Drupal\\\\va_gov_multilingual_tmgmt\\\\EventSubscriber\\\\Drupal\\\\tmgmt\\\\Form\\\\JobForm\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/src/EventSubscriber/FormEventSubscriber.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$form_object contains unknown class Drupal\\\\va_gov_multilingual_tmgmt\\\\EventSubscriber\\\\Drupal\\\\tmgmt\\\\Form\\\\JobForm\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_multilingual/modules/va_gov_multilingual_tmgmt/src/EventSubscriber/FormEventSubscriber.php
+
+		-
+			message: "#^Class Drupal\\\\textfield_counter\\\\Plugin\\\\Field\\\\FieldWidget\\\\TextFieldWithCounterWidget not found\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_multilingual/va_gov_multilingual.module
+
+		-
+			message: "#^Class Drupal\\\\textfield_counter\\\\Plugin\\\\Field\\\\FieldWidget\\\\TextfieldWithSummaryAndCounterWidget not found\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_multilingual/va_gov_multilingual.module
 
 		-
 			message: "#^Call to method setEditedFlag\\(\\) on an unknown class Drupal\\\\va_gov_notifications\\\\FlagDecisionsInterface\\.$#"
@@ -246,19 +391,39 @@ parameters:
 			path: docroot/modules/custom/va_gov_notifications/src/Event/Entity/EditedFlag.php
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 6
-			path: docroot/modules/custom/va_gov_post_api/src/Form/VaGovFacilityForceQueueForm.php
-
-		-
-			message: "#^Access to an undefined property Drupal\\\\va_gov_post_api\\\\Service\\\\PostFacilityService\\:\\:\\$Facility\\.$#"
-			count: 5
-			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
-
-		-
-			message: "#^Method Drupal\\\\va_gov_post_api\\\\Service\\\\PostFacilityService\\:\\:queueFacilityService\\(\\) should return int but return statement is missing\\.$#"
+			message: "#^Access to an undefined property Drupal\\\\va_gov_post_api\\\\Service\\\\PostFacilityBase\\:\\:\\$additionalInfoToPush\\.$#"
 			count: 1
-			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityService.php
+			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\va_gov_post_api\\\\Service\\\\PostFacilityBase\\:\\:\\$facility\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\va_gov_post_api\\\\Service\\\\PostFacilityBase\\:\\:\\$facilityNode\\.$#"
+			count: 3
+			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\va_gov_post_api\\\\Service\\\\PostFacilityBase\\:\\:\\$statusToPush\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$facility with type Drupal\\\\va_gov_post_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface is not subtype of native type Drupal\\\\node\\\\NodeInterface\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+
+		-
+			message: "#^Parameter \\$facility of method Drupal\\\\va_gov_post_api\\\\Service\\\\PostFacilityBase\\:\\:getParentLocationsPageUrl\\(\\) has invalid type Drupal\\\\va_gov_post_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php
+
+		-
+			message: "#^Function _post_api_add_facility_status_to_queue not found\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_post_api/va_gov_post_api.install
 
 		-
 			message: "#^Method Drupal\\\\va_gov_preview\\\\Encoder\\\\StaticEncoder\\:\\:encode\\(\\) should return string but return statement is missing\\.$#"
@@ -266,7 +431,32 @@ parameters:
 			path: docroot/modules/custom/va_gov_preview/src/Encoder/StaticEncoder.php
 
 		-
+			message: "#^PHPDoc tag @param for parameter \\$event with type Drupal\\\\va_gov_profile\\\\EventSubscriber\\\\Drupal\\\\core_event_dispatcher\\\\Event\\\\Entity\\\\EntityTypeAlterEvent is not subtype of native type Drupal\\\\core_event_dispatcher\\\\Event\\\\Entity\\\\EntityTypeAlterEvent\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_profile/src/EventSubscriber/EntityEventSubscriber.php
+
+		-
+			message: "#^Parameter \\$event of method Drupal\\\\va_gov_profile\\\\EventSubscriber\\\\EntityEventSubscriber\\:\\:entityTypeAlter\\(\\) has invalid type Drupal\\\\va_gov_profile\\\\EventSubscriber\\\\Drupal\\\\core_event_dispatcher\\\\Event\\\\Entity\\\\EntityTypeAlterEvent\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_profile/src/EventSubscriber/EntityEventSubscriber.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_profile/src/Plugin/Validation/Constraint/PersonPageRequiredFieldsConstraintValidator.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\:\\:\\$value\\.$#"
+			count: 2
+			path: docroot/modules/custom/va_gov_resources_and_support/va_gov_resources_and_support.deploy.php
+
+		-
 			message: "#^Access to an undefined property Drupal\\\\va_gov_user\\\\EventSubscriber\\\\UserImport\\:\\:\\$string_translation\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_user/src/EventSubscriber/UserImport.php
+
+		-
+			message: "#^PHPDoc tag @return with type array\\[int\\] is not subtype of native type array\\.$#"
 			count: 1
 			path: docroot/modules/custom/va_gov_user/src/EventSubscriber/UserImport.php
 
@@ -276,11 +466,31 @@ parameters:
 			path: docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
 
 		-
-			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-			count: 2
-			path: docroot/modules/custom/va_gov_user/src/Service/UserPermsService.php
+			message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\ContentEntityInterface\\:\\:isPublished\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityPreventReuse.php
 
 		-
-			message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\:\\:\\$value\\.$#"
+			message: "#^Cannot access property \\$data on object\\|true\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+
+		-
+			message: "#^Cannot access property \\$item_id on object\\|true\\.$#"
 			count: 2
-			path: docroot/modules/custom/va_gov_resources_and_support/va_gov_resources_and_support.deploy.php
+			path: docroot/modules/custom/va_gov_vet_center/src/Service/RequiredServices.php
+
+		-
+			message: "#^Call to an undefined method Drupal\\\\Core\\\\Form\\\\FormInterface\\:\\:getEntity\\(\\)\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+
+		-
+			message: "#^Cannot call method toArray\\(\\) on false\\.$#"
+			count: 1
+			path: docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+
+		-
+			message: "#^Variable \\$process might not be defined\\.$#"
+			count: 7
+			path: tests/scaling_performance.php


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15953. We are choosing to ignore existing phpstan errors so only new errors will fail the `va:test:phpstan` check. This ensures local testing matches the CI behaviour.

## Testing done

Tested locally using the phpstan composer script, i.e. running `composer run-script va:test:phpstan`. No more errors are observed.

## Screenshots

Before:
<img width="857" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/140737d4-716f-4ee2-91d6-6d296788dac7">
After:
<img width="850" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/6d989bb0-541f-4372-aa3e-9b67f8a2e049">

## QA steps

As user with access to this repository
1. Run the command `composer run-script va:test:phpstan` locally
   - [x] Validate that PHPStan runs successfully without errors.

### Definition of Done

- [ ] ~~Documentation has been updated, if applicable.~~
- [ ] ~~Tests have been added if necessary.~~
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] ~~If there are field changes, front end output has been thoroughly checked.~~

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
