### PR TITLE
VACMS-15715 Create and publish VA police pages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/ckeditor": "^1.0",
         "drupal/ckeditor_abbreviation": "^4.0@alpha",
         "drupal/coder": "^8.3",
+        "drupal/codit_menu_tools": "^1.0@alpha",
         "drupal/components": "^3.0@beta",
         "drupal/computed_breadcrumbs": "^1.1",
         "drupal/config_ignore": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15ab09b7bfd2007ab71ed4e1682f834b",
+    "content-hash": "3236114c7b94a9f420f610e22b6587ed",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3143,6 +3143,50 @@
                 "source": "https://www.drupal.org/project/coder"
             },
             "time": "2023-10-15T09:55:50+00:00"
+        },
+        {
+            "name": "drupal/codit_menu_tools",
+            "version": "1.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/codit_menu_tools.git",
+                "reference": "1.0.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/codit_menu_tools-1.0.0-alpha3.zip",
+                "reference": "1.0.0-alpha3",
+                "shasum": "25eea2ccf5054d2d62027f87e597c18fc000a3d5"
+            },
+            "require": {
+                "drupal/core": "^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha3",
+                    "datestamp": "1701920607",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "swirt",
+                    "homepage": "https://www.drupal.org/user/138230"
+                }
+            ],
+            "description": "Provides code methods and examples for developers to use while managing menus.",
+            "homepage": "https://www.drupal.org/project/codit_menu_tools",
+            "support": {
+                "source": "https://git.drupalcode.org/project/codit_menu_tools"
+            }
         },
         {
             "name": "drupal/components",
@@ -26708,6 +26752,7 @@
         "drupal/cer": 10,
         "drupal/change_labels": 20,
         "drupal/ckeditor_abbreviation": 15,
+        "drupal/codit_menu_tools": 15,
         "drupal/components": 10,
         "drupal/danse_content_moderation": 10,
         "drupal/entity_block": 10,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -26,6 +26,7 @@ module:
   ckeditor: 0
   ckeditor5: 0
   ckeditor_abbreviation: 0
+  codit_menu_tools: 0
   components: 0
   computed_breadcrumbs: 0
   config: 0

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.deploy.php
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.deploy.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Post deploy file VA Gov VAMC.
+ */
+
+/**
+ * Build top VA Police page and menu items for each system.
+ */
+function va_gov_vamc_deploy_build_va_police_9001(&$sandbox) {
+  \Drupal::moduleHandler()->loadInclude('va_gov_vamc', 'install');
+  $build_bundle = 'vamc_system_va_police';
+  _va_gov_vamc_sandbox_init($sandbox, '_va_gov_vamc_get_systems_to_process', [$build_bundle]);
+  _va_gov_vamc_create_system_content_pages($sandbox, $build_bundle, 'draft');
+  return _va_gov_vamc_sandbox_complete($sandbox, "Created @total {$build_bundle} nodes.");
+}

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
@@ -10,6 +10,7 @@ use Drupal\Core\Utility\UpdateException;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
+use Drupal\va_gov_lovell\LovellOps;
 use Psr\Log\LogLevel;
 
 /**
@@ -84,7 +85,9 @@ function _va_gov_vamc_get_systems_to_process($top_task_bundle) {
   $systems_to_process = [];
   $system_nids = _va_gov_get_vamc_systems();
   $systems_with_existing_pages_nids = _va_gov_get_systems_with_existing_pages($top_task_bundle);
-  $systems_needing_pages_nids = array_diff($system_nids, $systems_with_existing_pages_nids);
+  // Also remove Lovell Federal and Lovell Tricare.
+  $non_va_lovell = [LovellOps::TRICARE_SYSTEM_ID, LovellOps::LOVELL_FEDERAL_SYSTEM_ID];
+  $systems_needing_pages_nids = array_diff($system_nids, $systems_with_existing_pages_nids, $non_va_lovell);
   if (!empty($systems_needing_pages_nids)) {
     $needy_systems = Node::loadMultiple($systems_needing_pages_nids);
     foreach ($needy_systems as $needy_system) {
@@ -127,7 +130,7 @@ function _va_gov_get_vamc_systems() {
  *   The machine name of the top task bundle.
  *
  * @return array
- *   An array of system nids that aready have one of these top task pages.
+ *   An array of system nids that already have one of these top task pages.
  */
 function _va_gov_get_systems_with_existing_pages($top_task_bundle) {
   $existing_tt_nids = \Drupal::entityQuery('node')
@@ -143,30 +146,42 @@ function _va_gov_get_systems_with_existing_pages($top_task_bundle) {
 }
 
 /**
- * Creates top task pages.
+ * Creates designated facility pages for each VAMC system.
  *
  * @param array $sandbox
  *   Hook_update_n sandbox for keeping state.
  * @param string $build_bundle
  *   The bundle name of the node to build.
+ * @param string $moderation_state
+ *   The machine name of the moderation state to assign. default: draft.
+ * @param int $weight
+ *   The weight of the menu item.
  */
-function _va_gov_vamc_create_top_task_pages(array &$sandbox, $build_bundle) {
+function _va_gov_vamc_create_system_content_pages(array &$sandbox, string $build_bundle, string $moderation_state = 'draft', int $weight = -50) {
   $cms_migrator = 1317;
   // Run through a batch of 25.
   $i = 0;
+
   foreach ($sandbox['items_to_process'] as $system_nid => $system_info) {
     if (++$i > 25) {
       break;
     }
+
     $new_tt_page = Node::create([
       'type' => $build_bundle,
-      'status' => 0,
-      'moderation_state' => 'draft',
+      'status' => ($moderation_state === 'published') ? 1 : 0,
+      'moderation_state' => $moderation_state,
       'revision_log' => 'Created automatically.',
     ]);
     // CMS migrator.
     $new_tt_page->setOwnerId($cms_migrator);
     $new_tt_page->setRevisionUserId($cms_migrator);
+    if ($moderation_state === 'published') {
+      $new_tt_page->setPublished();
+    }
+    else {
+      $new_tt_page->setUnpublished();
+    }
     $new_tt_page->setUnpublished();
     $new_tt_page->setTitle(_va_gov_vamc_get_title($build_bundle));
     $new_tt_page->set('field_administration', $system_info['field_administration']);
@@ -177,9 +192,9 @@ function _va_gov_vamc_create_top_task_pages(array &$sandbox, $build_bundle) {
       'title' => _va_gov_vamc_get_title($build_bundle),
       'link' => ['uri' => "entity:node/{$new_tt_page->id()}"],
       'menu_name' => $system_info['menu_link_name'],
-      'enabled' => 0,
+      'enabled' => ($moderation_state === 'published') ? 1 : 0,
       'parent' => $system_info['menu_item_id'],
-      'weight' => -50,
+      'weight' => $weight,
     ])->save();
 
     unset($sandbox['items_to_process'][$system_nid]);
@@ -201,6 +216,7 @@ function _va_gov_vamc_get_title($build_bundle) {
     'vamc_system_medical_records_offi' => 'Medical records office',
     'vamc_system_billing_insurance' => 'Billing and insurance',
     'vamc_system_register_for_care' => 'Register for care',
+    'vamc_system_va_police' => 'VA police',
   ];
 
   return $lookup[$build_bundle] ?? 'MISTAKE - DELETE ME';
@@ -243,7 +259,7 @@ function va_gov_vamc_update_9003() {
 function va_gov_vamc_update_9004(&$sandbox) {
   $build_bundle = 'vamc_system_billing_insurance';
   _va_gov_vamc_sandbox_init($sandbox, '_va_gov_vamc_get_systems_to_process', [$build_bundle]);
-  _va_gov_vamc_create_top_task_pages($sandbox, $build_bundle);
+  _va_gov_vamc_create_system_content_pages($sandbox, $build_bundle);
   return _va_gov_vamc_sandbox_complete($sandbox, "Created @total {$build_bundle} nodes.");
 }
 
@@ -253,7 +269,7 @@ function va_gov_vamc_update_9004(&$sandbox) {
 function va_gov_vamc_update_9005(&$sandbox) {
   $build_bundle = 'vamc_system_medical_records_offi';
   _va_gov_vamc_sandbox_init($sandbox, '_va_gov_vamc_get_systems_to_process', [$build_bundle]);
-  _va_gov_vamc_create_top_task_pages($sandbox, $build_bundle);
+  _va_gov_vamc_create_system_content_pages($sandbox, $build_bundle);
   return _va_gov_vamc_sandbox_complete($sandbox, "Created @total {$build_bundle} nodes.");
 }
 
@@ -263,7 +279,7 @@ function va_gov_vamc_update_9005(&$sandbox) {
 function va_gov_vamc_update_9006(&$sandbox) {
   $build_bundle = 'vamc_system_register_for_care';
   _va_gov_vamc_sandbox_init($sandbox, '_va_gov_vamc_get_systems_to_process', [$build_bundle]);
-  _va_gov_vamc_create_top_task_pages($sandbox, $build_bundle);
+  _va_gov_vamc_create_system_content_pages($sandbox, $build_bundle);
   return _va_gov_vamc_sandbox_complete($sandbox, "Created @total {$build_bundle} nodes.");
 }
 
@@ -294,4 +310,14 @@ function va_gov_vamc_update_9007() {
     '%ct_count' => count($alerts),
     '%ct_updated' => $updated,
   ]);
+}
+
+/**
+ * Build top VA Police page for each system.
+ */
+function va_gov_vamc_update_9008(&$sandbox) {
+  $build_bundle = 'vamc_system_va_police';
+  _va_gov_vamc_sandbox_init($sandbox, '_va_gov_vamc_get_systems_to_process', [$build_bundle]);
+  _va_gov_vamc_create_system_content_pages($sandbox, $build_bundle, 'published', -46);
+  return _va_gov_vamc_sandbox_complete($sandbox, "Created @total {$build_bundle} nodes.");
 }

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
@@ -165,30 +165,30 @@ function _va_gov_vamc_create_system_content_pages(array &$sandbox, string $build
       break;
     }
 
-    $new_tt_page = Node::create([
+    $new_page = Node::create([
       'type' => $build_bundle,
       'status' => ($moderation_state === 'published') ? 1 : 0,
       'moderation_state' => $moderation_state,
       'revision_log' => 'Created automatically.',
     ]);
     // CMS migrator.
-    $new_tt_page->setOwnerId($cms_migrator);
-    $new_tt_page->setRevisionUserId($cms_migrator);
+    $new_page->setOwnerId($cms_migrator);
+    $new_page->setRevisionUserId($cms_migrator);
     if ($moderation_state === 'published') {
-      $new_tt_page->setPublished();
+      $new_page->setPublished();
     }
     else {
-      $new_tt_page->setUnpublished();
+      $new_page->setUnpublished();
     }
-    $new_tt_page->setUnpublished();
-    $new_tt_page->setTitle(_va_gov_vamc_get_title($build_bundle));
-    $new_tt_page->set('field_administration', $system_info['field_administration']);
-    $new_tt_page->set('field_office', $system_info['field_office']);
-    $new_tt_page->save();
+    $new_page->setUnpublished();
+    $new_page->setTitle(_va_gov_vamc_get_title($build_bundle));
+    $new_page->set('field_administration', $system_info['field_administration']);
+    $new_page->set('field_office', $system_info['field_office']);
+    $new_page->save();
 
     $menuManipulator = new MenuInsert($system_info['menu_link_name']);
     $menu_item_title = "VA police";
-    $menu_item_destination = "entity:node/{$new_tt_page->id()}";
+    $menu_item_destination = "entity:node/{$new_page->id()}";
     $menu_item_description = '';
     $menu_item_enabled = TRUE;
     $parent_title = '';

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.install
@@ -5,10 +5,10 @@
  * Install file for VA Gov VAMC.
  */
 
+use Drupal\codit_menu_tools\MenuInsert;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Utility\UpdateException;
 use Drupal\field\Entity\FieldConfig;
-use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
 use Drupal\va_gov_lovell\LovellOps;
 use Psr\Log\LogLevel;
@@ -57,7 +57,7 @@ function _va_gov_vamc_sandbox_init(array &$sandbox, $counter_callback, array $ca
 function _va_gov_vamc_sandbox_complete(array &$sandbox, $completed_message) {
   // Determine when to stop batching.
   $sandbox['current'] = ($sandbox['total'] - count($sandbox['items_to_process']));
-  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  $sandbox['#finished'] = (empty($sandbox['total'])) ? 1 : ($sandbox['current'] / $sandbox['total']);
   $vars = [
     '@completed' => $sandbox['current'],
     '@total' => $sandbox['total'],
@@ -154,10 +154,8 @@ function _va_gov_get_systems_with_existing_pages($top_task_bundle) {
  *   The bundle name of the node to build.
  * @param string $moderation_state
  *   The machine name of the moderation state to assign. default: draft.
- * @param int $weight
- *   The weight of the menu item.
  */
-function _va_gov_vamc_create_system_content_pages(array &$sandbox, string $build_bundle, string $moderation_state = 'draft', int $weight = -50) {
+function _va_gov_vamc_create_system_content_pages(array &$sandbox, string $build_bundle, string $moderation_state = 'draft') {
   $cms_migrator = 1317;
   // Run through a batch of 25.
   $i = 0;
@@ -188,14 +186,15 @@ function _va_gov_vamc_create_system_content_pages(array &$sandbox, string $build
     $new_tt_page->set('field_office', $system_info['field_office']);
     $new_tt_page->save();
 
-    MenuLinkContent::create([
-      'title' => _va_gov_vamc_get_title($build_bundle),
-      'link' => ['uri' => "entity:node/{$new_tt_page->id()}"],
-      'menu_name' => $system_info['menu_link_name'],
-      'enabled' => ($moderation_state === 'published') ? 1 : 0,
-      'parent' => $system_info['menu_item_id'],
-      'weight' => $weight,
-    ])->save();
+    $menuManipulator = new MenuInsert($system_info['menu_link_name']);
+    $menu_item_title = "VA police";
+    $menu_item_destination = "entity:node/{$new_tt_page->id()}";
+    $menu_item_description = '';
+    $menu_item_enabled = TRUE;
+    $parent_title = '';
+    $adjacent_sibling = 'Policies';
+    $place_below = FALSE;
+    $menuManipulator->addMenuItem($menu_item_title, $menu_item_destination, $menu_item_description, $menu_item_enabled, $parent_title, $adjacent_sibling, $place_below);
 
     unset($sandbox['items_to_process'][$system_nid]);
   }
@@ -310,14 +309,4 @@ function va_gov_vamc_update_9007() {
     '%ct_count' => count($alerts),
     '%ct_updated' => $updated,
   ]);
-}
-
-/**
- * Build top VA Police page for each system.
- */
-function va_gov_vamc_update_9008(&$sandbox) {
-  $build_bundle = 'vamc_system_va_police';
-  _va_gov_vamc_sandbox_init($sandbox, '_va_gov_vamc_get_systems_to_process', [$build_bundle]);
-  _va_gov_vamc_create_system_content_pages($sandbox, $build_bundle, 'published', -46);
-  return _va_gov_vamc_sandbox_complete($sandbox, "Created @total {$build_bundle} nodes.");
 }


### PR DESCRIPTION
## Description

Relates to #15715 

## Testing done


## Screenshots
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/8873ec44-eaf5-43ff-9b6d-958ed8b14f7b)

![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/dfe5c474-afe2-4bb3-9beb-2aaeade98833)


![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/173f3f0a-010b-4f27-8e80-dd8db47b51cf)

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As an admin
1. Go to the [content View filtered for VA Police](https://pr16277-0bcrespkm9ddsa3mevjqzbx6veutwfql.ci.cms.va.gov/admin/content?title=&type=vamc_system_va_police&moderation_state=All&owner=All) 
   - [x] Validate that there are 139 VA Police pages.
   - [x] Validate they are all in draft.  (this is so the menu items do not show on FE until we want them too)
2. Click on 5 VA Police pages
   - [x] Validate that in each of them, 'VA police' is nearly above "Policies"  ('nearly' because  in most cases they will be placed adjacent to but on top of "Policies"  However in some cases there may be multiple menu items that appear above policies, all with the exact same weight.  This should be rare.)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
