### PR TITLE
VAGOV-TEAM-97920: Form Builder Navbar

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
@@ -1,4 +1,92 @@
 /* page container */
-.va-gov-form-builder-page-container {
+.form-builder-page-container {
   font-family: var(--font-family-serif);
+}
+
+/* headings */
+.form-builder-page-container h1 {
+  font-size: var(--vads-font-size-heading-level-1);
+  line-height: var(--units-6);
+}
+
+.form-builder-page-container h2 {
+  font-size: var(--vads-font-size-heading-level-2);
+}
+
+.form-builder-page-container h2 {
+  font-size: var(--vads-font-size-heading-level-2);
+}
+
+.form-builder-page-container h3 {
+  font-size: var(--vads-font-size-heading-level-3);
+}
+
+.form-builder-page-container h4 {
+  font-size: var(--vads-font-size-heading-level-4);
+}
+
+.form-builder-page-container h5 {
+  font-size: var(--vads-font-size-heading-level-5);
+}
+
+.form-builder-page-container h6 {
+  font-size: var(--vads-font-size-heading-level-6);
+}
+
+/* header */
+.form-builder-header {
+  background-color: var(--va-blue-darkest);
+  color: var(--va-white);
+  padding-top: var(--units-1);
+}
+
+/* layout container */
+.form-builder-layout-container {
+  margin: 0 var(--units-7);
+}
+
+/* title */
+.form-builder-title {
+  margin-bottom: var(--units-1p5);
+}
+
+/* navbar */
+.form-builder-navbar__nav {
+  display: flex;
+}
+
+.form-builder-navbar__tabs {
+  display: flex;
+  gap: var(--units-5);
+  list-style: none;
+  margin: 0;
+}
+
+.form-builder-navbar__tab {
+  min-width: 100px;
+  padding: var(--units-1);
+  position: relative;
+  text-align: center;
+}
+
+.form-builder-navbar__tab--active {
+  border-bottom: var(--units-0p5) solid var(--uswds-system-color-gold-vivid-20);
+}
+
+.form-builder-navbar__link {
+  color: var(--vads-color-white);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--vads-font-line-height-default);
+  text-decoration: none;
+}
+
+.form-builder-navbar__link:hover {
+  background: transparent;
+  color: var(--vads-color-white);
+}
+
+.form-builder-navbar__tab--active .form-builder-navbar__link,
+.form-builder-navbar__tab--active .form-builder-navbar__link:hover {
+  color: var(--uswds-system-color-gold-vivid-20);
 }

--- a/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
@@ -63,8 +63,15 @@ class VaGovFormBuilderController extends ControllerBase {
     return [
       '#type' => 'page',
       'content' => $form,
+      // Add custom data.
       'form_builder_page_data' => [
         'active_tab' => $this->activeTab,
+      ],
+      // Add styles.
+      '#attached' => [
+        'library' => [
+          'va_gov_form_builder/va_gov_form_builder_styles',
+        ],
       ],
     ];
   }

