### PR TITLE
VACMS-17142: Update service content types post-Service Location migration

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -143,6 +143,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       label: 'Editorial workflow'
       region: content
       parent_name: ''

--- a/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_health_service.default.yml
@@ -23,13 +23,10 @@ dependencies:
   module:
     - allow_only_one
     - content_moderation
-    - entity_browser_entity_form
     - field_group
-    - ief_table_view_mode
     - limited_field_widgets
     - markup
     - paragraphs
-    - textfield_counter
 third_party_settings:
   field_group:
     group_governance:
@@ -50,7 +47,6 @@ third_party_settings:
     group_appointments:
       children:
         - field_referral_required
-        - field_walk_ins_accepted
       label: Requirements
       region: content
       parent_name: group_a
@@ -64,12 +60,7 @@ third_party_settings:
         open: true
     group_a:
       children:
-        - field_appointments_help_text
-        - field_hservice_appt_intro_select
-        - field_hservice_appt_leadin
-        - field_hservices_lead_in_default
         - group_appointments
-        - group_scheduling
       label: Appointments
       region: content
       parent_name: ''
@@ -91,9 +82,9 @@ third_party_settings:
         - field_online_scheduling_availabl
         - field_phone_numbers_paragraph
       label: Scheduling
-      region: content
-      parent_name: group_a
-      weight: 9
+      region: hidden
+      parent_name: ''
+      weight: 12
       format_type: fieldset
       format_settings:
         classes: ''
@@ -152,7 +143,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       label: 'Editorial workflow'
       region: content
       parent_name: ''
@@ -170,12 +160,6 @@ mode: default
 content:
   field_administration:
     type: options_select
-    weight: 4
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_appointments_help_text:
-    type: markup
     weight: 4
     region: content
     settings: {  }
@@ -199,62 +183,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_hservice_appt_intro_select:
-    type: options_buttons
-    weight: 5
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_hservice_appt_leadin:
-    type: string_textarea_with_counter
-    weight: 6
-    region: content
-    settings:
-      rows: 3
-      placeholder: ''
-      maxlength: 200
-      counter_position: after
-      js_prevent_submit: true
-      count_html_characters: false
-      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining.'
-    third_party_settings: {  }
-  field_hservices_lead_in_default:
-    type: markup
-    weight: 7
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
-    weight: 32
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_online_scheduling_availabl:
-    type: options_select
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_phone_numbers_paragraph:
-    type: inline_entity_form_complex_table_view_mode
-    weight: 1
-    region: content
-    settings:
-      form_mode: default
-      override_labels: true
-      label_singular: 'phone number'
-      label_plural: 'phone numbers'
-      allow_new: true
-      allow_existing: false
-      match_operator: CONTAINS
-      allow_duplicate: false
-      collapsible: false
-      collapsed: false
-      revision: false
-    third_party_settings:
-      entity_browser_entity_form:
-        entity_browser_id: _none
   field_referral_required:
     type: options_select
     weight: 27
@@ -287,12 +221,6 @@ content:
     third_party_settings:
       limited_field_widgets:
         limit_values: '3'
-  field_walk_ins_accepted:
-    type: options_select
-    weight: 28
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
     weight: 12
@@ -301,6 +229,13 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_appointments_help_text: true
+  field_hservice_appt_intro_select: true
+  field_hservice_appt_leadin: true
+  field_hservices_lead_in_default: true
+  field_online_scheduling_availabl: true
+  field_phone_numbers_paragraph: true
+  field_walk_ins_accepted: true
   langcode: true
   path: true
   promote: true

--- a/config/sync/core.entity_view_display.node.health_care_local_health_service.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_health_service.default.yml
@@ -23,7 +23,6 @@ dependencies:
     - allow_only_one
     - entity_reference_revisions
     - field_group
-    - markup
     - options
     - user
 third_party_settings:
@@ -33,7 +32,7 @@ third_party_settings:
       label: 'VHA and VAMC health service description'
       parent_name: ''
       region: hidden
-      weight: 13
+      weight: 21
       format_type: fieldset
       format_settings:
         classes: ''
@@ -44,7 +43,7 @@ third_party_settings:
       label: 'Facility description of service (this field will be no longer be used in 2021)'
       parent_name: ''
       region: hidden
