### PR TITLE
VACMS-17477: Updated character counter on News Releases

### DIFF
--- a/config/sync/core.entity_form_display.node.press_release.default.yml
+++ b/config/sync/core.entity_form_display.node.press_release.default.yml
@@ -113,9 +113,9 @@ content:
       placeholder: ''
       maxlength: 300
       counter_position: after
-      js_prevent_submit: false
+      js_prevent_submit: true
       count_html_characters: false
-      textcount_status_message: 'Characters Used: <span class="current_count">@current_length</span><br />Characters Remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
     third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
@@ -189,9 +189,9 @@ content:
       use_field_maxlength: false
       maxlength: 150
       counter_position: after
-      js_prevent_submit: false
+      js_prevent_submit: true
       count_html_characters: false
-      textcount_status_message: 'Characters Used: <span class="current_count">@current_length</span><br />Characters Remaining: <span class="remaining_count">@remaining_count</span>'
+      textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
     third_party_settings: {  }
   url_redirects:
     weight: 7

--- a/config/sync/field.field.node.press_release.field_intro_text.yml
+++ b/config/sync/field.field.node.press_release.field_intro_text.yml
@@ -10,7 +10,7 @@ field_name: field_intro_text
 entity_type: node
 bundle: press_release
 label: Introduction
-description: "<p>The first sentence (\"lede\") of the press release is displayed more prominently (<a href=\"#\">see screenshot</a>). It is also displayed in teaser lists of press releases.</p>"
+description: "<p>The first sentence (\"lede\") of the press release is displayed more prominently (<a href=\"#\">see screenshot</a>). It is also displayed in teaser lists of press releases.</p>\r\n\r\n<p>This should serve as a summary of the contents of the press release. Do not include the location or the em-dash – those are added automatically from the other fields.</p>"
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.press_release.field_intro_text.yml
+++ b/config/sync/field.field.node.press_release.field_intro_text.yml
@@ -10,7 +10,7 @@ field_name: field_intro_text
 entity_type: node
 bundle: press_release
 label: Introduction
-description: "<p>The first sentence (\"lede\") of the press release is displayed more prominently (<a href=\"#\">see screenshot</a>). It is also displayed in teaser lists of press releases.</p>\r\n\r\n<p>This should serve as a summary of the contents of the press release. Do not include the location or the em-dash – those are added automatically from the other fields.</p>\r\n<p><em>Maximum characters: 300</em></p>\r\n\r\n"
+description: "<p>The first sentence (\"lede\") of the press release is displayed more prominently (<a href=\"#\">see screenshot</a>). It is also displayed in teaser lists of press releases.</p>"
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/node.type.press_release.yml
+++ b/config/sync/node.type.press_release.yml
@@ -153,7 +153,7 @@ third_party_settings:
       - va-wilmington-health-care
     parent: 'pittsburgh-health-care:'
   node_title_help_text:
-    title_help: "The topic of this news release, in sentence case.<br/>\r\n<em>Maximum characters: 150</em>"
+    title_help: "The topic of this news release, in sentence case.<br/>"
   node_revision_delete:
     minimum_revisions_to_keep: 50
     minimum_age_to_delete: 0


### PR DESCRIPTION
## Description

Relates to #17477

## Testing done
Manual testing of the News Release content type on Tugboat

## Screenshots

![Screenshot 2024-09-05 at 3 43 09 PM](https://github.com/user-attachments/assets/2f7f949e-c5aa-4964-90ec-e0737eda171c)

![Screenshot 2024-09-05 at 3 42 03 PM](https://github.com/user-attachments/assets/01439229-8930-4cc3-a1c8-1671aa4ae985)

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

1. [Login to tugboat](https://pr19126-ggwoomryhlndqjoziwsiksgsu0q8y2wl.ci.cms.va.gov/) as a Content Admin (e.g. david.pickett@va.gov)
1. Go to Content > Add Content > [News release](https://pr19126-ggwoomryhlndqjoziwsiksgsu0q8y2wl.ci.cms.va.gov/node/add/press_release)
   - [ ] Type in the **Press Release Title** field and confirm the character counter works as intended
   - [ ] Type in the **Introduction** field and confirm the character counter works as intended

### Definition of Done

- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.


