### PR TITLE
VACMS-19616: Contact info block has remove button not working

### DIFF
--- a/config/sync/field.field.node.checklist.field_contact_information.yml
+++ b/config/sync/field.field.node.checklist.field_contact_information.yml
@@ -8,13 +8,17 @@ dependencies:
     - paragraphs.paragraphs_type.contact_information
   module:
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.checklist.field_contact_information
 field_name: field_contact_information
 entity_type: node
 bundle: checklist
 label: 'Need more help?'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -34,8 +38,17 @@ settings:
       alert_single:
         weight: 41
         enabled: false
+      audience_topics:
+        weight: 55
+        enabled: false
+      basic_accordion:
+        weight: 56
+        enabled: false
       button:
         weight: 42
+        enabled: false
+      centralized_content_descriptor:
+        weight: 58
         enabled: false
       checklist:
         weight: 43
@@ -52,20 +65,47 @@ settings:
       contact_information:
         weight: 47
         enabled: true
+      digital_form_address:
+        weight: 64
+        enabled: false
+      digital_form_identification_info:
+        weight: 65
+        enabled: false
+      digital_form_list_loop:
+        weight: 66
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 67
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 68
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 69
+        enabled: false
       downloadable_file:
         weight: 48
         enabled: false
       email_contact:
         weight: 49
         enabled: false
+      embedded_video:
+        weight: 72
+        enabled: false
       expandable_text:
         weight: 50
+        enabled: false
+      featured_content:
+        weight: 74
         enabled: false
       health_care_local_facility_servi:
         weight: 51
         enabled: false
       link_teaser:
         weight: 52
+        enabled: false
+      link_teaser_with_image:
+        weight: 77
         enabled: false
       list_of_link_teasers:
         weight: 53
@@ -75,6 +115,9 @@ settings:
         enabled: false
       lists_of_links:
         weight: 55
+        enabled: false
+      magichead_group:
+        weight: 81
         enabled: false
       media:
         weight: 56
@@ -109,6 +152,9 @@ settings:
       react_widget:
         weight: 66
         enabled: false
+      rich_text_char_limit_1000:
+        weight: 93
+        enabled: false
       service_location:
         weight: 67
         enabled: false
@@ -123,9 +169,6 @@ settings:
         enabled: false
       staff_profile:
         weight: 71
-        enabled: false
-      starred_horizontal_rule:
-        weight: 72
         enabled: false
       step:
         weight: 73

--- a/config/sync/field.field.node.faq_multiple_q_a.field_contact_information.yml
+++ b/config/sync/field.field.node.faq_multiple_q_a.field_contact_information.yml
@@ -8,13 +8,17 @@ dependencies:
     - paragraphs.paragraphs_type.contact_information
   module:
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.faq_multiple_q_a.field_contact_information
 field_name: field_contact_information
 entity_type: node
 bundle: faq_multiple_q_a
 label: 'Need more help?'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -34,8 +38,17 @@ settings:
       alert_single:
         weight: 41
         enabled: false
+      audience_topics:
+        weight: 55
+        enabled: false
+      basic_accordion:
+        weight: 56
+        enabled: false
       button:
         weight: 42
+        enabled: false
+      centralized_content_descriptor:
+        weight: 58
         enabled: false
       checklist:
         weight: 43
@@ -52,20 +65,47 @@ settings:
       contact_information:
         weight: 47
         enabled: true
+      digital_form_address:
+        weight: 64
+        enabled: false
+      digital_form_identification_info:
+        weight: 65
+        enabled: false
+      digital_form_list_loop:
+        weight: 66
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 67
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 68
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 69
+        enabled: false
       downloadable_file:
         weight: 48
         enabled: false
       email_contact:
         weight: 49
         enabled: false
+      embedded_video:
+        weight: 72
+        enabled: false
       expandable_text:
         weight: 50
+        enabled: false
+      featured_content:
+        weight: 74
         enabled: false
       health_care_local_facility_servi:
         weight: 51
         enabled: false
       link_teaser:
         weight: 52
+        enabled: false
+      link_teaser_with_image:
+        weight: 77
         enabled: false
       list_of_link_teasers:
         weight: 55
@@ -75,6 +115,9 @@ settings:
         enabled: false
       lists_of_links:
         weight: 53
+        enabled: false
+      magichead_group:
+        weight: 81
         enabled: false
       media:
         weight: 56
@@ -109,6 +152,9 @@ settings:
       react_widget:
         weight: 66
         enabled: false
+      rich_text_char_limit_1000:
+        weight: 93
+        enabled: false
       service_location:
         weight: 67
         enabled: false