-      weight: 12
+      weight: 20
       format_type: fieldset
       format_settings:
         classes: ''
@@ -52,17 +51,11 @@ third_party_settings:
         description: ''
     group_appointments:
       children:
-        - field_hservice_appt_intro_select
-        - field_hservice_appt_leadin
-        - field_hservices_lead_in_default
         - field_referral_required
-        - field_walk_ins_accepted
-        - field_online_scheduling_availabl
-        - field_phone_numbers_paragraph
       label: Appointments
       parent_name: ''
       region: content
-      weight: 1
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
@@ -78,44 +71,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 3
-    region: content
-  field_hservice_appt_intro_select:
-    type: list_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
-    region: content
-  field_hservice_appt_leadin:
-    type: basic_string
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 5
-    region: content
-  field_hservices_lead_in_default:
-    type: markup
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 6
-    region: content
-  field_online_scheduling_availabl:
-    type: list_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 9
-    region: content
-  field_phone_numbers_paragraph:
-    type: entity_reference_revisions_entity_view
-    label: above
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    weight: 10
+    weight: 1
     region: content
   field_referral_required:
     type: list_default
@@ -140,14 +96,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 2
-    region: content
-  field_walk_ins_accepted:
-    type: list_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 8
+    weight: 3
     region: content
 hidden:
   breadcrumbs: true
@@ -156,7 +105,13 @@ hidden:
   field_appointments_help_text: true
   field_facility_location: true
   field_facility_service_loc_help: true
+  field_hservice_appt_intro_select: true
+  field_hservice_appt_leadin: true
+  field_hservices_lead_in_default: true
   field_last_saved_by_an_editor: true
+  field_online_scheduling_availabl: true
+  field_phone_numbers_paragraph: true
+  field_walk_ins_accepted: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.vba_facility_service.default.yml
+++ b/config/sync/core.entity_view_display.node.vba_facility_service.default.yml
@@ -14,7 +14,6 @@ dependencies:
   module:
     - allow_only_one
     - entity_reference_revisions
-    - markup
     - user
 id: node.vba_facility_service.default
 targetEntityType: node
@@ -34,7 +33,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_service_location:
     type: entity_reference_revisions_entity_view
@@ -51,20 +50,14 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 1
-    region: content
-  field_vba_fac_serv_appt_default:
-    type: markup
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
+    weight: 2
     region: content
 hidden:
   breadcrumbs: true
   content_moderation_control: true
   field_administration: true
   field_last_saved_by_an_editor: true
+  field_vba_fac_serv_appt_default: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.vha_facility_nonclinical_service.default.yml
+++ b/config/sync/core.entity_view_display.node.vha_facility_nonclinical_service.default.yml
@@ -12,17 +12,43 @@ dependencies:
     - field.field.node.vha_facility_nonclinical_service.field_vamc_nonclin_appt_default
     - node.type.vha_facility_nonclinical_service
   module:
-    - markup
+    - allow_only_one
+    - entity_reference_revisions
     - user
 id: node.vha_facility_nonclinical_service.default
 targetEntityType: node
 bundle: vha_facility_nonclinical_service
 mode: default
 content:
-  field_vamc_nonclin_appt_default:
-    type: markup
+  field_enforce_unique_combo_offic:
+    type: allow_only_one
     label: above
     settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_facility_location:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_service_location:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_service_name_and_descripti:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
     third_party_settings: {  }
     weight: 1
     region: content
@@ -30,11 +56,8 @@ hidden:
   breadcrumbs: true
   content_moderation_control: true
   field_administration: true
-  field_enforce_unique_combo_offic: true
-  field_facility_location: true
   field_last_saved_by_an_editor: true
-  field_service_location: true
-  field_service_name_and_descripti: true
+  field_vamc_nonclin_appt_default: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.service_location.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_location.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
       label: Hours
       parent_name: group_service_location
       region: content
-      weight: 8
+      weight: 23
       format_type: fieldset
       format_settings:
         classes: ''
@@ -48,7 +48,7 @@ third_party_settings:
       label: 'Contact info'
       parent_name: group_service_location
       region: content
