### PR TITLE
VACMS-16237: Replace s3 address for assets.

### DIFF
--- a/scripts/web-build.sh
+++ b/scripts/web-build.sh
@@ -14,7 +14,7 @@ pushd "${repo_root}" > /dev/null
 composer va:web:prepare-dotenv
 touch ./.buildlock
 
-build_type="localhost"
+build_type="vagovdev"
 web_path="./web"
 build_path="${web_path}/build/${build_type}"
 rm -rf "${build_path}"
@@ -32,6 +32,20 @@ yarn build \
   --api="${build_api_url}" \
   --buildtype="${build_type}"
 popd
+
+echo "Replacing s3 address with local in generated files."
+assets_base_url="https://dev-va-gov-assets\.s3-us-gov-west-1\.amazonaws\.com"
+find \
+  "${build_path}/generated" \
+  -type f \
+  -exec sed -i "s#${assets_base_url}##g" {} \+;
+
+echo "Replacing s3 address with local in built content."
+dev_base_url="https://s3-us-gov-west-1\.amazonaws\.com/content\.dev\.va\.gov"
+find \
+  "${build_path}" \
+  -type f \
+  -exec sed -i -e "s#${dev_base_url}##g" {} \+;
 
 rm ./.buildlock
 

--- a/scripts/web-build.sh
+++ b/scripts/web-build.sh
@@ -14,10 +14,9 @@ pushd "${repo_root}" > /dev/null
 composer va:web:prepare-dotenv
 touch ./.buildlock
 
-build_type="vagovdev"
+build_type="localhost"
 web_path="./web"
 build_path="${web_path}/build/${build_type}"
-assets_base_url="https://dev-va-gov-assets\.s3-us-gov-west-1\.amazonaws\.com"
 rm -rf "${build_path}"
 
 pushd "${web_path}"
@@ -33,19 +32,6 @@ yarn build \
   --api="${build_api_url}" \
   --buildtype="${build_type}"
 popd
-
-echo "Replacing s3 address with local in generated files."
-find \
-  "${build_path}/generated" \
-  -type f \
-  -exec sed -i -e "s#${assets_base_url}##g" {} \+;
-
-echo "Replacing s3 address with local in built content."
-dev_base_url="https://s3-us-gov-west-1\.amazonaws\.com/content\.dev\.va\.gov"
-find \
-  "${build_path}" \
-  -type f \
-  -exec sed -i -e "s#${dev_base_url}##g" {} \+;
 
 rm ./.buildlock
 

--- a/scripts/web-build.sh
+++ b/scripts/web-build.sh
@@ -18,6 +18,7 @@ build_type="vagovdev"
 web_path="./web"
 build_path="${web_path}/build/${build_type}"
 assets_base_url="https://dev-va-gov-assets\.s3-us-gov-west-1\.amazonaws\.com"
+assets2_base_url="https://s3-us-gov-west-1\.amazonaws\.com/content\.dev\.va\.gov"
 rm -rf "${build_path}"
 
 pushd "${web_path}"
@@ -38,7 +39,14 @@ echo "Replacing s3 address with local in generated files."
 find \
   "${build_path}/generated" \
   -type f \
-  -exec sed -i "s#${assets_base_url}##g" {} \+;
+  -exec sed -i -e "s#${assets_base_url}##g" {} \+;
+
+echo "Replacing s3 address with local in built content."
+dev_base_url="https://s3-us-gov-west-1\.amazonaws\.com/content\.dev\.va\.gov"
+find \
+  "${build_path}" \
+  -type f \
+  -exec sed -i -e "s#${dev_base_url}##g" {} \+;
 
 rm ./.buildlock
 

--- a/scripts/web-build.sh
+++ b/scripts/web-build.sh
@@ -18,7 +18,6 @@ build_type="vagovdev"
 web_path="./web"
 build_path="${web_path}/build/${build_type}"
 assets_base_url="https://dev-va-gov-assets\.s3-us-gov-west-1\.amazonaws\.com"
-assets2_base_url="https://s3-us-gov-west-1\.amazonaws\.com/content\.dev\.va\.gov"
 rm -rf "${build_path}"
 
 pushd "${web_path}"


### PR DESCRIPTION
## Description

See #16237.

This does not fix all of the problem, but I think this fixes the immediate problem. There's a deeper, more significant issue with `vets-website` and `content-build`, I think, that will require considerable more effort (and greater risk) to fix.

## QA Steps
- [x] Navigate to https://web-xdksfw5fi4p35n7uzvs52f3zp306zypa.ci.cms.va.gov/
- [x] Verify that the source of the `content-build.css` file is local, not Dev.
- ![Screenshot 2024-01-09 at 5 12 03 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/1318579/dc368ae4-20e7-49be-a22a-fddb48a60438)