@@ -123,9 +169,6 @@ settings:
         enabled: false
       staff_profile:
         weight: 71
-        enabled: false
-      starred_horizontal_rule:
-        weight: 72
         enabled: false
       step:
         weight: 73

--- a/config/sync/field.field.node.media_list_images.field_contact_information.yml
+++ b/config/sync/field.field.node.media_list_images.field_contact_information.yml
@@ -8,13 +8,17 @@ dependencies:
     - paragraphs.paragraphs_type.contact_information
   module:
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.media_list_images.field_contact_information
 field_name: field_contact_information
 entity_type: node
 bundle: media_list_images
 label: 'Need more help?'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -34,8 +38,17 @@ settings:
       alert_single:
         weight: 41
         enabled: false
+      audience_topics:
+        weight: 55
+        enabled: false
+      basic_accordion:
+        weight: 56
+        enabled: false
       button:
         weight: 42
+        enabled: false
+      centralized_content_descriptor:
+        weight: 58
         enabled: false
       checklist:
         weight: 43
@@ -52,20 +65,47 @@ settings:
       contact_information:
         weight: 47
         enabled: true
+      digital_form_address:
+        weight: 64
+        enabled: false
+      digital_form_identification_info:
+        weight: 65
+        enabled: false
+      digital_form_list_loop:
+        weight: 66
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 67
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 68
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 69
+        enabled: false
       downloadable_file:
         weight: 48
         enabled: false
       email_contact:
         weight: 49
         enabled: false
+      embedded_video:
+        weight: 72
+        enabled: false
       expandable_text:
         weight: 50
+        enabled: false
+      featured_content:
+        weight: 74
         enabled: false
       health_care_local_facility_servi:
         weight: 51
         enabled: false
       link_teaser:
         weight: 52
+        enabled: false
+      link_teaser_with_image:
+        weight: 77
         enabled: false
       list_of_link_teasers:
         weight: 53
@@ -75,6 +115,9 @@ settings:
         enabled: false
       lists_of_links:
         weight: 55
+        enabled: false
+      magichead_group:
+        weight: 81
         enabled: false
       media:
         weight: 56
@@ -109,6 +152,9 @@ settings:
       react_widget:
         weight: 66
         enabled: false
+      rich_text_char_limit_1000:
+        weight: 93
+        enabled: false
       service_location:
         weight: 67
         enabled: false
@@ -123,9 +169,6 @@ settings:
         enabled: false
       staff_profile:
         weight: 71
-        enabled: false
-      starred_horizontal_rule:
-        weight: 72
         enabled: false
       step:
         weight: 73

--- a/config/sync/field.field.node.media_list_videos.field_contact_information.yml
+++ b/config/sync/field.field.node.media_list_videos.field_contact_information.yml
@@ -8,13 +8,17 @@ dependencies:
     - paragraphs.paragraphs_type.contact_information
   module:
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.media_list_videos.field_contact_information
 field_name: field_contact_information
 entity_type: node
 bundle: media_list_videos
 label: 'Need more help?'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -34,8 +38,17 @@ settings:
       alert_single:
         weight: 41
         enabled: false
+      audience_topics:
+        weight: 55
+        enabled: false
+      basic_accordion:
+        weight: 56
+        enabled: false
       button:
         weight: 42
+        enabled: false
+      centralized_content_descriptor:
+        weight: 58
         enabled: false
       checklist:
         weight: 43
@@ -52,20 +65,47 @@ settings:
       contact_information:
         weight: 47
         enabled: true
+      digital_form_address:
+        weight: 64
+        enabled: false
+      digital_form_identification_info:
+        weight: 65
+        enabled: false
+      digital_form_list_loop:
+        weight: 66
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 67
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 68
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 69
+        enabled: false
       downloadable_file:
         weight: 48
         enabled: false
       email_contact:
         weight: 49
         enabled: false
+      embedded_video:
+        weight: 72
+        enabled: false
       expandable_text:
         weight: 50
+        enabled: false
+      featured_content:
+        weight: 74
         enabled: false
       health_care_local_facility_servi:
         weight: 51
         enabled: false
       link_teaser:
         weight: 52
+        enabled: false
+      link_teaser_with_image:
+        weight: 77
         enabled: false
       list_of_link_teasers:
         weight: 53
@@ -75,6 +115,9 @@ settings:
         enabled: false
       lists_of_links:
         weight: 55
+        enabled: false
+      magichead_group:
+        weight: 81
         enabled: false
       media:
         weight: 56
