### PR TITLE
VATEAM-90732: Add OMB info fields to Digital Form

### DIFF
--- a/config/sync/core.entity_form_display.node.digital_form.default.yml
+++ b/config/sync/core.entity_form_display.node.digital_form.default.yml
@@ -5,15 +5,18 @@ dependencies:
   config:
     - field.field.node.digital_form.field_administration
     - field.field.node.digital_form.field_chapters
+    - field.field.node.digital_form.field_expiration_date
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
     - workflows.workflow.editorial
   module:
     - change_labels
     - content_moderation
+    - datetime
     - field_group
     - limited_field_widgets
     - no_table_drag
@@ -29,7 +32,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         classes: ''
@@ -38,6 +41,25 @@ third_party_settings:
         description: ''
         required_fields: true
         description_display: after
+    group_omb_info:
+      children:
+        - field_respondent_burden
+        - field_omb_number
+        - field_expiration_date
+      label: 'OMB info'
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        description: 'Text required by the Office of Management and Budget (OMB) to be present on all forms.'
+        required_fields: true
+        open: true
+        description_display: after
 id: node.digital_form.default
 targetEntityType: node
 bundle: digital_form
@@ -45,7 +67,7 @@ mode: default
 content:
   field_chapters:
     type: paragraphs_browser
-    weight: 5
+    weight: 6
     region: content
     settings:
       title: Step
@@ -78,6 +100,12 @@ content:
         add_another: ''
       no_table_drag:
         no_table_drag: false
+  field_expiration_date:
+    type: datetime_default
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
     weight: 2
@@ -86,11 +114,18 @@ content:
     third_party_settings: {  }
   field_omb_number:
     type: string_textfield
-    weight: 4
+    weight: 8
     region: content
     settings:
       size: 9
       placeholder: XXXX-XXXX
+    third_party_settings: {  }
+  field_respondent_burden:
+    type: number
+    weight: 7
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_va_form_number:
     type: string_textfield

--- a/config/sync/core.entity_view_display.node.digital_form.default.yml
+++ b/config/sync/core.entity_view_display.node.digital_form.default.yml
@@ -5,14 +5,37 @@ dependencies:
   config:
     - field.field.node.digital_form.field_administration
     - field.field.node.digital_form.field_chapters
+    - field.field.node.digital_form.field_expiration_date
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
   module:
+    - datetime
     - entity_reference_revisions
+    - field_group
     - user
+third_party_settings:
+  field_group:
+    group_omb_info:
+      children:
+        - field_respondent_burden
+        - field_omb_number
+        - field_expiration_date
+      label: 'OMB info'
+      parent_name: ''
+      region: content
+      weight: 1
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: true
+        description: ''
 id: node.digital_form.default
 targetEntityType: node
 bundle: digital_form
@@ -25,15 +48,33 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_expiration_date:
+    type: datetime_default
+    label: inline
+    settings:
+      timezone_override: ''
+      format_type: short_date_no_time
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_omb_number:
     type: string
-    label: above
+    label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 1
+    weight: 6
+    region: content
+  field_respondent_burden:
+    type: number_integer
+    label: inline
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 5
     region: content
   field_va_form_number:
     type: string

--- a/config/sync/core.entity_view_display.node.digital_form.external_content.yml
+++ b/config/sync/core.entity_view_display.node.digital_form.external_content.yml
@@ -6,9 +6,11 @@ dependencies:
     - core.entity_view_mode.node.external_content
     - field.field.node.digital_form.field_administration
     - field.field.node.digital_form.field_chapters
+    - field.field.node.digital_form.field_expiration_date
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
   module:
@@ -52,8 +54,10 @@ content:
 hidden:
   field_administration: true
   field_chapters: true
+  field_expiration_date: true
   field_last_saved_by_an_editor: true
   field_meta_tags: true
   field_omb_number: true
+  field_respondent_burden: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.digital_form.teaser.yml
+++ b/config/sync/core.entity_view_display.node.digital_form.teaser.yml
@@ -6,9 +6,11 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.digital_form.field_administration
     - field.field.node.digital_form.field_chapters
+    - field.field.node.digital_form.field_expiration_date
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
   module:
@@ -44,9 +46,11 @@ content:
 hidden:
   field_administration: true
   field_chapters: true
+  field_expiration_date: true
   field_last_saved_by_an_editor: true
   field_meta_tags: true
   field_omb_number: true
+  field_respondent_burden: true
   field_va_form_number: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.digital_form.field_expiration_date.yml
+++ b/config/sync/field.field.node.digital_form.field_expiration_date.yml
@@ -1,24 +1,25 @@
-uuid: a74fa585-127b-49f9-9533-de900988e8b1
+uuid: fa5b4181-5374-42bc-bcba-6c126c46e4fc
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_omb_number
+    - field.storage.node.field_expiration_date
     - node.type.digital_form
   module:
