### PR TITLE
VACMS-16108: Resolves cannot create reussable qa nodes

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -398,7 +398,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
     }
   }
 
-  _va_gov_backend_alter_standalone_page_validation($form);
+  _va_gov_backend_alter_standalone_page_validation($form, $form_state);
 
   // If Contact Information paragraph component.
   if (isset($form['field_contact_information'])) {
@@ -797,19 +797,28 @@ function _va_gov_backend_audience_topics_validation(array $form, FormStateInterf
  *
  * @param array $form
  *   Form array by reference.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current form state.
  */
-function _va_gov_backend_alter_standalone_page_validation(array &$form) {
+function _va_gov_backend_alter_standalone_page_validation(array &$form, FormStateInterface $form_state) {
+  // Check existence of 'field_standalone_page' user input. We need to use the
+  // un-sanitized user input here because of the timing of the form rebuild
+  // by the paragraph module.
+  $input = $form_state->getUserInput();
+  $standalone = !empty($input['field_standalone_page']['value']);
   // Add states + custom validation if the Standalone Page field is present.
-  if (isset($form['field_standalone_page'])) {
+  $field_tags_exists = !empty($form['field_tags']['widget']);
+  $field_related_information_exists = !empty($form['field_related_information']['widget'][0]['subform']['field_link']['widget']);
+  if (isset($form['field_standalone_page']) && $field_tags_exists && $field_related_information_exists) {
     $form['field_primary_category']['widget']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
     $form['field_tags']['widget'][0]['subform']['field_topics']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
     $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['uri']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
     $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['title']['#states']['required']['input[data-drupal-selector="edit-field-standalone-page-value"]'] = ['checked' => TRUE];
 
-    // Change field uri and title widget to optional.
-    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['uri']['#required'] = FALSE;
-    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['title']['#required'] = FALSE;
-    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['#required'] = FALSE;
+    // Require field uri and title widget if the standalone field is set.
+    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['uri']['#required'] = $standalone;
+    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['title']['#required'] = $standalone;
+    $form['field_related_information']['widget'][0]['subform']['field_link']['widget'][0]['#required'] = $standalone;
     // Buttons paragraph.
     foreach ($form['field_buttons']['widget'] as $key => $button) {
       if (is_numeric($key)) {
@@ -851,11 +860,24 @@ function _va_gov_backend_alter_standalone_page_validation(array &$form) {
  */
 function _va_gov_backend_standalone_page_validation(array &$form, FormStateInterface &$form_state) {
   if ($form_state->getValue('field_standalone_page')['value'] === 0) {
-    // If we don't unset this field, validation prevents the form from
-    // submitting. This is undesirable when the standalone option is not
-    // toggled on.
+    // If the standalone option is unset, we don't want any form errors on
+    // fields in the 'field_related_information' widget to prevent saving the
+    // form. Formerly, this was handled by using $form_state->unsetValue() on
+    // the 'field_related_information' field, but this stopped working at some
+    // point. So we conditionally remove the errors from the form state,
+    // re-applying any that do not have a 'field_related_information' parent.
+    $form_errors = $form_state->getErrors();
+    $form_state->clearErrors();
+    foreach ($form_errors as $path => $error) {
+      if (!str_starts_with($path, 'field_related_information')) {
+        $form_state->setErrorByName($path, $error);
+      }
+    }
+
+    // To prevent values from persisting on the entity.
     $form_state->unsetValue('field_related_information');
   }
+
   if (!empty($form_state->getValue('field_standalone_page')['value'])) {
     if (empty($form_state->getValue('field_primary_category'))) {
       $form['field_primary_category']['#required'] = TRUE;

--- a/tests/cypress/integration/features/content_type/q_a.feature
+++ b/tests/cypress/integration/features/content_type/q_a.feature
@@ -1,0 +1,6 @@
+@content_type__q_a
+Feature: Content Type: Reusable Q&A
+
+  Scenario: Log in and create a Reusable Q and A node.
+    Given I am logged in as a user with the "content_admin" role
+    Then I create a "q_a" node

--- a/tests/cypress/integration/step_definitions/common/i_create_a_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_create_a_node.js
@@ -392,6 +392,21 @@ const creators = {
     );
     return cy.wait(1000);
   },
+  q_a: () => {
+    cy.findAllByLabelText("Question").type(
+      `[Test Data] ${faker.lorem.word()}`,
+      { force: true }
+    );
+    cy.findAllByLabelText("Text").type(faker.lorem.sentence(), {
+      force: true,
+    });
+    cy.type_ckeditor(
+      "edit-field-answer-0-subform-field-wysiwyg-0-value",
+      faker.lorem.sentence()
+    );
+    cy.findAllByLabelText("Section").select("VACO", { force: true });
+    return cy;
+  },
 };
 
 Given("I create a {string} node", (contentType) => {


### PR DESCRIPTION
## Description

Relates to #16108

## Testing done
Cypress and manual testing.

## QA steps
As user a content admin
1. Visit /node/add/q_a
2. Fill out the required fields only and save the node
   - [x] Validate the Node saves without a form error.
3. Visit /node/add/q_a
4. Select the 'Enable standalone Resources and support page for this Q&A.' checkbox.
   - [x] Validate the link field under the 'Related information' fieldset is required

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`