### PR TITLE
VACMS-18723 Exported and added configs to git for Mission Explainer

### DIFF
--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_last_saved_by_an_editor
     - field.field.node.vet_center.field_media
+    - field.field.node.vet_center.field_mission_explainer
     - field.field.node.vet_center.field_office_hours
     - field.field.node.vet_center.field_official_name
     - field.field.node.vet_center.field_operating_status_facility
@@ -344,6 +345,15 @@ content:
     region: content
     settings:
       media_types: {  }
+    third_party_settings: {  }
+  field_mission_explainer:
+    type: entity_field_fetch_widget
+    weight: 27
+    region: content
+    settings:
+      show_field_label: true
+      show_link_to_source: false
+      show_source_updated_date: false
     third_party_settings: {  }
   field_office_hours:
     type: office_hours_default

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -64,7 +64,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 11
+      weight: 10
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -81,7 +81,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 12
+      weight: 11
       format_type: fieldset
       format_settings:
         classes: ''
@@ -93,7 +93,7 @@ third_party_settings:
       label: 'Direct line'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         classes: ''
@@ -108,7 +108,7 @@ third_party_settings:
       label: 'Top of page information'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
@@ -158,7 +158,7 @@ third_party_settings:
       label: 'Prepare for your visit'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -172,7 +172,7 @@ third_party_settings:
       label: 'Spotlight content'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         classes: ''
@@ -185,7 +185,7 @@ third_party_settings:
       label: "How we're different than a clinic (FAQs)"
       region: content
       parent_name: ''
-      weight: 10
+      weight: 9
       format_type: tooltip
       format_settings:
         show_label: '0'
@@ -247,7 +247,7 @@ third_party_settings:
       label: Services
       region: content
       parent_name: ''
-      weight: 7
+      weight: 8
       format_type: details
       format_settings:
         classes: ''
@@ -259,23 +259,23 @@ third_party_settings:
     group_mission_explainer:
       children:
         - field_mission_explainer
-      label: 'Mission Explainer'
+      label: 'Vet Center services overview'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: tooltip
       format_settings:
-        show_label: '1'
-        tooltip_description: ''
+        show_label: '0'
+        tooltip_description: "Why can’t I edit this?\r\nVHA keeps this content standardized to provide consistent messaging for Vet Center sites nationwide."
         description: ''
         required_fields: '1'
         id: ''
         classes: centralized
         show_empty_fields: 0
+        label_as_html: 0
         element: div
         label_element: h3
         attributes: ''
-        open: false
 id: node.vet_center.default
 targetEntityType: node
 bundle: vet_center
@@ -355,7 +355,7 @@ content:
     third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_form_display.node.vet_center.default.yml
@@ -64,7 +64,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 11
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -81,7 +81,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 10
+      weight: 12
       format_type: fieldset
       format_settings:
         classes: ''
@@ -108,7 +108,7 @@ third_party_settings:
       label: 'Top of page information'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -124,7 +124,7 @@ third_party_settings:
       label: 'Locations and contact information'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -185,7 +185,7 @@ third_party_settings:
       label: "How we're different than a clinic (FAQs)"
       region: content
       parent_name: ''
-      weight: 8
+      weight: 10
       format_type: tooltip
       format_settings:
         show_label: '0'
@@ -256,6 +256,26 @@ third_party_settings:
         open: true
         description: ''
         required_fields: false
+    group_mission_explainer:
+      children:
+        - field_mission_explainer
+      label: 'Mission Explainer'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: tooltip
+      format_settings:
+        show_label: '1'
+        tooltip_description: ''
+        description: ''
+        required_fields: '1'
+        id: ''
+        classes: centralized
+        show_empty_fields: 0
+        element: div
+        label_element: h3
+        attributes: ''
+        open: false
 id: node.vet_center.default
 targetEntityType: node
 bundle: vet_center
@@ -263,14 +283,14 @@ mode: default
 content:
   field_address:
     type: address_default
-    weight: 8
+    weight: 15
     region: content
     settings:
       wrapper_type: fieldset
     third_party_settings: {  }
   field_administration:
     type: options_select
-    weight: 4
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -285,7 +305,7 @@ content:
     third_party_settings: {  }
   field_cc_vet_center_call_center:
     type: entity_field_fetch_widget
-    weight: 14
+    weight: 13
     region: content
     settings:
       show_field_label: '1'
