### PR TITLE
Hide unneeded elements from JSON:API response for event and event_listing nodes

### DIFF
--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--event.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--event.yml
@@ -1,0 +1,304 @@
+uuid: 6f8c7d8a-8d93-4436-b814-30c4f7a1cf53
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.event
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: node--event
+disabled: false
+path: node/event
+resourceType: node--event
+resourceFields:
+  nid:
+    disabled: false
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: true
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  title:
+    disabled: false
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  promote:
+    disabled: true
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  breadcrumbs:
+    disabled: false
+    fieldName: breadcrumbs
+    publicName: breadcrumbs
+    enhancer:
+      id: ''
+  moderation_state:
+    disabled: false
+    fieldName: moderation_state
+    publicName: moderation_state
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  menu_link:
+    disabled: true
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: true
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: true
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  field_additional_information_abo:
+    disabled: false
+    fieldName: field_additional_information_abo
+    publicName: field_additional_information_abo
+    enhancer:
+      id: ''
+  field_additional_listings:
+    disabled: false
+    fieldName: field_additional_listings
+    publicName: field_additional_listings
+    enhancer:
+      id: ''
+  field_address:
+    disabled: false
+    fieldName: field_address
+    publicName: field_address
+    enhancer:
+      id: ''
+  field_administration:
+    disabled: false
+    fieldName: field_administration
+    publicName: field_administration
+    enhancer:
+      id: ''
+  field_body:
+    disabled: false
+    fieldName: field_body
+    publicName: field_body
+    enhancer:
+      id: ''
+  field_datetime_range_timezone:
+    disabled: false
+    fieldName: field_datetime_range_timezone
+    publicName: field_datetime_range_timezone
+    enhancer:
+      id: ''
+  field_description:
+    disabled: false
+    fieldName: field_description
+    publicName: field_description
+    enhancer:
+      id: ''
+  field_event_cost:
+    disabled: false
+    fieldName: field_event_cost
+    publicName: field_event_cost
+    enhancer:
+      id: ''
+  field_event_cta:
+    disabled: false
+    fieldName: field_event_cta
+    publicName: field_event_cta
+    enhancer:
+      id: ''
+  field_event_registrationrequired:
+    disabled: false
+    fieldName: field_event_registrationrequired
+    publicName: field_event_registrationrequired
+    enhancer:
+      id: ''
+  field_facility_location:
+    disabled: false
+    fieldName: field_facility_location
+    publicName: field_facility_location
+    enhancer:
+      id: ''
+  field_featured:
+    disabled: false
+    fieldName: field_featured
+    publicName: field_featured
+    enhancer:
+      id: ''
+  field_include_registration_info:
+    disabled: false
+    fieldName: field_include_registration_info
+    publicName: field_include_registration_info
+    enhancer:
+      id: ''
+  field_last_saved_by_an_editor:
+    disabled: true
+    fieldName: field_last_saved_by_an_editor
+    publicName: field_last_saved_by_an_editor
+    enhancer:
+      id: ''
+  field_link:
+    disabled: false
+    fieldName: field_link
+    publicName: field_link
+    enhancer:
+      id: ''
+  field_listing:
+    disabled: false
+    fieldName: field_listing
+    publicName: field_listing
+    enhancer:
+      id: ''
+  field_location_humanreadable:
+    disabled: false
+    fieldName: field_location_humanreadable
+    publicName: field_location_humanreadable
+    enhancer:
+      id: ''
+  field_location_type:
+    disabled: false
+    fieldName: field_location_type
+    publicName: field_location_type
+    enhancer:
+      id: ''
+  field_media:
+    disabled: false
+    fieldName: field_media
+    publicName: field_media
+    enhancer:
+      id: ''
+  field_meta_tags:
+    disabled: false
+    fieldName: field_meta_tags
+    publicName: field_meta_tags
+    enhancer:
+      id: ''
+  field_order:
+    disabled: false
+    fieldName: field_order
+    publicName: field_order
+    enhancer:
+      id: ''
+  field_publish_to_outreach_cal:
+    disabled: false
+    fieldName: field_publish_to_outreach_cal
+    publicName: field_publish_to_outreach_cal
+    enhancer:
+      id: ''
+  field_url_of_an_online_event:
+    disabled: false
+    fieldName: field_url_of_an_online_event
+    publicName: field_url_of_an_online_event
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--event_listing.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--event_listing.yml
@@ -1,0 +1,208 @@
+uuid: 6c470f73-ee4c-4fa9-81a0-51f2a4aa54b1
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.event_listing
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    page_limit: 50
+id: node--event_listing
+disabled: false
+path: node/event_listing
+resourceType: node--event_listing
+resourceFields:
+  nid:
+    disabled: false
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: true
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  title:
+    disabled: false
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  promote:
+    disabled: true
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  breadcrumbs:
+    disabled: false
+    fieldName: breadcrumbs
+    publicName: breadcrumbs
+    enhancer:
+      id: ''
+  moderation_state:
+    disabled: false
+    fieldName: moderation_state
+    publicName: moderation_state
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  menu_link:
+    disabled: true
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: true
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: true
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  field_administration:
+    disabled: false
+    fieldName: field_administration
+    publicName: field_administration
+    enhancer:
+      id: ''
+  field_description:
+    disabled: false
+    fieldName: field_description
+    publicName: field_description
+    enhancer:
+      id: ''
+  field_enforce_unique_combo:
+    disabled: false
+    fieldName: field_enforce_unique_combo
+    publicName: field_enforce_unique_combo
+    enhancer:
+      id: ''
+  field_intro_text:
+    disabled: false
+    fieldName: field_intro_text
+    publicName: field_intro_text
+    enhancer:
+      id: ''
+  field_last_saved_by_an_editor:
+    disabled: true
+    fieldName: field_last_saved_by_an_editor
+    publicName: field_last_saved_by_an_editor
+    enhancer:
+      id: ''
+  field_meta_tags:
+    disabled: false
+    fieldName: field_meta_tags
+    publicName: field_meta_tags
+    enhancer:
+      id: ''
+  field_office:
+    disabled: false
+    fieldName: field_office
+    publicName: field_office
+    enhancer:
+      id: ''

