### PR TITLE
VACMS-17018 Resolve VAMC menu assignment issues.

### DIFF
--- a/docroot/modules/custom/va_gov_media/va_gov_media.module
+++ b/docroot/modules/custom/va_gov_media/va_gov_media.module
@@ -80,4 +80,5 @@ function va_gov_media_clientside_validation_validator_info_alter(&$validators) {
   foreach ($validators as &$validator) {
     $validator['attachments']['library'][] = 'va_gov_media/cv.alt-text.validate';
   }
+  unset($validator);
 }

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -620,7 +620,7 @@ class MenuReductionService {
       return;
     }
     // This is not new so check the current parent exists in the reduced form.
-    elseif (!$current_menu_item_is_present || $this->isCurrentMenuSettingDisabled($form)) {
+    elseif (!$current_menu_item_is_present || $this->isCurrentMenuParentDisabledAndLocked($form)) {
       // Parent does not exist in reduced form, Put the original parent options
       // back to prevent data loss. The existing menu setting should not be
       // allowed, but it exists, so allow it to persist. It may have been
@@ -633,10 +633,11 @@ class MenuReductionService {
       $title .= " ($can_not_change)";
       $form['menu']['link']['menu_parent']['#title'] = $title;
     }
+
   }
 
   /**
-   * Checks to see if the current menu parent is disabled.
+   * Checks to see if the current menu parent is disabled and children locked.
    *
    * @param array $form
    *   The form array.
@@ -644,10 +645,31 @@ class MenuReductionService {
    * @return bool
    *   TRUE if the current menu parent is disabled.  FALSE otherwise.
    */
-  protected function isCurrentMenuSettingDisabled(array $form) : bool {
+  protected function isCurrentMenuParentDisabledAndLocked(array $form) : bool {
     $is_disabled = FALSE;
     $current_menu_setting = $form['menu']['link']['menu_parent']['#options'][$this->currentMenuParent] ?? '';
     if (strpos($current_menu_setting, 'Disabled no-link') !== FALSE) {
+      $is_disabled = TRUE;
+    }
+
+    return $is_disabled;
+  }
+
+  /**
+   * Checks if the current menu parent is disabled but might allow children.
+   *
+   * @param array $form
+   *   The form array.
+   * @param string $menu_parent
+   *   The id of the menu parent currently selected at node load.
+   *
+   * @return bool
+   *   TRUE if the current menu parent is disabled.  FALSE otherwise.
+   */
+  public static function isCurrentMenuParentDisabled(array $form, $menu_parent) : bool {
+    $is_disabled = FALSE;
+    $current_menu_setting = $form['menu']['link']['menu_parent']['#options'][$menu_parent] ?? '';
+    if (strpos($current_menu_setting, 'Disabled') !== FALSE) {
       $is_disabled = TRUE;
     }
 

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -616,7 +616,7 @@ class MenuReductionService {
       $form['menu']['link']['menu_parent']['#value'] = $this->currentMenuParent;
     }
     // Check for rare possibility that menu parent is the default menu root.
-    elseif ($this->currentMenuParent === "pittsburgh-health-care:") {
+    elseif (empty($this->currentMenuParent) || $this->currentMenuParent === "pittsburgh-health-care:") {
       return;
     }
     // This is not new so check the current parent exists in the reduced form.

--- a/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
+++ b/docroot/modules/custom/va_gov_menu_access/src/Service/MenuReductionService.php
@@ -270,11 +270,7 @@ class MenuReductionService {
 
         $menu_element_type = $this->getMenuItemType($alias);
         $menu_element_type = $menu_element_type ?? $this->checkForSeparator($allowed_separators, $menu_item);
-        if (str_contains($subject_uuid['option'], 'Work with us')) {
-          // This is a special case where we want to allow the menu item
-          // to be enabled.
-          $menu_element_type = self::ENABLED;
-        }
+
         $this->addAllowedParent($allowed_parents, $enabled_count, $menu_element_type, $subject_uuid);
       }
     }

--- a/docroot/modules/custom/va_gov_menu_access/va_gov_menu_access.module
+++ b/docroot/modules/custom/va_gov_menu_access/va_gov_menu_access.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\va_gov_menu_access\Service\MenuReductionService;
 
 /**
  * Implements hook_page_attachments().
@@ -55,7 +56,26 @@ function _va_gov_menu_access_hide_menu_fields(array &$form) {
  */
 function _va_gov_menu_access_set_menu_parent_requirement(array $form, FormStateInterface $form_state) {
   if ($form_state->getValue(['menu', 'enabled'])) {
-    $form['menu']['link']['menu_parent']['#required'] = TRUE;
+    $menu_parent = $form_state->getValue([
+      'menu',
+      'menu_parent',
+    ]);
+    if (MenuReductionService::isCurrentMenuParentDisabled($form, $menu_parent)) {
+      // The clientside_validation_jquery module's validation is too aggressive
+      // with the menu parent, and considers any option that is disabled as
+      // empty, even though there is a value in the option list.
+      // Since the parent field contains a disabled parent, we have to turn off
+      // clientside_validation for that field.
+      $form['menu']['link']['menu_parent']['#attributes']['novalidate'] = 'novalidate';
+      $form['menu']['link']['menu_parent']['#attributes']['formnovalidate'] = 'formnovalidate';
+      // Those should have been enough to make clientside_validation happy,
+      // but we need this too. No worries, there is drupal validation to prevent
+      // a save with no parent from succeeding.
+      $form['menu']['link']['menu_parent']['#required'] = FALSE;
+    }
+    else {
+      $form['menu']['link']['menu_parent']['#required'] = TRUE;
+    }
     $form['#validate'][] = '_va_gov_menu_access_parent_menu_selected_validation';
   }
   return $form;

--- a/docroot/modules/custom/va_gov_menu_access/va_gov_menu_access.module
+++ b/docroot/modules/custom/va_gov_menu_access/va_gov_menu_access.module
@@ -60,7 +60,7 @@ function _va_gov_menu_access_set_menu_parent_requirement(array $form, FormStateI
       'menu',
       'menu_parent',
     ]);
-    if (MenuReductionService::isCurrentMenuParentDisabled($form, $menu_parent)) {
+    if (!empty($menu_parent) && MenuReductionService::isCurrentMenuParentDisabled($form, $menu_parent)) {
       // The clientside_validation_jquery module's validation is too aggressive
       // with the menu parent, and considers any option that is disabled as
       // empty, even though there is a value in the option list.


### PR DESCRIPTION
## Description

Relates to #17018 (or closes?)


## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user RS (VAMC Content creator and content publisher in one VAMC health system section)
1. Go to https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/5579/edit
   - [x] Validate that the menu parent is "Work with us" and is not locked
   - [x] Validate that you can save the node successfully.

- [x] Validate Volunteer or donate https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/2434/edit is not locked
   - [x] Validate it can be saved. 
- [x] Validate Chaplain services https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/5683/edit is not locked.
   - [x] Validate it can be saved. 
- [x] Validate  Medical records office https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/2439/edit   (seems like this page should not exist as a detail page??)
   - [x] Validate it can be saved. 
- [x] Validate  Behavioral health providers https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/61301/edit is not locked
   - [x] Validate it can be saved. 
- [x] Validate Whole health https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/59861/edit is NOT locked
   - [x] Validate it can be saved. 
- [x] Validate VA Nursing https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/53624/edit is not locked
   - [x] Validate it can be saved. 
- [x] Validate Womens Veteran care https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/3084/edit is locked. 
   - [x] Validate it can be saved. 
2. Test creating new Go to https://pr16994-ksy8sixki8oyk0owsscsp9ijgfxn7pfi.ci.cms.va.gov/node/add/health_care_region_detail_page
   - [x] Validate that you can not pick "Work with us" as a menu parent option.
   - [x]  fill out all required fields
   - [x] Validate it can be saved when some other parent choice is made. 
3. Edit the page you just created and set the menu parent to "Select a value".
   - [x] Validate that php validation prevents the save
   - [x] Validate that you are able to select  parent after the failed save. (This was an existing defect, separate from this work.)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