@@ -303,7 +323,7 @@ content:
     third_party_settings: {  }
   field_cc_vet_center_featured_con:
     type: entity_field_fetch_widget
-    weight: 4
+    weight: 9
     region: content
     settings:
       show_field_label: '1'
@@ -312,7 +332,7 @@ content:
     third_party_settings: {  }
   field_facility_locator_api_id:
     type: string_textfield
-    weight: 7
+    weight: 13
     region: content
     settings:
       size: 60
@@ -320,14 +340,14 @@ content:
     third_party_settings: {  }
   field_geolocation:
     type: geofield_latlon
-    weight: 9
+    weight: 16
     region: content
     settings:
       html5_geolocation: false
     third_party_settings: {  }
   field_intro_text:
     type: string_textarea
-    weight: 12
+    weight: 15
     region: content
     settings:
       rows: 5
@@ -335,7 +355,7 @@ content:
     third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
-    weight: 11
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -348,16 +368,16 @@ content:
     third_party_settings: {  }
   field_mission_explainer:
     type: entity_field_fetch_widget
-    weight: 27
+    weight: 14
     region: content
     settings:
-      show_field_label: true
-      show_link_to_source: false
-      show_source_updated_date: false
+      show_field_label: 0
+      show_link_to_source: 0
+      show_source_updated_date: 0
     third_party_settings: {  }
   field_office_hours:
     type: office_hours_default
-    weight: 11
+    weight: 18
     region: content
     settings:
       collapsed: false
@@ -366,7 +386,7 @@ content:
         limit_values: '0'
   field_official_name:
     type: tooltip_textfield
-    weight: 9
+    weight: 13
     region: content
     settings:
       tooltip_text: "Why can’t I edit this?\r\nThis content is automatically populated from centralized databases, and helps maintain consistent information across all of VA.gov."
@@ -395,7 +415,7 @@ content:
     third_party_settings: {  }
   field_phone_number:
     type: telephone_default
-    weight: 10
+    weight: 17
     region: content
     settings:
       placeholder: ''
@@ -429,7 +449,7 @@ content:
     third_party_settings: {  }
   field_timezone:
     type: tzfield_default
-    weight: 12
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -465,7 +485,7 @@ content:
     third_party_settings: {  }
   title:
     type: tooltip_textfield
-    weight: 11
+    weight: 14
     region: content
     settings:
       tooltip_text: "Why can’t I edit this?\r\nThe common name is set up to keep a consistent format with other Vet Centers across all of VA.gov."

--- a/config/sync/core.entity_view_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_last_saved_by_an_editor
     - field.field.node.vet_center.field_media
+    - field.field.node.vet_center.field_mission_explainer
     - field.field.node.vet_center.field_office_hours
     - field.field.node.vet_center.field_official_name
     - field.field.node.vet_center.field_operating_status_facility
@@ -268,6 +269,13 @@ content:
         attribute: lazy
     third_party_settings: {  }
     weight: 11
+    region: content
+  field_mission_explainer:
+    type: entity_field_fetch
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 19
     region: content
   field_office_hours:
     type: office_hours

--- a/config/sync/core.entity_view_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.default.yml
@@ -44,7 +44,7 @@ third_party_settings:
       label: 'External content'
       parent_name: ''
       region: hidden
-      weight: 24
+      weight: 25
       format_type: fieldset
       format_settings:
         classes: ''
@@ -70,7 +70,7 @@ third_party_settings:
       label: 'Top of page information'
       parent_name: ''
       region: content
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -85,7 +85,7 @@ third_party_settings:
       label: 'Locations and contact information'
       parent_name: ''
       region: content
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -102,7 +102,7 @@ third_party_settings:
       label: 'Facility data'
       parent_name: group_locations_and_contact_info
       region: content
-      weight: 8
+      weight: 5
       format_type: tooltip
       format_settings:
         show_label: '0'
@@ -121,7 +121,7 @@ third_party_settings:
       label: 'Hours details and call center information'
       parent_name: group_locations_and_contact_info
       region: content
-      weight: 9
+      weight: 6
       format_type: tooltip
       format_settings:
         show_label: '0'
@@ -139,7 +139,7 @@ third_party_settings:
       label: 'Prepare for your visit'
       parent_name: ''
       region: content
-      weight: 5
+      weight: 6
       format_type: fieldset
       format_settings:
         classes: ''
