### PR TITLE
VACMS-18070: Adding a check for response header for files to pull from s3 buckets.

### DIFF
--- a/.ddev/mutagen/mutagen.yml
+++ b/.ddev/mutagen/mutagen.yml
@@ -3,8 +3,8 @@
 # and add your own configuration. If you override it you will
 # probably want to check it in.
 # Please do `ddev mutagen reset` after changing the file.
-# See DDEV Mutagen docs at
-# https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
+# See ddev mutagen docs at
+# https://ddev.readthedocs.io/en/latest/users/install/performance/
 # For detailed information about mutagen configuration options, see
 # https://mutagen.io/documentation/introduction/configuration
 sync:

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -238,24 +238,6 @@ if (!empty($GLOBALS['request']) &&
   $deploy_service->run($GLOBALS['request'], $app_root, $site_path);
 }
 
-// Because Jenkins can't resolve e.g. prod.cms.va.gov DNS, and only the
-// internal*elb addresses. And sometimes the host would return data with
-// "http://default/..." hostnames for files so we set the host here and pass it
-// to the `file_public_base_url` setting to fix that.
-if (!empty($webhost_on_cli)) {
-  if (PHP_SAPI === 'cli') {
-    // This is running from drush so set the webhost.
-    // Var $webhost_on_cli is set in <settings.<environment>.php.
-    $webhost = $webhost_on_cli;
-  }
-  else {
-    // This is running from an HTTP request.
-    $webhost = "{$_SERVER['REQUEST_SCHEME']}://{$_SERVER['HTTP_HOST']}";
-  }
-
-  $settings['file_public_base_url'] = "{$webhost}/sites/default/files";
-}
-
 // Monolog
 $settings['container_yamls'][] = __DIR__ . '/services/services.monolog.yml';
 

