### PR TITLE
VACMS-12664: Remove wrapping ul to avoid a11y issue.

### DIFF
--- a/docroot/themes/custom/vagovclaro/templates/node/node--landing-page--support-services-listing.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/node/node--landing-page--support-services-listing.html.twig
@@ -86,13 +86,13 @@
   {{ title_prefix }}
   {% if label and not page %}
     <h3{{ title_attributes }}>
-      <ul>{{ label }}</ul>
+      {{ label }}
     </h3>
   {% endif %}
   {{ title_suffix }}
 
   <div{{ content_attributes.addClass('node__content') }}>
-    <ul>{{ content }}</ul>
+    {{ content }}
   </div>
 
 </article>


### PR DESCRIPTION
## Description

Relates to #12664

## Testing done
Tested various entity types using the affected paragraph including checklists and R&S pages.

## Screenshots
![Screenshot 2024-02-01 at 1 17 45 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/c12123dd-914c-47ec-a58d-051ba8940fd3)
![Screenshot 2024-02-01 at 1 17 22 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/4c149722-a8b2-4094-b113-e78c7c221134)

## QA steps
As a content admin
1. Visit /resources/test-registry-exam-checklist
   - [ ] Under 'Contact Information', validate the label 'VA health care' is not wrapped in a <ul>
2. Visit /resources/getting-a-gi-bill-extension
   - [ ] Under 'Contact Information', validate the label 'VA health care' is not wrapped in a <ul>

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