@@ -109,6 +152,9 @@ settings:
       react_widget:
         weight: 66
         enabled: false
+      rich_text_char_limit_1000:
+        weight: 93
+        enabled: false
       service_location:
         weight: 67
         enabled: false
@@ -123,9 +169,6 @@ settings:
         enabled: false
       staff_profile:
         weight: 71
-        enabled: false
-      starred_horizontal_rule:
-        weight: 72
         enabled: false
       step:
         weight: 73

--- a/config/sync/field.field.node.q_a.field_contact_information.yml
+++ b/config/sync/field.field.node.q_a.field_contact_information.yml
@@ -8,13 +8,17 @@ dependencies:
     - paragraphs.paragraphs_type.contact_information
   module:
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.q_a.field_contact_information
 field_name: field_contact_information
 entity_type: node
 bundle: q_a
 label: 'Need more help?'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -34,8 +38,17 @@ settings:
       alert_single:
         weight: 41
         enabled: false
+      audience_topics:
+        weight: 55
+        enabled: false
+      basic_accordion:
+        weight: 56
+        enabled: false
       button:
         weight: 42
+        enabled: false
+      centralized_content_descriptor:
+        weight: 58
         enabled: false
       checklist:
         weight: 43
@@ -52,20 +65,47 @@ settings:
       contact_information:
         weight: 47
         enabled: true
+      digital_form_address:
+        weight: 64
+        enabled: false
+      digital_form_identification_info:
+        weight: 65
+        enabled: false
+      digital_form_list_loop:
+        weight: 66
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 67
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 68
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 69
+        enabled: false
       downloadable_file:
         weight: 48
         enabled: false
       email_contact:
         weight: 49
         enabled: false
+      embedded_video:
+        weight: 72
+        enabled: false
       expandable_text:
         weight: 50
+        enabled: false
+      featured_content:
+        weight: 74
         enabled: false
       health_care_local_facility_servi:
         weight: 51
         enabled: false
       link_teaser:
         weight: 52
+        enabled: false
+      link_teaser_with_image:
+        weight: 77
         enabled: false
       list_of_link_teasers:
         weight: 53
@@ -75,6 +115,9 @@ settings:
         enabled: false
       lists_of_links:
         weight: 55
+        enabled: false
+      magichead_group:
+        weight: 81
         enabled: false
       media:
         weight: 56
@@ -109,6 +152,9 @@ settings:
       react_widget:
         weight: 66
         enabled: false
+      rich_text_char_limit_1000:
+        weight: 93
+        enabled: false
       service_location:
         weight: 67
         enabled: false
@@ -123,9 +169,6 @@ settings:
         enabled: false
       staff_profile:
         weight: 71
-        enabled: false
-      starred_horizontal_rule:
-        weight: 72
         enabled: false
       step:
         weight: 73

--- a/config/sync/field.field.node.step_by_step.field_contact_information.yml
+++ b/config/sync/field.field.node.step_by_step.field_contact_information.yml
@@ -8,13 +8,17 @@ dependencies:
     - paragraphs.paragraphs_type.contact_information
   module:
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.step_by_step.field_contact_information
 field_name: field_contact_information
 entity_type: node
 bundle: step_by_step
 label: 'Need more help?'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -34,8 +38,17 @@ settings:
       alert_single:
         weight: 41
         enabled: false
+      audience_topics:
+        weight: 55
+        enabled: false
+      basic_accordion:
+        weight: 56
+        enabled: false
       button:
         weight: 42
+        enabled: false
+      centralized_content_descriptor:
+        weight: 58
         enabled: false
       checklist:
         weight: 43
@@ -52,20 +65,47 @@ settings:
       contact_information:
         weight: 47
         enabled: true
+      digital_form_address:
+        weight: 64
+        enabled: false
+      digital_form_identification_info:
+        weight: 65
+        enabled: false
+      digital_form_list_loop:
+        weight: 66
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 67
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 68
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 69
+        enabled: false
       downloadable_file:
         weight: 48
         enabled: false
       email_contact:
         weight: 49
         enabled: false
+      embedded_video:
+        weight: 72
+        enabled: false
       expandable_text:
         weight: 50
+        enabled: false
+      featured_content:
+        weight: 74
         enabled: false
       health_care_local_facility_servi:
         weight: 51
         enabled: false
       link_teaser:
         weight: 52
+        enabled: false
+      link_teaser_with_image:
+        weight: 77
         enabled: false
       list_of_link_teasers:
         weight: 53
@@ -75,6 +115,9 @@ settings:
         enabled: false
       lists_of_links:
         weight: 55
