### PR TITLE
VACMS-10119: Updates Column Order on Node Pages

### DIFF
--- a/docroot/themes/custom/vagovclaro/templates/page/page--node.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/page/page--node.html.twig
@@ -50,6 +50,14 @@
     {{ page.breadcrumb }}
 
     <div class="node-columns">
+      {% set has_sidebar_first = page.sidebar_first|render|striptags|trim is not empty %}
+      {% if has_sidebar_first %}
+        <aside class="layout-sidebar-first" aria-label="Section Menu" role="complementary">
+        {{ page.sidebar_first }}
+
+        </aside>{# /.layout-sidebar-first #}
+      {% endif %}
+
       <main class="page-content clearfix" role="main">
         <div class="visually-hidden"><a id="main-content" tabindex="-1"></a></div>
         {{ page.highlighted }}
@@ -60,14 +68,6 @@
 
         {{ page.content }}
       </main>
-
-      {% set has_sidebar_first = page.sidebar_first|render|striptags|trim is not empty %}
-      {% if has_sidebar_first %}
-        <aside class="layout-sidebar-first" aria-label="Section Menu" role="complementary">
-          {{ page.sidebar_first }}
-
-        </aside>{# /.layout-sidebar-first #}
-      {% endif %}
 
       {% if page.sidebar_second %}
         <aside class="layout-sidebar-second" aria-label="Content Metadata" role="complementary">


### PR DESCRIPTION
## Description

Updates node templates to untangle the column order.

Closes #10119.


## Testing done

Performed manual tests in local dev and Q/A environments to assert proper focus order.

## Screenshots

https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/f57ff8fd-251a-4de6-b8c9-ad3ea88f0312


## QA steps

What needs to be checked to prove this works?

One can verify by reviewing a VAMC Detail Page (e.g. - https://pr16225-ck8wkzmz2uol9ecn1hd28n5epfarh9x0.ci.cms.va.gov/san-diego-health-care/programs/resources)

Pressing `Tab` repeatedly should cycle through tabs, then breadcrumbs, before cycling focus on content through left, middle, and right columns.


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
