### PR TITLE
VAGOV-TEAM-97922: Adds sidebar placeholder

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
@@ -1,5 +1,8 @@
 /* page container */
 .form-builder-page-container {
+  --vads-color-divider: #a9aeb1;
+  --color-shadow: #00000040;
+
   font-family: var(--font-family-serif);
 }
 
@@ -42,7 +45,7 @@
 
 /* layout container */
 .form-builder-layout-container {
-  margin: 0 var(--units-7);
+  margin: var(--units-2p5) var(--units-7);
 }
 
 /* title */
@@ -89,4 +92,24 @@
 .form-builder-navbar__tab--active .form-builder-navbar__link,
 .form-builder-navbar__tab--active .form-builder-navbar__link:hover {
   color: var(--uswds-system-color-gold-vivid-20);
+}
+
+/* two-column layout */
+.form-builder-two-column-layout {
+  display: flex;
+  gap: var(--units-5);
+  justify-content: space-between;
+  width: 100%;
+}
+
+.form-builder-right-column {
+  padding-top: var(--units-2);
+}
+
+/* sidebar */
+.form-builder-sidebar {
+  border: 1px solid var(--vads-color-divider);
+  box-shadow: 0 4px 4px 0 var(--color-shadow);
+  padding: var(--units-2p5);
+  width: 340px;
 }

--- a/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
@@ -102,6 +102,10 @@
   width: 100%;
 }
 
+.form-builder-left-column {
+  min-width: 900px;
+}
+
 .form-builder-right-column {
   padding-top: var(--units-2);
 }

--- a/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page--va-gov-form-builder.html.twig
@@ -57,12 +57,21 @@
   </header>
 
   <div class="form-builder-layout-container">
-    <main class="page-content clearfix" role="main">
-      <div class="visually-hidden"><a id="main-content" tabindex="-1"></a></div>
-
-      {# The form content #}
-      {{ page.content }}
-
-    </main>
+    <div class="form-builder-two-column-layout">
+      <div class="form-builder-left-column">
+        <main class="page-content clearfix" role="main">
+          <div class="visually-hidden">
+            <a id="main-content" tabindex="-1"></a>
+          </div>
+          {{ page.content }}
+        </main>
+      </div>
+      <div class="form-builder-right-column">
+        <aside class="form-builder-sidebar">
+          <p>Sidebar content goes here.</p>
+        </aside>
+      </div>
+    </div>
   </div>
+
 </div>

--- a/tests/phpunit/va_gov_form_builder/functional/templates/FormBuilderPageTemplateTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/templates/FormBuilderPageTemplateTest.php
@@ -51,6 +51,9 @@ class FormBuilderPageTemplateTest extends VaGovExistingSiteBase {
 
     $navbarElement = $this->cssSelect('.form-builder-navbar');
     $this->assertCount(1, $navbarElement);
+
+    $sidebarElement = $this->cssSelect('.form-builder-sidebar');
+    $this->assertCount(1, $sidebarElement);
   }
 
   /**


### PR DESCRIPTION
## Description
Adds a sidebar with placeholder content to all Form Builder pages.

Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/97922

## Testing done
- Unit test updated to ensure presence of sidebar.
- Manual tests to ensure sidebar is present.

## Screenshots
![image](https://github.com/user-attachments/assets/74992c72-c22f-443a-9091-c82ad020490b)

## QA steps

1. Navigate to `/form-builder/intro`
   - [ ] Ensure sidebar placeholder is present
2. Navigate to `/form-builder/start-conversion`
   - [ ] Ensure sidebar placeholder is present

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Engine`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