+        enabled: false
+      magichead_group:
+        weight: 81
         enabled: false
       media:
         weight: 56
@@ -109,6 +152,9 @@ settings:
       react_widget:
         weight: 66
         enabled: false
+      rich_text_char_limit_1000:
+        weight: 93
+        enabled: false
       service_location:
         weight: 67
         enabled: false
@@ -123,9 +169,6 @@ settings:
         enabled: false
       staff_profile:
         weight: 71
-        enabled: false
-      starred_horizontal_rule:
-        weight: 72
         enabled: false
       step:
         weight: 73

--- a/config/sync/field.field.node.support_resources_detail_page.field_contact_information.yml
+++ b/config/sync/field.field.node.support_resources_detail_page.field_contact_information.yml
@@ -8,13 +8,17 @@ dependencies:
     - paragraphs.paragraphs_type.contact_information
   module:
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.support_resources_detail_page.field_contact_information
 field_name: field_contact_information
 entity_type: node
 bundle: support_resources_detail_page
 label: 'Need more help?'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -34,8 +38,17 @@ settings:
       alert_single:
         weight: 41
         enabled: false
+      audience_topics:
+        weight: 55
+        enabled: false
+      basic_accordion:
+        weight: 56
+        enabled: false
       button:
         weight: 42
+        enabled: false
+      centralized_content_descriptor:
+        weight: 58
         enabled: false
       checklist:
         weight: 43
@@ -52,20 +65,47 @@ settings:
       contact_information:
         weight: 47
         enabled: true
+      digital_form_address:
+        weight: 64
+        enabled: false
+      digital_form_identification_info:
+        weight: 65
+        enabled: false
+      digital_form_list_loop:
+        weight: 66
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 67
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 68
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 69
+        enabled: false
       downloadable_file:
         weight: 48
         enabled: false
       email_contact:
         weight: 49
         enabled: false
+      embedded_video:
+        weight: 72
+        enabled: false
       expandable_text:
         weight: 50
+        enabled: false
+      featured_content:
+        weight: 74
         enabled: false
       health_care_local_facility_servi:
         weight: 51
         enabled: false
       link_teaser:
         weight: 52
+        enabled: false
+      link_teaser_with_image:
+        weight: 77
         enabled: false
       list_of_link_teasers:
         weight: 55
@@ -75,6 +115,9 @@ settings:
         enabled: false
       lists_of_links:
         weight: 53
+        enabled: false
+      magichead_group:
+        weight: 81
         enabled: false
       media:
         weight: 56
@@ -109,6 +152,9 @@ settings:
       react_widget:
         weight: 66
         enabled: false
+      rich_text_char_limit_1000:
+        weight: 93
+        enabled: false
       service_location:
         weight: 67
         enabled: false
@@ -123,9 +169,6 @@ settings:
         enabled: false
       staff_profile:
         weight: 71
-        enabled: false
-      starred_horizontal_rule:
-        weight: 72
         enabled: false
       step:
         weight: 73

--- a/tests/cypress/integration/features/content_type/checklist.feature
+++ b/tests/cypress/integration/features/content_type/checklist.feature
@@ -16,6 +16,7 @@ Feature: Content Type: Checklist
     And the element with selector "#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-section-header-0-value" should have attribute "value" containing value "[Test Header Value]"
     And the element with selector "#edit-field-checklist-0-subform-field-checklist-sections-0-subform-field-checklist-items-0-value" should have attribute "value" containing value "[Test Items Value]"
     And the option "VACO" from dropdown with selector "#edit-field-administration" should be selected
+    And an element with the selector "#edit-field-contact-information-0-top-links-remove-button" should not exist
 
     # Make sure additional edits are saved
     And I fill in "Page title" with "[Test Data] Save and Continue Test"

--- a/tests/cypress/integration/features/content_type/support_resources_detail_page.feature
+++ b/tests/cypress/integration/features/content_type/support_resources_detail_page.feature
@@ -6,6 +6,7 @@ Feature: Content Type: Resources and Support Detail Page
     Given I am logged in as a user with the "content_admin" role
     When I am at "node/add/support_resources_detail_page"
     Then I should see "Tags"
+    And an element with the selector "#edit-field-contact-information-0-top-links-remove-button" should not exist
 
     Given I select option "- None -" from dropdown "Audience"
     Then I should not see an element with the selector "#edit-field-tags-0-subform-field-audience-beneficiares-wrapper"

