### PR TITLE
Revert "Bump datadog/dd-trace from 0.99.1 to 1.2.0 (#18744)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "composer/installers": "^2.2",
         "consolidation/site-process": "^5.2",
         "cweagans/composer-patches": "^1.7",
-        "datadog/dd-trace": "^1.2.0",
+        "datadog/dd-trace": "^0.99.0",
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
         "drupal/address": "^2.0",
         "drupal/admin_feedback": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5a37af9b430403e62bd2798d7bf8597",
+    "content-hash": "c16357598edccfbcbd2f97c322bc1578",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1176,22 +1176,22 @@
         },
         {
             "name": "datadog/dd-trace",
-            "version": "1.2.0",
+            "version": "0.99.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DataDog/dd-trace-php.git",
-                "reference": "dbdd9223ddf251e88d53bf0891c0b7fe241b8e9d"
+                "reference": "8de3b1fb481960857fff1d55d5e1862f7cf39fca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DataDog/dd-trace-php/zipball/dbdd9223ddf251e88d53bf0891c0b7fe241b8e9d",
-                "reference": "dbdd9223ddf251e88d53bf0891c0b7fe241b8e9d",
+                "url": "https://api.github.com/repos/DataDog/dd-trace-php/zipball/8de3b1fb481960857fff1d55d5e1862f7cf39fca",
+                "reference": "8de3b1fb481960857fff1d55d5e1862f7cf39fca",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
-                "php": "^7.0 || ^8.0.0"
+                "php": "^5.4 || ^7.0 || ^8.0.0"
             },
             "require-dev": {
                 "ext-posix": "*",
@@ -1204,14 +1204,6 @@
             "type": "library",
             "extra": {
                 "scenarios": {
-                    "openai": {
-                        "require": {
-                            "openai-php/client": "@stable"
-                        },
-                        "scenario-options": {
-                            "create-lockfile": false
-                        }
-                    },
                     "opentelemetry1": {
                         "require": {
                             "open-telemetry/sdk": "@stable",
@@ -1252,6 +1244,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "./src/api/ComposerBootstrap.php"
+                ],
                 "psr-4": {
                     "DDTrace\\": "./src/api/"
                 }
@@ -1279,9 +1274,9 @@
             ],
             "support": {
                 "issues": "https://github.com/DataDog/dd-trace-php/issues",
-                "source": "https://github.com/DataDog/dd-trace-php/tree/1.2.0"
+                "source": "https://github.com/DataDog/dd-trace-php/tree/0.99.1"
             },
-            "time": "2024-07-22T17:42:03+00:00"
+            "time": "2024-04-04T15:06:49+00:00"
         },
         {
             "name": "davedevelopment/stiphle",


### PR DESCRIPTION
This reverts commit 5bf0b1a7b4e8e4c9d9b9833d1217f2055782faca.

## Description

Relates to #_issueid_. (or closes?)

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
