### PR TITLE
VACMS-16242: Adds large square manually cropped image derivative.

### DIFF
--- a/config/sync/image.style.1_1_square_large.yml
+++ b/config/sync/image.style.1_1_square_large.yml
@@ -1,0 +1,34 @@
+uuid: bd90f725-df1c-43f4-aa5f-a6bcdd42b9ba
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.square
+  module:
+    - crop
+name: 1_1_square_large
+label: '1:1 square large'
+effects:
+  99727f11-9ba0-4b77-83c4-cf6b225c3bfd:
+    uuid: 99727f11-9ba0-4b77-83c4-cf6b225c3bfd
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: square
+      automatic_crop_provider: null
+  56613f9c-cd3a-464b-961f-12a8731ef468:
+    uuid: 56613f9c-cd3a-464b-961f-12a8731ef468
+    id: image_scale_and_crop
+    weight: 2
+    data:
+      width: 500
+      height: 500
+      anchor: center-center
+  2926c64d-82f2-4550-af7a-93abbe4797bc:
+    uuid: 2926c64d-82f2-4550-af7a-93abbe4797bc
+    id: image_scale
+    weight: 3
+    data:
+      width: 500
+      height: 500
+      upscale: false


### PR DESCRIPTION
## Description
Adds a manually cropped, 1:1 image scaled to 500x500.

Relates to #16242

## Screenshots
![Screenshot 2023-12-13 at 10 06 04 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/06741e32-582b-497f-926d-41e7377756a8)

## QA steps
As a content admine
1. Visit /sites/default/files/styles/1_1_square_large/public/2023-07/patient-nurse-hands.png
   - [x] Validate that the image is 500x500

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
