### PR TITLE
Update Content Build package to 0.0.3666.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -228,7 +228,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3660",
+        "va-gov/content-build": "^0.0.3666",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afae26ccfddaa3e444a61fd34f1d2279",
+    "content-hash": "cc5409aacd5faa175b81905e676d1265",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -26902,16 +26902,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3660",
+            "version": "v0.0.3666",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "5f3b240e0e86745a2866c1969578040630591ccb"
+                "reference": "be4e1f9d047e61dc076817cd97fc1796255bb9c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/5f3b240e0e86745a2866c1969578040630591ccb",
-                "reference": "5f3b240e0e86745a2866c1969578040630591ccb",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/be4e1f9d047e61dc076817cd97fc1796255bb9c0",
+                "reference": "be4e1f9d047e61dc076817cd97fc1796255bb9c0",
                 "shasum": ""
             },
             "type": "node-project",
@@ -26938,9 +26938,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3660"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3666"
             },
-            "time": "2025-01-07T17:22:23+00:00"
+            "time": "2025-01-17T18:46:38+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description
This brings the content-build package in composer.json up-to-date.

A ticket is open to restore the automated process: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20308
