### PR TITLE
VAGOV-TEAM-95675: Updates validation flagging to consider nested paths

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderNodeBase.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderNodeBase.php
@@ -84,7 +84,8 @@ abstract class FormBuilderNodeBase extends FormBuilderBase {
     // Loop through each violation and set errors on the form.
     if ($violations->count() > 0) {
       foreach ($violations as $violation) {
-        $fieldName = $violation->getPropertyPath();
+        // Account for nested property path(e.g. `field_omb_number.0.value`).
+        $fieldName = explode('.', $violation->getPropertyPath())[0];
 
         // Only concern ourselves with validation of fields used on this form.
         if (in_array($fieldName, $this->getFields())) {

--- a/tests/phpunit/va_gov_form_builder/unit/Form/Base/FormBuilderNodeBaseTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/Form/Base/FormBuilderNodeBaseTest.php
@@ -144,4 +144,35 @@ class FormBuilderNodeBaseTest extends VaGovUnitTestBase {
     $this->classInstance->validateForm($form, $formStateMock);
   }
 
+  /**
+   * Test the validateForm method with a deeply-nested violation path.
+   */
+  public function testValidateFormWithNestedViolationPath() {
+    $digitalFormNode = $this->createMock(Node::class);
+
+    // Has violation with a nested path; should raise an error the same way
+    // as if the path were not nested (on `test_field_1`).
+    $violationList = new ConstraintViolationList([
+      new ConstraintViolation('Invalid value 1', '', [], '', 'test_field_1.0.value', 'Invalid value'),
+    ]);
+
+    $digitalFormNode->method('validate')->willReturn($violationList);
+
+    $reflection = new \ReflectionClass($this->classInstance);
+    $digitalFormNodeProperty = $reflection->getProperty('digitalFormNode');
+    $digitalFormNodeProperty->setAccessible(TRUE);
+    $digitalFormNodeProperty->setValue($this->classInstance, $digitalFormNode);
+
+    $form = [];
+
+    $formStateMock = $this->createMock(FormStateInterface::class);
+    $formStateMock->expects($this->exactly(1))
+      ->method('setErrorByName')
+      ->withConsecutive(
+        ['test_field_1', 'Invalid value 1'],
+      );
+
+    $this->classInstance->validateForm($form, $formStateMock);
+  }
+
 }


### PR DESCRIPTION
## Description

Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/95675

## Testing done
- Unit test added
- Manual testing done:
  - Attempts to create a new Digital Form via Form Builder that has an OMB number that is too long.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/6cae5f89-ecbd-4f56-b75c-17acf279defd)

### After
![image](https://github.com/user-attachments/assets/f6473be4-cbe4-40c4-90f7-ad263ebf9c4d)


## QA steps

1. Navigate to `/form-builder/start-conversion`.
2. Enter information for a new form:
    - Enter an OMB number that is longer than 9 characters.
3. Confirm:
    - [ ] The validation error is raised as in the "After" screenshot shown above.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Engine`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
