### PR TITLE
VACMS-18311: Limit Aging Content Email to Specific Users

### DIFF
--- a/config/sync/eca.eca.aging_content_expired_fwb.yml
+++ b/config/sync/eca.eca.aging_content_expired_fwb.yml
@@ -54,7 +54,7 @@ actions:
     configuration:
       token_name: job
       type: va_gov_aging_content_notification
-      payload: "template_values:\r\n    uid: \"[node:author:uid]\"\r\n    template: aging_content_expired_fwb\r\nrestrict_delivery_to:\r\nvalues:\r\n    field_expired_date: \"[node:expiration_date:date:html_date]\"\r\n    field_target_entity:\r\n         target_id: \"[node:nid]\"\r\n    field_target_node_title: \"[node:title]\""
+      payload: "template_values:\r\n    uid: \"[node:revision_uid:target_id]\"\r\n    template: aging_content_expired_fwb\r\nvalues:\r\n    field_expired_date: \"[node:expiration_date:date:html_date]\"\r\n    field_target_entity:\r\n         target_id: \"[node:nid]\"\r\n    field_target_node_title: \"[node:title]\""
       queue: aging_content
     successors: {  }
   eca_trigger_content_entity_cus_1:

--- a/config/sync/eca.eca.aging_content_warn_fwb.yml
+++ b/config/sync/eca.eca.aging_content_warn_fwb.yml
@@ -54,7 +54,7 @@ actions:
     configuration:
       token_name: job
       type: va_gov_aging_content_notification
-      payload: "template_values:\r\n    uid: \"[node:author:uid]\"\r\n    template: aging_content_warn_fwb\r\nrestrict_delivery_to:\r\nvalues:\r\n    field_warning_date: \"[node:warning_date:date:html_date]\"\r\n    field_target_node_title: \"[node:title]\""
+      payload: "template_values:\r\n    uid: \"[node:revision_uid:target_id]\"\r\n    template: aging_content_warn_fwb\r\nvalues:\r\n    field_warning_date: \"[node:warning_date:date:html_date]\"\r\n    field_target_node_title: \"[node:title]\""
       queue: aging_content
     successors: {  }
   eca_trigger_content_entity_cus_1:

--- a/docroot/modules/custom/va_gov_notifications/src/JobTypeMessageNotifyBase.php
+++ b/docroot/modules/custom/va_gov_notifications/src/JobTypeMessageNotifyBase.php
@@ -176,11 +176,11 @@ class JobTypeMessageNotifyBase extends JobTypeBase implements ContainerFactoryPl
     // The allow list is comprehensive, so users not in the allow list, if
     // present, are restricted.
     if ($allow_only_to) {
-      return in_array($current_user, $payload['allow_delivery_only_to']);
+      return in_array($current_user, (array) $payload['allow_delivery_only_to']);
     }
     // If user is restricted, prevent sending.
     if ($restrict_to) {
-      return !in_array($current_user, $payload['restrict_delivery_to']);
+      return !in_array($current_user, (array) $payload['restrict_delivery_to']);
     }
     // Default to allow sending.
     return TRUE;

--- a/docroot/modules/custom/va_gov_notifications/src/JobTypeMessageNotifyBase.php
+++ b/docroot/modules/custom/va_gov_notifications/src/JobTypeMessageNotifyBase.php
@@ -169,7 +169,7 @@ class JobTypeMessageNotifyBase extends JobTypeBase implements ContainerFactoryPl
     // 2) restrict_delivery_to => Do not deliver mail to provided users.
     $restrict_to = !empty($payload['restrict_delivery_to']);
     $allow_only_to = !empty($payload['allow_delivery_only_to']);
-    if (!isset($restrict_to) || !isset($allow_to)) {
+    if (!isset($restrict_to) && !isset($allow_to)) {
       return TRUE;
     }
     $current_user = $message->getOwnerId();
@@ -180,7 +180,7 @@ class JobTypeMessageNotifyBase extends JobTypeBase implements ContainerFactoryPl
     }
     // If user is restricted, prevent sending.
     if ($restrict_to) {
-      return in_array($current_user, $payload['restrict_delivery_to']);
+      return !in_array($current_user, $payload['restrict_delivery_to']);
     }
     // Default to allow sending.
     return TRUE;

