### PR TITLE
VACMS-16642 Remove Drush launcher in preparation for upgrade to drush 12

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -111,10 +111,6 @@ services:
         - echo "${OAUTH_PUBLIC_KEY}" >> ${TUGBOAT_ROOT}/public.key
         - echo "${OAUTH_PRIVATE_KEY}" >> ${TUGBOAT_ROOT}/private.key
 
-        # Install drush-launcher, if desired.
-        - wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
-        - chmod +x /usr/local/bin/drush
-
         # Link the document root to the expected path. This example links /docroot
         # to the docroot.
         - ln -snf "${TUGBOAT_ROOT}/docroot" "${DOCROOT}"

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -210,14 +210,14 @@ services:
 
 
         # https://www.drush.org/latest/deploycommand/ (updatedb, cache:rebuild, config:import, deploy:hook)
-        - drush deploy
+        - bash -lc 'drush deploy'
 
         # Disable sitewide alerts so as not to interfere with testing.
-        - drush sitewide-alert:disable
+        - bash -lc 'drush sitewide-alert:disable'
 
         # Prevent continuous releases from running on Tugboat, and reset to ready.
-        - drush sset va_gov_build_trigger.continuous_release_enabled 0
-        - drush sset va_gov_build_trigger.release_state ready
+        - bash -lc 'drush sset va_gov_build_trigger.continuous_release_enabled 0'
+        - bash -lc 'drush sset va_gov_build_trigger.release_state ready'
 
         # Setup background processing service.  This uses runit to keep process up
         # See https://docs.tugboat.qa/setting-up-services/how-to-set-up-services/running-a-background-process


### PR DESCRIPTION
## Description

Closes #16642.

## Testing done
https://tugboat.vfs.va.gov/6595b708ad79a291083265b6

## Screenshots


## QA steps

Drush commands ran successfully. (See logs)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
