### PR TITLE
VATEAM-90582: Add 21-4140 Digital Form to seed script

### DIFF
--- a/scripts/content/digital-forms.php
+++ b/scripts/content/digital-forms.php
@@ -21,7 +21,7 @@ function run() {
   $env = getenv('CMS_ENVIRONMENT_TYPE') ?: 'ci';
   exit_if_not_local_or_tugboat($env);
 
-  create_digital_form();
+  create_digital_forms();
 }
 
 /**
@@ -40,6 +40,14 @@ function create_digital_form() {
     ->field_chapters
     ->appendItem(create_step('Step without Date of Birth', FALSE));
   save_node_revision($digital_form, 'Created by the content script', TRUE);
+}
+
+/**
+ * Creates test Digital Forms.
+ */
+function create_digital_forms() {
+  create_digital_form();
+  create_digital_form();
 }
 
 /**

--- a/scripts/content/digital-forms.php
+++ b/scripts/content/digital-forms.php
@@ -42,7 +42,7 @@ function create_digital_form(
   ],
   array $steps = [
     [],
-    ['title' => 'Step without Date of Birth', 'includeDob' => FALSE],
+    ['title' => 'Step without Date of Birth', 'include_dob' => FALSE],
   ],
 ) {
   $digital_form = Node::create($values);
@@ -66,7 +66,7 @@ function create_digital_forms() {
     'moderation_state' => 'published',
   ];
   $form_21_4140_steps = [
-    ['title' => "Veteran's personal information", 'includeDob' => TRUE],
+    ['title' => "Veteran's personal information", 'include_dob' => TRUE],
   ];
 
   create_digital_form();
@@ -91,6 +91,6 @@ function create_step(
   return Paragraph::create([
     'type' => 'digital_form_name_and_date_of_bi',
     'field_title' => $values['title'] ?? 'Script Generated Step',
-    'field_include_date_of_birth' => $values['includeDob'] ?? TRUE,
+    'field_include_date_of_birth' => $values['include_dob'] ?? TRUE,
   ]);
 }

--- a/scripts/content/digital-forms.php
+++ b/scripts/content/digital-forms.php
@@ -26,19 +26,31 @@ function run() {
 
 /**
  * Creates a Digital Form with hard-coded values.
+ *
+ * @param array $values
+ *   The Node values.
+ * @param array $steps
+ *   An array of arrays. The inner arrays contain step values.
  */
-function create_digital_form() {
-  $digital_form = Node::create([
+function create_digital_form(
+  array $values = [
     'type' => 'digital_form',
     'title' => 'Script Generated Digital Form',
     'field_va_form_number' => '123456789',
     'field_omb_number' => '1234-5678',
     'moderation_state' => 'published',
-  ]);
-  $digital_form->field_chapters->appendItem(create_step());
-  $digital_form
-    ->field_chapters
-    ->appendItem(create_step('Step without Date of Birth', FALSE));
+  ],
+  array $steps = [
+    [],
+    ['title' => 'Step without Date of Birth', 'includeDob' => FALSE],
+  ],
+) {
+  $digital_form = Node::create($values);
+
+  foreach ($steps as $step_values) {
+    $digital_form->field_chapters->appendItem(create_step($step_values));
+  }
+
   save_node_revision($digital_form, 'Created by the content script', TRUE);
 }
 
@@ -46,8 +58,19 @@ function create_digital_form() {
  * Creates test Digital Forms.
  */
 function create_digital_forms() {
+  $form_21_4140 = [
+    'type' => 'digital_form',
+    'title' => 'Employment Questionnaire',
+    'field_va_form_number' => '21-4140',
+    'field_omb_number' => '2900-0079',
+    'moderation_state' => 'published',
+  ];
+  $form_21_4140_steps = [
+    ['title' => "Veteran's personal information", 'includeDob' => TRUE],
+  ];
+
   create_digital_form();
-  create_digital_form();
+  create_digital_form($form_21_4140, $form_21_4140_steps);
 }
 
 /**
@@ -56,21 +79,18 @@ function create_digital_forms() {
  * For now, this only creates the Name and Date of Birth step.
  * That will change as more patterns are added.
  *
- * @param string $title
- *   The step title.
- * @param bool $includeDob
- *   Should the step include the date of birth field?
+ * @param array $values
+ *   The values for the Paragraph.
  *
  * @return \Drupal\paragraphs\Entity\Paragraph
  *   The created Step.
  */
 function create_step(
-  string $title = 'Script Generated Step',
-  bool $includeDob = TRUE,
+  array $values = [],
 ): Paragraph {
   return Paragraph::create([
     'type' => 'digital_form_name_and_date_of_bi',
-    'field_title' => $title,
-    'field_include_date_of_birth' => $includeDob,
+    'field_title' => $values['title'] ?? 'Script Generated Step',
+    'field_include_date_of_birth' => $values['includeDob'] ?? TRUE,
   ]);
 }


### PR DESCRIPTION
## Description
Adds VA Form 21-4140 to the Digital Form seed script created in #19025.

- Closes department-of-veterans-affairs/va.gov-team#90582

## Testing done
Ran the script in my local environment and verified the creation of a Digital Form with the correct info for VA Form 21-4140.

## Screenshots
VA Form 21-4140 as generated by the script:
<img width="808" alt="Screenshot 2024-08-26 at 3 50 06 PM" src="https://github.com/user-attachments/assets/a1f102b0-ac00-4c5f-80dd-231ecbd1630e">

## QA steps

As an administrator
1. Open the command line and navigate to the `va.gov-cms` repo.
2. Start the CMS: `ddev start`
3. Enter the terminal for the web server: `ddev ssh`
4. Run the script: `drush scr scripts/content/digital-forms.php`
5. Go to Manage > Content
   - [ ] Verify that a Digital Form was created with the title "Employment Questionnaire"
6. Click the title
7. Validate the following fields
   - [ ] Form number: 21-4140
   - [ ] OMB Number: 2900-0079
   - [ ] Steps: 1 step titled "Veteran's personal information"

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