-      weight: 9
+      weight: 24
       format_type: fieldset
       format_settings:
         classes: ''
@@ -61,7 +61,7 @@ third_party_settings:
       label: Address
       parent_name: group_service_location
       region: content
-      weight: 7
+      weight: 22
       format_type: fieldset
       format_settings:
         classes: ''
@@ -70,9 +70,8 @@ third_party_settings:
         open: true
     group_service_location:
       children:
-        - field_task_oriented_header
-        - field_service_location_descripti
-        - field_service_delivery_options
+        - group_service_options
+        - group_appointments
         - group_address
         - group_hours
         - group_contact_info
@@ -85,6 +84,39 @@ third_party_settings:
         classes: ''
         id: ''
         description: ''
+    group_appointments:
+      children:
+        - field_appt_intro_text_type
+        - field_appt_intro_text_custom
+        - field_use_facility_phone_number
+        - field_other_phone_numbers
+        - field_online_scheduling_avail
+      label: Appointments
+      parent_name: group_service_location
+      region: content
+      weight: 21
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        description_display: after
+    group_service_options:
+      children:
+        - field_office_visits
+        - field_virtual_support
+      label: 'Service Options'
+      parent_name: group_service_location
+      region: content
+      weight: 20
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        description_display: after
 id: paragraph.service_location.default
 targetEntityType: paragraph
 bundle: service_location
@@ -103,7 +135,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 15
+    weight: 13
     region: content
   field_appt_intro_text_type:
     type: list_default
@@ -182,7 +214,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 14
+    weight: 15
     region: content
   field_phone:
     type: entity_reference_revisions_entity_view
@@ -210,7 +242,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 13
+    weight: 14
     region: content
   field_use_main_facility_phone:
     type: boolean

--- a/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
@@ -22,9 +22,10 @@ Scenario: Log in and create VAMC Facility Health Service as a Lovell editor
   Then I select option "Cardiology at Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-regional-health-service"
 
 # Phone number AJAX test
-  Then I click the "Add new phone number" button
+  Then I click to expand "Appointments"
+  And I click the "Add new phone number" button
   And I wait "20" seconds
-  Then I should see an element with the selector "[data-drupal-selector*='edit-field-phone-numbers-paragraph-form-']"
+  Then I should see an element with the selector "[data-drupal-selector*='edit-field-service-location-0-subform-field-other-phone-numbers-wrapper']"
 
 # Lovell Federal umbrella test
   Then I scroll to position "bottom"


### PR DESCRIPTION
## Description

Relates to #17142

## Testing done
Manual

## Screenshots
<img width="1329" alt="Screenshot 2024-02-13 at 1 24 31 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/10411319/9d1f679a-53c8-4d3e-bac4-a7484443cd10">
<img width="1566" alt="Screenshot 2024-02-13 at 1 40 53 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/10411319/93abd5d7-9303-4a1c-b2d1-0fe7e09ae528">


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As a user with administrative access
1. Go to add a VAMC Facility Health Service node (/node/add/health_care_local_health_service) and verify the following fields are not visible:
   - [x] Appointment intro text
   - [x] Appointment lead-in text
   - [x] Are walkins accepted?
   - [x] Is online scheduling available for this service?
   - [x] Phone numbers for appointments
2. Edit a Service Region page (i.e. /node/61786/edit)
   - [x] Add some content to the service location section (Office visits, virtual support, appointment intro text, custom text, ust the facility phone number, other phone numbers, is online scheduling available)
   - [x] Make note of the order of the fields on the page and save the page.
   - [x] Click on the view tab and verify that the order of the page is the same as the edit tab.
4. Edit a VAMC Facility Health Service page
   - [x] Make note of the order of the fields on the page
   - [x] Click on the view tab and verify that the order of the page is the same as the edit tab.
5. Edit a VAMC Facility Non-clinical Service page
   - [x] Make note of the order of the fields on the page
   - [x] Click on the view tab and verify that the order of the page is the same as the edit tab.
6. Edit a VBA Facility Health Service page
   - [x] You may first need to generate a page by filling in all of the required fields and saving.
   - [x] Make note of the order of the fields on the page
   - [x] Click on the view tab and verify that the order of the page is the same as the edit tab.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
