### PR TITLE
VACMS-9885 site previewer

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -6,3 +6,4 @@ features:
   feature_health_connect_number: FEATURE_HEALTH_CONNECT_NUMBER
   feature_event_outreach_checkbox: FEATURE_EVENT_OUTREACH_CHECKBOX
   feature_event_outreach_checkbox_all: FEATURE_EVENT_OUTREACH_CHECKBOX_ALL
+  feature_next_story_preview: FEATURE_NEXT_STORY_PREVIEW

--- a/config/sync/next.next_entity_type_config.node.news_story.yml
+++ b/config/sync/next.next_entity_type_config.node.news_story.yml
@@ -1,0 +1,12 @@
+uuid: 67c41c39-6232-472c-807a-088084bb6b6f
+langcode: en
+status: true
+dependencies: {  }
+id: node.news_story
+site_resolver: site_selector
+configuration:
+  sites:
+    next_build_preview_server: next_build_preview_server
+  field_name: {  }
+revalidator: ''
+revalidator_configuration: {  }

--- a/config/sync/next.next_entity_type_config.node.story_listing.yml
+++ b/config/sync/next.next_entity_type_config.node.story_listing.yml
@@ -1,0 +1,11 @@
+uuid: b7fce347-c71d-4af8-ad58-3916f96d9829
+langcode: en
+status: true
+dependencies: {  }
+id: node.story_listing
+site_resolver: site_selector
+configuration:
+  sites:
+    next_build_preview_server: next_build_preview_server
+revalidator: ''
+revalidator_configuration: {  }

--- a/config/sync/next.settings.yml
+++ b/config/sync/next.settings.yml
@@ -1,10 +1,10 @@
 _core:
   default_config_hash: xRrZztTZj9Lor1bWUC6p2aB3S29Vg8m94UrOwc5AZps
 langcode: en
-site_previewer: iframe
+site_previewer: link
 site_previewer_configuration:
   width: 100%
-  sync_route: false
+  sync_route: 0
   sync_route_skip_routes: ''
 preview_url_generator: simple_oauth
 preview_url_generator_configuration:

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -29,7 +29,6 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\TermInterface;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
-use Drupal\va_gov_build_trigger\Form\PreviewForm;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
 
@@ -967,53 +966,6 @@ function va_gov_backend_preprocess_page_title(&$variables) {
     if (in_array($vocab, $vocabs) && isset($variables['title'])) {
       $markup = Markup::create('All articles in: ' . $term->getName());
       $variables['title'] = $markup;
-    }
-  }
-}
-
-/**
- * Add va_gov preview button to view node on the front end.
- */
-function va_gov_backend_preprocess_page(&$variables) {
-
-  $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node instanceof NodeInterface) {
-    // It's a node.
-    $exclusion_types_from_config = \Drupal::service('va_gov_backend.exclusion_types')->getExcludedTypes();
-    $list_types = [
-      // List pages don't play nicely with preview.
-      'event_listing',
-      'health_services_listing,',
-      'leadership_listing',
-      'locations_listing',
-      'press_releases_listing',
-      'publication_listing',
-      'story_listing',
-    ];
-    $exclusion_types = array_merge(array_values($exclusion_types_from_config), array_values($list_types));
-    $last_saved_by_an_editor = $node->get('field_last_saved_by_an_editor')->value;
-    $variables['page']['last_saved_by_an_editor'] = $last_saved_by_an_editor ? \Drupal::service('date.formatter')->format($last_saved_by_an_editor, 'custom', 'F j Y g:ia') : 'Unknown';
-    // Exclude staff pages without bios.
-    if ($node->bundle() === 'person_profile' && $node->field_complete_biography_create->value === '0') {
-      $exclusion_types[] = 'person_profile';
-    }
-    // Make sure we aren't on the node form or an excluded type.
-    $route_name = \Drupal::routeMatch()->getRouteName();
-    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    if (($route_name !== 'entity.node.edit_form') &&
-      (!in_array($node->bundle(), $exclusion_types)) &&
-      ($language === 'en')) {
-      // Make sure we aren't on /training-guide.
-      $current_uri = \Drupal::request()->getRequestUri();
-      if ($current_uri !== '/training-guide') {
-        $node = \Drupal::routeMatch()->getParameter('node');
-        $nid = $node->id();
-        $host = \Drupal::request()->getHost();
-        $preview_form = new PreviewForm();
-        $url = $preview_form->getEnvironment($host, $nid);
-        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
-        $variables['page']['sidebar_second']['#markup'] = $button;
-      }
     }
   }
 }