--- a/tests/phpunit/va_gov_notifications/functional/AgingContentFullWidthBannerTest.php
+++ b/tests/phpunit/va_gov_notifications/functional/AgingContentFullWidthBannerTest.php
@@ -81,8 +81,13 @@ class AgingContentFullWidthBannerTest extends VaGovExistingSiteBase {
     // Enable the ECA if it is not already.
     /** @var \Drupal\eca\Entity\Eca $eca */
     $eca = \Drupal::entityTypeManager()->getStorage('eca')->load("aging_content_{$type}_fwb");
+
     $status = $eca->status();
     $eca->enable();
+    // Ensure that the ECA model will always fire during cron.
+    $current_events = $events = $eca->get('events');
+    $events['eca_base_eca_cron']['configuration']['frequency'] = '* * * * *';
+    $eca->set('events', $events);
     $eca->save();
 
     // Run cron to queue the job.
@@ -95,6 +100,7 @@ class AgingContentFullWidthBannerTest extends VaGovExistingSiteBase {
 
     // Set ECA to previous state. This is to prevent duplicate queued items.
     $eca->setStatus($status);
+    $eca->set('events', $current_events);
     $eca->save();
 
     // Run cron again to execute the job, which sends the notification.

--- a/tests/phpunit/va_gov_notifications/kernel/JobTypeMessageNotifyBaseTest.php
+++ b/tests/phpunit/va_gov_notifications/kernel/JobTypeMessageNotifyBaseTest.php
@@ -80,6 +80,7 @@ class JobTypeMessageNotifyBaseTest extends KernelTestBase {
         'uid' => 1,
         'template' => 'foo_template',
       ],
+      // @todo update tests to account for allow & restricted changes.
       'restrict_delivery_to' => [1],
     ];
     $job = new Job([
@@ -103,6 +104,7 @@ class JobTypeMessageNotifyBaseTest extends KernelTestBase {
         'uid' => 1,
         'template' => 'foo_template',
       ],
+      // @todo update tests to account for allow & restricted changes.
       'restrict_delivery_to' => [2],
     ];
     $job = new Job([

--- a/tests/phpunit/va_gov_notifications/kernel/JobTypeMessageNotifyBaseTest.php
+++ b/tests/phpunit/va_gov_notifications/kernel/JobTypeMessageNotifyBaseTest.php
@@ -80,8 +80,7 @@ class JobTypeMessageNotifyBaseTest extends KernelTestBase {
         'uid' => 1,
         'template' => 'foo_template',
       ],
-      // @todo update tests to account for allow & restricted changes.
-      'restrict_delivery_to' => [1],
+      'restrict_delivery_to' => [2],
     ];
     $job = new Job([
       'type' => 'test_job_type',
@@ -95,17 +94,62 @@ class JobTypeMessageNotifyBaseTest extends KernelTestBase {
   }
 
   /**
-   * Tests the process method with an error due to missing template values.
+   * Tests the process method with an error due to restricted delivery setting.
    */
-  public function testProcessFailureRecipientAllowList() {
+  public function testProcessFailureRecipientRestrictList() {
     $payload = [
       'values' => [],
       'template_values' => [
         'uid' => 1,
         'template' => 'foo_template',
       ],
-      // @todo update tests to account for allow & restricted changes.
-      'restrict_delivery_to' => [2],
+      'restrict_delivery_to' => [1],
+    ];
+    $job = new Job([
+      'type' => 'test_job_type',
+      'payload' => $payload,
+      'state' => Job::STATE_QUEUED,
+    ]);
+
+    $result = $this->jobType->process($job);
+    $this->assertEquals(Job::STATE_FAILURE, $result->getState());
+    $this->assertEquals('Recipient is not on the allow list for message 1.', $result->getMessage());
+  }
+
+  /**
+   * Tests the process method for successful sending using allow list.
+   */
+  public function testProcessSuccessRecipientAllowList() {
+    $payload = [
+      'values' => [],
+      'template_values' => [
+        'uid' => 1,
+        'template' => 'foo_template',
+      ],
+      'allow_delivery_only_to' => [1],
+    ];
+    $job = new Job([
+      'type' => 'test_job_type',
+      'payload' => $payload,
+      'state' => Job::STATE_QUEUED,
+    ]);
+
+    $result = $this->jobType->process($job);
+    $this->assertEquals(Job::STATE_SUCCESS, $result->getState());
+    $this->assertEquals('Message 1 sent successfully.', $result->getMessage());
+  }
+
+  /**
+   * Tests the process method for failure sending using allow list.
+   */
+  public function testProcessFailureRecipientAllowList() {
+    $payload = [
+      'values' => [],
+      'template_values' => [
+        'uid' => 2,
+        'template' => 'foo_template',
+      ],
+      'allow_delivery_only_to' => [1],
     ];
     $job = new Job([
       'type' => 'test_job_type',
@@ -134,7 +178,6 @@ class JobTypeMessageNotifyBaseTest extends KernelTestBase {
     $this->expectExceptionMessage('Missing template_values in payload for job id');
     $result = $this->jobType->process($job);
     $this->assertEquals(Job::STATE_FAILURE, $result->getState());
-
   }
 
 }


### PR DESCRIPTION
## Description

Relates to #18311

Adds both a comprehensive whitelist (allow_delivery_only_to) , and a blacklist (restrict_delivery_to), to recipient delivery access checks in Aging Content's custom message delivery Job Type. The lists accept any number of user id's for which to restrict/allow.

## Testing done
Tested using a combination of white and blacklisted users.

## Screenshots
![Screenshot 2024-07-09 at 12 49 20 PM](https://github.com/department-of-veterans-affairs/va.gov-cms/assets/221539/fb77d591-66a7-4a1d-9238-699eec281729)

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As a administrator
1. Visit /admin/config/workflow/eca/aging_content_expired_fwb/edit
2. Under 'Workflow options', check the 'Enabled' checkbox, and save the form
3. Visit /admin/config/workflow/eca/aging_content_expired_fwb/action/create_advancedqueue_job/edit
4. In the 'Payload', add these lines:
```
restrict_delivery_to:
  295
```
5. Save the form
6. Run cron
7. Go to /admin/config/system/queues
- [ ] Verify there is a job in the 'Queued' status
8. Disable the ECA workflow (reverse of step 2 to disable the checkbox). This prevents queuing a duplicate message.
9. Run cron
10. Go to /admin/config/system/queues
 - [ ] Validate there is a job in the 'Failed' status with the message: Recipient is not on the allow list for message [xxx]
11. Visit /admin/config/workflow/eca/aging_content_expired_fwb/action/create_advancedqueue_job/edit
12. In the 'Payload', change the key 'restrict_delivery_to' to 'allow_delivery_only_to'.
13. Save the form
14. Perform step 2 (enable the workflow)
15. Run cron
16. Inverse step 2 (disable the workflow)
17. Visit /admin/config/workflow/eca/aging_content_expired_fwb/action/create_advancedqueue_job/edit
 - [ ] Validate there is a job with the "success" status.

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
