### PR TITLE
Add sitewide label to flagged facilities runbooks

### DIFF
--- a/.github/ISSUE_TEMPLATE/runbook-facility-url-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-url-change.md
@@ -3,7 +3,7 @@ name: Runbook - Facility URL Change
 about: Submit a request to change the URL of a facility
 title: 'URL Change for: <insert facility name>'
 labels: Drupal engineering, Facilities, Flagged Facilities, Redirect request, User
-  support
+  support, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-nca-facility-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-nca-facility-closed.md
@@ -3,7 +3,7 @@ name: Runbook - NCA Facility closed
 about: Steps for archiving a NCA facility in VA.gov CMS.
 title: 'NCA Facility closed: <insert_name>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, NCA, User
-  support
+  support, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-nca-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-nca-facility-name-change.md
@@ -3,7 +3,7 @@ name: Runbook - NCA Facility name change
 about: Steps for updating names and URLs
 title: 'NCA Facility name change: <insert_name>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, NCA, User
-  support
+  support, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-nca-facility-new.md
+++ b/.github/ISSUE_TEMPLATE/runbook-nca-facility-new.md
@@ -3,7 +3,7 @@ name: Runbook - New NCA Facility
 about: changing facility information in the CMS for NCA facilities
 title: 'New NCA Facility: <insert_name_of_facility>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VBA
+  VBA, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-facility-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-facility-closed.md
@@ -3,7 +3,7 @@ name: Runbook - VAMC Facility closed
 about: Steps for archiving a VAMC facility in VA.gov CMS.
 title: 'VAMC Facility closed: <insert_name>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VAMC
+  VAMC, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-facility-duplicate-or-section-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-facility-duplicate-or-section-change.md
@@ -3,7 +3,7 @@ name: Runbook - VAMC facility duplicate record or section change
 about: How to update the section of a VAMC.
 title: 'VAMC Facility duplicate record or section change: <insert_name_of_vamc>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VAMC
+  VAMC, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-facility-name-change.md
@@ -3,7 +3,7 @@ name: Runbook - VAMC Facility name change
 about: Steps for updating names and URLs
 title: 'VAMC Facility name change: <insert_name>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VAMC
+  VAMC, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-facility-new.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-facility-new.md
@@ -3,7 +3,7 @@ name: Runbook - New VAMC Facility
 about: changing facility information in the CMS for VAMC facilities
 title: 'New VAMC Facility: <insert_name_of_facility>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VAMC
+  VAMC, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
@@ -3,7 +3,7 @@ name: Runbook - VAMC system name change
 about: How to update the name of a VAMC.
 title: 'VAMC system name change: <insert_name_of_vamc>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VAMC
+  VAMC, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vba-facility-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vba-facility-closed.md
@@ -3,7 +3,7 @@ name: Runbook - VBA Facility closed
 about: Steps for archiving a VBA facility in VA.gov CMS.
 title: 'VBA Facility closed: <insert_name>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VBA
+  VBA, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vba-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vba-facility-name-change.md
@@ -3,7 +3,7 @@ name: Runbook - VBA Facility name change
 about: Steps for updating names and URLs
 title: 'VBA Facility name change: <insert_name>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VBA
+  VBA, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vba-facility-new.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vba-facility-new.md
@@ -3,7 +3,7 @@ name: Runbook - New VBA Facility
 about: changing facility information in the CMS for VBA facilities
 title: 'New VBA Facility: <insert_name_of_facility>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  VBA
+  VBA, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-cap-to-outstation.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-cap-to-outstation.md
@@ -3,7 +3,7 @@ name: Runbook - Vet Center CAP becomes an Outstation
 about: Steps for upgrading a CAP to an Outstation
 title: 'Vet Center CAP becomes an Outstation: <insert_name_of_facility>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  Vet Center
+  Vet Center, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-closed.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-closed.md
@@ -3,7 +3,7 @@ name: Runbook - Vet Center, Outstation, Mobile Vet Center Facility closed
 about: Steps for archiving a Vet Center facility in VA.gov CMS.
 title: 'Vet Center Facility closed: <insert_name>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  Vet Center
+  Vet Center, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-new.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-new.md
@@ -3,7 +3,7 @@ name: Runbook - New Vet Center Facility
 about: changing facility information in the CMS for Vet Center facilities
 title: 'New Vet Center Facility: <insert_name_of_facility>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  Vet Center
+  Vet Center, sitewide
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-outstation-to-vet-center.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-outstation-to-vet-center.md
@@ -3,7 +3,7 @@ name: Runbook - Vet Center Outstation becomes a Vet Center
 about: Steps for upgrading an outstation to a full Vet Center
 title: 'Outstation becomes Vet Center: <insert_name_of_facility>'
 labels: Change request, Drupal engineering, Facilities, Flagged Facilities, User support,
-  Vet Center
+  Vet Center, sitewide
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description
Github projects automation relies on having the `sitewide` label on issues that should show up in our board. Adding to all Flagged Facilities runbooks that didn't have it already. 