### PR TITLE
VAGOV-TEAM-97904: Adds Form Builder Page Template

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
@@ -1,0 +1,40 @@
+{#
+/**
+ * @file
+ * VA.gov Form Builder's implementation of a single page.
+ *
+ * Nearly identical to VAgovClaro's implementation, except:
+ * - An outermost page container has been added.
+ * - The header includes additional content (navbar, eventually)
+ * - Breadcrumbs have been removed
+ *
+ * For more information:
+ * @see docroot/themes/custom/vagovclaro/templates/page/page.html.twig
+ */
+#}
+<div class="va-gov-form-builder-page-container">
+  <header class="content-header clearfix">
+    <div class="layout-container">
+      {{ page.header }}
+
+      <div class="va-gov-form-builder-navbar">
+        <!-- This is a placeholder for our navigation bar -->
+      </div>
+    </div>
+  </header>
+
+  <div class="layout-container">
+    {{ page.pre_content }}
+
+    <main class="page-content clearfix" role="main">
+      <div class="visually-hidden"><a id="main-content" tabindex="-1"></a></div>
+      {{ page.highlighted }}
+      {% if page.help %}
+      <div class="help">
+        {{ page.help }}
+      </div>
+      {% endif %}
+      {{ page.content }}
+    </main>
+  </div>
+</div>

--- a/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.module
+++ b/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.module
@@ -17,3 +17,30 @@ function va_gov_form_builder_entity_bundle_field_info_alter(&$fields, EntityType
 
   return $fields;
 }
+
+/**
+ * Implements hook_theme().
+ */
+function va_gov_form_builder_theme() {
+  return [
+    'va_gov_form_builder_page' => [
+      'template' => 'page--va-gov-form-builder',
+      'path' => \Drupal::service('extension.list.module')->getPath('va_gov_form_builder') . '/templates',
+    ],
+  ];
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK().
+ */
+function va_gov_form_builder_theme_suggestions_page(array &$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $suggestions = [];
+
+  // Apply custom page template for all Form Builder routes.
+  if (strpos($route_name, 'va_gov_form_builder.') === 0) {
+    $suggestions[] = 'va_gov_form_builder_page';
+  }
+
+  return $suggestions;
+}

--- a/tests/phpunit/va_gov_form_builder/functional/templates/FormBuilderPageTemplateTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/templates/FormBuilderPageTemplateTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace tests\phpunit\va_gov_form_builder\functional\templates;
+
+use Tests\Support\Classes\VaGovExistingSiteBase;
+
+/**
+ * Functional test of page--va-gov-form-builder.html Twig template.
+ *
+ * This test suite takes the approach of testing a single route
+ * that should result in rendering a page that utilizes the
+ * page template under test. In this way, we can test the expected
+ * behavior of the template file in a consistent manner, assuming
+ * the route properly utilizes the theme (which is tested elswhere).
+ *
+ * The route that makes the most sense here
+ * is the `entry` route, as that should always be present, regardless
+ * of potential future changes to Form Builder pages. The entry route
+ * will redirect to the first content page.
+ *
+ * @group functional
+ * @group all
+ */
+class FormBuilderPageTemplateTest extends VaGovExistingSiteBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  private static $modules = ['va_gov_form_builder'];
+
+  /**
+   * Setup the environment for each test.
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->drupalLogin($this->createUser(['edit any digital_form content']));
+
+    // Form Builder entry.
+    $this->drupalGet('/form-builder');
+  }
+
+  /**
+   * Test that expected elements are present.
+   */
+  public function testExpectedElementsExist() {
+    $this->assertSession()->statusCodeEquals(200);
+
+    $containerElement = $this->cssSelect('.va-gov-form-builder-page-container');
+    $this->assertCount(1, $containerElement);
+
+    $navbarElement = $this->cssSelect('.va-gov-form-builder-navbar');
+    $this->assertCount(1, $navbarElement);
+  }
+
+  /**
+   * Test that unexpected elements are not present.
+   */
+  public function testUnexpectedElementsDoNotExist() {
+    $this->assertSession()->statusCodeEquals(200);
+
+    $breadcrumbsElement = $this->cssSelect('#block-vagovclaro-breadcrumbs');
+    $this->assertCount(0, $breadcrumbsElement);
+  }
+
+}

--- a/tests/phpunit/va_gov_form_builder/unit/ModuleTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/ModuleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace tests\phpunit\va_gov_form_builder\unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Extension\ModuleExtensionList;
+use DrupalFinder\DrupalFinder;
+use Tests\Support\Classes\VaGovUnitTestBase;
+
+/**
+ * Unit tests for va_gov_form_builder.module.
+ *
+ * @group unit
+ * @group all
+ */
+class ModuleTest extends VaGovUnitTestBase {
+
+  /**
+   * The path to the module being tested.
+   *
+   * @var string
+   */
+  private $modulePath = 'modules/custom/va_gov_form_builder';
+
+  /**
+   * Setup the environment for each test.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Find Drupal root.
+    $drupalFinder = new DrupalFinder();
+    $drupalFinder->locateRoot(__DIR__);
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+
+    // Require the module file so we can test it.
+    require_once $drupalRoot . '/' . $this->modulePath . '/va_gov_form_builder.module';
+
+    // Mock the extension.list.module service.
+    $extensionListMock = $this->createMock(ModuleExtensionList::class);
+    $extensionListMock->expects($this->once())
+      ->method('getPath')
+      ->with('va_gov_form_builder')
+      ->willReturn($this->modulePath);
+
+    // Create a mock container.
+    $container = new ContainerBuilder();
+    $container->set('extension.list.module', $extensionListMock);
+
+    // Set the mocked container as the global Drupal container.
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Tests va_gov_form_builder_theme().
+   *
+   * @covers ::va_gov_form_builder_theme
+   */
+  public function testVaGovFormBuilderHookTheme() {
+    // Call the function to test.
+    $result = va_gov_form_builder_theme();
+
+    // Assert the expected theme definition exists.
+    $this->assertArrayHasKey('va_gov_form_builder_page', $result);
+    $this->assertEquals('page--va-gov-form-builder', $result['va_gov_form_builder_page']['template']);
+    $this->assertEquals($this->modulePath . '/templates', $result['va_gov_form_builder_page']['path']);
+  }
+
+}


### PR DESCRIPTION
## Description
- Adds a pagel-level Twig template for Form Builder pages.
- Applies this template to all Form Builder routes (all routes that begin with `va_gov_form_builder.`.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/97904

## Testing done
- Unit tests added
  - Ensure theme hook sets the appropriate `template` and `path` properties.
  - Ensure theme-suggestions hook returns the appropriate theme suggestion.
  - Ensure template includes expected elements (page wrapper, navbar).
  - Ensure template does not include elements that should be removed relative to default theme (breadcrumbs).
- Manual testing done locally to confirm all expected routes have the template applied.

## Screenshots
Here is a local screenshot. Other environments might lack the debugging information, but the other two highlighted pieces are the critical parts.
![image](https://github.com/user-attachments/assets/feb43fc6-6984-4096-b626-be647aa54457)

## QA steps
1. Navigate to `/form-builder/intro`
   - [x] Ensure rendered markup includes the elements noted in the screenshot.
2. Navigate to `/form-builder/start-conversion`
   - [x] Ensure rendered markup includes the elements noted in the screenshot.
3. Continue with additional routes as desired.

### Definition of Done
- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review
- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Engine`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
