### PR TITLE
VACMS-18705: Upgrade memcache and memcache_admin modules.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,8 +117,8 @@
         "drupal/linkychecker": "^2.2",
         "drupal/linkyreplacer": "^2.2",
         "drupal/markup": "^2.0",
-        "drupal/memcache": "2.5.0",
-        "drupal/memcache_admin": "2.5.0",
+        "drupal/memcache": "2.6.0",
+        "drupal/memcache_admin": "2.6.0",
         "drupal/menu_breadcrumb": "^2.0@alpha",
         "drupal/menu_export": "^1.2",
         "drupal/menu_force": "^2.0",
@@ -461,9 +461,6 @@
             },
             "drupal/linkit": {
                 "3049946 - Linkit unpublished nodes not included": "https://www.drupal.org/files/issues/2023-11-09/linkit-unpublished-nodes-not-included-3049946-34.patch"
-            },
-            "drupal/memcache": {
-                "3058121 - Use persistent connections": "https://www.drupal.org/files/issues/2020-09-10/3058121-16.patch"
             },
             "drupal/menu_item_extras": {
                 "3210468 - The 'bundle' field is not always populated with the menu name": "https://www.drupal.org/files/issues/2021-04-23/3210468.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a6df916dd8bdead24de75f9ff14b587",
+    "content-hash": "aee206a49b4f1d522d405401baad9d1f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9151,26 +9151,26 @@
         },
         {
             "name": "drupal/memcache",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/memcache.git",
-                "reference": "8.x-2.5"
+                "reference": "8.x-2.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/memcache-8.x-2.5.zip",
-                "reference": "8.x-2.5",
-                "shasum": "a01db2a9b7122a397c4f4ad66e0a380d1148a157"
+                "url": "https://ftp.drupal.org/files/projects/memcache-8.x-2.6.zip",
+                "reference": "8.x-2.6",
+                "shasum": "c58d66e426134c082490dca25b057c6ae0ea3d2a"
             },
             "require": {
-                "drupal/core": "^9.1 || ^10"
+                "drupal/core": "^9.5 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.5",
-                    "datestamp": "1661188440",
+                    "version": "8.x-2.6",
+                    "datestamp": "1720732159",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9227,16 +9227,16 @@
         },
         {
             "name": "drupal/memcache_admin",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "require": {
-                "drupal/core": "^9.1 || ^10",
+                "drupal/core": "^9.5 || ^10 || ^11",
                 "drupal/memcache": "*"
             },
             "type": "metapackage",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.5",
-                    "datestamp": "1661188440",
+                    "version": "8.x-2.6",
+                    "datestamp": "1720732159",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Description

Closes #18705

## Testing done

Verified that memcache and memcache_admin have upgraded to version 2.6.0 without error.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