--- a/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
@@ -32,6 +32,13 @@ class VaGovFormBuilderController extends ControllerBase {
   private $drupalFormBuilder;
 
   /**
+   * The active tab in the form builder.
+   *
+   * @var 'forms'|'content'|'layout'
+   */
+  private $activeTab;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
@@ -39,6 +46,27 @@ class VaGovFormBuilderController extends ControllerBase {
     $instance->drupalFormBuilder = $container->get('form_builder');
 
     return $instance;
+  }
+
+  /**
+   * Returns a render array representing the page with the passed-in form.
+   *
+   * @param string $formName
+   *   The filename of the form to be rendered.
+   * @param string $nid
+   *   The node id, passed in when the form in question edits an existing node.
+   */
+  private function getFormPage($formName, $nid = NULL) {
+    // @phpstan-ignore-next-line
+    $form = $this->drupalFormBuilder->getForm('Drupal\va_gov_form_builder\Form\\' . $formName, $nid);
+
+    return [
+      '#type' => 'page',
+      'content' => $form,
+      'form_builder_page_data' => [
+        'active_tab' => $this->activeTab,
+      ],
+    ];
   }
 
   /**
@@ -52,22 +80,24 @@ class VaGovFormBuilderController extends ControllerBase {
    * Intro page.
    */
   public function intro() {
-    return $this->drupalFormBuilder->getForm('Drupal\va_gov_form_builder\Form\Intro');
+    $this->activeTab = 'forms';
+    return $this->getFormPage('Intro');
   }
 
   /**
    * Start-conversion page.
    */
   public function startConversion() {
-    return $this->drupalFormBuilder->getForm('Drupal\va_gov_form_builder\Form\StartConversion');
+    $this->activeTab = 'forms';
+    return $this->getFormPage('StartConversion');
   }
 
   /**
    * Name-and-date-of-birth page.
    */
   public function nameAndDob($nid) {
-    // @phpstan-ignore-next-line
-    return $this->drupalFormBuilder->getForm('Drupal\va_gov_form_builder\Form\NameAndDob', $nid);
+    $this->activeTab = 'content';
+    return $this->getFormPage('NameAndDob', $nid);
   }
 
 }

--- a/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
@@ -15,16 +15,6 @@ abstract class FormBuilderBase extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     // Add styles.
-    $form['#attached']['html_head'][] = [
-      [
-        '#tag' => 'link',
-        '#attributes' => [
-          'rel' => 'stylesheet',
-          'href' => 'https://unpkg.com/@department-of-veterans-affairs/css-library@0.16.0/dist/tokens/css/variables.css',
-        ],
-      ],
-      'external_stylesheet',
-    ];
     $form['#attached']['library'][] = 'va_gov_form_builder/va_gov_form_builder_styles';
 
     return $form;

--- a/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
@@ -12,12 +12,13 @@ abstract class FormBuilderBase extends FormBase {
 
   /**
    * {@inheritdoc}
+   *
+   * After initially containing some logic, this function
+   * is now empty, and this entire class is a candiate
+   * for removal. Leaving it here for now, as it might prove
+   * necessary as we continue on.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    // Add styles.
-    $form['#attached']['library'][] = 'va_gov_form_builder/va_gov_form_builder_styles';
-
-    return $form;
   }
 
 }

--- a/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Form/Base/FormBuilderBase.php
@@ -14,9 +14,6 @@ abstract class FormBuilderBase extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['#theme'] = 'va_gov_form_builder';
-    $form['#title'] = $this->t('Form Builder');
-
     // Add styles.
     $form['#attached']['html_head'][] = [
       [

--- a/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
@@ -25,7 +25,8 @@
         <nav class="form-builder-navbar__nav">
           <ul class="form-builder-navbar__tabs">
 
-            <li class="form-builder-navbar__tab {{
+            <li class="form-builder-navbar__tab form-builder-navbar__tab--forms
+              {{
                 active_tab == 'forms' ? 'form-builder-navbar__tab--active'
                 : ''
               }}"
@@ -33,7 +34,7 @@
               <a href="#" class="form-builder-navbar__link">Forms</a>
             </li>
 
-            <li class="form-builder-navbar__tab
+            <li class="form-builder-navbar__tab form-builder-navbar__tab--content
               {{
                 active_tab == 'content' ? 'form-builder-navbar__tab--active'
                 : ''
@@ -41,7 +42,7 @@
               <a href="#" class="form-builder-navbar__link">Content</a>
             </li>
 
-            <li class="form-builder-navbar__tab
+            <li class="form-builder-navbar__tab form-builder-navbar__tab--layout
               {{
                 active_tab == 'layout' ? 'form-builder-navbar__tab--active'
                 : ''

--- a/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
@@ -3,38 +3,65 @@
  * @file
  * VA.gov Form Builder's implementation of a single page.
  *
- * Nearly identical to VAgovClaro's implementation, except:
- * - An outermost page container has been added.
- * - The header includes additional content (navbar, eventually)
- * - Breadcrumbs have been removed
+ * The variables available to this template are passed from the controller:
+ * - page
+ *   - content: The main content of the page; the individual form
+ * - form_builder_page_data
+ *   - active_tab: The active tab in the navbar
  *
- * For more information:
- * @see docroot/themes/custom/vagovclaro/templates/page/page.html.twig
+ * @see /docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
  */
 #}
-<div class="va-gov-form-builder-page-container">
-  <header class="content-header clearfix">
-    <div class="layout-container">
-      {{ page.header }}
+<div class="form-builder-page-container">
+  <header class="form-builder-header">
+    <div class="form-builder-layout-container">
 
-      <div class="va-gov-form-builder-navbar">
-        <!-- This is a placeholder for our navigation bar -->
+      <div class="form-builder-title">
+        <h1 class="form-builder-title__page-title">Form Builder</h1>
+      </div>
+
+      {% set active_tab = page.form_builder_page_data.active_tab %}
+      <div class="form-builder-navbar">
+        <nav class="form-builder-navbar__nav">
+          <ul class="form-builder-navbar__tabs">
+
+            <li class="form-builder-navbar__tab {{
+                active_tab == 'forms' ? 'form-builder-navbar__tab--active'
+                : ''
+              }}"
+            >
+              <a href="#" class="form-builder-navbar__link">Forms</a>
+            </li>
+
+            <li class="form-builder-navbar__tab
+              {{
+                active_tab == 'content' ? 'form-builder-navbar__tab--active'
+                : ''
+              }}">
+              <a href="#" class="form-builder-navbar__link">Content</a>
+            </li>
+
+            <li class="form-builder-navbar__tab
+              {{
+                active_tab == 'layout' ? 'form-builder-navbar__tab--active'
+                : ''
+              }}"
+            >
+              <a href="#" class="form-builder-navbar__link">Layout</a>
+            </li>
+          </ul>
+        </nav>
       </div>
     </div>
   </header>
 