--- a/tests/cypress/integration/step_definitions/common/i_create_a_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_create_a_node.js
@@ -447,6 +447,9 @@ const creators = {
       "edit-field-steps-0-subform-field-step-0-subform-field-wysiwyg-0-value",
       faker.lorem.sentence()
     );
+    cy.get("#edit-field-contact-information-0-top-links-remove-button").should(
+      "not.exist"
+    );
     return cy.wait(1000);
   },
   q_a: () => {
@@ -462,6 +465,9 @@ const creators = {
       faker.lorem.sentence()
     );
     cy.findAllByLabelText("Section").select("VACO", { force: true });
+    cy.get("#edit-field-contact-information-0-top-links-remove-button").should(
+      "not.exist"
+    );
     return cy;
   },
   press_release: () => {


### PR DESCRIPTION
## Description
Removes the remove button on the contact information paragraph on several content types by making the 'contact information' field required.

Relates to #19616

## Testing done
Tested manually and via cypress

# Screenshots
<img width="899" alt="Screenshot 2025-01-07 at 11 36 53 AM" src="https://github.com/user-attachments/assets/4b853996-5fbc-49c0-bb06-d02346f56129" />
<img width="870" alt="Screenshot 2025-01-07 at 11 36 58 AM" src="https://github.com/user-attachments/assets/37c28bc0-1d21-4ab8-8c06-a379679595bc" />


## QA steps

As a content admin
1. Visit the '[add Checklist](https://pr20222-jl1yo5qz9xvmvkqeaakbhf4sq9gt1aje.ci.cms.va.gov/node/add/checklist)' page
   - [x] Validate that there is no 'Remove' button on the Contact Information paragraph.
   - [x] Under 'Select contacts', select the 'Benefit Hub contacts' option.
   - [x] Validate you see the widget change to use the 'Benefit Hub contacts' widget (see above screenshot)
2. Visit the '[add FAQ page](https://pr20222-jl1yo5qz9xvmvkqeaakbhf4sq9gt1aje.ci.cms.va.gov/node/add/faq_multiple_q_a)' page
   - [x] Validate that there is no 'Remove' button on the Contact Information paragraph.
   - [x] Under 'Select contacts', select the 'Benefit Hub contacts' option.
   - [x] Validate you see the widget change to use the 'Benefit Hub contacts' widget (see above screenshot)
3. Visit the '[add Image List](https://pr20222-jl1yo5qz9xvmvkqeaakbhf4sq9gt1aje.ci.cms.va.gov/node/add/media_list_images)' page
   - [x] Validate that there is no 'Remove' button on the Contact Information paragraph.
   - [x] Under 'Select contacts', select the 'Benefit Hub contacts' option.
   - [x] Validate you see the widget change to use the 'Benefit Hub contacts' widget (see above screenshot)
4. Visit the '[add Video List](https://pr20222-jl1yo5qz9xvmvkqeaakbhf4sq9gt1aje.ci.cms.va.gov/node/add/media_list_videos)' page
   - [x] Validate that there is no 'Remove' button on the Contact Information paragraph.
   - [x] Under 'Select contacts', select the 'Benefit Hub contacts' option.
   - [x] Validate you see the widget change to use the 'Benefit Hub contacts' subform (see above screenshot)
5. Visit the '[add Reusable Q&A](https://pr20222-jl1yo5qz9xvmvkqeaakbhf4sq9gt1aje.ci.cms.va.gov/node/add/q_a)' page
   - [x] Validate that there is no 'Remove' button on the Contact Information paragraph.
   - [x] Under 'Select contacts', select the 'Benefit Hub contacts' option.
   - [x] Validate you see the widget change to use the 'Benefit Hub contacts' subform (see above screenshot)
6. Visit the '[add Step-by-Step](https://pr20222-jl1yo5qz9xvmvkqeaakbhf4sq9gt1aje.ci.cms.va.gov/node/add/step_by_step)' page
   - [x] Validate that there is no 'Remove' button on the Contact Information paragraph.
   - [x] Under 'Select contacts', select the 'Benefit Hub contacts' option.
   - [x] Validate you see the widget change to use the 'Benefit Hub contacts' subform (see above screenshot)
7. Visit the 'add [Resources and Support Detail Page](https://pr20222-jl1yo5qz9xvmvkqeaakbhf4sq9gt1aje.ci.cms.va.gov/node/add/support_resources_detail_page)' page
   - [x] Validate that there is no 'Remove' button on the Contact Information paragraph.
   - [x] Under 'Select contacts', select the 'Benefit Hub contacts' option.
   - [x] Validate you see the widget change to use the 'Benefit Hub contacts' subform (see above screenshot)

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
