### PR TITLE
VACMS-19406: Excludes the Manila VAMC from getting auotomated path

### DIFF
--- a/docroot/modules/custom/va_gov_manila/src/EventSubscriber/ManilaEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_manila/src/EventSubscriber/ManilaEventSubscriber.php
@@ -167,6 +167,10 @@ class ManilaEventSubscriber implements EventSubscriberInterface {
       if ($section_id !== $this->manilaVaSystemId) {
         return;
       }
+      // Leave the System page alone.
+      elseif ($section_id === $this->manilaVaSystemId && $entity->bundle() === 'health_care_region_page') {
+        return;
+      }
 
       // Determine which prefixes are valid based on section.
       $manila_prefix = [$this->manilaVaSystemId => 'manila-va-clinic'];


### PR DESCRIPTION
## Description

Relates to #19406

## Testing done
Manually

## Screenshots
![Screenshot 2025-01-30 at 18 07 39](https://github.com/user-attachments/assets/cc0c8e4b-af3e-4249-b36b-0762cc0217a3)

## QA steps
### Set up QA Content Publisher
- [x] Log in as an admin
- [x] Assign the following roles to QA Content Publisher:
  - [x] Content creator - VAMC
  - [x] Content publisher 
  - [x] Content admin
- [x] Assign the following section to QA Content Publisher:
  - [x] Manila VA Clinic   

### Save Manila VA Clinic System page
- [ ] Log in as [QA Content Publisher](https://pr20377-9vesbiymz63hv4dhozmlgrgkmqqcnczk.ci.cms.va.gov/)
- [ ] Edit the [Manila VA Clinic VAMC System page](https://pr20377-9vesbiymz63hv4dhozmlgrgkmqqcnczk.ci.cms.va.gov/node/72609/edit)
- [ ] Confirm that the alias is set to /manila-va-system
- [ ] Publish the system
- [ ] Confirm that the URL is set to "/manila-va-system"

### Create an Event
- [ ] Create an Event
- [ ] Set the **Section** to "Manila VA Clinic"
- [ ] Fill out all required fields
- [ ] Publish the event
- [ ] Confirm that the url includes "/manila-va-clinic"
- [ ] Confirm that the url does not include "/manila-va-system"

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

