### PR TITLE
VACMS-17241 Rework service location script for keeping state and reporting

### DIFF
--- a/scripts/content/VACMS-15559-migrate-service-location-from-node-to-paragraph.php
+++ b/scripts/content/VACMS-15559-migrate-service-location-from-node-to-paragraph.php
@@ -10,6 +10,7 @@
  * It should only be run 1 time or it will duplicate phone data.
  *
  * If for some reason the run crashes before it is complete:
+ * - It is safe to re-run the script as it should pick up where it left off.
  * - Go to /admin/config/va-gov-post-api/config
  * - Uncheck the box for 'Bypass data comparison'
  * - Click the 'Save' button.
@@ -44,9 +45,10 @@ function run(): string {
 function va_gov_vamc_deploy_migrate_service_data_to_service_location(&$sandbox) {
   $source_bundle = 'health_care_local_health_service';
   script_library_sandbox_init($sandbox, 'get_nids_of_type', [$source_bundle, FALSE]);
-  new ServiceLocationMigration($sandbox);
+  $migrator = new ServiceLocationMigration();
+  $msg = $migrator->run($sandbox);
   $new_service_locations = $sandbox['service_locations_created_count'] ?? 0;
   $updated_service_locations = $sandbox['service_locations_updated_count'] ?? 0;
   $forward_revisions = $sandbox['forward_revisions_count'] ?? 0;
-  return script_library_sandbox_complete($sandbox, "migrated @total {$source_bundle} nodes into {$new_service_locations} new service_location paragraphs, and {$updated_service_locations} updated. Also updated {$forward_revisions} forward revisions.");
+  return $msg . script_library_sandbox_complete($sandbox, "migrated @total {$source_bundle} nodes into {$new_service_locations} new service_location paragraphs, and {$updated_service_locations} updated. Also updated {$forward_revisions} forward revisions.");
 }


### PR DESCRIPTION
## Description

Relates to #17241

This can not be merged into integration until #17236 is merged to main AND #15622 is then rebased on main.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

IN the terminal
1. run `ddev drush scr ./scripts/content/VACMS-15559-migrate-service-location-from-node-to-paragraph.php`
   - [x] Validate that output looks like this
   
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/77e0b2d6-b1cc-4d61-9086-394496df4bf8)

   
2. Use Ctrl-C to halt the script.
3. Make note of the last reported item to run.
   
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/7d24c46a-cf15-46b1-8dc7-d928a3cf2ec3)

5. run the script again
   - [x] Validate that it picks up where it left off.  It will be off by one, but not because of a code error.  See my comment father down.  ctrl C actually undoes the last database transaction. This happening has more to do with how ctrl C works than how the code works.
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/5752113/ee06054f-55d1-4413-81a2-fd8aab228d1c)



### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