--- a/docroot/sites/default/settings/settings.local.php
+++ b/docroot/sites/default/settings/settings.local.php
@@ -55,3 +55,35 @@ $settings['memcache']['servers'] = [
 $settings['cms_datadog_api_key'] = getenv('CMS_DATADOG_API_KEY');
 
 $settings['va_cms_bot_github_auth_token'] = getenv('GITHUB_TOKEN') ?: 'fake-token';
+
+// Because Jenkins can't resolve e.g. prod.cms.va.gov DNS, and only the
+// internal*elb addresses. And sometimes the host would return data with
+// "http://default/..." hostnames for files so we set the host here and pass it
+// to the `file_public_base_url` setting to fix that.
+if (!empty($webhost_on_cli)) {
+  if (PHP_SAPI === 'cli') {
+    // This is running from drush so set the webhost.
+    // Var $webhost_on_cli is set in <settings.<environment>.php.
+    $webhost = $webhost_on_cli;
+  }
+  else {
+    // This is running from an HTTP request.
+    $webhost = "{$_SERVER['REQUEST_SCHEME']}://{$_SERVER['HTTP_HOST']}";
+  }
+
+  // Setting the custom header to switch the file base URL in next-build
+  // Uncomment this next line to test that the header is being set
+  header('File-Public-Base-Url-Check: true');
+
+  // Get all headers
+  $headersArray = headers_list();
+
+  // If the header is set in the response headers
+  if (in_array('File-Public-Base-Url-Check: true', $headersArray, true)) {
+    // Make the file base url point to staging
+    $settings['file_public_base_url'] = "https://dsva-vagov-staging-cms-files.s3.us-gov-west-1.amazonaws.com";
+  } else {
+    // Otherwise use the default webhost
+    $settings['file_public_base_url'] = "{$webhost}/sites/default/files";
+  }
+}

--- a/docroot/sites/default/settings/settings.local.php
+++ b/docroot/sites/default/settings/settings.local.php
@@ -73,7 +73,7 @@ if (!empty($webhost_on_cli)) {
 
   // Setting the custom header to switch the file base URL in next-build
   // Uncomment this next line to test that the header is being set
-  header('File-Public-Base-Url-Check: true');
+  // header('File-Public-Base-Url-Check: true');
 
   // Get all headers
   $headersArray = headers_list();

--- a/docroot/sites/default/settings/settings.staging.php
+++ b/docroot/sites/default/settings/settings.staging.php
@@ -47,3 +47,35 @@ $settings['trusted_host_patterns'] = [
 $settings['va_gov_frontend_url'] = 'https://staging.va.gov';
 $settings['va_gov_frontend_build_type'] = 'brd';
 $settings['github_actions_deploy_env'] = 'staging';
+
+// Because Jenkins can't resolve e.g. prod.cms.va.gov DNS, and only the
+// internal*elb addresses. And sometimes the host would return data with
+// "http://default/..." hostnames for files so we set the host here and pass it
+// to the `file_public_base_url` setting to fix that.
+if (!empty($webhost_on_cli)) {
+    if (PHP_SAPI === 'cli') {
+      // This is running from drush so set the webhost.
+      // Var $webhost_on_cli is set in <settings.<environment>.php.
+      $webhost = $webhost_on_cli;
+    }
+    else {
+      // This is running from an HTTP request.
+      $webhost = "{$_SERVER['REQUEST_SCHEME']}://{$_SERVER['HTTP_HOST']}";
+    }
+  
+    // Setting the custom header to switch the file base URL in next-build
+    // Uncomment this next line to test that the header is being set
+    // header('File-Public-Base-Url-Check: true');
+  
+    // Get all headers
+    $headersArray = headers_list();
+  
+    // If the header is set in the response headers
+    if (in_array('File-Public-Base-Url-Check: true', $headersArray, true)) {
+      // Make the file base url point to staging
+      $settings['file_public_base_url'] = "https://dsva-vagov-staging-cms-files.s3.us-gov-west-1.amazonaws.com";
+    } else {
+      // Otherwise use the default webhost
+      $settings['file_public_base_url'] = "{$webhost}/sites/default/files";
+    }
+  }

--- a/docroot/sites/default/settings/settings.tugboat.php
+++ b/docroot/sites/default/settings/settings.tugboat.php
@@ -92,3 +92,35 @@ $config['simplesamlphp_auth.settings']['activate'] = $is_pull_request;
 // Settings supporting broken link report import.
 $settings['broken_link_report_import_enabled'] = TRUE;
 $settings['broken_link_report_location'] = '/var/lib/tugboat/docroot/vendor/va-gov/content-build/logs/vagovdev-broken-links.json';
+
+// Because Jenkins can't resolve e.g. prod.cms.va.gov DNS, and only the
+// internal*elb addresses. And sometimes the host would return data with
+// "http://default/..." hostnames for files so we set the host here and pass it
+// to the `file_public_base_url` setting to fix that.
+if (!empty($webhost_on_cli)) {
+  if (PHP_SAPI === 'cli') {
+    // This is running from drush so set the webhost.
+    // Var $webhost_on_cli is set in <settings.<environment>.php.
+    $webhost = $webhost_on_cli;
+  }
+  else {
+    // This is running from an HTTP request.
+    $webhost = "{$_SERVER['REQUEST_SCHEME']}://{$_SERVER['HTTP_HOST']}";
+  }
+
+  // Setting the custom header to switch the file base URL in next-build
+  // Uncomment this next line to test that the header is being set
+  // header('File-Public-Base-Url-Check: true');
+
+  // Get all headers
+  $headersArray = headers_list();
+
+  // If the header is set in the response headers
+  if (in_array('File-Public-Base-Url-Check: true', $headersArray, true)) {
+    // Make the file base url point to staging
+    $settings['file_public_base_url'] = "https://dsva-vagov-staging-cms-files.s3.us-gov-west-1.amazonaws.com";
+  } else {
+    // Otherwise use the default webhost
+    $settings['file_public_base_url'] = "{$webhost}/sites/default/files";
+  }
+}


### PR DESCRIPTION
## Description
This work will check for a response header (File-Public-Base-Url-Check) to be present. If it is, it will set the file-base-url for assets to point to the appropriate s3 bucket. If not, it will use webhost variable. This work will initially not have any effect. Once the header has been set in next-build, we should see the assets' paths being directed to the s3 buckets.

Relates to #_18070_. (or closes?)

## Testing done
Tested locally.
Setting variable to both pass and fail to check results in the settings files.

## Screenshots
This is an image of a media asset pulling from the staging s3 bucket because the logic passed:
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/166155028/b64d4026-57ef-45d6-95a9-77730f75bd51)

This is the same media asset with the check failing and it pulling from webhost variable:
![image](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/166155028/4de7bf44-4f39-482b-a007-703c6401a66b)


## QA steps

What needs to be checked to prove this works?
We need to first set the response header in next-build to the specified key/value pair. Then check out assets' url (like an image url) to see if it's pointing to the s3 bucket or to the webhost.
What needs to be checked to prove it didn't break any related things?
Any image or media assets that were working before, need to still work.
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
