### PR TITLE
VACMS-18112: Changes cardinality of Service location appt phone #s

### DIFF
--- a/config/sync/field.storage.paragraph.field_other_phone_numbers.yml
+++ b/config/sync/field.storage.paragraph.field_other_phone_numbers.yml
@@ -13,7 +13,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: 5
+cardinality: 9
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
## Description

Relates to #18112

## Testing done
Manually

## Screenshots
![Screenshot 2024-05-14 at 10 45 01 AM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/0bf4e924-929c-4f3f-8657-0954f0f4be44)


## QA steps
### Set up QA Content Publisher
- [x] As an admin, update the QA Content Publisher
  - [x] Assign the following roles
    - [x] Content creator - VAMC
    - [x] Content publisher
  - [x] Assign the following Section
    - [x] VA Boston health care

### Test the cardinality of the appointment phone numbers in Service Location
- [ ] Login as QA Content Publisher
- [ ] Go to  [Endocrinology - Brockton VA Medical Center](https://pr18117-5m1klo3nwuomf1on9zhsmxlcym2pqeyj.ci.cms.va.gov/node/66893/edit)
- [ ] Confirm that you can add up to 9 appointment numbers

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