+    - datetime
     - tmgmt_content
 third_party_settings:
   tmgmt_content:
     excluded: false
-id: node.digital_form.field_omb_number
-field_name: field_omb_number
+id: node.digital_form.field_expiration_date
+field_name: field_expiration_date
 entity_type: node
 bundle: digital_form
-label: 'OMB Number'
-description: 'Format: XXXX-XXXX'
+label: 'Expiration date'
+description: 'The form expiration date.'
 required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: datetime

--- a/config/sync/field.field.node.digital_form.field_respondent_burden.yml
+++ b/config/sync/field.field.node.digital_form.field_respondent_burden.yml
@@ -1,0 +1,28 @@
+uuid: a8a630a0-e849-49b6-8a8b-799a1e85012f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_respondent_burden
+    - node.type.digital_form
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.digital_form.field_respondent_burden
+field_name: field_respondent_burden
+entity_type: node
+bundle: digital_form
+label: 'Respondent burden'
+description: 'How many minutes the form is expected to take.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ' minute| minutes'
+field_type: integer

--- a/config/sync/field.storage.node.field_expiration_date.yml
+++ b/config/sync/field.storage.node.field_expiration_date.yml
@@ -1,0 +1,20 @@
+uuid: aa2a5ea2-6260-4b42-921f-76ccd0f21220
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_expiration_date
+field_name: field_expiration_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_respondent_burden.yml
+++ b/config/sync/field.storage.node.field_respondent_burden.yml
@@ -1,0 +1,20 @@
+uuid: 5412244a-523a-4734-80ed-53f8016430ff
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_respondent_burden
+field_name: field_respondent_burden
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/phpunit/va_gov_content_types/functional/Entity/DigitalFormTest.php
+++ b/tests/phpunit/va_gov_content_types/functional/Entity/DigitalFormTest.php
@@ -18,6 +18,8 @@ class DigitalFormTest extends VaGovExistingSiteBase {
    */
   public function testBundleClass() {
     $digital_form_attrs = [
+      'field_expiration_date' => '2025-08-28',
+      'field_respondent_burden' => 5,
       'field_va_form_number' => '12345',
       'field_omb_number' => '1234-5678',
       'title' => 'Test Digital Form',
@@ -32,8 +34,16 @@ class DigitalFormTest extends VaGovExistingSiteBase {
       $digital_form_attrs['field_va_form_number']
     );
     $this->assertEquals(
+      $node->get('field_expiration_date')->getString(),
+      $digital_form_attrs['field_expiration_date']
+    );
+    $this->assertEquals(
       $node->get('field_omb_number')->getString(),
       $digital_form_attrs['field_omb_number']
+    );
+    $this->assertEquals(
+      $node->get('field_respondent_burden')->getString(),
+      $digital_form_attrs['field_respondent_burden']
     );
   }
 


### PR DESCRIPTION
## Description
Adds all fields necessary to render an accurate [OMB info component](https://design.va.gov/components/omb-info) on each form. Specifically, adds the following two fields:

- Expiration date (`string`, will be converted to expected pattern in `content-build`)
- Respondent Burden (`integer`, in minutes)

These two fields are grouped together with OMB Number to form an "OMB Info" field group.

- Closes department-of-veterans-affairs/va.gov-team#90732

## Testing done
Updated the Digital Form bundle class test with the new fields. Tested the form and view displays locally.

## Screenshots
The "OMB info" field group in the form display:
<img width="868" alt="Screenshot 2024-08-28 at 2 27 51 PM" src="https://github.com/user-attachments/assets/9a26d9de-11b7-4c46-b3d8-35817e0b3abe">

The "OMB info" field group in the node display:
<img width="604" alt="Screenshot 2024-08-28 at 2 29 27 PM" src="https://github.com/user-attachments/assets/09012a36-e4ca-47c2-b2ea-80d6a52116c7">

## QA steps

As an administrator
1. Go to Manage > Content > Add content > Digital Form
   - [ ] Verify the "OMB info" field group is visible and the following fields are contained within it:
      - [ ] "Respondent burden"
      - [ ] "OMB Number"
      - [ ] "Expiration date"
2. Verify all three of the above fields are required.
3. Enter data in the "Respondent burden" field
   - [ ] Verify you can only enter numbers.
   - [ ] Verify you can only enter numbers greater than or equal to 0.
4. Select a date in the "Expiration date" field.
   - [ ] Verify it displays the date in MM/DD/YYYY format.
5. Fill out the other required fields on the Digital Form and click "Save" at the bottom of the page.
   - [ ] Verify the Digital Form saves successfully and the view page looks similar to the above screenshot.

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
