### PR TITLE
VACMS-18244: comment out access chagnes for add media forms

### DIFF
--- a/docroot/modules/custom/va_gov_media/src/EventSubscriber/VaGovMediaAddRouteSubscriber.php
+++ b/docroot/modules/custom/va_gov_media/src/EventSubscriber/VaGovMediaAddRouteSubscriber.php
@@ -16,14 +16,14 @@ final class VaGovMediaAddRouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection): void {
-    $addFormRoute = $collection->get('entity.media.add_form');
-    $addFormRoute?->setRequirements([
-      '_role' => 'administrator+content_admin',
-    ]);
-    $addPageRoute = $collection->get('entity.media.add_page');
-    $addPageRoute?->setRequirements([
-      '_role' => 'administrator+content_admin',
-    ]);
+//    $addFormRoute = $collection->get('entity.media.add_form');
+//    $addFormRoute?->setRequirements([
+//      '_role' => 'administrator+content_admin',
+//    ]);
+//    $addPageRoute = $collection->get('entity.media.add_page');
+//    $addPageRoute?->setRequirements([
+//      '_role' => 'administrator+content_admin',
+//    ]);
   }
 
 }


### PR DESCRIPTION
## Description

Closes #18244 

## Testing done
Tested locally.

## Screenshots
![Screenshot 2024-05-31 at 08 40 05](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/109987005/cc7d2bb9-ce70-460a-b8e2-da938ef5b911)


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As Stephen.Westerfield@va.gov
1. Log in and 
   - [ ] Validate that the Content->Media->Add media menu is present and opens its page
2. Then
   - [ ] Validate that the add Document - External menu item exists and opens its form
   - [ ] Validate that the add Document menu item exists and opens its form
   - [ ] Validate that the add Image menu item exists and opens its form
   - [ ] Validate that the add Video menu item exists and opens its form

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
