### PR TITLE
VACMS-20358: Updates Forms audit for language

### DIFF
--- a/config/sync/views.view.va_forms.yml
+++ b/config/sync/views.view.va_forms.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.storage.node.field_administration
     - field.storage.node.field_va_form_administration
     - field.storage.node.field_va_form_issue_date
+    - field.storage.node.field_va_form_language
     - field.storage.node.field_va_form_name
     - field.storage.node.field_va_form_revision_date
     - field.storage.node.field_va_form_title
@@ -33,6 +34,7 @@ dependencies:
     - datetime
     - link
     - node
+    - options
     - rest
     - serialization
     - taxonomy
@@ -1289,7 +1291,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.roles
       tags:
@@ -2138,6 +2139,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_va_form_language:
+          id: field_va_form_language
+          table: node__field_va_form_language
+          field: field_va_form_language
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Form Language'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       filters:
         type:
           id: type
@@ -2663,6 +2726,66 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_va_form_language_value:
+          id: field_va_form_language_value
+          table: node__field_va_form_language
+          field: field_va_form_language_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_va_form_language_value_op
+            label: 'Form Language'
+            description: ''
+            use_operator: true
+            operator: field_va_form_language_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_va_form_language_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vba: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+              next_js: '0'
+              translation_manager: '0'
+              rates_editor: '0'
+              form_builder_user: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
       filter_groups:
         operator: AND
         groups:
@@ -2746,6 +2869,7 @@ display:
         - 'config:field.storage.node.field_administration'
         - 'config:field.storage.node.field_va_form_administration'
         - 'config:field.storage.node.field_va_form_issue_date'
+        - 'config:field.storage.node.field_va_form_language'
         - 'config:field.storage.node.field_va_form_name'
         - 'config:field.storage.node.field_va_form_revision_date'
         - 'config:field.storage.node.field_va_form_tool_url'
@@ -3540,6 +3664,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_va_form_language:
+          id: field_va_form_language
+          table: node__field_va_form_language
+          field: field_va_form_language
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Form Language'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       filters:
         type:
           id: type
@@ -4065,6 +4251,66 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_va_form_language_value:
+          id: field_va_form_language_value
+          table: node__field_va_form_language
+          field: field_va_form_language_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_va_form_language_value_op
+            label: 'Form Language '
+            description: ''
+            use_operator: true
+            operator: field_va_form_language_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_va_form_language_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vba: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+              next_js: '0'
+              translation_manager: '0'
+              rates_editor: '0'
+              form_builder_user: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
       filter_groups:
         operator: AND
         groups:
@@ -4158,6 +4404,7 @@ display:
         - 'config:field.storage.node.field_administration'
         - 'config:field.storage.node.field_va_form_administration'
         - 'config:field.storage.node.field_va_form_issue_date'
+        - 'config:field.storage.node.field_va_form_language'
         - 'config:field.storage.node.field_va_form_name'
         - 'config:field.storage.node.field_va_form_revision_date'
         - 'config:field.storage.node.field_va_form_tool_url'
@@ -4194,7 +4441,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.roles
       tags:


### PR DESCRIPTION
## Description

Relates to #20358

## Testing done
Manually

## Screenshots
![Screenshot 2025-01-31 at 14 13 34](https://github.com/user-attachments/assets/01fbd333-205f-4615-87ca-5a7c11d3bc99)


## QA steps
### Set up a QA Content Publisher
- [x] Log in as an admin
- [x] Assign the following role to QA Content Publisher:
- [x] Content admin

### Check the VA Forms Audit
- [x] Log in as [QA Content Publisher](https://pr20379-ttjfeetyjbjkrocu4dhgacpeokwbzqrq.ci.cms.va.gov/)
- [x] Go to the [VA Forms audit](https://pr20379-ttjfeetyjbjkrocu4dhgacpeokwbzqrq.ci.cms.va.gov/admin/content/va-forms/audit)
- [x] Change the **Form Language" filter
- [x] Apply the change
- [x] Confirm that the result is expected
- [x] Click **Download CSV**
- [x] Confirm that the same results are downloaded

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