--- a/docroot/modules/custom/va_gov_preview/src/EventSubscriber/PreviewEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_preview/src/EventSubscriber/PreviewEventSubscriber.php
@@ -6,11 +6,10 @@ namespace Drupal\va_gov_preview\EventSubscriber;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\core_event_dispatcher\EntityHookEvents;
-use Drupal\core_event_dispatcher\Event\Entity\EntityViewEvent;
 use Drupal\feature_toggle\FeatureStatus;
 use Drupal\node\NodeInterface;
 use Drupal\preprocess_event_dispatcher\Event\PagePreprocessEvent;
+use Drupal\va_gov_build_trigger\Form\PreviewForm;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -29,7 +28,6 @@ class PreviewEventSubscriber implements EventSubscriberInterface {
    * The entity manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManager
-   *  The entity manager.
    */
   private $entityTypeManager;
 
@@ -41,7 +39,7 @@ class PreviewEventSubscriber implements EventSubscriberInterface {
   protected $routeMatch;
 
   /**
-   * TRUE if the outreach checkbox feature toggle is enabled.
+   * TRUE if the next preview checkbox feature toggle is enabled.
    *
    * @var bool
    */
@@ -56,9 +54,9 @@ class PreviewEventSubscriber implements EventSubscriberInterface {
    *   Provides an interface for classes representing the result of routing.
    */
   public function __construct(
-    EntityTypeManager   $entityTypeManager,
-    RouteMatchInterface $route_match,
-    FeatureStatus       $feature_status,
+    EntityTypeManager             $entityTypeManager,
+    RouteMatchInterface           $route_match,
+    FeatureStatus                 $feature_status,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->routeMatch = $route_match;
@@ -70,7 +68,6 @@ class PreviewEventSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents(): array {
     return [
-//      EntityHookEvents::ENTITY_VIEW => 'generatePreviewButton',
       PagePreprocessEvent::name() => 'preprocessPage',
     ];
   }
@@ -91,39 +88,99 @@ class PreviewEventSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $vars['page']['sidebar_second']['#markup'] = '<a>foo bar</a>';
+    $route_name = $this->routeMatch->getRouteName();
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
-    dpm($event);
-    dpm($vars);
+    // Make sure we aren't on the node form or an excluded type.
+    if (($route_name !== 'entity.node.edit_form') && ($language === 'en')) {
+      $last_saved_by_an_editor = $node->get('field_last_saved_by_an_editor')->value;
+      $vars['page']['last_saved_by_an_editor'] = $last_saved_by_an_editor ? \Drupal::service('date.formatter')->format($last_saved_by_an_editor, 'custom', 'F j Y g:ia') : 'Unknown';
+
+      $button = $this->generatePreviewButton($node);
+      $vars['page']['sidebar_second']['#markup'] = $button;
+    }
   }
 
   /**
    * Generate a preview button for a node.
-   *
-   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityViewEvent $event
-   *   The event.
+   * @param \Drupal\node\NodeInterface $node
+   *    Node.
    */
-  public function generatePreviewButton(EntityViewEvent $event): void {
-    $entity = $event->getEntity();
-
-    if ($entity instanceof NodeInterface) {
-      $route_name = $this->routeMatch->getRouteName();
-      $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-
-      if (($route_name !== 'entity.node.edit_form') && ($language === 'en')) {
-        dpm('event subscribed successfully');
-        dpm($event);
-
-        $build = &$event->getBuild();
-        $build['extra_markup'] = [
-          '#region' => 'sidebar_second',
-          '#markup' => 'this is extra markup',
-        ];
-
-        dpm($build);
-      }
+  protected function generatePreviewButton(NodeInterface $node): string|null {
+    // If next-build enabled, use drupal/next generated link. Needs to come first because listing types are enabled here.
+    if ($this->next_preview_enabled && $this->checkNextEnabledTypes($node->bundle())) {
+      $test = $this->generateNextBuildPreviewLink($node);
+      $button = $test;
     }
+    // Otherwise return default preview experience.
+    else {
+      if ($this->checkExcludedTypes($node)) {
+        return null;
+      }
+      // Make sure we aren't on /training-guide.
+      $current_uri = \Drupal::request()->getRequestUri();
+      if ($current_uri === '/training-guide') {
+        return null;
+      }
+
+      $node = $this->routeMatch->getParameter('node');
+      $nid = $node->id();
+      $host = \Drupal::request()->getHost();
+      $preview_form = new PreviewForm();
+      $url = $preview_form->getEnvironment($host, $nid);
+      $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">' . $this->t('Preview'). '</a>';
+    }
+    return $button;
   }
 
+  /**
+   * Next-build enabled preview requires certain config entities to exist for a node type.
+   *
+   * @param string $type
+   * @return bool
+   */
+  protected function checkNextEnabledTypes(string $type): bool {
+    // Replace this array with a config check.
+    $enabled_types = ['news_story', 'story_listing'];
+    return in_array($type, $enabled_types);
+  }
+
+  /**
+   * Existing preview functionality has some conditions.
+   *
+   * @param NodeInterface $node
+   * @return bool
+   */
+  protected function checkExcludedTypes(NodeInterface $node): bool {
+    $exclusion_types_from_config = \Drupal::service('va_gov_backend.exclusion_types')->getExcludedTypes();
+    $list_types = [
+      // List pages don't play nicely with preview.
+      'event_listing',
+      'health_services_listing,',
+      'leadership_listing',
+      'locations_listing',
+      'press_releases_listing',
+      'publication_listing',
+      'story_listing',
+    ];
+    $exclusion_types = array_merge(array_values($exclusion_types_from_config), array_values($list_types));
+    // Exclude staff pages without bios.
+    if ($node->bundle() === 'person_profile' && $node->get('field_complete_biography_create')->value === '0') {
+      $exclusion_types[] = 'person_profile';
+    }
+
+    return (in_array($node->bundle(), $exclusion_types));
+  }
+
+  /**
+   * Generate a preview link targeting an associated next-build server.
+   *
+   * @param NodeInterface $node
+   * @return string
+   */
+  protected function generateNextBuildPreviewLink(NodeInterface $node): string {
+
+    return 'https://a-link-from-next' . $node->getTitle();
+  }
 
 }

--- a/docroot/modules/custom/va_gov_preview/src/EventSubscriber/PreviewEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_preview/src/EventSubscriber/PreviewEventSubscriber.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Drupal\va_gov_preview\EventSubscriber;
+
+
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\core_event_dispatcher\EntityHookEvents;
+use Drupal\core_event_dispatcher\Event\Entity\EntityViewEvent;
+use Drupal\feature_toggle\FeatureStatus;
+use Drupal\node\NodeInterface;
+use Drupal\preprocess_event_dispatcher\Event\PagePreprocessEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * VA.gov Lovell Entity Event Subscriber.
+ */
+class PreviewEventSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The Feature toggle name for outreach checkbox.
+   */
+  const NEXT_PREVIEW_FEATURE_NAME = 'feature_next_story_preview';
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   *  The entity manager.
+   */
+  private $entityTypeManager;
+
+  /**
+   * The route match interface.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * TRUE if the outreach checkbox feature toggle is enabled.
+   *
+   * @var bool
+   */
+  private bool $next_preview_enabled;
+
+  /**
+   * Constructs the EventSubscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The string entity type service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   Provides an interface for classes representing the result of routing.
+   */
+  public function __construct(
+    EntityTypeManager   $entityTypeManager,
+    RouteMatchInterface $route_match,
+    FeatureStatus       $feature_status,
+  ) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->routeMatch = $route_match;
+    $this->next_preview_enabled = $feature_status->getStatus(self::NEXT_PREVIEW_FEATURE_NAME);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+//      EntityHookEvents::ENTITY_VIEW => 'generatePreviewButton',
+      PagePreprocessEvent::name() => 'preprocessPage',
+    ];
+  }
+
+  /**
+   * Preprocess a node page to display the preview button.
+   *
+   * @param \Drupal\preprocess_event_dispatcher\Event\PagePreprocessEvent $event
+   *   Event.
+   */
+  public function preprocessPage(PagePreprocessEvent $event): void {
+    /** @var \Drupal\preprocess_event_dispatcher\Variables\PageEventVariables $variables */
+    $variables = $event->getVariables();
+    $node = $variables->getNode();
+    $vars = &$variables->getRootVariablesByReference();
+
+    if ($node === NULL) {
+      return;
+    }
+
+    $vars['page']['sidebar_second']['#markup'] = '<a>foo bar</a>';
+
+    dpm($event);
+    dpm($vars);
+  }
+
+  /**
+   * Generate a preview button for a node.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityViewEvent $event
+   *   The event.
+   */
+  public function generatePreviewButton(EntityViewEvent $event): void {
+    $entity = $event->getEntity();
+
+    if ($entity instanceof NodeInterface) {
+      $route_name = $this->routeMatch->getRouteName();
+      $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+      if (($route_name !== 'entity.node.edit_form') && ($language === 'en')) {
+        dpm('event subscribed successfully');
+        dpm($event);
+
+        $build = &$event->getBuild();
+        $build['extra_markup'] = [
+          '#region' => 'sidebar_second',
+          '#markup' => 'this is extra markup',
+        ];
+
+        dpm($build);
+      }
+    }
+  }
+
+
+}

--- a/docroot/modules/custom/va_gov_preview/src/Plugin/Next/SitePreviewer/Link.php
+++ b/docroot/modules/custom/va_gov_preview/src/Plugin/Next/SitePreviewer/Link.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\va_gov_preview\Plugin\Next\SitePreviewer;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\next\Plugin\SitePreviewerBase;
+
+/**
+ * Provides a link to the preview page.
+ *
+ * @SitePreviewer(
+ *  id = "link",
+ *  label = "Link to preview",
+ *  description = "Displays a link to the preview page."
+ * )
+ */
+class Link extends SitePreviewerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(EntityInterface $entity, array $sites) {
+    $build = [];
+
+    foreach ($sites as $site) {
+      $build[] = [
+        '#type' => 'link',
+        '#title' => $this->t('Preview'),
+        '#url' => $site->getPreviewUrlForEntity($entity),
+        '#attributes' => [
+          'class' => ['button', 'button--primary', 'node-preview-button'],
+          'target' => '_blank',
+        ],
+      ];
+    }
+
+    return $build;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.info.yml
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.info.yml
@@ -8,4 +8,5 @@ type: module
 core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:serialization
+  - drupal:hook_event_dispatcher
   - va_gov_build_trigger

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.module
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
+use Drupal\va_gov_build_trigger\Form\PreviewForm;
 
 /**
  * Implements hook_help().
@@ -17,5 +19,93 @@ function va_gov_preview_help($route_name, RouteMatchInterface $route_match) {
       $output .= '<h3>' . t('VA.gov Content Preview') . '</h3>';
       $output .= '<p>' . t('This module provides content previewing.') . '</p>';
       return $output;
+  }
+}
+
+/**
+ * Alter the result of \Drupal\next\Plugin\SitePreviewerInterface::render.
+ *
+ * This hook is called after the preview has been assembled.
+ *
+ * @param array &$preview
+ *   The preview renderable array from the site_previewer.
+ * @param array $context
+ *   Context in which the entity is previewed with the following keys:
+ *   - 'plugin': the site_previewer plugin.
+ *   - 'entity': the entity in preview.
+ *   - 'sites': the sites for this entity.
+ *   - 'original_build': the original un-altered build.
+ *
+ * @ingroup next_api
+ */
+function va_gov_preview_next_site_preview_alter(array &$preview, array $context) {
+  // Prevent drupal/next overwriting the existing node view content section.
+  $preview['content'] = $context['original_build'][0]['content'];
+  unset($preview[0]);
+}
+
+/**
+ * Add va_gov preview button to view node on the front end.
+ */
+function va_gov_preview_preprocess_page(&$variables) {
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof NodeInterface) {
+    $route_name = \Drupal::routeMatch()->getRouteName();
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    // Check feature flags for NB preview.
+    $next_build_preview = \Drupal::service('feature_toggle.feature_status')->getStatus('feature_next_story_preview');
+
+    // Gather content types that enable NB preview.
+    // Make sure we aren't on the node form or an excluded type.
+    if (($route_name !== 'entity.node.edit_form') && ($language === 'en')) {
+
+      // Set last saved info for all node view displays.
+      $last_saved_by_an_editor = $node->get('field_last_saved_by_an_editor')->value;
+      $variables['page']['last_saved_by_an_editor'] = $last_saved_by_an_editor ? \Drupal::service('date.formatter')->format($last_saved_by_an_editor, 'custom', 'F j Y g:ia') : 'Unknown';
+
+      // Use NB preview link for node preview button if enabled.
+      if ($next_build_preview && $node->bundle() === 'news_story') {
+
+        // Generate preview url for node here.
+        $url = 'https://testing';
+        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
+
+        $variables['page']['sidebar_second']['#markup'] = $button;
+      }
+      // Otherwise use existing preview button functionality.
+      else {
+        $exclusion_types_from_config = \Drupal::service('va_gov_backend.exclusion_types')->getExcludedTypes();
+        $list_types = [
+          // List pages don't play nicely with preview.
+          'event_listing',
+          'health_services_listing,',
+          'leadership_listing',
+          'locations_listing',
+          'press_releases_listing',
+          'publication_listing',
+          'story_listing',
+        ];
+        $exclusion_types = array_merge(array_values($exclusion_types_from_config), array_values($list_types));
+        // Exclude staff pages without bios.
+        if ($node->bundle() === 'person_profile' && $node->field_complete_biography_create->value === '0') {
+          $exclusion_types[] = 'person_profile';
+        }
+        if (!in_array($node->bundle(), $exclusion_types)) {
+          // Make sure we aren't on /training-guide.
+          $current_uri = \Drupal::request()->getRequestUri();
+          if ($current_uri !== '/training-guide') {
+            $node = \Drupal::routeMatch()->getParameter('node');
+            $nid = $node->id();
+            $host = \Drupal::request()->getHost();
+            $preview_form = new PreviewForm();
+            $url = $preview_form->getEnvironment($host, $nid);
+            $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
+            $variables['page']['sidebar_second']['#markup'] = $button;
+          }
+        }
+      }
+    }
   }
 }

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.module
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.module
@@ -47,65 +47,65 @@ function va_gov_preview_next_site_preview_alter(array &$preview, array $context)
 /**
  * Add va_gov preview button to view node on the front end.
  */
-function va_gov_preview_preprocess_page(&$variables) {
-
-  $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node instanceof NodeInterface) {
-    $route_name = \Drupal::routeMatch()->getRouteName();
-    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-
-    // Check feature flags for NB preview.
-    $next_build_preview = \Drupal::service('feature_toggle.feature_status')->getStatus('feature_next_story_preview');
-
-    // Gather content types that enable NB preview.
-    // Make sure we aren't on the node form or an excluded type.
-    if (($route_name !== 'entity.node.edit_form') && ($language === 'en')) {
-
-      // Set last saved info for all node view displays.
-      $last_saved_by_an_editor = $node->get('field_last_saved_by_an_editor')->value;
-      $variables['page']['last_saved_by_an_editor'] = $last_saved_by_an_editor ? \Drupal::service('date.formatter')->format($last_saved_by_an_editor, 'custom', 'F j Y g:ia') : 'Unknown';
-
-      // Use NB preview link for node preview button if enabled.
-      if ($next_build_preview && $node->bundle() === 'news_story') {
-
-        // Generate preview url for node here.
-        $url = 'https://testing';
-        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
-
-        $variables['page']['sidebar_second']['#markup'] = $button;
-      }
-      // Otherwise use existing preview button functionality.
-      else {
-        $exclusion_types_from_config = \Drupal::service('va_gov_backend.exclusion_types')->getExcludedTypes();
-        $list_types = [
-          // List pages don't play nicely with preview.
-          'event_listing',
-          'health_services_listing,',
-          'leadership_listing',
-          'locations_listing',
-          'press_releases_listing',
-          'publication_listing',
-          'story_listing',
-        ];
-        $exclusion_types = array_merge(array_values($exclusion_types_from_config), array_values($list_types));
-        // Exclude staff pages without bios.
-        if ($node->bundle() === 'person_profile' && $node->field_complete_biography_create->value === '0') {
-          $exclusion_types[] = 'person_profile';
-        }
-        if (!in_array($node->bundle(), $exclusion_types)) {
-          // Make sure we aren't on /training-guide.
-          $current_uri = \Drupal::request()->getRequestUri();
-          if ($current_uri !== '/training-guide') {
-            $node = \Drupal::routeMatch()->getParameter('node');
-            $nid = $node->id();
-            $host = \Drupal::request()->getHost();
-            $preview_form = new PreviewForm();
-            $url = $preview_form->getEnvironment($host, $nid);
-            $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
-            $variables['page']['sidebar_second']['#markup'] = $button;
-          }
-        }
-      }
-    }
-  }
-}
+//function va_gov_preview_preprocess_page(&$variables) {
+//
+//  $node = \Drupal::routeMatch()->getParameter('node');
+//  if ($node instanceof NodeInterface) {
+//    $route_name = \Drupal::routeMatch()->getRouteName();
+//    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+//
+//    // Check feature flags for NB preview.
+//    $next_build_preview = \Drupal::service('feature_toggle.feature_status')->getStatus('feature_next_story_preview');
+//
+//    // Gather content types that enable NB preview.
+//    // Make sure we aren't on the node form or an excluded type.
+//    if (($route_name !== 'entity.node.edit_form') && ($language === 'en')) {
+//
+//      // Set last saved info for all node view displays.
+//      $last_saved_by_an_editor = $node->get('field_last_saved_by_an_editor')->value;
+//      $variables['page']['last_saved_by_an_editor'] = $last_saved_by_an_editor ? \Drupal::service('date.formatter')->format($last_saved_by_an_editor, 'custom', 'F j Y g:ia') : 'Unknown';
+//
+//      // Use NB preview link for node preview button if enabled.
+//      if ($next_build_preview && $node->bundle() === 'news_story') {
+//
+//        // Generate preview url for node here.
+//        $url = 'https://testing';
+//        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
+//
+//        $variables['page']['sidebar_second']['#markup'] = $button;
+//      }
+//      // Otherwise use existing preview button functionality.
+//      else {
+//        $exclusion_types_from_config = \Drupal::service('va_gov_backend.exclusion_types')->getExcludedTypes();
+//        $list_types = [
+//          // List pages don't play nicely with preview.
+//          'event_listing',
+//          'health_services_listing,',
+//          'leadership_listing',
+//          'locations_listing',
+//          'press_releases_listing',
+//          'publication_listing',
+//          'story_listing',
+//        ];
+//        $exclusion_types = array_merge(array_values($exclusion_types_from_config), array_values($list_types));
+//        // Exclude staff pages without bios.
+//        if ($node->bundle() === 'person_profile' && $node->field_complete_biography_create->value === '0') {
+//          $exclusion_types[] = 'person_profile';
+//        }
+//        if (!in_array($node->bundle(), $exclusion_types)) {
+//          // Make sure we aren't on /training-guide.
+//          $current_uri = \Drupal::request()->getRequestUri();
+//          if ($current_uri !== '/training-guide') {
+//            $node = \Drupal::routeMatch()->getParameter('node');
+//            $nid = $node->id();
+//            $host = \Drupal::request()->getHost();
+//            $preview_form = new PreviewForm();
+//            $url = $preview_form->getEnvironment($host, $nid);
+//            $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
+//            $variables['page']['sidebar_second']['#markup'] = $button;
+//          }
+//        }
+//      }
+//    }
+//  }
+//}

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.module
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.module
@@ -6,8 +6,6 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\node\NodeInterface;
-use Drupal\va_gov_build_trigger\Form\PreviewForm;
 
 /**
  * Implements hook_help().
@@ -43,69 +41,3 @@ function va_gov_preview_next_site_preview_alter(array &$preview, array $context)
   $preview['content'] = $context['original_build'][0]['content'];
   unset($preview[0]);
 }
-
-/**
- * Add va_gov preview button to view node on the front end.
- */
-//function va_gov_preview_preprocess_page(&$variables) {
-//
-//  $node = \Drupal::routeMatch()->getParameter('node');
-//  if ($node instanceof NodeInterface) {
-//    $route_name = \Drupal::routeMatch()->getRouteName();
-//    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-//
-//    // Check feature flags for NB preview.
-//    $next_build_preview = \Drupal::service('feature_toggle.feature_status')->getStatus('feature_next_story_preview');
-//
-//    // Gather content types that enable NB preview.
-//    // Make sure we aren't on the node form or an excluded type.
-//    if (($route_name !== 'entity.node.edit_form') && ($language === 'en')) {
-//
-//      // Set last saved info for all node view displays.
-//      $last_saved_by_an_editor = $node->get('field_last_saved_by_an_editor')->value;
-//      $variables['page']['last_saved_by_an_editor'] = $last_saved_by_an_editor ? \Drupal::service('date.formatter')->format($last_saved_by_an_editor, 'custom', 'F j Y g:ia') : 'Unknown';
-//
-//      // Use NB preview link for node preview button if enabled.
-//      if ($next_build_preview && $node->bundle() === 'news_story') {
-//
-//        // Generate preview url for node here.
-//        $url = 'https://testing';
-//        $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
-//
-//        $variables['page']['sidebar_second']['#markup'] = $button;
-//      }
-//      // Otherwise use existing preview button functionality.
-//      else {
-//        $exclusion_types_from_config = \Drupal::service('va_gov_backend.exclusion_types')->getExcludedTypes();
-//        $list_types = [
-//          // List pages don't play nicely with preview.
-//          'event_listing',
-//          'health_services_listing,',
-//          'leadership_listing',
-//          'locations_listing',
-//          'press_releases_listing',
-//          'publication_listing',
-//          'story_listing',
-//        ];
-//        $exclusion_types = array_merge(array_values($exclusion_types_from_config), array_values($list_types));
-//        // Exclude staff pages without bios.
-//        if ($node->bundle() === 'person_profile' && $node->field_complete_biography_create->value === '0') {
-//          $exclusion_types[] = 'person_profile';
-//        }
-//        if (!in_array($node->bundle(), $exclusion_types)) {
-//          // Make sure we aren't on /training-guide.
-//          $current_uri = \Drupal::request()->getRequestUri();
-//          if ($current_uri !== '/training-guide') {
-//            $node = \Drupal::routeMatch()->getParameter('node');
-//            $nid = $node->id();
-//            $host = \Drupal::request()->getHost();
-//            $preview_form = new PreviewForm();
-//            $url = $preview_form->getEnvironment($host, $nid);
-//            $button = '<a class="button button--primary js-form-submit form-submit node-preview-button" rel="noopener" target="_blank" href="' . $url . '">Preview</a>';
-//            $variables['page']['sidebar_second']['#markup'] = $button;
-//          }
-//        }
-//      }
-//    }
-//  }
-//}

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.services.yml
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.services.yml
@@ -10,8 +10,8 @@ services:
       [
         '@entity_type.manager',
         '@current_route_match',
-        "@next.entity_type.manager",
-        "@next.settings.manager",
+        '@next.entity_type.manager',
+        '@next.settings.manager',
         '@feature_toggle.feature_status'
       ]
     tags:

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.services.yml
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.services.yml
@@ -6,6 +6,13 @@ services:
       - { name: encoder, priority: 10, format: static_html }
   va_gov_preview.entity_event_subscriber:
     class: Drupal\va_gov_preview\EventSubscriber\PreviewEventSubscriber