--- a/tests/phpunit/API/JsonApiRequestTest.php
+++ b/tests/phpunit/API/JsonApiRequestTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace tests\phpunit\API;
+
+use Tests\Support\Classes\VaGovExistingSiteBase;
+
+/**
+ * A test to confirm amount of nodes by type.
+ *
+ * @group functional
+ * @group all
+ */
+class JsonApiRequestTest extends VaGovExistingSiteBase
+{
+
+  /**
+   * Provides list of resource routes for the JSON:API response tests.
+   */
+  public function routeProvider() {
+    return [
+      ['/jsonapi/node/event'],
+      ['/jsonapi/node/event_listing'],
+      ['/jsonapi/node/news_story'],
+      ['/jsonapi/node/story_listing'],
+    ];
+  }
+
+  /**
+   * Test JSON:API responses exclude certain fields.
+   *
+   * @group services
+   * @group all
+   *
+   * @dataProvider routeProvider
+   */
+  public function testJsonApiResponseExcludesFields($route) {
+    $keysToExclude = [
+      'vid',
+      'revision_timestamp',
+      'revision_uid',
+      'revision_log',
+      'uid',
+      'promote',
+      'sticky',
+      'default_langcode',
+      'revision_default',
+      'revision_translation_affected',
+      'menu_link',
+      'content_translation_source',
+      'content_translation_outdate',
+      'field_last_saved_by_an_editor',
+    ];
+
+    $user = $this->createUser();
+    $user->addRole('content_api_consumer');
+    $user->setPassword('t3st0ma4tic');
+    $user->save();
+
+    $userInfo = ['name' => $user->getAccountName(), 'password' => 't3st0ma4tic'];
+    $json_string = $this->getBodyFromURL( "$route?page[limit]=5", $userInfo);
+
+    // Decode JSON response.
+    $collectionData = json_decode($json_string, true);
+
+    // Ensure that the collection contains items.
+    $this->assertNotEmpty($collectionData);
+
+    // Ensure that the collection contains five items.
+    $this->assertCount(5, $collectionData['data']);
+
+    // Ensure that the collection does not contain a 'uid' field.
+    $this->assertArrayNotHasKey('uid', $collectionData['data'][1]['relationships']);
+
+    // Assert that fields are not present in the collection response.
+    array_walk_recursive($collectionData['data'],
+      fn($value, $key) => $this->assertNotContains($key, $keysToExclude, "Key '$key' should not be present")
+    );
+
+    // Pick an ID from the collection.
+    $nodeUuid = $collectionData['data'][1]['id']; // Assuming the first item is always present.
+
+    // Request the individual node using the picked ID.
+    $nodeResponse = $this->getBodyFromURL( "$route/$nodeUuid", $userInfo);
+
+    // Decode JSON response for the individual node.
+    $nodeData = json_decode($nodeResponse, true);
+
+    // Assert that fields are not present in the individual node response.
+    array_walk_recursive($nodeData['data'],
+      fn($value, $key) => $this->assertNotContains($key, $keysToExclude, "Key '$key' should not be present")
+    );
+  }
+
+  /**
+   * @param string $path
+   * @param string $name
+   *
+   * @return \Psr\Http\Message\StreamInterface
+   */
+  public function getBodyFromURL(string $path, array $user): \Psr\Http\Message\StreamInterface
+  {
+    try {
+      $response = \Drupal::httpClient()->get($this->baseUrl . $path, [
+        'auth' => [$user['name'], $user['password']],
+        'headers' => [
+          'Content-Type' => 'application/json',
+        ],
+      ]);
+
+      $this->assertEquals('200', $response->getStatusCode(), 'Request returned status code ' . $response->getStatusCode());
+
+      $json_string = $response->getBody();
+    } catch (RequestException $e) {
+      fwrite(STDERR, print_r($e, TRUE));
+    }
+    return $json_string;
+  }
+}


### PR DESCRIPTION
## Description

Closes #16190

This is my first PR into this repo so I might be missing lots of things. Feel free to RTFM! me with some links...

## Testing done

A functional test is included in the PR to check for fields excluded in the configuration update. It also tests the configuration already added previously for JSON:API.

## Screenshots

N/A

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As a user with the "content_api_consumer" role
1. Go to "/jsonapi/node/event".
   - [ ] Validate that the fields listed in #16190 are not in the response.
2. Then navigate to an individual resource listed in the collection. 
   - [ ] Validate that the fields listed in #16190 are not in the response.
3. Then validate the Acceptance Criteria from issue #16190 
  - [ ] event and event_listing responses do not contain the data identified below
  - [ ] changes are delivered as json_api_extras config

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [x] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
