### PR TITLE
VACMS-18178: Removed Mental Health from services to withhold

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceBase.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityServiceBase.php
@@ -73,7 +73,6 @@ abstract class PostFacilityServiceBase extends PostFacilityBase {
   protected $servicesToWithhold = [
       // Key: service name (not used) => Value: TID.
     'Caregiver support' => 48,
-    'Mental health care' => 43,
   ];
 
   /**


### PR DESCRIPTION
## Description

Relates to #18178

## Testing done
Manually and with Lighthouse

## Screenshots
N/A

## QA steps
- [x] As an admin, make a change to a [VAMC facility Mental health service](https://pr18323-wcw0uvyils3ob7vodhxg3qklwpfzdnhy.ci.cms.va.gov/node/69774/edit).
- [x] Coordinate with Adam from Lighthouse to let him know that we want to test the successful receipt of the service data in the sandbox environment.
- [x] Push the service by processing the [Post API queue](https://pr18323-wcw0uvyils3ob7vodhxg3qklwpfzdnhy.ci.cms.va.gov/admin/config/post-api/queue).
- [x] Confirm with Adam that it was received.


### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
