### PR TITLE
VACMS-16827 Fix loading of alt text field definitions.

### DIFF
--- a/docroot/modules/custom/va_gov_media/src/EventSubscriber/MediaEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_media/src/EventSubscriber/MediaEventSubscriber.php
@@ -106,11 +106,11 @@ class MediaEventSubscriber implements EventSubscriberInterface {
       }
 
       $delta = $element['#delta'];
-      $fieldDefinition = $entity->getFieldDefinition('image');
+      $fieldDefinition = $entity->getFieldDefinition($element['#field_name']);
 
       $keys = [$element['#entity_type']];
       $keys[] = $entity->id() ? $entity->id() : 0;
-      if (method_exists($fieldDefinition, 'id')) {
+      if (is_object($fieldDefinition) && method_exists($fieldDefinition, 'id')) {
         $field_definition_id = str_replace('.', '--', $fieldDefinition->id());
       }
       else {


### PR DESCRIPTION
## Description

Relates to #16827

## Testing done


## Screenshots
This is the field screenshot (an image field) on a content model document not throwing a white screen error.   
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/220ecf90-71a2-4374-97d2-0ab395ddca99)

Here is the validation working as intended 
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/30bb83ea-d603-41a8-adf4-0b0d2c74db2f)

![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/47f0da5a-d989-463c-b053-a3f01df173e0)


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As as an admin

1. Go to https://pr16832-znatffbqk2zl4bpmw6zutmhlayqwav47.ci.cms.va.gov/admin/structure/cm_document/5/edit
   - [x] validate that there is no error and you can edit the page
   - [x] validate that you can add an image into the screenshot field.
   - [x] validate that if you put "Picture of snoopy" in the alt text that when you attempt to save you get a validation error
   - [x] validate that if you put "snoopy.jpg" in the alt text that when you attempt to save you get a validation error
   - [x] validate that if you put "a lovely black spotted beagle." in the alt text that you are able to save the CM Document.
2. Go to [edit a benefit detail page](https://pr16832-znatffbqk2zl4bpmw6zutmhlayqwav47.ci.cms.va.gov/node/3011/edit)
3. in the "Main content" field click the "Add content block" button and and choose a "Embedded image" content paragraph.
4. Add an image.  
   - [x] validate that if you put "Picture of snoopy" in the alt text that when you attempt to save you get a validation error
   - [x] validate that if you put "snoopy.jpg" in the alt text that when you attempt to save you get a validation error
   - [x] validate that if you put "a lovely black spotted beagle." in the alt text that you are able to save the Benefit detail page.
5. Navigate to [edit an existing Media entity](https://pr16832-znatffbqk2zl4bpmw6zutmhlayqwav47.ci.cms.va.gov/media/29710/edit)
    - [x] validate that if you put "Picture of snoopy" in the alt text that when you attempt to save you get a validation error
   - [x] validate that if you put "snoopy.jpg" in the alt text that when you attempt to save you get a validation error
   - [x] validate that if you put "a lovely black spotted beagle." in the alt text that you are able to save the Media entity.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
