### PR TITLE
Refresh Tugboat Preview ID cache from PR cache scope

### DIFF
--- a/.github/workflows/tugboat-refresh-cache-dispatch.yml
+++ b/.github/workflows/tugboat-refresh-cache-dispatch.yml
@@ -5,16 +5,14 @@ on:
     - cron: '0 */6 * * *'
 jobs:
   # Collects the cache keys that need to be refreshed
-  collect_cache_keys:
-    name: Collect Tugboat Preview ID cache keys that need to be refreshed
-    outputs:
-      matrix: ${{ steps.cache-keys.outputs.result }}
+  dispatch_cache_keys:
+    name: Dispatch Tugboat Preview ID cache keys that need to be refreshed
     runs-on: ubuntu-latest
     steps:
       - name: Cross reference open PRs against cache keys in repo
-        id: cache-keys
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
+          github-token: ${{ secrets.LABEL_API_TOKEN }}
           script: |
             const prs = await github.paginate(
               github.rest.pulls.list,
@@ -43,32 +41,14 @@ jobs:
               console.log(`Key: ${key}`)
             }
 
-            const toRefresh = []
             for (const pr of prs) {
               if (cacheKeys.includes(`${{ runner.os }}-tugboat-preview-id-pr-${pr}`)) {
                 console.log(`Need to refresh: ${pr}`)
-                toRefresh.push(pr)
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: `${pr}`,
+                  labels: ['refresh-tugboat-cache'],
+                });
               }
             }
-
-            const result = JSON.stringify(toRefresh)
-            console.log(`Refresh Keys: ${result}`)
-            return result
-          result-encoding: string
-
-  # Refresh cache for given keys
-  refresh_cache:
-    name: Refresh cache for given keys
-    needs: [ collect_cache_keys ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        value: ${{fromJSON(needs.collect_cache_keys.outputs.matrix)}}
-    steps:
-      - name: Refresh Preview ID
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: .tugboat_preview.txt
-          key: ${{ runner.os }}-tugboat-preview-id-pr-${{ matrix.value }}
-      - name: Cleanup temporary file
-        run: rm .tugboat_preview.txt

--- a/.github/workflows/tugboat-refresh-cache-responder.yml
+++ b/.github/workflows/tugboat-refresh-cache-responder.yml
@@ -1,0 +1,29 @@
+
+
+name: Refresh Tugboat Preview ID Cache
+on:
+  pull_request:
+    types: [ labeled ]
+jobs:
+  refresh_cache:
+    name: Refresh Tugboat Preview ID Cache
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'refresh-tugboat-cache' }}
+    steps:
+      - name: Refresh Preview ID
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: .tugboat_preview.txt
+          key: ${{ runner.os }}-tugboat-preview-id-pr-${{ github.event.pull_request.number }}
+      - name: Cleanup temporary file
+        run: rm .tugboat_preview.txt
+      - name: Remove refresh label
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              name: 'refresh-tugboat-cache',
+            });


### PR DESCRIPTION
## Description

Resolves #16561

## Testing done

Tested in va.gov-cms-test using https://github.com/department-of-veterans-affairs/va.gov-cms-test/pull/1469. The last two triggered refreshes were successful. Note the name of the workflow job was updated to clarify functionality.

## Screenshots

<img width="874" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/b09f44ce-5c5b-4189-9890-ebde6bfd8741">
<img width="1359" alt="image" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/2030323/9490699f-b244-4d16-a61c-4cd2497f6bb7">


## QA steps

TBD

- The cache refresh workflow is tested in this PR. The cron trigger update won't take effect until merged to main.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