-    arguments: ['@entity_type.manager', '@current_route_match', '@feature_toggle.feature_status']
+    arguments:
+      [
+        '@entity_type.manager',
+        '@current_route_match',
+        "@next.entity_type.manager",
+        "@next.settings.manager",
+        '@feature_toggle.feature_status'
+      ]
     tags:
       - { name: event_subscriber }

--- a/docroot/modules/custom/va_gov_preview/va_gov_preview.services.yml
+++ b/docroot/modules/custom/va_gov_preview/va_gov_preview.services.yml
@@ -4,3 +4,8 @@ services:
     arguments: ['@messenger', '@string_translation']
     tags:
       - { name: encoder, priority: 10, format: static_html }
+  va_gov_preview.entity_event_subscriber:
+    class: Drupal\va_gov_preview\EventSubscriber\PreviewEventSubscriber
+    arguments: ['@entity_type.manager', '@current_route_match', '@feature_toggle.feature_status']
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
## Description
Closes #9885. Closes #9891.

This PR creates a feature flag for next preview, some next entity types to enable preview, and refactors the existing preview button logic from `va_gov_backend.module` to an Event Subscriber inside of `va_gov_preview`.

## Testing done
Enabled the feature flag and then tested a combination of nodes to ensure that next preview worked when enabled and that existing preview logic remained unchanged:

