### PR TITLE
VACMS-16322 Fix VC Outstation typo

### DIFF
--- a/config/sync/field.field.node.vet_center_outstation.field_official_name.yml
+++ b/config/sync/field.field.node.vet_center_outstation.field_official_name.yml
@@ -14,7 +14,7 @@ id: node.vet_center_outstation.field_official_name
 field_name: field_official_name
 entity_type: node
 bundle: vet_center_outstation
-label: 'Name of Vet Center - Oustation'
+label: 'Name of Vet Center - Outstation'
 description: 'The official name of the Vet Center. To request a correction or update, <a class="admin-help-email-tpl" target="_blank" href="mailto:api@va.gov?bcc=vadrupalcms@va.gov&subject=Requested updates to [js_entry_facility_name] facility data&body=Dear API team,%0D%0A%0D%0AI would like to request an update to data for my facility.%0D%0A%0D%0AFacility%0D%0AFacility Name: [js_entry_facility_name]%0D%0AFacility ID: [js_entry_facility_id]%0D%0A%0D%0AAffected data%0D%0AThe following type of information needs to be updated:%0D%0A[Add your response here, for example: facility name, address, phone number, etc.]%0D%0A%0D%0ARequested Update%0D%0APlease make the following changes:%0D%0A[Add your response here, for example, ''change street address from 123 Fake Street to 456 Real Street.'']">email an administrator</a>.'
 required: false
 translatable: true


### PR DESCRIPTION
## Description

Relates to #16322 


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As any user 
1. Go to [a Vet Center Outstation](https://pr16482-b62wvnvjfnjt4fhc1kqi6v4vtzwjwl9g.ci.cms.va.gov/san-juan-vet-center/st-thomas-vet-center-outstation) 
   - [ ] Validate that below the page title you see "Name of Vet Center - Outstation"  and not "Oustation"
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/8b271e56-37e9-48b8-86ed-58e2e0ff48a5)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
