### PR TITLE
Set page cache from one day to one hour.

### DIFF
--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ
 cache:
   page:
-    max_age: 86400
+    max_age: 3600
 css:
   preprocess: false
   gzip: true


### PR DESCRIPTION
## Description
Editors logging in with their PIV cards have found that they are locked out of the CMS with an error relating to browser cookies. It has been determined that the routes requesting the tokens are getting cached when they shouldn't be. As a quick fix we are setting the global page cache time from one day to one hour. We are hoping that this keeps folks from getting locked out of the system waiting for the cache to expire.

Relates to #20339

## Testing done
Testing will need to be done in prod with monitoring of datadog and feedback from editors who were having issues with PIV login.

## QA steps

What needs to be checked to prove this works? 
 - Once deployed navigate to `/admin/config/development/performance` and validate that the Browser and proxy cache maximum age is set to 1 hour.

What needs to be checked to prove it didn't break any related things?
 - Observe datadog dashboard: https://vagov.ddog-gov.com/dashboard/vnk-g4s-fru/cms-prod--staging
 - Compare EC2 for cms CPU and Memory graphs against historic values. Identify any new spikes
 - Also compare Database Connections

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
