### PR TITLE
VACMS-17515: Adds condition for new nonclinical service

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
@@ -50,7 +50,9 @@ function va_gov_vamc_form_alter(&$form, FormStateInterface $form_state, $form_id
       _va_gov_vamc_vbo_facility_status_form_ui($form, $form_state);
     }
   }
-  if ($form_id === 'node_vha_facility_nonclinical_service_edit_form') {
+  if ($form_id === 'node_vha_facility_nonclinical_service_edit_form' ||
+    $form_id === 'node_vha_facility_nonclinical_service_form') {
+    // We need to remove fields that are not relevant to non-clinical services.
     _va_gov_vamc_remove_service_location_fields_from_non_clinical_services($form);
   }
 }


### PR DESCRIPTION
## Description

Relates to #17515 

## Testing done
Locally and in Tugboat

## Screenshots
![Screenshot 2024-05-28 at 4 18 04 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/f26b7991-8242-4946-a250-cb41ea0851cd)


## QA steps
### Set up QA Content Publisher
- [x] As an admin, update the QA Content Publisher
  - [x] Assign the following roles
    - [x] Content creator - VAMC
    - [x] Content publisher
  - [x] Assign the following Section
    - [x] VA Boston health care

### Add and Edit a VAMC Facility Non-clinical Service
- [ ] As QA Content Publisher, [create a VAMC Facility Non-clinical Service](https://pr18238-eypvkc5lyki8lrjhedyaw8483ewgqpvs.ci.cms.va.gov/node/add/vha_facility_nonclinical_service) (Medical Records at Holdrege VA Clinic in the VA Nebraska-Western Iowa health care Section)
- [ ] Confirm that Service options is not showing in Service locations
- [ ] Confirm that Appointments is not showing in Service locations
- [ ] Save the node
- [ ] Edit the node
- [ ] Confirm that Service options is not showing in Service locations
- [ ] Confirm that Appointments is not showing in Service locations

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