@@ -152,7 +152,7 @@ third_party_settings:
       label: "How we're different than a clinic (FAQs)"
       parent_name: ''
       region: content
-      weight: 7
+      weight: 8
       format_type: tooltip
       format_settings:
         show_label: '1'
@@ -171,7 +171,7 @@ third_party_settings:
       label: 'Featured content'
       parent_name: ''
       region: content
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -184,11 +184,29 @@ third_party_settings:
       label: 'National featured content'
       parent_name: group_featured_content
       region: content
-      weight: 7
+      weight: 10
       format_type: tooltip
       format_settings:
         show_label: '0'
         tooltip_description: "Why can’t I edit this?\r\nThis national feature managed by VHA will display alongside locally-relevant content."
+        description: ''
+        id: ''
+        classes: centralized
+        show_empty_fields: 0
+        element: div
+        label_element: h3
+        attributes: ''
+    group_mission_explainer:
+      children:
+        - field_mission_explainer
+      label: 'Mission Explainer'
+      parent_name: ''
+      region: content
+      weight: 2
+      format_type: tooltip
+      format_settings:
+        show_label: '1'
+        tooltip_description: ''
         description: ''
         id: ''
         classes: centralized
@@ -250,7 +268,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   field_intro_text:
     type: basic_string
@@ -268,14 +286,14 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 11
+    weight: 7
     region: content
   field_mission_explainer:
     type: entity_field_fetch
-    label: above
+    label: visually_hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 19
+    weight: 4
     region: content
   field_office_hours:
     type: office_hours
@@ -310,7 +328,7 @@ content:
       schema:
         enabled: false
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   field_official_name:
     type: string
@@ -349,14 +367,14 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 7
+    weight: 9
     region: content
   field_timezone:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   field_vet_center_feature_content:
     type: entity_reference_revisions_entity_view
@@ -365,7 +383,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 8
+    weight: 11
     region: content
 hidden:
   breadcrumbs: true

--- a/config/sync/core.entity_view_display.node.vet_center.default.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.default.yml
@@ -44,7 +44,7 @@ third_party_settings:
       label: 'External content'
       parent_name: ''
       region: hidden
-      weight: 25
+      weight: 24
       format_type: fieldset
       format_settings:
         classes: ''
@@ -70,7 +70,7 @@ third_party_settings:
       label: 'Top of page information'
       parent_name: ''
       region: content
-      weight: 3
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
@@ -199,18 +199,19 @@ third_party_settings:
     group_mission_explainer:
       children:
         - field_mission_explainer
-      label: 'Mission Explainer'
+      label: 'Vet Center services overview'
       parent_name: ''
       region: content
-      weight: 2
+      weight: 3
       format_type: tooltip
       format_settings:
-        show_label: '1'
-        tooltip_description: ''
+        show_label: '0'
+        tooltip_description: "Why can’t I edit this?\r\nVHA keeps this content standardized to provide consistent messaging for Vet Center sites nationwide."
         description: ''
         id: ''
         classes: centralized
         show_empty_fields: 0
+        label_as_html: 0
         element: div
         label_element: h3
         attributes: ''

--- a/config/sync/core.entity_view_display.node.vet_center.external_content.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.external_content.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_last_saved_by_an_editor
     - field.field.node.vet_center.field_media
+    - field.field.node.vet_center.field_mission_explainer
     - field.field.node.vet_center.field_office_hours
     - field.field.node.vet_center.field_official_name
     - field.field.node.vet_center.field_operating_status_facility
@@ -130,6 +131,7 @@ hidden:
   field_intro_text: true
   field_last_saved_by_an_editor: true
   field_media: true
+  field_mission_explainer: true
   field_official_name: true
   field_operating_status_facility: true
   field_operating_status_more_info: true

--- a/config/sync/core.entity_view_display.node.vet_center.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.ief_table.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_last_saved_by_an_editor
     - field.field.node.vet_center.field_media
+    - field.field.node.vet_center.field_mission_explainer
     - field.field.node.vet_center.field_office_hours
     - field.field.node.vet_center.field_official_name
     - field.field.node.vet_center.field_operating_status_facility
@@ -71,6 +72,7 @@ hidden:
   field_intro_text: true
   field_last_saved_by_an_editor: true
   field_media: true
+  field_mission_explainer: true
   field_office_hours: true
   field_official_name: true
   field_operating_status_facility: true

