### PR TITLE
VACMS-15318 Add feature toggle for mobile app promo banners

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -5,3 +5,4 @@ features:
   feature_single_value_field_link: FEATURE_SINGLE_VALUE_FIELD_LINK
   feature_health_connect_number: FEATURE_HEALTH_CONNECT_NUMBER
   feature_next_story_preview: FEATURE_NEXT_STORY_PREVIEW
+  feature_mobile_app_promo: FEATURE_MOBILE_APP_PROMO


### PR DESCRIPTION
Ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15318

Adding a feature toggle to control display of the mobile app promo banners on iOS Chrome and Android Chrome & Firefox. We need a way to quickly turn the banners off if they cause problems in production. This will be removed when we have confirmed the functionality is stable.