### PR TITLE
VACMS-7563 Change 80 mile radius to 120 in help text.

### DIFF
--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -308,7 +308,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       '<p class="vc-help-text"><strong>Review nearby locations</strong>
       <br />Nearby locations provide alternative
         options to the main and satellite locations and are automatically selected based on the
-        five closest locations in an 80-mile radius.</p>
+        five closest locations in an 120-mile radius.</p>
 
         <p class="vc-help-text"><a target="_blank" href="@preview_link">Preview page to review nearby locations (opens in a new tab)</a></p>
 


### PR DESCRIPTION
## Description

Relates to #7563

## Testing done
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/784d96d8-4825-4d27-b668-e48905cae0cc)


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As an admin
1. Go to a Vet Center locations list page /node/28186/edit
   - [x] Validate the help text under the "Nearby Vet Centers and Outstations" says "120-mile radius"


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

