### PR TITLE
VACMS-19516 Email signup widget feature toggle

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -2,6 +2,7 @@ _core:
   default_config_hash: daCVJgiGNXHoQmWA2-cvaQEapbq7AGlBQtopOWTqqlw
 features:
   feature_all_hub_side_navs: FEATURE_ALL_HUB_SIDE_NAVS
+  feature_email_update_widget: FEATURE_EMAIL_UPDATE_WIDGET
   feature_health_connect_number: FEATURE_HEALTH_CONNECT_NUMBER
   feature_next_story_preview: FEATURE_NEXT_STORY_PREVIEW
   feature_decision_review_rum: FEATURE_DECISION_REVIEW_RUM


### PR DESCRIPTION
## Description

In support of converting the email signup (at the bottom of the homepage) to a React widget, we need a CMS feature toggle to conditionally change the full form to a simple div for the widget in content-build.

Ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19516