### PR TITLE
Adding in VAMC Top Task pages

### DIFF
--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
@@ -158,6 +158,7 @@ content:
       time_format: G
       compress: false
       grouped: false
+      show_empty: true
       show_closed: all
       closed_format: Closed
       all_day_format: 'All day open'

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.default.yml
@@ -174,6 +174,7 @@ content:
         closed_text: 'Currently closed'
       exceptions:
         title: 'Exception hours'
+        replace_exceptions: false
         restrict_exceptions_to_num_days: 7
         date_format: long
         all_day_format: 'All day open'

--- a/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.search_index.yml
+++ b/config/sync/core.entity_view_display.node.vamc_system_billing_insurance.search_index.yml
@@ -131,6 +131,7 @@ content:
       time_format: G
       compress: false
       grouped: false
+      show_empty: true
       show_closed: all
       closed_format: Closed
       all_day_format: 'All day open'
@@ -146,6 +147,7 @@ content:
         closed_text: 'Currently closed'
       exceptions:
         title: 'Exception hours'
+        replace_exceptions: false
         restrict_exceptions_to_num_days: 7
         date_format: long
         all_day_format: 'All day open'

--- a/config/sync/views.view.non_clinical_services.yml
+++ b/config/sync/views.view.non_clinical_services.yml
@@ -597,6 +597,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: open
             closed_format: Closed
             separator:
@@ -678,6 +679,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: all
             closed_format: Closed
             separator:
@@ -1868,6 +1870,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: open
             closed_format: Closed
             separator:
@@ -1949,6 +1952,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: all
             closed_format: Closed
             separator:
@@ -3143,6 +3147,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: open
             closed_format: Closed
             separator:
@@ -3224,6 +3229,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: all
             closed_format: Closed
             separator:
@@ -4483,6 +4489,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: open
             closed_format: Closed
             separator:
@@ -4564,6 +4571,7 @@ display:
             time_format: g
             compress: true
             grouped: true
+            show_empty: true
             show_closed: all
             closed_format: Closed
             separator:


### PR DESCRIPTION
@omahane There were a few additional spots where I specified `show_empty: true`. I was originally gonna leave a comment on your PR, but it was faster to just collect my recommendations in their own branch.

On VAMC System and Billing and Insurance pages there is an Office Hours widget that also needs the config to show if empty:

![screencapture-pr17451-3coflbqwjllvbyoghxxvvqqwwrsnq0mg-ci-cms-va-gov-eastern-colorado-health-care-billing-and-insurance-2024-03-08-17_37_13](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/51967950/f176f7cd-3611-4a92-869d-1bd1cd008d7f)

Similarly, the Views for Non-Clinical Services appearing on the 3 different top taps pages should also show hours if all empty

![screencapture-pr17451-3coflbqwjllvbyoghxxvvqqwwrsnq0mg-ci-cms-va-gov-salt-lake-city-health-care-billing-and-insurance-2024-03-08-18_21_14](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/51967950/293e00ae-a518-4dac-a269-ef2590d5153a)