**Next preview:**
Story:
https://va-gov-cms.ddev.site/butler-health-care/stories/this-suicide-prevention-month-the-butler-va-offers-veterans-support
![Screenshot 2023-11-15 at 9 19 59 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/11279744/6a10ab74-e34b-4d1d-9db7-4fde100f0b6b)

Story (draft revision):
https://va-gov-cms.ddev.site/node/61531/latest
![Screenshot 2023-11-15 at 9 19 52 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/11279744/80be65cd-0528-4c57-ad9e-0f6bf47634b3)

**Existing preview:**
VAMC detail page:
https://va-gov-cms.ddev.site/southern-nevada-health-care/work-with-us/internships-and-fellowships/nurse-practitioner-residency
![Screenshot 2023-11-15 at 9 20 10 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/11279744/8ce6bec4-c3a8-492f-b492-6f5bb9077dc1)

**No preview (excluded type):**
Events list:
https://va-gov-cms.ddev.site/northport-health-care/events
![Screenshot 2023-11-15 at 9 20 04 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/11279744/2624cf17-5a52-47db-a869-5cadcc9a6407)

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

- Check a story node, note that the existing preview button is unchanged, using the current preview link format
- Enable the feature flag and return to a story node, note that the preview url now points to the next build server
- Check an Event List node, note that there is no preview button
- Check a VAMC detail page, note that the preview button is generated with existing preview link format (not pointing at next-build)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [x] `Accelerated Publishing`