### PR TITLE
VACMS-16378: Remove content moderation widget from Term View on VA Services Taxonomy

### DIFF
--- a/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.default.yml
@@ -46,11 +46,6 @@ targetEntityType: taxonomy_term
 bundle: health_care_service_taxonomy
 mode: default
 content:
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 0
-    region: content
   description:
     type: text_default
     label: above
@@ -278,3 +273,4 @@ hidden:
   field_owner: true
   langcode: true
   search_api_excerpt: true
+  content_moderation_control: true


### PR DESCRIPTION
## Description

Relates to #16378. (or closes?)

## Testing done

Tugboat verification

## Screenshots

Tugboat evidence 

![screencapture-cms-jtrlmy1vphfmtfkmkvy6lsnwi1rbovwh-ci-cms-va-gov-health-care-life-insurance-2023-12-13-15_27_30](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/51967950/dd39aa18-e8ff-4259-a384-112f2bafbadb)


## QA steps

What needs to be checked to prove this works?

As [tanekwa.bournes@va.gov](mailto:tanekwa.bournes@va.gov)
1. Do this
   - [x] Go to [health-care/life-insurance](https://cms-jtrlmy1vphfmtfkmkvy6lsnwi1rbovwh.ci.cms.va.gov/health-care/life-insurance)
2. Then
   - [x] Confirm that there is  no Moderation state widget

What needs to be checked to prove it didn't break any related things?

As an admin [christian.burk@va.gov](mailto:christian.burk@va.gov)
1. Do this
   - [x] Go to [/taxonomy/term/1147/edit](https://cms-jtrlmy1vphfmtfkmkvy6lsnwi1rbovwh.ci.cms.va.gov/taxonomy/term/1147/edit)
2. Then
   - [x] Confirm the Editorial workflow box at the bottom still contains the expected Workflow States in the Change to: dropdown.
 
### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
