### PR TITLE
Add command for running PHP Code Beautifier and Fixer (phpcbf)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -533,6 +533,7 @@
         "va:drush": "Run Drush transparently (all arguments will be passed).",
         "va:npm": "Run NPM transparently (all arguments will be passed).",
         "va:nuke": "Remove all Composer package and cache directories.",
+        "va:phpcbf": "Run PHP Code Beautifier and Fixer transparently (all arguments will be passed).",
         "va:remove-git-dirs": "Remove .git directories within this directory, e.g. those created by Composer.",
         "va:set-path": "Display a command for updating the path to include `./bin`.",
         "va:ds:drupal": "Build the Drupal theme.",
@@ -621,6 +622,11 @@
             "# Remove all Composer package and cache directories.",
             "! ./scripts/should-run-directly.sh || ./scripts/nuke-composer-directories.sh",
             "./scripts/should-run-directly.sh || ddev composer va:nuke --"
+        ],
+        "va:phpcbf": [
+            "# Run PHP Code Beautifier and Fixer transparently (all arguments will be passed).",
+            "! ./scripts/should-run-directly.sh || bin/phpcbf -p --",
+            "./scripts/should-run-directly.sh || ddev composer va:phpcbf --"
         ],
         "va:proxy:socks": [
             "# Set up a SOCKS proxy.",


### PR DESCRIPTION
## Description

Closes #16198 

## Testing done

Tested locally by running `composer run-script va:phpcbf`

## Screenshots

Testing the added command on a subdirectory containing phpcs errors shows that the errors have been fixed:
<img width="1072" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/da697560-afee-4c45-a749-28e8c462fe6b">
Note that the error code of phpcbf is returned as 1 even if all errors are fixed: https://github.com/squizlabs/PHP_CodeSniffer/issues/3057. We can choose to ignore this error code but since this script is expected to run locally, I don't think this is necessary.

## QA steps

As user with access to this directory
1. Introduce a phpcs error such as unsorted usings.
   - e.g. edit usings of `docroot/modules/custom/va_gov_backend/src/Plugin/Validation/Constraint/PreventAbsoluteUrlsAsPathsInLinksValidator.php` to:
```
use Drupal\Component\Utility\Html;
use Symfony\Component\Validator\ConstraintValidator;
use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\TextValidatorTrait;
use Drupal\va_gov_backend\Plugin\Validation\Constraint\Traits\ValidatorContextAccessTrait;
use Symfony\Component\Validator\Constraint;
```
2. Run `composer run-script va:phpcbf ./docroot/modules/custom/va_gov_backend`
   - [x] Validate that the use statements are now sorted
   - [x] The output looks similar to the one attached above.

### Definition of Done

- [ ] ~~Documentation has been updated, if applicable.~~
- [ ] ~~Tests have been added if necessary.~~
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] ~~If there are field changes, front end output has been thoroughly checked.~~

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
