### PR TITLE
VAGOV-TEAM-94247: Adds test-user creation to script.

### DIFF
--- a/scripts/content/form-builder.php
+++ b/scripts/content/form-builder.php
@@ -2,13 +2,21 @@
 
 /**
  * @file
- * Creates Digital Form test data for local and Tugboat environments.
+ * Creates Form Builder test data for local and Tugboat environments.
+ *
+ * 1. Creates Digital Form test nodes:
+ *  - Form 21-4140.
+ *  - Generic form.
+ * 2. Creates users with and without Form Builder access:
+ *  - User with 'access form builder' perm via 'Form Builder user' role.
+ *  - User without 'access form builder' perm via 'Authenticated user' role.
  *
  *  !!!! DO NOT RUN ON PROD !!!!
  */
 
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\user\Entity\User;
 
 require_once __DIR__ . '/script-library.php';
 
@@ -22,6 +30,7 @@ function run() {
   exit_if_not_local_or_tugboat($env);
 
   create_digital_forms();
+  create_users();
 }
 
 /**
@@ -187,4 +196,48 @@ function your_personal_info(
   );
 
   return $your_personal_info;
+}
+
+/**
+ * Creates a test user.
+ *
+ * @param string $username
+ *   The username of the user. If empty, a unique value is generated.
+ * @param string $role
+ *   The machine name of the role. Defaults to basic role 'authenticated'.
+ */
+function create_user($username = NULL, $role = 'authenticated') {
+
+  if (!$username) {
+    $username = 'user_' . uniqid();
+  }
+
+  $existing_user = user_load_by_name($username);
+  if ($existing_user) {
+    debug_log_message('User ' . $username . ' already exists. User not created.');
+    return;
+  }
+
+  $user = User::create([
+    'name' => $username,
+    'pass' => 'drupal8',
+    'mail' => $username . '@example.com',
+    'status' => TRUE,
+    'roles' => [$role],
+  ]);
+
+  $user->save();
+
+  debug_log_message('User ' . $username . ' created with role ' . $role);
+}
+
+/**
+ * Creates test users with and without Form Builder access.
+ */
+function create_users() {
+  // Create a user who does not have Form Builder access.
+  create_user('test_user_no_form_builder');
+
+  // Create a user who has Form Builder access.
+  create_user('test_user_form_builder', 'form_builder_user');
 }


### PR DESCRIPTION
## Description
This PR adds the creation of two test users to the pre-existing content-creation script. Notably, this PR changes the filename of the existing script from `digital-forms.php` to `form-builder.php`.  This was done to more accurately reflect the grouping of  user creation with digital-form creation. While the creation of digital form test nodes can technically be useful outside the context of Form Builder, the creation of test users is something separate. Since both are being used primarily for testing the Form Builder, the name change feels appropriate here, and, notably, better than creating two separate scripts that need to be run independently.

To execute the script, execute this command in the terminal: `drush scr scripts/content/form-builder.php`.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/94247

## Testing done
Ran the script locally and confirmed the creation of two new test users. Ran it again to confirm that it properly handles the case where the users already exist.

## Screenshots
### Success.
![image](https://github.com/user-attachments/assets/e46ed5a2-1a35-494b-b32d-86197747579c)

### Failure. Users already exist.
![image](https://github.com/user-attachments/assets/241f0b82-df84-43af-886f-cfab6b7ff584)


## QA steps
1. Execute this command in the terminal: `drush scr scripts/content/form-builder.php`.
   - [x] Validate that the success message above is displayed.
   - [x] Validate that two new users exist in the system.
2. Execute the command again.
   - [x] Validate that the user-already-exists messages from above are displayed.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Engine`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
