### PR TITLE
is change_labels breaking paragraph field widget?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "drupal/better_exposed_filters": "^6.0",
         "drupal/block_content_permissions": "^1.6",
         "drupal/cer": "^5.0@beta",
-        "drupal/change_labels": "dev-3326097-remove-dependency-on-drupal-autoservices#7f92f90b456ac2f394dd434257e39e1d9b3086eb",
         "drupal/ckeditor": "^1.0",
         "drupal/ckeditor_abbreviation": "^4.0@alpha",
         "drupal/coder": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -242,7 +242,6 @@
             "type": "composer",
             "url": "https://packages.drupal.org/8",
             "exclude": [
-                "drupal/change_labels"
             ]
         },
         "assets": {
@@ -271,10 +270,7 @@
                 }
             }
         },
-        "drupal/change_labels": {
-            "type": "git",
-            "url": "https://git.drupalcode.org/issue/change_labels-3326097.git"
-        }
+
     },
     "config": {
         "apcu-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -241,8 +241,6 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8",
-            "exclude": [
-            ]
         },
         "assets": {
             "type": "composer",

--- a/composer.lock
+++ b/composer.lock
@@ -2917,39 +2917,7 @@
                 "source": "https://git.drupalcode.org/project/cer"
             }
         },
-        {
-            "name": "drupal/change_labels",
-            "version": "dev-3326097-remove-dependency-on-drupal-autoservices",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/issue/change_labels-3326097.git",
-                "reference": "7f92f90b456ac2f394dd434257e39e1d9b3086eb"
-            },
-            "require": {
-                "drupal/core": "^9.2 || ^10",
-                "drupal/core_event_dispatcher": "^3 || ^4",
-                "drupal/field_event_dispatcher": "^3 || ^4",
-                "drupal/hook_event_dispatcher": "^3 || ^4"
-            },
-            "type": "drupal-module",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Rodrigo Aguilera",
-                    "homepage": "https://www.drupal.org/u/rodrigoaguilera",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "Modify labels for entity forms.",
-            "homepage": "https://drupal.org/project/change_labels",
-            "support": {
-                "issues": "https://www.drupal.org/project/issues/change_labels",
-                "source": "https://git.drupalcode.org/project/change_labels"
-            },
-            "time": "2022-12-08T18:55:31+00:00"
-        },
+
         {
             "name": "drupal/ckeditor",
             "version": "1.0.2",
@@ -26857,7 +26825,6 @@
     "stability-flags": {
         "drupal/advancedqueue": 5,
         "drupal/cer": 10,
-        "drupal/change_labels": 20,
         "drupal/ckeditor_abbreviation": 15,
         "drupal/codit_menu_tools": 15,
         "drupal/components": 10,

--- a/config/sync/core.entity_form_display.block_content.cta_with_link.default.yml
+++ b/config/sync/core.entity_form_display.block_content.cta_with_link.default.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.field.block_content.cta_with_link.field_related_info_links
     - workflows.workflow.editorial
   module:
-    - change_labels
     - content_moderation
     - field_group
     - linkit
@@ -124,8 +123,6 @@ content:
       linkit_profile: default
       linkit_auto_link_text: false
     third_party_settings:
-      change_labels:
-        add_another: 'Add another link'
   info:
     type: string_textfield
     weight: 0

--- a/config/sync/core.entity_form_display.cm_document.cm_document.default.yml
+++ b/config/sync/core.entity_form_display.cm_document.cm_document.default.yml
@@ -16,7 +16,6 @@ dependencies:
     - field.field.cm_document.cm_document.field_stakeholders
     - image.style.medium
   module:
-    - change_labels
     - content_model_documentation
     - field_group
     - image
@@ -73,8 +72,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another source'
+
   field_data_pushed_to:
     type: options_buttons
     weight: 2
@@ -83,8 +81,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another destination'
+
   field_diagram:
     type: mermaid_diagram_widget
     weight: 1
@@ -93,8 +90,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another diagram'
+
   field_link_to_cms_design_system:
     type: link_default
     weight: 5
@@ -105,8 +101,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another link to CMS Design System'
+
   field_link_to_va_design_system:
     type: link_default
     weight: 7
@@ -117,8 +112,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another link to VA design system'
+
   field_links_to_design:
     type: link_default
     weight: 4
@@ -129,8 +123,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another design link'
+
   field_links_to_research:
     type: link_default
     weight: 6
@@ -141,8 +134,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another link to research'
+
   field_other_links:
     type: link_default
     weight: 5
@@ -153,8 +145,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another link'
+
   field_related_knowledgebase:
     type: entity_reference_autocomplete
     weight: 3
@@ -167,8 +158,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another Knowledge Base article link'
+
   field_screenshots:
     type: image_image
     weight: 6
@@ -179,9 +169,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another screenshot'
-        remove_label: ''
+
   field_stakeholders:
     type: options_buttons
     weight: 4

--- a/config/sync/core.entity_form_display.node.banner.default.yml
+++ b/config/sync/core.entity_form_display.node.banner.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - workflows.workflow.editorial
   module:
     - allowed_formats
-    - change_labels
+
     - content_moderation
     - field_group
     - limited_field_widgets
@@ -110,8 +110,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another path'
+
   moderation_state:
     type: moderation_state_default
     weight: 21

--- a/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.campaign_landing_page.default.yml
@@ -524,8 +524,7 @@ content:
         show_drag_and_drop: true
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: ''
+
   field_clp_spotlight_cta:
     type: paragraphs
     weight: 16

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -31,7 +31,7 @@ dependencies:
   module:
     - address
     - allowed_formats
-    - change_labels
+
     - content_moderation
     - field_group
     - limited_field_widgets
@@ -280,8 +280,7 @@ content:
           YEARLY: '0'
       limited_field_widgets:
         limit_values: '1'
-      change_labels:
-        add_another: ''
+
   field_description:
     type: string_textfield
     weight: 3
@@ -351,8 +350,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '1'
-      change_labels:
-        add_another: ''
+
   field_location_humanreadable:
     type: string_textfield
     weight: 16

--- a/config/sync/core.entity_form_display.node.promo_banner.default.yml
+++ b/config/sync/core.entity_form_display.node.promo_banner.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - node.type.promo_banner
     - workflows.workflow.editorial
   module:
-    - change_labels
+
     - content_moderation
     - field_group
     - limited_field_widgets
@@ -93,8 +93,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another path'
+
   moderation_state:
     type: moderation_state_default
     weight: 13

--- a/config/sync/core.entity_form_display.node.service_region.default.yml
+++ b/config/sync/core.entity_form_display.node.service_region.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - node.type.service_region
     - workflows.workflow.editorial
   module:
-    - change_labels
+
     - content_moderation
     - field_group
     - limited_field_widgets
@@ -133,8 +133,7 @@ content:
         show_drag_and_drop: true
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: ''
+
   field_service_name_and_descripti:
     type: options_select
     weight: 2

--- a/config/sync/core.entity_form_display.node.vamc_system_va_police.default.yml
+++ b/config/sync/core.entity_form_display.node.vamc_system_va_police.default.yml
@@ -18,7 +18,7 @@ dependencies:
     - workflows.workflow.editorial
   module:
     - allow_only_one
-    - change_labels
+
     - content_moderation
     - entity_field_fetch
     - field_group
@@ -212,8 +212,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '1'
-      change_labels:
-        add_another: 'Add another phone number'
+
   moderation_state:
     type: moderation_state_default
     weight: 11

--- a/config/sync/core.entity_form_display.node.vba_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.vba_facility.default.yml
@@ -40,7 +40,7 @@ dependencies:
   module:
     - address
     - allowed_formats
-    - change_labels
+
     - content_moderation
     - entity_field_fetch
     - field_group
@@ -510,8 +510,7 @@ content:
         add_in_between_link_count: 3
         delete_confirmation: false
         show_drag_and_drop: true
-      change_labels:
-        add_another: ''
+
   field_location_services:
     type: entity_reference_paragraphs
     weight: 5
@@ -526,8 +525,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: ''
+
   field_media:
     type: media_library_widget
     weight: 4
@@ -617,8 +615,7 @@ content:
         show_drag_and_drop: true
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: ''
+
   field_shared_vha_location:
     type: entity_reference_autocomplete
     weight: 17

--- a/config/sync/core.entity_form_display.node.vba_facility_service.default.yml
+++ b/config/sync/core.entity_form_display.node.vba_facility_service.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - workflows.workflow.editorial
   module:
     - allow_only_one
-    - change_labels
+
     - content_moderation
     - field_group
     - limited_field_widgets
@@ -134,8 +134,7 @@ content:
         show_drag_and_drop: true
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: ''
+
   field_service_name_and_descripti:
     type: options_select
     weight: 3

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -29,7 +29,6 @@ dependencies:
     - workflows.workflow.editorial
   module:
     - address
-    - change_labels
     - content_moderation
     - entity_browser_entity_form
     - entity_field_fetch

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -450,6 +450,7 @@ content:
         add_above: '0'
         collapse_edit_all: '0'
         duplicate: '0'
+    third_party_settings: {  }
   flag:
     weight: 6
     region: content

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -450,7 +450,6 @@ content:
         add_above: '0'
         collapse_edit_all: '0'
         duplicate: '0'
-    third_party_settings: {  }
   flag:
     weight: 6
     region: content

--- a/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - field.field.paragraph.q_a_group.field_section_header
     - paragraphs.paragraphs_type.q_a_group
   module:
-    - change_labels
+
     - entity_browser_table
     - limited_field_widgets
     - text
@@ -44,8 +44,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: ''
+
   field_rich_wysiwyg:
     type: text_textarea
     weight: 1

--- a/config/sync/core.entity_form_display.taxonomy_term.va_benefits_taxonomy.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.va_benefits_taxonomy.default.yml
@@ -25,7 +25,7 @@ dependencies:
   module:
     - allow_only_one
     - allowed_formats
-    - change_labels
+
     - content_moderation
     - field_group
     - limited_field_widgets
@@ -221,8 +221,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another form'
+
   field_va_benefit_app_help:
     type: text_textarea
     weight: 8
@@ -273,8 +272,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another link'
+
   field_va_benefit_eligibility_ov:
     type: magichead_paragraphs_classic
     weight: 24
@@ -289,8 +287,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another section'
+
   field_va_benefit_legislation:
     type: link_default
     weight: 5
@@ -301,8 +298,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another link'
+
   field_va_benefit_long_summary:
     type: text_textarea
     weight: 10
@@ -321,8 +317,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another name'
+
   field_va_benefit_prerequisite:
     type: entity_reference_autocomplete
     weight: 6
@@ -335,8 +330,7 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '0'
-      change_labels:
-        add_another: 'Add another link'
+
   field_va_benefit_teaser_summary:
     type: string_textarea_with_counter
     weight: 7

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -22,7 +22,7 @@ module:
   block_diff_ui: 0
   breakpoint: 0
   cer: 0
-  change_labels: 0
+
   ckeditor5: 0
   ckeditor_abbreviation: 0
   codit_menu_tools: 0


### PR DESCRIPTION
## Description

Back when QAing a PR, I noticed a [weird behavior on the Paragraphs Field widget settings](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/16145#discussion_r1396005350)

Seems like this code is adding the `Button label for "Add another` anytime a field widget settings is called, even if we don't want it to
https://git.drupalcode.org/issue/change_labels-3326097/-/blob/1.0.x/src/AutoEventSubscriber/ChangeAddAnotherLabelSubscriber.php



## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
