### PR TITLE
VACMS-19375: Fix for undefined anchor links.

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/js/anchor_links.js
+++ b/docroot/themes/custom/vagovclaro/assets/js/anchor_links.js
@@ -14,7 +14,7 @@
 
   Drupal.behaviors.vagovclaroAnchorLinks = {
     attach: function attach() {
-      $('a[href^="#"][href!="#"]:not([href^="#edit-group"])').click(function (event) {
+      $('a[href="#"][href!="#"]:not([href^="#edit-group"])').click(function (event) {
         event.preventDefault();
 
         var target = $(event.target).attr("href");

--- a/docroot/themes/custom/vagovclaro/assets/js/anchor_links.js
+++ b/docroot/themes/custom/vagovclaro/assets/js/anchor_links.js
@@ -14,6 +14,7 @@
 
   Drupal.behaviors.vagovclaroAnchorLinks = {
     attach: function attach() {
+      //removed XOR operator because it was causing an issue where anchor lins were undefined VACMS-19375
       $('a[href="#"][href!="#"]:not([href^="#edit-group"])').click(function (event) {
         event.preventDefault();
 


### PR DESCRIPTION
## Description
Closes #19375 

## Testing done
Went to various pages within the CMS and navigated anchor links using the tab key. Verified that, on click, anchor link was defined and did not lose focus.


## Screenshots


## QA steps

What needs to be checked to prove this works? Tab though and click anchor links
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Navigate to the home page in the CMS
2. Click on the VA logo in the upper left corner
3. Tab and click on the "Skip to main content" link
4. Verify that the url is now appended by #main-content
5. Verify that tabbing further brings you into the main content section (VACO, NCA, etc)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
