### PR TITLE
VACMS-16233 make script batches pick up where they left off

### DIFF
--- a/scripts/content/VACMS-16233-reorder-vamc-menu-items.php
+++ b/scripts/content/VACMS-16233-reorder-vamc-menu-items.php
@@ -12,7 +12,10 @@
  * If for some reason the run crashes before it is complete:
  * - Check CMS recent log messages for cause
  * /admin/reports/dblog?type%5B%5D=codit_menu_tools
- * - Simply re-run the script.
+ * - Simply re-run the script, it will pick up where it left off.
+ * - If for some reason you need to start it at a different number, you can use
+ *   `drush php:eval '\Drupal::state()->set("script_library__va_gov_vamc_get_system_menus", DESIRED_NUMBER);'`
+ *   to set the last number that ran successfully.
  */
 
 use Drupal\codit_menu_tools\MenuManipulator;
@@ -47,8 +50,8 @@ function run(): string {
  */
 function va_gov_vamc_deploy_resort_vamc_menus(&$sandbox) {
   script_library_sandbox_init($sandbox, '_va_gov_vamc_get_system_menus', []);
-  _va_gov_vamc_arrange_menus($sandbox);
-  return script_library_sandbox_complete($sandbox, "Re-arranged @total VAMC System Menus.");
+  $message = _va_gov_vamc_arrange_menus($sandbox);
+  return $message . script_library_sandbox_complete($sandbox, "Re-arranged @total VAMC System Menus.");
 }
 
 /**
@@ -91,9 +94,9 @@ function _va_gov_vamc_arrange_menus(&$sandbox) {
   ];
   $menu_arranger = new MenuManipulator($menu_name);
   $menu_arranger->matchPattern($pattern);
-  $message = "The menu {$sandbox['items_to_process'][$menu_name]} had been rearranged.";
+  $message = "The menu {$sandbox['items_to_process'][$menu_name]} had been rearranged. ";
+  // It has been run successfully, so remove it.
   unset($sandbox['items_to_process'][$menu_name]);
-  $sandbox['current']++;
 
   return $message;
 }

--- a/scripts/content/script-library.php
+++ b/scripts/content/script-library.php
@@ -317,6 +317,17 @@ function script_library_sandbox_init(array &$sandbox, $counter_callback, array $
       $sandbox['items_to_process'] = call_user_func_array($counter_callback, $callback_args);
       $sandbox['total'] = count($sandbox['items_to_process']);
       $sandbox['current'] = 0;
+      $sandbox['multi_run_state_key'] = "script_library_$counter_callback";
+
+      // This seems like the first run, see if there is already a state saved
+      // from a previous attempt.
+      $last_run_completed = \Drupal::state()->get($sandbox['multi_run_state_key']);
+      if (!is_null($last_run_completed)) {
+        // A state exists, so alter the 'current' and 'items_to_process'.
+        $sandbox['current'] = $last_run_completed + 1;
+        // Remove the last successful run, and all that came before it.
+        $sandbox['items_to_process'] = array_slice($sandbox['items_to_process'], $last_run_completed);
+      }
     }
     else {
       // Something went wrong could not use callback. Throw exception.
@@ -325,6 +336,7 @@ function script_library_sandbox_init(array &$sandbox, $counter_callback, array $
       );
     }
   }
+  $sandbox['element'] = array_key_first($sandbox['items_to_process']);
 }
 
 /**
@@ -341,17 +353,23 @@ function script_library_sandbox_init(array &$sandbox, $counter_callback, array $
 function script_library_sandbox_complete(array &$sandbox, $completed_message) {
   // Determine when to stop batching.
   $sandbox['current'] = ($sandbox['total'] - count($sandbox['items_to_process']));
+  // Save the 'current' value to state, to record a successful run.
+  \Drupal::state()->set($sandbox['multi_run_state_key'], $sandbox['current']);
   $sandbox['#finished'] = (empty($sandbox['total'])) ? 1 : ($sandbox['current'] / $sandbox['total']);
   $vars = [
     '@completed' => $sandbox['current'],
+    '@element' => $sandbox['element'],
     '@total' => $sandbox['total'],
   ];
-  $message = t('Processing... @completed/@total.', $vars) . PHP_EOL;
+
+  $message = t('Processed @element. @completed/@total.', $vars) . PHP_EOL;
   // Log the all finished notice.
   if ($sandbox['#finished'] === 1) {
     Drupal::logger('va_gov_vamc')->log(LogLevel::INFO, $completed_message, $vars);
     $logged_message = new FormattableMarkup($completed_message, $vars);
     $message = t('Process completed:') . " {$logged_message}" . PHP_EOL;
+    // Delete the state as it is no longer needed.
+    \Drupal::state()->delete($sandbox['multi_run_state_key']);
   }
   return $message;
 }

--- a/scripts/content/script-library.php
+++ b/scripts/content/script-library.php
@@ -365,7 +365,7 @@ function script_library_sandbox_complete(array &$sandbox, $completed_message) {
   $message = t('Processed @element. @completed/@total.', $vars) . PHP_EOL;
   // Log the all finished notice.
   if ($sandbox['#finished'] === 1) {
-    Drupal::logger('va_gov_vamc')->log(LogLevel::INFO, $completed_message, $vars);
+    Drupal::logger('script_library')->log(LogLevel::INFO, $completed_message, $vars);
     $logged_message = new FormattableMarkup($completed_message, $vars);
     $message = t('Process completed:') . " {$logged_message}" . PHP_EOL;
     // Delete the state as it is no longer needed.


### PR DESCRIPTION
## Description

Relates to #16233

This makes it possible to resume the menu altering script from any given point if the script dies like it did the [first two attempts to run it on prod.](https://dsva.slack.com/archives/CT4GZBM8F/p1707842079725229?thread_ts=1707759434.620499&cid=CT4GZBM8F) 

This creates the ability for the execution of batched scripts to keep state using the Drupal State API  to keep track of the last successfully completed  batch and pick up where it left off on subsequent runs.

On prod the script ran out of memory processing  run number 118.   It is most likely that 118 ran successfully and it was actually 119 that failed, but to be safe, we will run it from 117 on by doing the following

- Set the last run state  to 117 with
  `ddev drush state:set script_library__va_gov_vamc_get_system_menus 117`
- Run the script with `drush scr ./scripts/content/VACMS-16233-reorder-vamc-menu-items.php`

## Testing done


## Screenshots


## QA steps

- [x] Login to [Tugboat dashboard](https://tugboat.vfs.va.gov/65cc20c5067b1809aa527bf6) 
- [x] Open the php terminal
- [x] run `ddev drush state:set script_library__va_gov_vamc_get_system_menus 117`
- [x] run `drush scr ./scripts/content/VACMS-16233-reorder-vamc-menu-items.php`
- [x] Validate output looks like: 
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/8fa33b2b-2776-4496-9a38-2ac6d967671e)
- [x] When complete, validate that VA Spokane health care has been re-ordered (the first item in the resumed
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/4cb91cca-bdc6-4a0f-a2fe-4e9a3f9e6257)

- [x] validate that VA St Cloud menu has been rearranged (to rule out off-by-one error)
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/848c32f6-d523-4da4-9017-1b6a57df408c)

- [x] validate VA Lebanon has been  rearranged (to rule out off by one error on other end - the last one in the list)
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/fc45a2ce-e5e3-41f2-96b8-2dd70bfc2376)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
