### PR TITLE
VACMS-17114: Service location fields lighthouse push

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -280,6 +280,45 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
   }
 
   /**
+   * Get the type of lead-in text, favoring the most specific.
+   *
+   * @param string $lead_in_type
+   *   The lead-in text type selected.
+   *
+   * @return string
+   *   The most specific lead-in text.
+   */
+  protected function getAppointmentLeadInType(string $lead_in_type) {
+
+    switch ($lead_in_type) {
+
+      case 'customize_text':
+        $text = $lead_in_type;
+        break;
+
+      case 'use_default_text':
+        $text = ($this->apptIntroType === 'customize_text')
+          ? $this->apptIntroType
+          : $lead_in_type;
+        break;
+
+      case 'remove_text':
+        $text = ($this->apptIntroType === 'customize_text'
+          || $this->apptIntroType === 'use_default_text')
+          ? $this->apptIntroType
+          : $lead_in_type;
+        break;
+
+      default:
+        $text = $lead_in_type;
+
+        break;
+    }
+
+    return $this->stringNullify($text);
+  }
+
+  /**
    * Gets the appropriate appointment intro text.
    *
    * @return string
@@ -418,9 +457,7 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
 
         // Set the appointment text values to the non-default for the service.
         $field_appt_intro_text_type = $location->get('field_appt_intro_text_type')->value;
-        $this->apptIntroType = ($this->apptIntroType === "customize_text")
-          ? $this->apptIntroType
-          : $field_appt_intro_text_type;
+        $this->apptIntroType = $this->getAppointmentLeadInType($field_appt_intro_text_type);
         $this->apptIntroText = (!empty($this->apptIntroText))
           ? $this->apptIntroText
           : $this->stringNullify($location->get('field_appt_intro_text_custom')->value);

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -356,15 +356,28 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
    * @return string
    *   The type of service location text that the user chose.
    */
