### PR TITLE
VACMS-18855 Find Forms feature toggle for PDF modal

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -5,3 +5,4 @@ features:
   feature_health_connect_number: FEATURE_HEALTH_CONNECT_NUMBER
   feature_next_story_preview: FEATURE_NEXT_STORY_PREVIEW
   feature_decision_review_rum: FEATURE_DECISION_REVIEW_RUM
+  feature_find_forms_modal: FEATURE_FIND_FORMS_MODAL


### PR DESCRIPTION
## Description

Re: Find Forms form detail pages
Create a feature toggle to use new markup in content-build in support of re-adding the PDF modal back.

Issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18855