### PR TITLE
VAGOV-TEAM-97909: Form Builder Theme

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
@@ -1,0 +1,4 @@
+/* page container */
+.va-gov-form-builder-page-container {
+  font-family: var(--font-family-serif);
+}

--- a/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
@@ -14,7 +14,21 @@ abstract class FormBuilderBase extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['#theme'] = 'va_gov_form_builder';
     $form['#title'] = $this->t('Form Builder');
+
+    // Add styles.
+    $form['#attached']['html_head'][] = [
+      [
+        '#tag' => 'link',
+        '#attributes' => [
+          'rel' => 'stylesheet',
+          'href' => 'https://unpkg.com/@department-of-veterans-affairs/css-library@0.16.0/dist/tokens/css/variables.css',
+        ],
+      ],
+      'external_stylesheet',
+    ];
+    $form['#attached']['library'][] = 'va_gov_form_builder/va_gov_form_builder_styles';
 
     return $form;
   }

--- a/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.libraries.yml
+++ b/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.libraries.yml
@@ -1,0 +1,5 @@
+va_gov_form_builder_styles:
+  version: 1.x
+  css:
+    theme:
+      css/va_gov_form_builder.css: {}

--- a/tests/phpunit/va_gov_form_builder/unit/Form/Base/FormBuilderBaseTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/Form/Base/FormBuilderBaseTest.php
@@ -45,8 +45,32 @@ class FormBuilderBaseTest extends VaGovUnitTestBase {
 
     $form = $this->classInstance->buildForm($form, $formStateMock);
 
+    // Title.
     $this->assertArrayHasKey('#title', $form);
     $this->assertEquals($form['#title'], 'Form Builder');
+
+    // CSS.
+    $this->assertArrayHasKey('#attached', $form);
+
+    // 1. Form Builder Library.
+    $this->assertArrayHasKey('html_head', $form['#attached']);
+    $this->assertNotEmpty($form['#attached']['html_head']);
+
+    $found = FALSE;
+    foreach ($form['#attached']['html_head'] as $html_head_item) {
+      if (
+        isset($html_head_item[0]['#attributes']['href']) &&
+        $html_head_item[0]['#attributes']['href'] === 'https://unpkg.com/@department-of-veterans-affairs/css-library@0.16.0/dist/tokens/css/variables.css'
+      ) {
+        $found = TRUE;
+        break;
+      }
+    }
+    $this->assertTrue($found, 'The html_head array contains a link with the unpkg token url.');
+
+    // 2. External CSS.
+    $this->assertArrayHasKey('library', $form['#attached']);
+    $this->assertContains('va_gov_form_builder/va_gov_form_builder_styles', $form['#attached']['library']);
   }
 
 }


### PR DESCRIPTION
## Description
This PR implements the beginning of a Form Builder theme. It does a few things:
1. Defines a Form Builder library.
2. Creates a base Form Builder css file and connects it to the library.
3. Imports external VADS token css from UNPKG.
4. Attaches the two css files from the above two steps to all Form Builder pages.

Note that this PR does not do much to actually implement the design via css. It only sets things up to be able to do that in later work. For now, the only visible change (to prove this works) is to set the `font-family` at the page level. As seen in the below screenshots, the font was previously sans-serif and is now serif.

Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/97909

## Testing done
- Unit test added to confirm css files are being attached to the form pages.
- Manually inspected page to confirm expected css is applied.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/47e7d8bf-964c-48f7-b76c-2080a43f56a9)

### After
![image](https://github.com/user-attachments/assets/8cc22fd3-cc96-4397-86bc-def1bb44f773)


## QA steps
1. Load any Form Builder page
   - [ ] Confirm that the font is a serif font.
   - [ ] Inspect an element and confirm, specifically, that the css definition is:
    ```
    .va-gov-form-builder-page-container {
        font-family: var(--font-family-serif);
    }
    ```

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Engine`


### Is this PR blocked by another PR?
- [] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