-  protected function getAppointmentPhoneType($from_facility = FALSE) {
+  protected function getAppointmentPhoneType($from_facility) {
+    // If the class property's already set to the actionable non-default,
+    // bail out.
+    if (!empty($this->apptPhoneType)) {
+      return $this->apptPhoneType;
+    }
     $map = [
       // Value => Return.
       // Lighthouse decided to receive these as strings since non-bool options.
       '0' => 'false',
       '1' => 'true',
     ];
-
     return $map[$from_facility];
+  }
+
+  protected function getAppointmentPhones(array $phone_paragraphs = []) {
+     // If the class property's already set to the actionable non-default,
+     // bail out.
+    if (!empty($this->apptPhones)) {
+      return $this->apptPhones;
+    }
+    return $this->getPhones($this->apptPhoneType, $phone_paragraphs);
   }
 
   /**
@@ -464,12 +477,9 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
 
         // Set the appointment phone values to the non-default for the service.
         $field_appt_phone_type = $location->get('field_use_facility_phone_number')->value;
-        $this->apptPhoneType = (!empty($this->apptPhoneType) && ($this->apptPhoneType === "false"))
-          ? $this->apptPhoneType
-          : $this->getAppointmentPhoneType($field_appt_phone_type);
-        $this->apptPhones = (!empty($this->apptPhones))
-          ? $this->apptPhones
-          : $this->getPhones($this->apptPhoneType, $location->get('field_other_phone_numbers')->referencedEntities());
+        $this->apptPhoneType = $this->getAppointmentPhoneType($field_appt_phone_type);
+        $this->apptPhones = $this->getAppointmentPhones($location->get('field_other_phone_numbers')->referencedEntities());
+
 
         // Set the online scheduling value to yes for the service if so chosen.
         $this->isOnlineSchedulingAvail = ($this->isOnlineSchedulingAvail !== 'false'

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -53,9 +53,9 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
   /**
    * Whether online scheduling is available.
    *
-   * @var bool
+   * @var string
    */
-  protected $isOnlineSchedulingAvail = FALSE;
+  protected $isOnlineSchedulingAvail = "";
 
   /**
    * Adds facility service data to Post API queue.

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -435,7 +435,8 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
           : $this->getPhones($this->apptPhoneType, $location->get('field_other_phone_numbers')->referencedEntities());
 
         // Set the online scheduling value to yes for the service if so chosen.
-        $this->isOnlineSchedulingAvail = ($this->isOnlineSchedulingAvail !== 'false')
+        $this->isOnlineSchedulingAvail = ($this->isOnlineSchedulingAvail !== 'false'
+          && !empty($this->isOnlineSchedulingAvail))
           ? $this->isOnlineSchedulingAvail
           : $this->getOnlineScheduling($location->get('field_online_scheduling_avail')->value);
 

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -427,7 +427,7 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
 
         // Set the appointment phone values to the non-default for the service.
         $field_appt_phone_type = $location->get('field_use_facility_phone_number')->value;
-        $this->apptPhoneType = (!empty($this->apptPhoneType) && ((bool) $this->apptPhoneType === FALSE))
+        $this->apptPhoneType = (!empty($this->apptPhoneType) && ($this->apptPhoneType === "false"))
           ? $this->apptPhoneType
           : $this->getAppointmentPhoneType($field_appt_phone_type);
         $this->apptPhones = (!empty($this->apptPhones))

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -434,8 +434,8 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
           ? $this->apptPhones
           : $this->getPhones($this->apptPhoneType, $location->get('field_other_phone_numbers')->referencedEntities());
 
-        // Set the online scheduling value to the yes for the service.
-        $this->isOnlineSchedulingAvail = ($this->isOnlineSchedulingAvail)
+        // Set the online scheduling value to yes for the service if so chosen.
+        $this->isOnlineSchedulingAvail = ($this->isOnlineSchedulingAvail !== 'false')
           ? $this->isOnlineSchedulingAvail
           : $this->getOnlineScheduling($location->get('field_online_scheduling_avail')->value);
 

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -245,31 +245,6 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
   }
 
   /**
-   * Get appointment phones.
-   *
-   * @param string $phone_type
-   *   The type of phone for appointments.
-   *   Options: 0 (use other phone numbers), 1 (use facility number)
-   * @param array $appt_phone_numbers
-   *   The phone numbers from the appointment phone reference field.
-   *
-   * @return array
-   *   Array of appointment phone numbers.
-   */
-  protected function getApptPhones(string $phone_type, array $appt_phone_numbers = []) : ?array {
-    // If the property's been set, it's the first service location,
-    // so we'll give that the priority.
-    if (!empty($this->apptPhones)) {
-      return $this->apptPhones;
-    }
-    if (!isset($phone_type)) {
-      return NULL;
-    }
-    return $this->getPhones((bool) $phone_type, $appt_phone_numbers);
-
-  }
-
-  /**
    * Assembles the phone data and returns an array of phone objects.
    *
    * @param bool $from_facility
@@ -451,7 +426,9 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
 
     // Get the phones from the first service location for appointments.
     $field_appt_phone_type = $service_location->get('field_use_facility_phone_number')->value;
-    $this->apptPhones = $this->getApptPhones($field_appt_phone_type, $service_location->get('field_other_phone_numbers')->referencedEntities());
+    $this->apptPhones = (!empty($this->apptPhones))
+      ? $this->apptPhones
+      : $this->getPhones((bool) $field_appt_phone_type, $service_location->get('field_other_phone_numbers')->referencedEntities());
 
     // Set the online scheduling value to yes for the service if so chosen.
     $this->isOnlineSchedulingAvail = ($this->isOnlineSchedulingAvail !== 'false'

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -380,9 +380,10 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
 
         // Set the office visits policy to non-default for the service.
         $office_visits = $location->get('field_office_visits')->value;
-        $this->officeVisits = ($this->officeVisits === "yes_with_or_without_appointment")
-          ? $this->officeVisits :
-          $this->stringNullify($office_visits);
+        $this->officeVisits = (($this->officeVisits !== "yes_with_or_without_appointment")
+          ||  !isset($this->officeVisits))
+          ? $this->stringNullify($office_visits)
+          : $this->officeVisits;
 
         // Set the appointment text values to the non-default for the service.
         $field_appt_intro_text_type = $location->get('field_appt_intro_text_type')->value;
@@ -435,7 +436,7 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
         // currently sourced from the facility service node.
         $service_location->referral_required = $this->getReferralRequired();
         $service_location->walk_ins_accepted = $location->get('field_office_visits')->value;
-        $service_location->online_scheduling_available = $location->get('field_online_scheduling_avail')->value;
+        $service_location->online_scheduling_available = $this->getOnlineScheduling($location->get('field_online_scheduling_avail')->value);
 
         $service_locations[] = $service_location;
       }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -347,6 +347,40 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
   }
 
   /**
+   * Finds the best way to visit, among options chosen.
+   *
+   * @param string $office_visits
+   *   The machine value of the Office visits option.
+   */
+  protected function chooseBestOfficeVisitOption(string $office_visits) {
+    switch ($office_visits) {
+
+      case 'yes_with_or_without_appointment':
+        $text = $office_visits;
+        break;
+
+      case 'yes_first_come_first_served_basis':
+      case 'yes_appointment_only':
+        $text = ($this->officeVisits === 'yes_with_or_without_appointment')
+          ? $this->officeVisits
+          : $office_visits;
+        break;
+
+      case 'no':
+        $text = ($this->officeVisits === 'yes_with_or_without_appointment'
+        || $this->officeVisits === 'yes_first_come_first_served_basis'
+        || $this->officeVisits === 'yes_appointment_only')
+        ? $this->officeVisits
+        : $office_visits;
+        break;
+
+      default:
+        $text = $office_visits;
+    }
+    return $this->stringNullify($text);
+  }
+
+  /**
    * Builds the array of service locations.
    *
    * @return array
@@ -380,10 +414,7 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
 
         // Set the office visits policy to non-default for the service.
         $office_visits = $location->get('field_office_visits')->value;
-        $this->officeVisits = (($this->officeVisits !== "yes_with_or_without_appointment")
-          ||  !isset($this->officeVisits))
-          ? $this->stringNullify($office_visits)
-          : $this->officeVisits;
+        $this->officeVisits = $this->chooseBestOfficeVisitOption($office_visits);
 
         // Set the appointment text values to the non-default for the service.
         $field_appt_intro_text_type = $location->get('field_appt_intro_text_type')->value;

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -347,8 +347,8 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
         // They will eventually be part of the CMS service location, but are
         // currently sourced from the facility service node.
         $service_location->referral_required = $this->getReferralRequired();
-        $service_location->walk_ins_accepted = $this->getWalkInsAccepted();
-        $service_location->online_scheduling_available = $this->getOnlineSchedulingAvailable();
+        $service_location->walk_ins_accepted = $location->get('field_office_visits')->value;
+        $service_location->online_scheduling_available = $location->get('field_online_scheduling_avail')->value;
 
         $service_locations[] = $service_location;
       }

--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceVamc.php
@@ -348,39 +348,6 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
   }
 
   /**
-   * Get the non-default service location appointment phone type.
-   *
-   * @param string $from_facility
-   *   The value of a single service location's appointment phone type.
-   *
-   * @return string
-   *   The type of service location text that the user chose.
-   */
-  protected function getAppointmentPhoneType($from_facility) {
-    // If the class property's already set to the actionable non-default,
-    // bail out.
-    if (!empty($this->apptPhoneType)) {
-      return $this->apptPhoneType;
-    }
-    $map = [
-      // Value => Return.
-      // Lighthouse decided to receive these as strings since non-bool options.
-      '0' => 'false',
-      '1' => 'true',
-    ];
-    return $map[$from_facility];
-  }
-
-  protected function getAppointmentPhones(array $phone_paragraphs = []) {
-     // If the class property's already set to the actionable non-default,
-     // bail out.
-    if (!empty($this->apptPhones)) {
-      return $this->apptPhones;
-    }
-    return $this->getPhones($this->apptPhoneType, $phone_paragraphs);
-  }
-
-  /**
    * Gets the online scheduling value.
    *
    * @param string $online_scheduling_avail
@@ -477,9 +444,7 @@ class PostFacilityServiceVamc extends PostFacilityServiceBase {
 
         // Set the appointment phone values to the non-default for the service.
         $field_appt_phone_type = $location->get('field_use_facility_phone_number')->value;
-        $this->apptPhoneType = $this->getAppointmentPhoneType($field_appt_phone_type);
-        $this->apptPhones = $this->getAppointmentPhones($location->get('field_other_phone_numbers')->referencedEntities());
-
+        $this->apptPhones[] = $this->getPhones($field_appt_phone_type, $location->get('field_other_phone_numbers')->referencedEntities());
 
         // Set the online scheduling value to yes for the service if so chosen.
         $this->isOnlineSchedulingAvail = ($this->isOnlineSchedulingAvail !== 'false'


### PR DESCRIPTION
## Description

Relates to #17114

## Testing done
Manually

## Screenshots


## QA steps
## Edit [Nutrition, food, and dietary care - Union Boulevard VA Clinic](https://pr17213-fgfubdrzlofutvmkh92bmpgc4nerie5f.ci.cms.va.gov/node/53542/edit)
Make sure it has three service locations with the following values:

### Service location 1
- [x] **Office visits** = "No"
- [x] **Appointment introduction text** = "Remove text"
- [x] **Phone number for appointments** > **Use the facility phone number** = "Checked"
- [x] **Other phone numbers** is blank
- [x] **Is online scheduling available for this service?** = "No"
- [x] Filling in all other required fields

### Service location 2
- [x] **Office visits** = "Yes, by appointment only"
- [x] **Appointment introduction text** = "Use default text"
- [x] **Phone number for appointments** > **Use the facility phone number** = "Unchecked"
- [x] **Other phone numbers** has one number added
- [x] **Is online scheduling available for this service?** = "Yes"
- [x] Filling in all other required fields

### Service location 3
- [x] **Office visits** = "Yes, with or without an appointment"
- [x] **Appointment introduction text** = "Customize text" and add some custom text
- [x] **Phone number for appointments** > **Use the facility phone number** = "Unchecked"
- [x] **Other phone numbers** has two numbers added
- [x] **Is online scheduling available for this service?** = "No"
- [x] Filling in all other fields
  - [x] **Address**
    - [x] **Name of office or location**
    - [x] **Building name/number**
    - [x] **Wing, Floor, or Room Number**
    - [x] **Street address** > **Use the facility's street address?** = "Unchecked"
      - [x] Add an Address
  - [x] **Hours** > **Use the facility's hours** = "Provide specific hours for this service"
    - [x] Fill in hours or a comment for each day
    - [x] Fill in **Additional Hours options (e.g. On-Call, Appointments may be available outside these hours, please call.)**
  - [x] **Contact info** > **Phone** > **Use the general facility phone number** = "Unchecked"
    - [x] Click **Add new phone number** and add one
  - [x] **Email** > **Email contacts** > click **Add new email address"** and add one
- [x] Save the node
- [x] Go to the [Post API queue](https://pr17213-fgfubdrzlofutvmkh92bmpgc4nerie5f.ci.cms.va.gov/admin/config/post-api/queue)
- [x] Verify that the last entry in the queue has all the values in each Service location and that the following fields are as follows:
```
"payload": {
        "detailed_services": [
        	{
        		"appointment_leadin": = "<Your custom text>",
        		"appointment_phones": [
                    {
                        [<An array of phone numbers entered plus the main facility phone>]
                    }
                ]
                "walk_ins_accepted": "yes_with_or_without_appointment"
                "online_scheduling_available": "true"
        	}
        ]
    }
```

**Note: You could do many other runs of this test to confirm that each of the intended "tip of the outlying option" is present in the service-level output. I calculate that there are 48 combinations.**
Other options worth trying:
- [x] Multiple service locations using the facility number for appointments
- [x] Choosing only the default and "No" values
- [x] Changing the order of the which service locations have the "tip of the outlying option," making them the only, the first, the middle or the last.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

