### PR TITLE
VACMS-17501: Shows and hides hours appropriately

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/service_location_hours.es6.js
+++ b/docroot/modules/custom/va_gov_backend/js/service_location_hours.es6.js
@@ -2,40 +2,38 @@
  * @file
  */
 
-(($, Drupal) => {
+(($, Drupal, once) => {
   const displayHours = (value, toggle, table) => {
     if (toggle.checked && table) {
       if (toggle.value === value) {
         table.style.display = "block";
         if (value === "0") {
-          $(table)
-            .once("button-build")
-            .each(function makeToolTip() {
-              const button = document.createElement("button");
-              button.className = "tooltip-toggle";
-              button.value =
-                "Why can't I edit this? VHA keeps these descriptions standardized to help Veterans identify the services they need.";
-              button.type = "button";
-              // Add css formatting from "tippy" css library.
-              button.ariaLabel = "tooltip";
-              button.setAttribute(
-                "data-tippy",
-                "Why can't I edit this?\nVHA keeps these descriptions standardized to help Veterans identify the services they need."
-              );
-              button.setAttribute("data-tippy-pos", "right");
-              button.setAttribute("data-tippy-animate", "fade");
-              button.setAttribute("data-tippy-size", "large");
-              table.className = `no-content health_service_text_container field-group-tooltip tooltip-layout centralized css-tooltip`;
-              // Smash it all together.
-              table.appendChild(button);
-              window.tippy(button, {
-                content: () => button.value,
-                theme: "tippy_popover",
-                placement: "right",
-                arrow: true,
-                offset: [15, 0],
-              });
+          $(once("button-build", table)).each(function makeToolTip() {
+            const button = document.createElement("button");
+            button.className = "tooltip-toggle";
+            button.value =
+              "Why can't I edit this? VHA keeps these descriptions standardized to help Veterans identify the services they need.";
+            button.type = "button";
+            // Add css formatting from "tippy" css library.
+            button.ariaLabel = "tooltip";
+            button.setAttribute(
+              "data-tippy",
+              "Why can't I edit this?\nVHA keeps these descriptions standardized to help Veterans identify the services they need."
+            );
+            button.setAttribute("data-tippy-pos", "right");
+            button.setAttribute("data-tippy-animate", "fade");
+            button.setAttribute("data-tippy-size", "large");
+            table.className = `no-content health_service_text_container field-group-tooltip tooltip-layout centralized css-tooltip`;
+            // Smash it all together.
+            table.appendChild(button);
+            window.tippy(button, {
+              content: () => button.value,
+              theme: "tippy_popover",
+              placement: "right",
+              arrow: true,
+              offset: [15, 0],
             });
+          });
         }
       } else {
         table.style.display = "none";
@@ -80,4 +78,4 @@
       });
     },
   };
-})(jQuery, Drupal);
+})(jQuery, window.Drupal, window.once);

--- a/docroot/modules/custom/va_gov_backend/js/service_location_hours.js
+++ b/docroot/modules/custom/va_gov_backend/js/service_location_hours.js
@@ -4,26 +4,23 @@
 * https://www.drupal.org/node/2815083
 * @preserve
 **/
-
-(function ($, Drupal) {
+(function ($, Drupal, once) {
   var displayHours = function displayHours(value, toggle, table) {
     if (toggle.checked && table) {
       if (toggle.value === value) {
         table.style.display = "block";
         if (value === "0") {
-          $(table).once("button-build").each(function makeToolTip() {
+          $(once("button-build", table)).each(function makeToolTip() {
             var button = document.createElement("button");
             button.className = "tooltip-toggle";
             button.value = "Why can't I edit this? VHA keeps these descriptions standardized to help Veterans identify the services they need.";
             button.type = "button";
-
             button.ariaLabel = "tooltip";
             button.setAttribute("data-tippy", "Why can't I edit this?\nVHA keeps these descriptions standardized to help Veterans identify the services they need.");
             button.setAttribute("data-tippy-pos", "right");
             button.setAttribute("data-tippy-animate", "fade");
             button.setAttribute("data-tippy-size", "large");
             table.className = "no-content health_service_text_container field-group-tooltip tooltip-layout centralized css-tooltip";
-
             table.appendChild(button);
             window.tippy(button, {
               content: function content() {
@@ -41,7 +38,6 @@
       }
     }
   };
-
   Drupal.behaviors.vaGovServiceLocationHours = {
     attach: function attach(context) {
       var hourSelects = document.querySelectorAll(".field--name-field-hours input");
@@ -49,21 +45,18 @@
         hourSelects.forEach(function (hourSelect) {
           var hours = hourSelect.parentElement.parentElement.parentElement.parentElement.parentElement.nextElementSibling;
           var facilityHours = hourSelect.parentElement.parentElement.parentElement.parentElement.nextElementSibling;
-
           displayHours("2", hourSelect, hours);
           displayHours("0", hourSelect, facilityHours);
         });
       });
-
       context.addEventListener("click", function () {
         hourSelects.forEach(function (hourSelect) {
           var hours = hourSelect.parentElement.parentElement.parentElement.parentElement.parentElement.nextElementSibling;
           var facilityHours = hourSelect.parentElement.parentElement.parentElement.parentElement.nextElementSibling;
-
           displayHours("2", hourSelect, hours);
           displayHours("0", hourSelect, facilityHours);
         });
       });
     }
   };
-})(jQuery, Drupal);
+})(jQuery, window.Drupal, window.once);


### PR DESCRIPTION
## Description

Relates to #17501

## Testing done
Manually


## Screenshots
### Before the PR
![multiple-service-locations](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/90749f9a-6306-46ba-824b-21f2c2a1b10f)

### After the PR
![fixed-exampe-multiple-service-locations](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/ac6580a5-b675-4b00-9e1b-b6b8826b6ca4)


## QA steps
### Set up test user
- [x] Log in as an admin and set QA Content Publisher to the following:
  - [x] Roles:
    - [x] Content publisher
    - [x] Content creator - VAMC
    - [x] Content creator - VBA
  - [x] Sections:
    - [x] VA Boston health care 
    - [x] Cheyenne VA Regional Benefit Office

### VBA Facility Service
- [x] As QA Content Publisher, create a [new VBA Facility Health Service](https://pr17536-blserdo6lxzoiqyqy3luaxjvylnvrvc4.ci.cms.va.gov/node/add/vba_facility_service)
- [x] Fill in the required fields
- [x] Add 2 addition Service locations
- [x] Go to the 3rd Service location
- [x] Click the **Hours** accordion
- [x] Confirm that "Use the facility's hours" is selected
- [x] Confirm that the hours form element is not showing
- [x] Click "Provide specific hours for this service"
- [x] Confirm that the hours form element is showing
- [x] Check the browser developer tools console
- [x] Confirm that no "once()"-related errors are showing

_Note: The facility hours are not being pulled in on VBA, even after saving the node and editing it once more. I'll capture that need in a separate ticket._

### VAMC Facility Health Service
- [x] Go to [Amputation care - Jamaica Plain VA Medical Center](https://pr17536-blserdo6lxzoiqyqy3luaxjvylnvrvc4.ci.cms.va.gov/node/30310/edit)
- [x] Add 2 Service locations to have a total of 3
- [x] On each of the 3 Service locations:
  - [x] Click **Hours** to open accordion
  - [x] Confirm that "Use the facility's hours" is chosen
  - [x] Confirm that the facility hours are are showing in a grey box
  - [x] Confirm that the hours form element is not showing
  - [x] Click **Provide specific hours for this service**
  - [x] Confirm that the hours form element is showing
  - [x] Confirm that the facility hours are not showing
- [x] Save the node with at least one Service location using facility hours and one using provided hours
- [x] Confirm that node:view shows the expected hours content

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