--- a/config/sync/core.entity_view_display.node.vet_center.teaser.yml
+++ b/config/sync/core.entity_view_display.node.vet_center.teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.vet_center.field_intro_text
     - field.field.node.vet_center.field_last_saved_by_an_editor
     - field.field.node.vet_center.field_media
+    - field.field.node.vet_center.field_mission_explainer
     - field.field.node.vet_center.field_office_hours
     - field.field.node.vet_center.field_official_name
     - field.field.node.vet_center.field_operating_status_facility
@@ -53,6 +54,7 @@ hidden:
   field_intro_text: true
   field_last_saved_by_an_editor: true
   field_media: true
+  field_mission_explainer: true
   field_office_hours: true
   field_official_name: true
   field_operating_status_facility: true

--- a/config/sync/field.field.node.vet_center.field_mission_explainer.yml
+++ b/config/sync/field.field.node.vet_center.field_mission_explainer.yml
@@ -1,0 +1,29 @@
+uuid: 8267f35a-a032-472e-bf58-d3532acdeb04
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_mission_explainer
+    - node.type.vet_center
+  module:
+    - entity_field_fetch
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.vet_center.field_mission_explainer
+field_name: field_mission_explainer
+entity_type: node
+bundle: vet_center
+label: 'Mission Explainer'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  target_entity_type: node
+  target_entity_id: '16142'
+  field_to_fetch: field_content_block
+  target_paragraph_uuid: '158439'
+field_type: entity_field_fetch

--- a/config/sync/field.storage.node.field_mission_explainer.yml
+++ b/config/sync/field.storage.node.field_mission_explainer.yml
@@ -1,0 +1,19 @@
+uuid: 045bf2f9-fa88-48de-8624-baac70ad6cfc
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_field_fetch
+    - node
+id: node.field_mission_explainer
+field_name: field_mission_explainer
+entity_type: node
+type: entity_field_fetch
+settings: {  }
+module: entity_field_fetch
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Description
Added a Mission Explainer content block to the Vet center content type.
Relates to #18723
## Testing done


## Screenshots
### Centralized Content
<img width="1014" alt="Screenshot 2024-08-07 at 9 14 15 AM" src="https://github.com/user-attachments/assets/7841d998-769d-476d-89a1-4d8e8c16ca0b">
<img width="1793" alt="Screenshot 2024-08-09 at 9 08 15 AM" src="https://github.com/user-attachments/assets/942dd6b1-f4f7-440e-aecc-a760bbb446c3">

### Vet Center Content Type
<img width="930" alt="Screenshot 2024-08-09 at 12 49 24 PM" src="https://github.com/user-attachments/assets/fa54dd85-60d2-4e14-b3c7-3f9e8eaf561b">


## QA steps

As a drupal admin:
### Validate that a centralized content descriptor content block was added to VetCenter Centralized Content
- [x] Visit https://pr18890-tt9t9v1nunrmm5opymrkq5ncspqnmuxa.ci.cms.va.gov/centralized-content/national-vet-center-content
- [x] Validate this block has two fields, One for the title and one for the rich text field
- [x] content block is populated with the following copy: 

> "Our services
> We offer these confidential services at our Vet Centers:
> 
> Counseling and a range of other services for individuals, families, and group sessions
> Alternative therapies and events may be offered such as art, equine, yoga, or fly fishing
> Connections to more support in VA and your community
> Note: You may be eligible for these services no matter your discharge status or eligibility for VA health care. And we won’t share anything about you or the services you receive at a Vet Center without your permission."

- [x] Content block shows on node:edit and node:view(if low LOE) on VetCenter Content Type

### Update Nodes by performing a bulk edit to the centralized content 

- [x] Go to the bulk edit page [filtered by vet center content type](https://pr18890-tt9t9v1nunrmm5opymrkq5ncspqnmuxa.ci.cms.va.gov/admin/content/bulk?title=&type=vet_center&moderation_state=All&taxonomy_entity_index_tid_depth=All)
- [x] Select all results
- [x] Choose modify field values, and apply
- [x] Choose Mission Explainer field
- [x] Apply and confirm

- [x] Then check a [Vet Center](https://pr18890-tt9t9v1nunrmm5opymrkq5ncspqnmuxa.ci.cms.va.gov/duluth-vet-center) node for Mission Explainer on node view.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
