### PR TITLE
VACMS-14623: Staff profile has no alias on publish

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1945,6 +1945,12 @@ function _va_gov_backend_disable_autopath_alias(FieldableEntityInterface $entity
       // Disable the pathauto pattern.
       $entity->path->pathauto = 0;
     }
+    elseif (!$path_alias_set) {
+      // If this is not set pathauto already is 0,
+      // so we need to explicitly set it to 1
+      // to get an alias generated.
+      $entity->path->pathauto = 1;
+    }
   }
 }
 

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1933,10 +1933,10 @@ function _va_gov_backend_disable_autopath_alias(FieldableEntityInterface $entity
     $toggled_on_this_save = $current_use_alias_pattern && !$original_use_alias_pattern;
     $active_entity = \Drupal::entityTypeManager()->getStorage('node')->load($entity->id());
     $published_previously = ($active_entity instanceof NodeInterface) ? $active_entity->isPublished() : FALSE;
-    // Determine whether path alias is set.
     $path = '/node/' . (int) $active_entity->nid->value;
     $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
     $path_alias = \Drupal::service('path_alias.manager')->getAliasByPath($path, $langcode);
+    // If the path_alias is the node path, alias is not set.
     $path_alias_set = (bool) preg_match('/\/node\/\d+/', $path_alias) ? FALSE : TRUE;
 
     if ($path_alias_set && $published_previously && !$toggled_on_this_save) {

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1933,9 +1933,15 @@ function _va_gov_backend_disable_autopath_alias(FieldableEntityInterface $entity
     $toggled_on_this_save = $current_use_alias_pattern && !$original_use_alias_pattern;
     $active_entity = \Drupal::entityTypeManager()->getStorage('node')->load($entity->id());
     $published_previously = ($active_entity instanceof NodeInterface) ? $active_entity->isPublished() : FALSE;
+    // Determine whether path alias is set.
+    $path = '/node/' . (int) $active_entity->nid->value;
+    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $path_alias = \Drupal::service('path_alias.manager')->getAliasByPath($path, $langcode);
+    $path_alias_set = (bool) preg_match('/\/node\/\d+/', $path_alias) ? FALSE : TRUE;
 
-    if ($published_previously && !$toggled_on_this_save) {
-      // This was published and this was not an intentional toggle on.
+    if ($path_alias_set && $published_previously && !$toggled_on_this_save) {
+      // This has a path alias, was published,
+      // and was not an intentional toggle on.
       // Disable the pathauto pattern.
       $entity->path->pathauto = 0;
     }


### PR DESCRIPTION
## Description

Relates to #14623

## Testing done
Manually

## Screenshots
<img width="1552" alt="Screenshot 2024-01-11 at 9 17 41 AM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/1d118b5f-cca8-44d3-929a-65c833a59009">


## QA steps

### What needs to be checked to prove this works?
- [x] [Log in](https://pr16820-fgcq7ewvt3kjxag3eaygv788krkxuroi.ci.cms.va.gov/) as an admin 
- [x] Give Victor.A.MCTest the following role
  - [x] Content creator - Vet Center
- [x]  Assign Victor.A.MCTest to the following section in Workbench Access
  - [x] Albany Vet Center

### Create a staff profile, saving to Publish
- [x] [Log in](https://pr16820-fgcq7ewvt3kjxag3eaygv788krkxuroi.ci.cms.va.gov/) as Victor.A.MCTest
- [x] Create a [staff profile](https://pr16820-fgcq7ewvt3kjxag3eaygv788krkxuroi.ci.cms.va.gov/node/add/person_profile)
- [x] Fill in the required fields
- [x] Save to publish
- [x] Confirm that the staff profile has a URL alias

### Edit a staff profile, saving to Publish
- [x] As Victor.A.MCTest
- [x] Edit the staff profile you just created
- [x] Change the name of the person
- [x] Save to publish
- [x] Confirm that the staff profile URL alias is unchanged

### Create a Vet Center Community Access Point, saving to Publish
- [x] As Victor.A.MCTest
- [x] Create a [Vet Center - Community Access Point (CAP)](https://pr16820-fgcq7ewvt3kjxag3eaygv788krkxuroi.ci.cms.va.gov/node/add/vet_center_cap)
- [x] Fill in the required fields
- [x] Save to publish
- [x] Confirm that the Vet Center CAP has a URL alias

### What needs to be checked to prove it didn't break any related things?
### Create a News Release, saving to Publish
- [x] As Victor.A.MCTest
- [x] Go to create a [News Release](https://pr16820-fgcq7ewvt3kjxag3eaygv788krkxuroi.ci.cms.va.gov/node/add/press_release)
- [x] Fill in the required fields
- [x] Save to publish
- [x] Confirm that the news release has a URL alias

#### Edit a News release
As an admin, edit a node that currently has no alias. Such as https://pr16820-fgcq7ewvt3kjxag3eaygv788krkxuroi.ci.cms.va.gov/node/64553  
- [x] save the revision as published.  
- [x] validate that the alias is created.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


