### PR TITLE
Add field_last_saved_by_an_editor back to JSON:API responses

### DIFF
--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--event.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--event.yml
@@ -243,7 +243,7 @@ resourceFields:
     enhancer:
       id: ''
   field_last_saved_by_an_editor:
-    disabled: true
+    disabled: false
     fieldName: field_last_saved_by_an_editor
     publicName: field_last_saved_by_an_editor
     enhancer:

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--event_listing.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--event_listing.yml
@@ -189,7 +189,7 @@ resourceFields:
     enhancer:
       id: ''
   field_last_saved_by_an_editor:
-    disabled: true
+    disabled: false
     fieldName: field_last_saved_by_an_editor
     publicName: field_last_saved_by_an_editor
     enhancer:

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--news_story.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--news_story.yml
@@ -197,7 +197,7 @@ resourceFields:
     enhancer:
       id: ''
   field_last_saved_by_an_editor:
-    disabled: true
+    disabled: false
     fieldName: field_last_saved_by_an_editor
     publicName: field_last_saved_by_an_editor
     enhancer:

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--person_profile.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--person_profile.yml
@@ -207,7 +207,7 @@ resourceFields:
     enhancer:
       id: ''
   field_last_saved_by_an_editor:
-    disabled: true
+    disabled: false
     fieldName: field_last_saved_by_an_editor
     publicName: field_last_saved_by_an_editor
     enhancer:

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--story_listing.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--story_listing.yml
@@ -183,7 +183,7 @@ resourceFields:
     enhancer:
       id: ''
   field_last_saved_by_an_editor:
-    disabled: true
+    disabled: false
     fieldName: field_last_saved_by_an_editor
     publicName: field_last_saved_by_an_editor
     enhancer:

--- a/tests/phpunit/API/JsonApiRequestTest.php
+++ b/tests/phpunit/API/JsonApiRequestTest.php
@@ -21,6 +21,7 @@ class JsonApiRequestTest extends VaGovExistingSiteBase {
       ['/jsonapi/node/event'],
       ['/jsonapi/node/event_listing'],
       ['/jsonapi/node/news_story'],
+      ['/jsonapi/node/person_profile'],
       ['/jsonapi/node/story_listing'],
     ];
   }
@@ -48,7 +49,6 @@ class JsonApiRequestTest extends VaGovExistingSiteBase {
       'menu_link',
       'content_translation_source',
       'content_translation_outdate',
-      'field_last_saved_by_an_editor',
     ];
 
     $user = $this->createUser();


### PR DESCRIPTION
## Description

Relates to work in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16382 . Just need to add a field back to the JSON:API response so it can be used on the frontend.

## Testing done

Modified and ran PHPUnit test in `tests/phpunit/API/JsonApiRequestTest.php`. Manually tested using QA steps.

## QA steps

1. Use these paths for testing '/jsonapi/node/event', '/jsonapi/node/event_listing', '/jsonapi/node/news_story', '/jsonapi/node/person_profile', '/jsonapi/node/story_listing'
2. Log into the CMS as a user who can access JSON:API resources. "content_api_consumer" is a role with those permissions. 
3. Load each resource collection listed above and make sure `field_last_saved_by_an_editor` is included in the response.
4. Navigate to an individual item in each collection and make sure `field_last_saved_by_an_editor` is included in the response.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [x] `Accelerated Publishing`

