### PR TITLE
VACMS-16543: turn off Create for simplesamlphp_auth, prevent ghost accounts

### DIFF
--- a/config/local/simplesamlphp_auth.settings.yml
+++ b/config/local/simplesamlphp_auth.settings.yml
@@ -9,7 +9,7 @@ header_no_cache: false
 role:
   population: ''
   eval_every_time: false
-register_users: true
+register_users: false
 allow:
   set_drupal_pwd: true
   default_login: true

--- a/config/prod/simplesamlphp_auth.settings.yml
+++ b/config/prod/simplesamlphp_auth.settings.yml
@@ -4,7 +4,7 @@ login_link_display_name: 'Login with PIV or other Smartcard.'
 debug: false
 secure: true
 httponly: false
-register_users: true
+register_users: false
 header_no_cache: false
 allow:
   default_login: true

--- a/config/stg/simplesamlphp_auth.settings.yml
+++ b/config/stg/simplesamlphp_auth.settings.yml
@@ -4,7 +4,7 @@ login_link_display_name: 'Login with PIV or other Smartcard.'
 debug: false
 secure: true
 httponly: false
-register_users: true
+register_users: false
 header_no_cache: false
 allow:
   default_login: true

--- a/config/tugboat/simplesamlphp_auth.settings.yml
+++ b/config/tugboat/simplesamlphp_auth.settings.yml
@@ -4,7 +4,7 @@ login_link_display_name: 'Login with PIV or other Smartcard.'
 debug: true
 secure: true
 httponly: false
-register_users: true
+register_users: false
 header_no_cache: false
 allow:
   default_login: true


### PR DESCRIPTION
## Description

Closes #16543.

## Testing done

Tested on test.prod with my account and Erika Washburns assistance. Confirmed turning this off prevents someone from logging in unless an account has already been created for them. 

## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

Should be good as long as automated testing passes.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
