### PR TITLE
VACMS-7673: Enable metrics collection on new content types when they are created.

### DIFF
--- a/docroot/modules/custom/va_gov_content_types/src/EventSubscriber/EntityBundleCreateEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_content_types/src/EventSubscriber/EntityBundleCreateEventSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\va_gov_content_types\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\core_event_dispatcher\EntityHookEvents;
+use Drupal\core_event_dispatcher\Event\Entity\EntityBundleCreateEvent;
+use Drupal\prometheus_exporter\MetricsCollectorManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribes to EntityBundleCreateEvent events.
+ *
+ * We use this event to ensure that prometheus_exporter exports the node count
+ * for newly-created bundles.
+ */
+class EntityBundleCreateEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [];
+    $events[EntityHookEvents::ENTITY_BUNDLE_CREATE][] = ['onEntityBundleCreate'];
+    return $events;
+  }
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  private ConfigFactoryInterface $configFactory;
+
+  /**
+   * The Prometheus Exporter metrics collector manager.
+   *
+   * @var \Drupal\prometheus_exporter\MetricsCollectorManager
+   */
+  private MetricsCollectorManager $metricsCollectorManager;
+
+  /**
+   * Constructor for EntityBundleEventSubscriber objects.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Drupal\prometheus_exporter\MetricsCollectorManager $metricsCollectorManager
+   *   The Prometheus Exporter metrics collector manager.
+   */
+  public function __construct(ConfigFactoryInterface $configFactory, MetricsCollectorManager $metricsCollectorManager) {
+    $this->configFactory = $configFactory;
+    $this->metricsCollectorManager = $metricsCollectorManager;
+  }
+
+  /**
+   * Respond to the entity_bundle_create event.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Entity\EntityBundleCreateEvent $event
+   *   The event to process.
+   */
+  public function onEntityBundleCreate(EntityBundleCreateEvent $event): void {
+    $entityTypeId = $event->getEntityTypeId();
+    if ($entityTypeId !== 'node') {
+      return;
+    }
+    $this->enableNodeCountOnContentType($event->getBundle());
+  }
+
+  /**
+   * Enable node_count for the specified content type.
+   *
+   * @param string $contentType
+   *   The content type to enable.
+   */
+  public function enableNodeCountOnContentType(string $contentType): void {
+    $config = $this->configFactory->getEditable('prometheus_exporter.settings');
+    $bundles = $config->get('collectors.node_count.settings.bundles') ?? [];
+    $bundles[$contentType] = $contentType;
+    $config->set('collectors.node_count.settings.bundles', $bundles);
+    $config->save();
+    $this->metricsCollectorManager->syncPluginConfig();
+  }
+
+}

--- a/docroot/modules/custom/va_gov_content_types/va_gov_content_types.services.yml
+++ b/docroot/modules/custom/va_gov_content_types/va_gov_content_types.services.yml
@@ -1,0 +1,6 @@
+services:
+  va_gov_content_types.entity_bundle_create_event_subscriber:
+    class: Drupal\va_gov_content_types\EventSubscriber\EntityBundleCreateEventSubscriber
+    arguments: ['@config.factory', '@prometheus_exporter.metrics_collector_manager']
+    tags:
+      - { name: event_subscriber }

--- a/tests/phpunit/va_gov_content_types/functional/EventSubscriber/EntityBundleCreateEventSubscriberTest.php
+++ b/tests/phpunit/va_gov_content_types/functional/EventSubscriber/EntityBundleCreateEventSubscriberTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace tests\phpunit\va_gov_content_types\functional\EventSubscriber;
+
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\va_gov_content_types\EventSubscriber\EntityBundleCreateEventSubscriber;
+use Tests\Support\Classes\VaGovExistingSiteBase;
+
+/**
+ * Functional test of the EntityBundleCreateEventSubscriber class.
+ *
+ * @group functional
+ * @group all
+ *
+ * @coversDefaultClass \Drupal\va_gov_content_types\EventSubscriber\EntityBundleCreateEventSubscriber
+ */
+class EntityBundleCreateEventSubscriberTest extends VaGovExistingSiteBase {
+
+  use ContentTypeCreationTrait;
+
+  /**
+   * Verify that the service is registered and can be instantiated.
+   */
+  public function testServiceRegistered(): void {
+    $this->assertInstanceOf(EntityBundleCreateEventSubscriber::class, $this->container->get('va_gov_content_types.entity_bundle_create_event_subscriber'));
+  }
+
+  /**
+   * Verify the prometheus_exporter config is updated.
+   */
+  public function testOnEntityBundleCreate(): void {
+    $config = $this->container->get('config.factory')->get('prometheus_exporter.settings');
+    $bundles = $config->get('collectors.node_count.settings.bundles') ?? [];
+    // Generate a random machine name that is unlikely to exist.
+    $typeName = strtolower($this->randomMachineName(8));
+    $this->assertArrayNotHasKey($typeName, $bundles);
+
+    $this->createContentType([
+      'type' => $typeName,
+      'name' => 'My Test Content Type ' . $typeName,
+    ]);
+
+    $config = $this->container->get('config.factory')->get('prometheus_exporter.settings');
+    $bundles = $config->get('collectors.node_count.settings.bundles') ?? [];
+    $this->assertArrayHasKey($typeName, $bundles);
+  }
+
+}


### PR DESCRIPTION
## Description

Closes #7673.

## QA Steps

- [x] Automated tests pass.
- [x] https://pr16436-qkrzm3acl5nehah7qxwdwskm59eb2cvz.ci.cms.va.gov/metrics (after tests have run) should contain a reference to a new content type with 0 nodes, 0 published, 0 unpublished.