### PR TITLE
[DOCS] Add steps for fixing aliases and names in the CMS for term changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/taxonomy-update-term.yml
+++ b/.github/ISSUE_TEMPLATE/taxonomy-update-term.yml
@@ -75,6 +75,7 @@ body:
       - [ ] Content is reviewed by relevant stakeholders
       - [ ] (List any necessary review and approval steps here)
       - [ ] Term is published
+      If term is a VA Service:
       - [ ] Bulk resave system services to pick up name change (filtered for the old name)
       - [ ] Bulk Update alias for all system services (filtered for new name)
       - [ ] Bulk update facility services (filtered for the old name)

--- a/.github/ISSUE_TEMPLATE/taxonomy-update-term.yml
+++ b/.github/ISSUE_TEMPLATE/taxonomy-update-term.yml
@@ -75,7 +75,7 @@ body:
       - [ ] Content is reviewed by relevant stakeholders
       - [ ] (List any necessary review and approval steps here)
       - [ ] Term is published
-      If term is a VA Service:
+      If term is part of VA Service Taxonomy & the term name changes:
       - [ ] Bulk resave system services to pick up name change (filtered for the old name)
       - [ ] Bulk Update alias for all system services (filtered for new name)
       - [ ] Bulk update facility services (filtered for the old name)

--- a/.github/ISSUE_TEMPLATE/taxonomy-update-term.yml
+++ b/.github/ISSUE_TEMPLATE/taxonomy-update-term.yml
@@ -75,5 +75,9 @@ body:
       - [ ] Content is reviewed by relevant stakeholders
       - [ ] (List any necessary review and approval steps here)
       - [ ] Term is published
+      - [ ] Bulk resave system services to pick up name change (filtered for the old name)
+      - [ ] Bulk Update alias for all system services (filtered for new name)
+      - [ ] Bulk update facility services (filtered for the old name)
+      - [ ] Bulk update alias for all facility services (filtered for new name)
   validations:
     required: true


### PR DESCRIPTION
## Description

Relates to this [Slack thread](https://dsva.slack.com/archives/C0FQSS30V/p1704910454485849) 

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user facilities team member
   - [ ] Validate that the step added to the ACs in this template match the steps that [will one day be automated](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7315) 


### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
