### PR TITLE
VACMS-17426: Requires VA facility location when the event is using a VA facility location type

### DIFF
--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -298,7 +298,7 @@
   const toggleFacilityLocationRequiredFields = (enableDisable, addRemove) => {
     // Facility location field.
     if (fieldFacilityLocation) {
-      fieldFacilityLocation.setAttribute("required", "required");
+      fieldFacilityLocation.required = enableDisable;
     }
     if (fieldFacilityLocationLabel) {
       fieldFacilityLocationLabel.classList[addRemove]("form-required");

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.es6.js
@@ -57,6 +57,9 @@
   const fieldFacilityLocation = document.getElementById(
     "edit-field-facility-location-0-target-id"
   );
+  const fieldFacilityLocationLabel = document.querySelector(
+    "label[for='edit-field-facility-location-0-target-id']"
+  );
   const fieldLocationTypeOnline = document.getElementById(
     "edit-field-location-type-online"
   );
@@ -292,11 +295,22 @@
     }
   };
 
+  const toggleFacilityLocationRequiredFields = (enableDisable, addRemove) => {
+    // Facility location field.
+    if (fieldFacilityLocation) {
+      fieldFacilityLocation.setAttribute("required", "required");
+    }
+    if (fieldFacilityLocationLabel) {
+      fieldFacilityLocationLabel.classList[addRemove]("form-required");
+    }
+  };
+
   const toggleLocationElements = () => {
     targetLocationElements.forEach((element) => {
       element.style.display = "none";
     });
     toggleAddressRequiredFields(false, "remove");
+    toggleFacilityLocationRequiredFields(false, "remove");
     if (fieldLocationTypeFacility.checked) {
       fieldFacilityLocationWrapper.style.display = "block";
       fieldLocationHumanreadableWrapper.style.display = "block";
@@ -305,6 +319,7 @@
       fieldAddressLine2.value = "";
       fieldAddressLocality.value = "";
       fieldAddressAdminArea.value = "";
+      toggleFacilityLocationRequiredFields(true, "add");
     }
     if (fieldLocationTypeNonFacility.checked) {
       fieldLocationHumanreadableWrapper.style.display = "block";

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -138,7 +138,7 @@
   };
   var toggleFacilityLocationRequiredFields = function toggleFacilityLocationRequiredFields(enableDisable, addRemove) {
     if (fieldFacilityLocation) {
-      fieldFacilityLocation.setAttribute("required", "required");
+      fieldFacilityLocation.required = enableDisable;
     }
     if (fieldFacilityLocationLabel) {
       fieldFacilityLocationLabel.classList[addRemove]("form-required");

--- a/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
+++ b/docroot/modules/custom/va_gov_events/js/eventFormHelpers.js
@@ -25,6 +25,7 @@
   var targetLocationElements = document.querySelectorAll("#edit-field-facility-location-wrapper, #edit-field-url-of-an-online-event-wrapper, #edit-field-location-humanreadable-wrapper, #edit-field-address-wrapper");
   var fieldFacilityLocationWrapper = document.getElementById("edit-field-facility-location-wrapper");
   var fieldFacilityLocation = document.getElementById("edit-field-facility-location-0-target-id");
+  var fieldFacilityLocationLabel = document.querySelector("label[for='edit-field-facility-location-0-target-id']");
   var fieldLocationTypeOnline = document.getElementById("edit-field-location-type-online");
   var fieldAddressWrapper = document.getElementById("edit-field-address-wrapper");
   var fieldUrlOfOnlineEvent = document.getElementById("edit-field-url-of-an-online-event-0-uri");
@@ -135,11 +136,20 @@
       fieldAddressAdminAreaLabel.classList[addRemove]("form-required");
     }
   };
+  var toggleFacilityLocationRequiredFields = function toggleFacilityLocationRequiredFields(enableDisable, addRemove) {
+    if (fieldFacilityLocation) {
+      fieldFacilityLocation.setAttribute("required", "required");
+    }
+    if (fieldFacilityLocationLabel) {
+      fieldFacilityLocationLabel.classList[addRemove]("form-required");
+    }
+  };
   var toggleLocationElements = function toggleLocationElements() {
     targetLocationElements.forEach(function (element) {
       element.style.display = "none";
     });
     toggleAddressRequiredFields(false, "remove");
+    toggleFacilityLocationRequiredFields(false, "remove");
     if (fieldLocationTypeFacility.checked) {
       fieldFacilityLocationWrapper.style.display = "block";
       fieldLocationHumanreadableWrapper.style.display = "block";
@@ -148,6 +158,7 @@
       fieldAddressLine2.value = "";
       fieldAddressLocality.value = "";
       fieldAddressAdminArea.value = "";
+      toggleFacilityLocationRequiredFields(true, "add");
     }
     if (fieldLocationTypeNonFacility.checked) {
       fieldLocationHumanreadableWrapper.style.display = "block";

--- a/tests/cypress/integration/features/content_type/event.feature
+++ b/tests/cypress/integration/features/content_type/event.feature
@@ -20,6 +20,7 @@ Feature: Content Type: Event
     And I fill in autocomplete field with selector "#edit-field-url-of-an-online-event-0-uri" with value "https://va.gov"
     And I select the "At a VA facility" radio button
     Then an element with the selector "#edit-field-facility-location-0-target-id" should be empty
+    And the element with selector "#edit-field-facility-location-0-target-id" should have attribute "required"
     When I select the "At a non-VA location" radio button
     Then an element with the selector "#edit-field-address-0-address-address-line1" should be empty
     And an element with the selector "#edit-field-address-0-address-locality" should be empty


### PR DESCRIPTION
## Description

Forces an Event with a Facility location type to also specify the Facility location.

Relates to #17426

## Testing done
Manual and cypress

## Screenshots
![Screenshot 2024-04-16 at 7 19 28 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/79aeb1fa-4e33-4c5d-9e06-8bda1f2b3947)

## QA steps
As a content admin

1. Visit node/add/event
2. Set the 'Location type' to "At a VA facility"
   - [x] Validate that the 'Facility location' field is visible and required

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
