### PR TITLE
Update character count status message on "Rich text - 1000 character limit" paragraph type

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.q_a_group.default.yml
@@ -66,7 +66,7 @@ content:
       counter_position: after
       js_prevent_submit: true
       count_html_characters: false
-      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
     third_party_settings: {  }
   translation:
     weight: 10

--- a/config/sync/core.entity_form_display.paragraph.rich_text_char_limit_1000.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.rich_text_char_limit_1000.default.yml
@@ -24,7 +24,7 @@ content:
       counter_position: after
       js_prevent_submit: true
       count_html_characters: false
-      textcount_status_message: 'Characters remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
     third_party_settings:
       allowed_formats:
         hide_help: '0'


### PR DESCRIPTION
## Description

Relates to #16659. 

#16659 provides new guidance on how the status message on character count status messages should be worded. This PR would update wording on the Paragraph Type: **Rich text - 1000 character limit**.

This came out of [feedback](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16073) from the [VBA Regional Office CMS collab cycle](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10241). The Facilities team is using the paragraph type on VBA Centralized Content.

However, the paragraph type is primarily used on Public Websites products:

![entity-diagram-paragraph-rich-text-char-limit-1000](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/51967950/59b39765-ede1-4f46-8421-9d7bc7d81afc)


## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
