### PR TITLE
VACMS-19974: Adds help text to general field

### DIFF
--- a/config/sync/field.field.block_content.connect_with_us.field_external_link.yml
+++ b/config/sync/field.field.block_content.connect_with_us.field_external_link.yml
@@ -16,7 +16,7 @@ field_name: field_external_link
 entity_type: block_content
 bundle: connect_with_us
 label: 'External link'
-description: 'Enter a link to the office homepage on legacy va.gov or another external site.'
+description: 'Enter a link to the office homepage on legacy va.gov or another external site. Link text will be used in both the primary Connect with us link and social media links.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
## Description

Relates to #19974

## Testing done
Manually

## Screenshots
![Screenshot 2025-01-17 at 12 43 03](https://github.com/user-attachments/assets/ec019b03-0c10-4dcb-b41c-d568958d38b1)


## QA steps
- As a content admin.
- Edit the [Connect with us VBA block](https://pr20301-0lpaofd5vk5kkfkhgdoh1fbkbvfx8fhn.ci.cms.va.gov/admin/content/block/324?destination=/admin/content/block)
- [ ] Confirm that the new help text for **External link** includes "Link text will be used in both the primary Connect with us link and social media links."

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
