### PR TITLE
VACMS-12666: Removes duplicate sections on system health service pages.

### DIFF
--- a/config/sync/core.entity_view_display.node.health_care_local_health_service.system_services_listings.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_health_service.system_services_listings.yml
@@ -1,0 +1,159 @@
+uuid: d5b7a358-c460-4ab7-b84e-399a37336059
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.system_services_listings
+    - field.field.node.health_care_local_health_service.field_administration
+    - field.field.node.health_care_local_health_service.field_appointments_help_text
+    - field.field.node.health_care_local_health_service.field_enforce_unique_combo
+    - field.field.node.health_care_local_health_service.field_facility_location
+    - field.field.node.health_care_local_health_service.field_facility_service_loc_help
+    - field.field.node.health_care_local_health_service.field_hservice_appt_intro_select
+    - field.field.node.health_care_local_health_service.field_hservice_appt_leadin
+    - field.field.node.health_care_local_health_service.field_hservices_lead_in_default
+    - field.field.node.health_care_local_health_service.field_last_saved_by_an_editor
+    - field.field.node.health_care_local_health_service.field_online_scheduling_availabl
+    - field.field.node.health_care_local_health_service.field_phone_numbers_paragraph
+    - field.field.node.health_care_local_health_service.field_referral_required
+    - field.field.node.health_care_local_health_service.field_regional_health_service
+    - field.field.node.health_care_local_health_service.field_service_location
+    - field.field.node.health_care_local_health_service.field_walk_ins_accepted
+    - node.type.health_care_local_health_service
+  module:
+    - allow_only_one
+    - entity_reference_revisions
+    - field_group
+    - layout_builder
+    - markup
+    - options
+    - user
+third_party_settings:
+  field_group:
+    group_vha_health_service_name_an:
+      children: {  }
+      label: 'VHA and VAMC health service description'
+      parent_name: ''
+      region: hidden
+      weight: 15
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+    group_facility_description_of_se:
+      children: {  }
+      label: 'Facility description of service (this field will be no longer be used in 2021)'
+      parent_name: ''
+      region: hidden
+      weight: 14
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+    group_appointments:
+      children:
+        - field_hservice_appt_intro_select
+        - field_hservice_appt_leadin
+        - field_hservices_lead_in_default
+        - field_referral_required
+        - field_walk_ins_accepted
+        - field_online_scheduling_availabl
+        - field_phone_numbers_paragraph
+      label: Appointments
+      parent_name: ''
+      region: content
+      weight: 0
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.health_care_local_health_service.system_services_listings
+targetEntityType: node
+bundle: health_care_local_health_service
+mode: system_services_listings
+content:
+  field_enforce_unique_combo:
+    type: allow_only_one
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_hservice_appt_intro_select:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_hservice_appt_leadin:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_hservices_lead_in_default:
+    type: markup
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_online_scheduling_availabl:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_phone_numbers_paragraph:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_referral_required:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_service_location:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_walk_ins_accepted:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
+    region: content
+hidden:
+  breadcrumbs: true
+  content_moderation_control: true
+  field_administration: true
+  field_appointments_help_text: true
+  field_facility_location: true
+  field_facility_service_loc_help: true
+  field_last_saved_by_an_editor: true
+  field_regional_health_service: true
+  langcode: true
+  links: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.regional_health_care_service_des.default.yml
+++ b/config/sync/core.entity_view_display.node.regional_health_care_service_des.default.yml
@@ -79,7 +79,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: default
+      view_mode: system_services_listings
       link: false
     third_party_settings: {  }
     weight: 5

--- a/config/sync/core.entity_view_mode.node.system_services_listings.yml
+++ b/config/sync/core.entity_view_mode.node.system_services_listings.yml
@@ -1,0 +1,11 @@
+uuid: 2ec8f0a2-659f-49ee-af60-cbef3d0211e7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.system_services_listings
+label: 'System Services Listings'
+description: 'This is a view mode for the VAMC Facility Health Service content type when it is being referenced by a VAMC System Health Service.'
+targetEntityType: node
+cache: true


### PR DESCRIPTION
## Description

Relates to #12666 .

## Testing done
Manual

## Screenshots
<details>
<summary>Screenshot after duplicates are removed</summary>
<img width="948" alt="Screenshot 2024-03-21 at 9 27 33 AM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/10411319/330ce218-8c2b-4ff3-a0e1-ec78b1cd35be">
</details>

## QA steps

1. Browse to a System Health Service page (i.e. /montana-health-care/health-services/radiology-at-va-montana-health-care)
   - [x] Validate that the fields labeled 'VHA health service name and description' and 'VAMC system description' show up on the top of the page.
   - [x] Validate that those same fields no longer show up under each Facility description.
2. Browse  to a Facility Health Service page (i.e. /montana-health-care/locations/dr-joseph-medicine-crow-va-clinic/radiology)
   - [x] Validate that the fields 'VHA health service name and description' and 'VAMC system description of service' still show up at the top of the page.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