-  <div class="layout-container">
-    {{ page.pre_content }}
-
+  <div class="form-builder-layout-container">
     <main class="page-content clearfix" role="main">
       <div class="visually-hidden"><a id="main-content" tabindex="-1"></a></div>
-      {{ page.highlighted }}
-      {% if page.help %}
-      <div class="help">
-        {{ page.help }}
-      </div>
-      {% endif %}
+
+      {# The form content #}
       {{ page.content }}
+
     </main>
   </div>
 </div>

--- a/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.libraries.yml
+++ b/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.libraries.yml
@@ -3,3 +3,5 @@ va_gov_form_builder_styles:
   css:
     theme:
       css/va_gov_form_builder.css: {}
+      https://unpkg.com/@department-of-veterans-affairs/css-library@0.16.0/dist/tokens/css/variables.css:
+        {}

--- a/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.module
+++ b/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.module
@@ -23,8 +23,8 @@ function va_gov_form_builder_entity_bundle_field_info_alter(&$fields, EntityType
  */
 function va_gov_form_builder_theme() {
   return [
-    'va_gov_form_builder_page' => [
-      'template' => 'page--va-gov-form-builder',
+    'page__va_gov_form_builder' => [
+      'base hook' => 'page',
       'path' => \Drupal::service('extension.list.module')->getPath('va_gov_form_builder') . '/templates',
     ],
   ];
@@ -39,7 +39,7 @@ function va_gov_form_builder_theme_suggestions_page(array &$variables) {
 
   // Apply custom page template for all Form Builder routes.
   if (strpos($route_name, 'va_gov_form_builder.') === 0) {
-    $suggestions[] = 'va_gov_form_builder_page';
+    $suggestions[] = 'page__va_gov_form_builder';
   }
 
   return $suggestions;

--- a/tests/phpunit/va_gov_form_builder/functional/Controller/VaGovFormBuilderControllerTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Controller/VaGovFormBuilderControllerTest.php
@@ -42,6 +42,19 @@ class VaGovFormBuilderControllerTest extends VaGovExistingSiteBase {
   }
 
   /**
+   * Tests css is included.
+   */
+  public function testCssIncluded() {
+    $page = $this->controller->intro();
+
+    $this->assertContains(
+      'va_gov_form_builder/va_gov_form_builder_styles',
+      $page['#attached']['library'],
+      "The library 'va_gov_form_builder/va_gov_form_builder_styles' is successfully attached."
+    );
+  }
+
+  /**
    * Tests the entry method redirects correctly.
    */
   public function testEntryRedirect() {
@@ -55,20 +68,20 @@ class VaGovFormBuilderControllerTest extends VaGovExistingSiteBase {
    * Tests the intro method returns an Intro form.
    */
   public function testIntro() {
-    $form = $this->controller->intro();
+    $page = $this->controller->intro();
 
-    $this->assertArrayHasKey('#type', $form);
-    $this->assertArrayHasKey('working_with_form_builder_header', $form);
+    $this->assertArrayHasKey('content', $page);
+    $this->assertArrayHasKey('working_with_form_builder_header', $page['content']);
   }
 
   /**
    * Tests the startConversion method returns a StartConversion form.
    */
   public function testStartConversion() {
-    $form = $this->controller->startConversion();
+    $page = $this->controller->startConversion();
 
-    $this->assertArrayHasKey('#type', $form);
-    $this->assertArrayHasKey('start_new_conversion_header', $form);
+    $this->assertArrayHasKey('content', $page);
+    $this->assertArrayHasKey('start_new_conversion_header', $page['content']);
   }
 
   /**
@@ -81,10 +94,10 @@ class VaGovFormBuilderControllerTest extends VaGovExistingSiteBase {
       'field_chapters' => [],
     ]);
 
-    $form = $this->controller->nameAndDob($node->id());
+    $page = $this->controller->nameAndDob($node->id());
 
-    $this->assertArrayHasKey('#type', $form);
-    $this->assertArrayHasKey('name_and_dob_header', $form);
+    $this->assertArrayHasKey('content', $page);
+    $this->assertArrayHasKey('name_and_dob_header', $page['content']);
   }
 
 }

--- a/tests/phpunit/va_gov_form_builder/functional/Form/IntroTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/IntroTest.php
@@ -20,7 +20,7 @@ class IntroTest extends VaGovExistingSiteBase {
   private static $modules = ['va_gov_form_builder'];
 
   /**
-   * Setup the environment for each test.
+   * Set up the environment for each test.
    */
   public function setUp(): void {
     parent::setUp();
@@ -30,7 +30,7 @@ class IntroTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test the form is accessible to a user with the correct privilege.
+   * Test that the form is accessible to a user with the correct privilege.
    */
   public function testFormLoads() {
     $this->assertSession()->statusCodeEquals(200);
@@ -38,7 +38,7 @@ class IntroTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test the form is not accessible to a user without the correct privilege.
+   * Test that the form is not accessible to a user without privilege.
    */
   public function testFormDoesNotLoad() {
     // Log out the good user and log in a user without permission.
@@ -46,6 +46,14 @@ class IntroTest extends VaGovExistingSiteBase {
     $this->drupalGet('/form-builder/intro');
 
     $this->assertSession()->statusCodeNotEquals(200);
+  }
+
+  /**
+   * Test that the active tab is correct.
+   */
+  public function testActiveTab() {
+    $activeTab = $this->getSession()->getPage()->find('css', '.form-builder-navbar__tab--active');
+    $this->assertTrue($activeTab->hasClass('form-builder-navbar__tab--forms'), 'The expected tab is active.');
   }
 
   /**

--- a/tests/phpunit/va_gov_form_builder/functional/Form/NameAndDobTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/NameAndDobTest.php
@@ -48,7 +48,7 @@ class NameAndDobTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Setup the environment for each test.
+   * Set up the environment for each test.
    */
   public function setUp(): void {
     parent::setUp();
@@ -65,21 +65,29 @@ class NameAndDobTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test the form is accessible to a user with the correct privilege.
+   * Test that the form is accessible to a user with the correct privilege.
    */
   public function testFormLoads() {
     $this->sharedTestFormLoads($this->getFormPageUrl(), 'Collecting Name and Date of birth');
   }
 
   /**
-   * Test the form is not accessible to a user without the correct privilege.
+   * Test that the form is not accessible to a user without privilege.
    */
   public function testFormDoesNotLoad() {
     $this->sharedTestFormDoesNotLoad($this->getFormPageUrl());
   }
 
   /**
-   * Test the form submission adds a chapter when not already present.
+   * Test that the active tab is correct.
+   */
+  public function testActiveTab() {
+    $activeTab = $this->getSession()->getPage()->find('css', '.form-builder-navbar__tab--active');
+    $this->assertTrue($activeTab->hasClass('form-builder-navbar__tab--content'), 'The expected tab is active.');
+  }
+
+  /**
+   * Test that the form submission adds a chapter when not already present.
    */
   public function testFormSubmissionAddsChapter() {
     $formInput = [
@@ -93,7 +101,7 @@ class NameAndDobTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test the form submission does not add a chapter when already present.
+   * Test that the form submission does not add a chapter when already present.
    */
   public function testFormSubmissionDoesNotAddChapter() {
     // Add a chapter to begin.
@@ -116,7 +124,7 @@ class NameAndDobTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test the 'Back' button takes the user back to the start-conversion page.
+   * Test that the 'Back' button takes the user to the start-conversion page.
    */
   public function testBackButton() {
     $this->click('.button#edit-back');

--- a/tests/phpunit/va_gov_form_builder/functional/Form/StartConversionTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/StartConversionTest.php
@@ -32,7 +32,7 @@ class StartConversionTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Setup the environment for each test.
+   * Set up the environment for each test.
    */
   public function setUp(): void {
     parent::setUp();
@@ -42,21 +42,29 @@ class StartConversionTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test the form is accessible to a user with the correct privilege.
+   * Test that the form is accessible to a user with the correct privilege.
    */
   public function testFormLoads() {
     $this->sharedTestFormLoads($this->getFormPageUrl(), 'Start a new conversion');
   }
 
   /**
-   * Test the form is not accessible to a user without the correct privilege.
+   * Test that the form is not accessible to a user without privilege.
    */
   public function testFormDoesNotLoad() {
     $this->sharedTestFormDoesNotLoad($this->getFormPageUrl());
   }
 
   /**
-   * Test the form submission succeeds.
+   * Test that the active tab is correct.
+   */
+  public function testActiveTab() {
+    $activeTab = $this->getSession()->getPage()->find('css', '.form-builder-navbar__tab--active');
+    $this->assertTrue($activeTab->hasClass('form-builder-navbar__tab--forms'), 'The expected tab is active.');
+  }
+
+  /**
+   * Test that the form submission succeeds.
    *
    * When proper information is entered, form should be submitted.
    */
@@ -71,8 +79,9 @@ class StartConversionTest extends VaGovExistingSiteBase {
     ];
     $this->submitForm($formInput, 'Continue');
 
-    // Check if the form submission was successful.
-    $this->assertSession()->pageTextNotContains('error has been found');
+    // Successful submission should take user to next page.
+    $nextPageUrl = $this->getSession()->getCurrentUrl();
+    $this->assertStringContainsString('/name-and-dob', $nextPageUrl);
   }
 
   /**
@@ -90,7 +99,7 @@ class StartConversionTest extends VaGovExistingSiteBase {
     $this->submitForm($formInput, 'Continue');
 
     // Check if the form submission was successful.
-    $this->assertSession()->pageTextContains('error has been found');
+    $this->assertSession()->pageTextContains('Expiration date field is required.');
   }
 
   /**

--- a/tests/phpunit/va_gov_form_builder/functional/templates/FormBuilderPageTemplateTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/templates/FormBuilderPageTemplateTest.php
@@ -46,10 +46,10 @@ class FormBuilderPageTemplateTest extends VaGovExistingSiteBase {
   public function testExpectedElementsExist() {
     $this->assertSession()->statusCodeEquals(200);
 
-    $containerElement = $this->cssSelect('.va-gov-form-builder-page-container');
+    $containerElement = $this->cssSelect('.form-builder-page-container');
     $this->assertCount(1, $containerElement);
 
-    $navbarElement = $this->cssSelect('.va-gov-form-builder-navbar');
+    $navbarElement = $this->cssSelect('.form-builder-navbar');
     $this->assertCount(1, $navbarElement);
   }
 

--- a/tests/phpunit/va_gov_form_builder/unit/Form/Base/FormBuilderBaseTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/Form/Base/FormBuilderBaseTest.php
@@ -28,6 +28,8 @@ class FormBuilderBaseTest extends VaGovUnitTestBase {
    * Setup the environment for each test.
    */
   public function setUp(): void {
+    $this->markTestSkipped('Skipping all tests in this file.');
+
     parent::setUp();
 
     // Create an anonymous instance of a class that extends our abstract class.
@@ -44,33 +46,6 @@ class FormBuilderBaseTest extends VaGovUnitTestBase {
     $formStateMock = $this->createMock(FormStateInterface::class);
 
     $form = $this->classInstance->buildForm($form, $formStateMock);
-
-    // Title.
-    $this->assertArrayHasKey('#title', $form);
-    $this->assertEquals($form['#title'], 'Form Builder');
-
-    // CSS.
-    $this->assertArrayHasKey('#attached', $form);
-
-    // 1. Form Builder Library.
-    $this->assertArrayHasKey('html_head', $form['#attached']);
-    $this->assertNotEmpty($form['#attached']['html_head']);
-
-    $found = FALSE;
-    foreach ($form['#attached']['html_head'] as $html_head_item) {
-      if (
-        isset($html_head_item[0]['#attributes']['href']) &&
-        $html_head_item[0]['#attributes']['href'] === 'https://unpkg.com/@department-of-veterans-affairs/css-library@0.16.0/dist/tokens/css/variables.css'
-      ) {
-        $found = TRUE;
-        break;
-      }
-    }
-    $this->assertTrue($found, 'The html_head array contains a link with the unpkg token url.');
-
-    // 2. External CSS.
-    $this->assertArrayHasKey('library', $form['#attached']);
-    $this->assertContains('va_gov_form_builder/va_gov_form_builder_styles', $form['#attached']['library']);
   }
 
 }

--- a/tests/phpunit/va_gov_form_builder/unit/LibrariesTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/LibrariesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace tests\phpunit\va_gov_form_builder\unit;
+
+use DrupalFinder\DrupalFinder;
+use Symfony\Component\Yaml\Yaml;
+use Tests\Support\Classes\VaGovUnitTestBase;
+
+/**
+ * Unit tests for va_gov_form_builder.libraries.yml.
+ *
+ * @group unit
+ * @group all
+ */
+class LibrariesTest extends VaGovUnitTestBase {
+
+  /**
+   * The path to the module being tested.
+   *
+   * @var string
+   */
+  private $modulePath = 'modules/custom/va_gov_form_builder';
+
+  /**
+   * The libraries defined in libraries.yml.
+   *
+   * @var array{
+   *   css?: array{
+   *     theme?: array<string, mixed>
+   *   },
+   *   js?: array<string, mixed>,
+   *   dependencies?: array<string>
+   * }
+   */
+  private $libraries;
+
+  /**
+   * Set up the environment for each test.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Find Drupal root.
+    $drupalFinder = new DrupalFinder();
+    $drupalFinder->locateRoot(__DIR__);
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+
+    $yamlFile = $drupalRoot . '/' . $this->modulePath . '/va_gov_form_builder.libraries.yml';
+
+    $this->libraries = Yaml::parseFile($yamlFile);
+  }
+
+  /**
+   * Tests that the library definition contains necessary css.
+   */
+  public function testLibraryCss() {
+    $this->assertArrayHasKey('va_gov_form_builder_styles', $this->libraries);
+    $this->assertArrayHasKey('css', $this->libraries['va_gov_form_builder_styles']);
+    $this->assertArrayHasKey('theme', $this->libraries['va_gov_form_builder_styles']['css']);
+
+    $cssArray = array_keys($this->libraries['va_gov_form_builder_styles']['css']['theme']);
+
+    // Assert Form Builder css is present.
+    $this->assertContains('css/va_gov_form_builder.css', $cssArray, 'Form Builder css is present.');
+
+    // Assert external VADS tokens definition is present.
+    $matches = preg_grep('/unpkg.*@department-of-veterans-affairs.*css-library.*tokens\/css\/variables.css/', $cssArray);
+    $this->assertNotEmpty($matches, 'VADS tokens css is present.');
+  }
+
+}

--- a/tests/phpunit/va_gov_form_builder/unit/ModuleTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/ModuleTest.php
@@ -31,7 +31,7 @@ class ModuleTest extends VaGovUnitTestBase {
   private $container;
 
   /**
-   * Setup the environment for each test.
+   * Set up the environment for each test.
    */
   protected function setUp(): void {
     parent::setUp();
@@ -69,9 +69,9 @@ class ModuleTest extends VaGovUnitTestBase {
     $result = va_gov_form_builder_theme();
 
     // Assert the expected theme definition exists.
-    $this->assertArrayHasKey('va_gov_form_builder_page', $result);
-    $this->assertEquals('page--va-gov-form-builder', $result['va_gov_form_builder_page']['template']);
-    $this->assertEquals($this->modulePath . '/templates', $result['va_gov_form_builder_page']['path']);
+    $this->assertArrayHasKey('page__va_gov_form_builder', $result);
+    $this->assertEquals('page', $result['page__va_gov_form_builder']['base hook']);
+    $this->assertEquals($this->modulePath . '/templates', $result['page__va_gov_form_builder']['path']);
   }
 
   /**
@@ -96,7 +96,7 @@ class ModuleTest extends VaGovUnitTestBase {
     $suggestions = va_gov_form_builder_theme_suggestions_page($variables);
 
     // Assert the expected theme suggestion is returned.
-    $this->assertContains('va_gov_form_builder_page', $suggestions);
+    $this->assertContains('page__va_gov_form_builder', $suggestions);
   }
 
 }


### PR DESCRIPTION
## Description
This PR adds a navbar (three tabs) to the Form Builder page template. More importantly, it sets things up to be able to pass custom data from each form to the wrapping page template. In this case, we needed that to be able to pass the `activeTab` value to the page template. It might be used for additional values as we go.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/97920

## Testing done
- Unit tests added.
- Manual tests done:
  - Correct active tab on each page.

## Screenshots
![image](https://github.com/user-attachments/assets/d704422b-cf30-4f02-a792-9383818e2c1b)


## QA steps
1. Visit `/form-builder/intro`
   - [x] Ensure navbar with three tabs displays
   - [x] Ensure the "Forms" tab is active
2. Proceed to '/form-builder/start-conversion`
   - [x] Ensure navbar with three tabs displays
   - [x] Ensure the "Forms" tab is active
3. Fill out form and proceed to next page (name-and-dob)
   - [x] Ensure navbar with three tabs displays
   - [x] Ensure the "Content" tab is active
4. Visit some page outside Form Builder, like `node/add/digital_form`
   - [x] Ensure navbar with three tabs does _not_ display.
   - [x] Ensure the page looks "right" (ensure no styling issues that might arise if our css styles were being applied outside our module).

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Builder`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
