### PR TITLE
Update queue_runner.sh

### DIFF
--- a/scripts/queue_runner/queue_runner.sh
+++ b/scripts/queue_runner/queue_runner.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -l
 
 cd "${TUGBOAT_ROOT}"
 ./bin/drush advancedqueue:queue:process command_runner 2>&1


### PR DESCRIPTION
Should actually kick off automatic content builds on Tugboat, which've been broken since #16654.