### PR TITLE
VACMS-17676: prevent removal required services

### DIFF
--- a/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vet_center/src/EventSubscriber/EntityEventSubscriber.php
@@ -240,7 +240,69 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $is_admin = $this->userPermsService->hasAdminRole(TRUE);
     if (!$is_admin) {
       $this->disableFacilityServiceChange($form, $form_state);
+      // $this->disableArchivingRequiredServicesNonAdmins($form, $form_state);
     }
+    $this->showServiceAsRequiredOrOptional($form, $form_state);
+
+  }
+
+  /**
+   * Disable archiving required services for non-admins.
+   */
+  public function disableArchivingRequiredServicesNonAdmins(array &$form, FormStateInterface $form_state) {
+    $required_services = $this->requiredServices->getRequiredServices();
+    $form_object = $form_state->getFormObject();
+    $node = $form_object->getEntity();
+    $service_id = $node->field_service_name_and_descripti->target_id;
+    if (in_array($service_id, $required_services)) {
+      $form['field_archived']['#disabled'] = TRUE;
+    }
+  }
+
+  /**
+   * Show service as required or optional.
+   *
+   * @param array $form
+   *   The node form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function showServiceAsRequiredOrOptional(array &$form, FormStateInterface $form_state) {
+    $required_services = $this->requiredServices->getRequiredServices();
+    $form_object = $form_state->getFormObject();
+    $node = $form_object->getEntity();
+    $service_id = $node->field_service_name_and_descripti->target_id;
+    $service_name = $node->field_service_name_and_descripti->entity->getName();
+    if (in_array($service_id, $required_services)) {
+      // This is a required service.
+      $service_required_or_optional = $this->t('required');
+      $can_or_cannot = $this->t('cannot');
+      $service_required_or_optional_capitalized = $this->t('Required');
+    }
+    else {
+      // This is an optional service.
+      $service_required_or_optional = $this->t('optional');
+      $can_or_cannot = $this->t('can');
+      $service_required_or_optional_capitalized = $this->t('Optional');
+    }
+    $required_or_optional_markup = new FormattableMarkup(
+      '<div class="field-group-tooltip not-editable centralized field-group-html-element tooltip-layout">
+      <p class="vc-help-text"><strong>:service_required_or_optional_capitalized Service</strong>
+      <br />:service_name is a :required_or_optional service. :service_required_or_optional_capitalized services :can_or_cannot be archived. Learn more in the <a href="https://prod.cms.va.gov/help/vet-centers/how-to-edit-a-vet-center-service" target="_blank">Knowledge Base article about Vet Center Services (opens in a new window).</a></p>
+      </div>',
+      [
+        ':service_required_or_optional_capitalized' => $service_required_or_optional_capitalized,
+        ':required_or_optional' => $service_required_or_optional,
+        ':service_name' => $service_name,
+        ':can_or_cannot' => $can_or_cannot,
+      ]
+    );
+    $form['service_optional_or_required'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('@markup', ['@markup' => $required_or_optional_markup]),
+      '#weight' => 5,
+    ];
+
   }
 
   /**

--- a/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
@@ -15,6 +15,40 @@ Scenario: Editors should not be able to rename a Vet Center - Facility Service
   And I click the "Unlock" link
   And I click the "Confirm break lock" button
 
+Scenario: Editors should be able to archive an optional Vet Center - Facility Service
+  Given I am logged in as a user with the roles "content_creator_vet_center, content_publisher, content_editor"
+  # Escanaba Vet Center
+  And my workbench access sections are set to "392"
+  # Escanaba Vet Center - Workshops and Classes
+  When I am at "node/19570/edit"
+  And I scroll to element "select#edit-moderation-state-0-state"
+  Then an option with the text "Archived" from dropdown with selector "select#edit-moderation-state-0-state" should be visible
+  Then I scroll to position "bottom"
+  And I click the "Unlock" link
+  And I click the "Confirm break lock" button
+
+Scenario: Editors should be not able to archive a required Vet Center - Facility Service
+  Given I am logged in as a user with the roles "content_creator_vet_center, content_publisher, content_editor"
+  # Escanaba Vet Center
+  And my workbench access sections are set to "392"
+  # Escanaba Vet Center - Addiction
+  When I am at "node/17597/edit"
+  And I scroll to element "select#edit-moderation-state-0-state"
+  Then an option with the text "Archived" from dropdown with selector "select#edit-moderation-state-0-state" should not be visible
+  Then I scroll to position "bottom"
+  And I click the "Unlock" link
+  And I click the "Confirm break lock" button
+
+Scenario: Admins should be able to archive a required Vet Center - Facility Service
+  Given I am logged in as a user with the "administrator" role
+  # Escanaba Vet Center - Addiction
+  When I am at "node/17597/edit"
+  And I scroll to element "select#edit-moderation-state-0-state"
+  Then an option with the text "Archived" from dropdown with selector "select#edit-moderation-state-0-state" should be visible
+  Then I scroll to position "bottom"
+  And I click the "Unlock" link
+  And I click the "Confirm break lock" button
+
 Scenario: Administrators should be able to rename a Vet Center - Facility Service
   Given I am logged in as a user with the "administrator" role
   # Escanaba Vet Center - Telehealth

--- a/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
@@ -41,8 +41,8 @@ Scenario: Editors should be not able to archive a required Vet Center - Facility
 
 Scenario: Admins should be able to archive a required Vet Center - Facility Service
   Given I am logged in as a user with the "administrator" role
-  # Escanaba Vet Center - Addiction
-  When I am at "node/17597/edit"
+  # Escanaba Vet Center - Suicide prevention
+  When I am at "node/17926/edit"
   And I scroll to element "select#edit-moderation-state-0-state"
   Then an option with the text "Archived" from dropdown with selector "select#edit-moderation-state-0-state" should be visible
   Then I scroll to position "bottom"


### PR DESCRIPTION
## Description

Relates to #17676 

## Testing done
Manually and with Cypress

## Screenshots
### Optional Service
<img width="1306" alt="Screenshot 2024-06-13 at 14 27 15" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/5d60f88b-fbce-4ffd-a2c4-4fb7021f4972">

### Required Service
<img width="1372" alt="Screenshot 2024-06-13 at 14 16 15" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/b5c2db7d-a3ff-49ab-ac43-cb24c211f322">

### Option Service moderation state for Editors
<img width="1197" alt="Screenshot 2024-06-13 at 14 32 08" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/b66a703f-f156-4e42-a424-c4135a3b6b54">

### Required service moderation state for Editors
<img width="1197" alt="Screenshot 2024-06-13 at 14 32 08" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/766573/51f4865a-de6e-44cf-86ce-08acd58dbea2">

 

## QA steps
### Set up QA Content Publisher
- [x] As an admin, update the QA Content Publisher
  - [x] Assign the following roles
    - [x] Content creator - Vet Center
    - [x] Content publisher
  - [x] Assign the following Section
    - [x] Boston Vet Center
 

### Edit a Vet Center - Facility Service as a Vet Center editor
- [x] As QA Content Publisher, go to [Boston Vet Center - Telehealth](https://pr18318-psfh72ycmimh8ryfuvdjibp4glpkhz1e.ci.cms.va.gov/node/37728/edit), an optional service
  - [x] Confirm the "Optional service" box is there and is accurate
  - [x] Confirm that "Archived" is an option in the **Moderation state** dropdown
- [x] As QA Content Publisher, go to [Boston Vet Center - Addiction and substance use care](https://pr18318-psfh72ycmimh8ryfuvdjibp4glpkhz1e.ci.cms.va.gov/node/37718/edit), a required service
  - [x] Confirm the "Required service" box is there and is accurate
  - [x] Confirm that "Archived" is **not** an option in the **Moderation state** dropdown

Edit as an admin
- [x] As QA Content Publisher, go to [Boston Vet Center - Women Veteran care](https://pr18318-psfh72ycmimh8ryfuvdjibp4glpkhz1e.ci.cms.va.gov/node/38546/edit), an optional service
  - [x] Confirm the "Optional service" box is there and is accurate
  - [x] Confirm that "Archived" is an option in the **Moderation state** dropdown
- [x] As QA Content Publisher, go to [Boston Vet Center - Suicide prevention](https://pr18318-psfh72ycmimh8ryfuvdjibp4glpkhz1e.ci.cms.va.gov/node/37727/edit), a required service
  - [x] Confirm the "Required service" box is there and is accurate
  - [ ] Confirm that "Archived" is **not** an option in the **Moderation state** dropdown


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
