### PR TITLE
VACMS-19567: remove duplicate block revisions tab

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -429,6 +429,9 @@
             "drupal/entity_clone": {
                 "3112577 - Cloning child references to nodes has potential to cause memory resource issues": "patches/3112577-entity-clone-child-node-system-drain.patch"
             },
+            "drupal/entity_diff_ui": {
+                "3406627 - Duplicated Block Revisions tabs": "patches/3406627-duplicate-blocks-revisions-tabs.patch"
+            },
             "drupal/entity_reference_hierarchy": {
                 "3219011 - reference fields are shown twice when ERwH is installed": "patches/3219011-ERwH-removes-preconfigured-fields.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c12d6e97a7ccb78896326d5d8e5d99c1",
+    "content-hash": "171df4af6fc9f1952499ebd98e0434e7",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/3406627-duplicate-blocks-revisions-tabs.patch
+++ b/patches/3406627-duplicate-blocks-revisions-tabs.patch
@@ -1,0 +1,11 @@
+diff --git a/modules/block_diff_ui/block_diff_ui.links.task.yml b/modules/block_diff_ui/block_diff_ui.links.task.yml
+deleted file mode 100644
+index 3196d095f69ed5adcb2b030191c5edcad860ca3f..0000000000000000000000000000000000000000
+--- a/modules/block_diff_ui/block_diff_ui.links.task.yml
++++ /dev/null
+@@ -1,5 +0,0 @@
+-entity.block_content.version_history:
+-  route_name: entity.block_content.version_history
+-  base_route: entity.block_content.canonical
+-  title: 'Revisions'
+-  weight: 20


### PR DESCRIPTION
## Description

Closes #19567 

## Testing done
Tested locally

## Screenshots

![CleanShot2024-10-22at10 16 29](https://github.com/user-attachments/assets/065fe177-f923-4295-af94-b4fdc316f576)

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

1. Navigate to `/block/278/revisions`
   - [ ] Validate that there is only one Revisions tab

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
