### PR TITLE
VACMS-14136: Editors should not be able to rename VAMC facility services.

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -52,6 +52,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       'hook_event_dispatcher.form_node_vamc_system_register_for_care_form.alter' => 'alterTopTaskNodeForm',
       'hook_event_dispatcher.form_node_vamc_system_va_police_edit_form.alter' => 'alterTopTaskNodeForm',
       'hook_event_dispatcher.form_node_vamc_system_va_police_form.alter' => 'alterTopTaskNodeForm',
+      'hook_event_dispatcher.form_node_health_care_local_health_service_edit_form.alter' => 'alterFacilityServiceNodeForm',
       EntityHookEvents::ENTITY_INSERT => 'entityInsert',
       EntityHookEvents::ENTITY_PRE_SAVE => 'entityPresave',
       EntityHookEvents::ENTITY_VIEW_ALTER => 'entityViewAlter',
@@ -333,6 +334,40 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       }
     }
     $form['#attached']['library'][] = 'va_gov_vamc/limit_vamcs_to_workbench';
+  }
+
+  /**
+   * Alter the VAMC Facility Service node form.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent $event
+   *   The event.
+   */
+  public function alterFacilityServiceNodeForm(FormIdAlterEvent $event): void {
+    $form = &$event->getForm();
+    $form_state = $event->getFormState();
+    $is_admin = $this->userPermsService->hasAdminRole(TRUE);
+    if (!$is_admin) {
+      $this->disableFacilityServiceChange($form, $form_state);
+    }
+  }
+
+  /**
+   * Disables basic info fields on existing nodes for editors.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The state of the form.
+   */
+  public function disableFacilityServiceChange(array &$form, FormStateInterface $form_state): void {
+    /** @var \Drupal\Core\Entity\EntityFormInterface $form_object */
+    $form_object = $form_state->getFormObject();
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $form_object->getEntity();
+    if (!$node->isNew()) {
+      $form['field_facility_location']['#disabled'] = TRUE;
+      $form['field_regional_health_service']['#disabled'] = TRUE;
+    }
   }
 
   /**

--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -237,7 +237,10 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   public function alterVetCenterServiceNodeForm(FormIdAlterEvent $event): void {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
-    $this->disableFacilityServiceChange($form, $form_state);
+    $is_admin = $this->userPermsService->hasAdminRole(TRUE);
+    if (!$is_admin) {
+      $this->disableFacilityServiceChange($form, $form_state);
+    }
   }
 
   /**

--- a/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
@@ -42,3 +42,35 @@ Scenario: Log in and create VAMC Facility Health Service as a non-Lovell editor
   Then I click the button with selector "#edit-group-health-service-and-facilit"
   Then I select option "Brockton VA Medical Center | VA Boston health care" from dropdown with selector "#edit-field-facility-location"
   Then I select option "Audiology and speech at VA Boston health care" from dropdown with selector "#edit-field-regional-health-service"
+
+Scenario: Editors should not be able to rename a VAMC Facility Health Service
+  Given I am logged in as a user with the roles "vamc_content_creator, content_publisher, content_editor, content_admin"
+  # VA Iron Mountain health care
+  And my workbench access sections are set to "350"
+  # Primary care - Marquette VA Clinic
+  When I am at "node/30733/edit"
+  And I click to expand "Health service and facility basic info"
+  Then an element with the selector 'select[data-drupal-selector^="edit-field-facility-location"]' should be disabled
+  And an element with the selector 'select[data-drupal-selector^="edit-field-regional-health-service"]' should be disabled
+  Then I scroll to position "bottom"
+  And I click the "Unlock" link
+  And I click the "Confirm break lock" button
+
+Scenario: Administrators should be able to rename a VAMC Facility Health Service
+  Given I am logged in as a user with the "administrator" role
+  # Primary care - Marquette VA Clinic
+  When I am at "node/30733"
+  Then I should see "Primary care - Marquette VA Clinic"
+
+  Then I click the edit tab
+  And I click to expand "Health service and facility basic info"
+  Then an element with the selector 'select[data-drupal-selector^="edit-field-facility-location"]' should not be disabled
+  And an element with the selector 'select[data-drupal-selector^="edit-field-regional-health-service"]' should not be disabled
+
+  # Ironwood VA Clinic
+  Then I select option '1635' from dropdown with selector 'select[data-drupal-selector^="edit-field-facility-location"]'
+  # Chiropractic at VA Iron Mountain health care
+  And I select option '35578' from dropdown with selector 'select[data-drupal-selector^="edit-field-regional-health-service"]'
+  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
+  And I save the node
+  Then I should see "Chiropractic - Ironwood VA Clinic"

--- a/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
@@ -1,0 +1,34 @@
+@content_type__vet_center_facility_health_servi
+Feature: CMS Users may effectively interact with the Vet Center - Facility Service form
+  In order to confirm that cms users have access to the necessary functionality
+  As anyone involved in the project
+  I need to have certain functionality available
+
+Scenario: Editors should not be able to rename a Vet Center - Facility Service
+  Given I am logged in as a user with the roles "content_creator_vet_center, content_publisher, content_editor, content_admin"
+  # Escanaba Vet Center
+  And my workbench access sections are set to "392"
+  # Escanaba Vet Center - Telehealth
+  When I am at "node/17927/edit"
+  And an element with the selector 'select[data-drupal-selector^="edit-field-service-name-and-descripti"]' should be disabled
+  Then I scroll to position "bottom"
+  And I click the "Unlock" link
+  And I click the "Confirm break lock" button
+
+Scenario: Administrators should be able to rename a Vet Center - Facility Service
+  Given I am logged in as a user with the "administrator" role
+  # Escanaba Vet Center - Telehealth
+  When I am at "node/17927"
+  Then I should see "Escanaba Vet Center - Telehealth"
+
+  Then I click the edit tab
+  Then an element with the selector 'select[data-drupal-selector^="edit-field-office"]' should not be disabled
+  And an element with the selector 'select[data-drupal-selector^="edit-field-service-name-and-descripti"]' should not be disabled
+
+  # Duluth Vet Center
+  Then I select option '3751' from dropdown with selector 'select[data-drupal-selector^="edit-field-office"]'
+  # Women Veteran Care
+  And I select option '57' from dropdown with selector 'select[data-drupal-selector^="edit-field-service-name-and-descripti"]'
+  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
+  And I save the node
+  Then I should see "Duluth Vet Center - Women Veteran care"


### PR DESCRIPTION
## Description

Relates to #14136.

## Testing done
Cypress tests created as well as manual testing

## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user `QA Content Editor`
1. Edit a VAMC Facility Health Service node (e.g. 'Pharmacy - Orlando VA Medical Center' /node/22635/edit)
   - [x] Expand the `Health service and facility basic info` section.
   - [x] Verify that the `Facility` and `VAMC system health service` dropdowns are disabled.

As an administrator
1. Edit a VAMC Facility Health Service node (you can use the same example as above)
   - [x] Expand the `Health service and facility basic info` section.
   - [x] Verify that the `Facility` and `VAMC system health service` dropdowns are not disabled.
2. Edit a Vet Center - Facility Service node (e.g. Jackson Vet Center - Workshops and classes' /node/44823/edit)
   - [x] Verify that `Vet Center` and `Service name` dropdowns are not disabled.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
