### PR TITLE
VACMS-16232: Removes Legacy Patch Causing Double Spacing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -380,7 +380,6 @@
                 "Internal Claro tweaks": "patches/claro-css-tweaks.patch",
                 "2767243 - Create a theme suggestion for taxonomy terms by view mode": "https://www.drupal.org/files/issues/core-theme-suggestion-for-taxonomy-view-modes-2767243-14.patch",
                 "2775665 - MenuLinkContent updateLink function generates a PHP Warning for override-able keys that are not present in the loaded entity": "https://www.drupal.org/files/issues/2021-09-17/updateLink-2775665-14.patch",
-                "2975602 - Html::serialize() escapes backslash-r to &#13;": "https://www.drupal.org/files/issues/2018-05-27/2975602-2-html_serialize.patch",
                 "Claro claro_preprocess_input()": "patches/drupal-core-claro_preprocess_input.patch",
                 "1156338 - Fixed maximum number of field values, but use «add more» similar to when cardinality «unlimited» is used": "https://www.drupal.org/files/issues/2022-01-27/drupal-fix-limited-cardinality-fields-1156338-23.patch",
                 "2942404 - Contentinfo landmark" : "https://www.drupal.org/files/issues/2023-06-30/2942404-messages-should-have-role-status.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7dc7f601e5556712d299620dcb27b2e0",
+    "content-hash": "35774bde30d44b309b85235627346447",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## Description

Relates to #16232

 Removes [legacy d.o. patch #2975602](https://drupal.org/project/drupal/issues/2975602)

## Testing done

Manual testing asserting the double spacing issue is no longer present.

This includes:
- Reviewing previous entries where this issue was known to be present.
- Creating new records and verifying that double spacing doesn't occur.


## Screenshots
There's no longer any double spacing in the address area of [the page noted in the original issue](https://pr16266-ddxmaen8oegyetikx6pjima6ad89zkfe.ci.cms.va.gov/resources/how-do-i-notify-va-of-my-intent-to-file)

![20231201--1158](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/02fcbf29-b320-44bb-a198-b4555de8e317)



Created a test Event using the following as its description:

![20231201--1206](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/60a1e99d-7d02-4cdd-a8ab-f643dad86e84)

Renders w/o double spacing:

![20231201--1221](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/607178/98d82710-9daa-4e14-996e-dee8213881a3)


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`