### PR TITLE
VACMS-15901: Removes facilities not in user sections

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -419,12 +419,12 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
   // Only run when on a node.
   // Additionally, reduce the number of times called when editing a paragraph,
   // which will have a triggering_element set.
-  if (isset($form['#entity_type'])
-    && $form['#entity_type'] === 'node'
-    && (!$form_state->getTriggeringElement())) {
+  $base_form_id = $form_state->getBuildInfo()['base_form_id'] ?? '';
+  if ((!$form_state->getTriggeringElement()) && ($base_form_id === "node_form")) {
     $targets = [
       'field_office',
       'field_listing',
+      'field_facility_location',
     ];
     _va_gov_backend_dropdown_field_access($form, $targets);
   }
@@ -1043,6 +1043,13 @@ function _va_gov_backend_dropdown_field_access(array &$form, array $targets) {
             if (!in_array($option_key, $allowed_options)) {
               unset($form[$target]['widget']['#options'][$header_key][$option_key]);
             }
+          }
+        }
+        elseif (!empty($option_header)) {
+          // If not an array, it's just an option.
+          // If not in the allowed items array, take it out.
+          if (!in_array($header_key, $allowed_options)) {
+            unset($form[$target]['widget']['#options'][$header_key]);
           }
         }
       }

--- a/tests/cypress/integration/features/content_type/vba_facility_service.feature
+++ b/tests/cypress/integration/features/content_type/vba_facility_service.feature
@@ -1,0 +1,21 @@
+@content_type__vba_facility_service
+Feature: CMS User may effectively interact with the VBA Facility service form
+  In order to confirm that cms user have access to the necessary functionality
+  As anyone involved in the project
+  I need to have certain functionality available
+
+  Scenario: Log in and try to create a VBA Facility service as a VBA editor
+    When I am logged in as a user with the roles "content_creator_vba, content_publisher"
+    And my workbench access sections are set to "1065"
+    And I am at "/node/add/vba_facility_service"
+    Then I should see an option with the text "Columbia VA Regional Benefit Office" from dropdown with selector "#edit-field-office"
+    And I should not see an option with the text "Cheyenne VA Regional Benefit Office" from dropdown with selector "#edit-field-office"
+
+Scenario: Log in and try to create a VBA Facility service as a VBA editor with 2 sections
+    When I am logged in as a user with the roles "content_creator_vba, content_publisher"
+    And my workbench access sections are set to "1065,1104"
+    And I am at "/node/add/vba_facility_service"
+    Then I should see an option with the text "Cheyenne VA Regional Benefit Office" from dropdown with selector "#edit-field-office"
+    And I should see an option with the text "Columbia VA Regional Benefit Office" from dropdown with selector "#edit-field-office"
+    And I should not see an option with the text "Denver VA Regional Benefit Office" from dropdown with selector "#edit-field-office"
+


### PR DESCRIPTION
## Description

Relates to #15901
Relates to #15391
Relates to #7538
Relates to #12737
Relates to #15906

## Testing done
Manually
Cypress

## Screenshots
### VBA Facility Service (intended content type)
![Screenshot 2024-01-08 at 1 12 43 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/140a083b-22af-4cf1-a9c7-0f1c00e189a4)


### Events (an affected content type)
![Screenshot 2024-01-05 at 3 34 57 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/b545e5fe-53f9-450d-b2df-057be9be8b4c)


## QA steps

### What needs to be checked to prove this works?

- [x] Create facility service as editor in Cheyenne VA Regional Benefit Office
  - [x] Log in as "test_Chanelle18"
  - [x] Create a [VBA Facility service](https://pr16663-qymzgx6nhcrlbdd8ahjuxg5xqw6l4sff.ci.cms.va.gov/node/add/vba_facility_service) 
  - [x] Confirm that the **Facility** dropdown only shows facilities in the "Cheyenne VA Regional Benefit Office" section
  - [x] Choose "VA Regional Benefit Satellite Office at Sheridan VA Medical Center" from the **Facility** dropdown
  - [x] Choose "Home Loans" from the **Service name** dropdown
  - [x] Save the node
  - [x] Log out
- [x] Edit facility as editor in Cheyenne and Columbia sections
  - [x] Log in as "test_Lucy.Abernathy30" 
  - [x] Edit the "Home loans" service you just created
  - [x] Confirm that the **Facility** dropdown only shows facilities in the Cheyenne and Columbia sections

### What needs to be checked to prove it didn't break any related things?

- [x] Spot-check one content type for each of the winnowed fields
  - [x] Create an Event (to check `field_listing`)
    - [x] Log in as "QA Content Publisher," an editor in only one section
      - [x] Create an [event](https://pr16663-qymzgx6nhcrlbdd8ahjuxg5xqw6l4sff.ci.cms.va.gov/node/add/event)
      - [x] Confirm that you can only choose a facility in the user's section from the **Where should the event be listed?** dropdown.
    - [x] Log in as "Victor.A.MCtest," an editor in the "Outreach hub" and other sections
    - [x] Create an [event](https://pr16663-qymzgx6nhcrlbdd8ahjuxg5xqw6l4sff.ci.cms.va.gov/node/add/event)
      - [x] Confirm that you can only choose a facility in the user's sections or "Outreach and events: outreach events" from the **Where should the event be listed?** dropdown.
  - [x] Create a VAMC Facility Health Service (to check `field_facility_location`)
    - [x] As Victor.A.MCtest, create a [VAMC Facility health service](https://pr16663-qymzgx6nhcrlbdd8ahjuxg5xqw6l4sff.ci.cms.va.gov/node/add/health_care_local_health_service)
    - [x] Confirm that you can only choose a facility in one of the user's sections from the **Facility** dropdown.
  - [x] Create a VAMC Detail Page (to check `field_office`)
    - [x]  As Victor.A.MCtest, create a [VAMC Detail Page](https://pr16663-qymzgx6nhcrlbdd8ahjuxg5xqw6l4sff.ci.cms.va.gov/node/add/health_care_region_detail_page).
    - [x] Confirm that you can only choose a VAMC system in one of the user's sections from the **Related office or health care system** dropdown.

Testing Google spreadsheet:
https://docs.google.com/spreadsheets/d/17WXvo_QAPvB02Xlm0_np1uQWy83u3dbfJnRxAQdG_h0/edit#gid=0

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`



