### PR TITLE
VAGOV-TEAM-101602: Breadcrumbs

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/va_gov_form_builder.css
@@ -81,6 +81,41 @@
   padding: var(--units-1p5);
 }
 
+/* breadcrumbs */
+.form-builder-breadcrumbs {
+  margin: var(--units-5) 0;
+}
+
+.form-builder-breadcrumbs__list {
+  display: flex;
+  font-family: var(--font-source-sans);
+  gap: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.form-builder-breadcrumbs__list-item {
+  align-items: center;
+  display: flex;
+}
+
+.form-builder-breadcrumbs__list-item::after {
+  color: #666;
+  content: ">";
+  font-family: monospace;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.form-builder-breadcrumbs__list-item:last-child {
+  font-weight: var(--font-weight-bold);
+}
+
+.form-builder-breadcrumbs__list-item:last-child::after {
+  content: "";
+}
+
 /* buttons */
 .form-builder-button,
 a.form-builder-button {

--- a/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
@@ -119,7 +119,7 @@ class VaGovFormBuilderController extends ControllerBase {
       $breadcrumbTrail = [
         [
           'label' => 'Home',
-          'url' => '/form-builder/home',
+          'url' => Url::fromRoute('va_gov_form_builder.home')->toString(),
         ],
       ];
     }
@@ -129,7 +129,7 @@ class VaGovFormBuilderController extends ControllerBase {
         return [];
       }
 
-      $layoutUrl = "/form-builder/{$this->digitalForm->id()}/layout";
+      $layoutUrl = Url::fromRoute('va_gov_form_builder.layout', ['nid' => $this->digitalForm->id()])->toString();
       $breadcrumbTrail = $this->generateBreadcrumbs('home', $this->digitalForm->getTitle(), $layoutUrl);
     }
 
@@ -225,6 +225,7 @@ class VaGovFormBuilderController extends ControllerBase {
         'nid' => $digitalForm->id(),
         'title' => $digitalForm->getTitle(),
         'formNumber' => $digitalForm->get('field_va_form_number')->value,
+        'url' => Url::fromRoute('va_gov_form_builder.layout', ['nid' => $digitalForm->id()])->toString(),
       ];
     }
 

--- a/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
@@ -124,19 +124,18 @@ class VaGovFormBuilderController extends ControllerBase {
       ];
     }
 
-    elseif ($parent === 'form_info') {
-      $formInfoUrl = "/form-builder/{$this->digitalForm->id()}/form-info";
-      $breadcrumbTrail = $this->generateBreadcrumbs('home', 'Form info', $formInfoUrl);
-    }
-
     elseif ($parent === 'layout') {
+      if (!$this->digitalForm) {
+        return [];
+      }
+
       $layoutUrl = "/form-builder/{$this->digitalForm->id()}/layout";
-      $breadcrumbTrail = $this->generateBreadcrumbs('form_info', "Layout", $layoutUrl);
+      $breadcrumbTrail = $this->generateBreadcrumbs('home', $this->digitalForm->getTitle(), $layoutUrl);
     }
 
     $breadcrumbTrail[] = [
       'label' => $label,
-      'url' => $url,
+      'url' => $url ? $url : '#content',
     ];
 
     return $breadcrumbTrail;
@@ -250,7 +249,6 @@ class VaGovFormBuilderController extends ControllerBase {
   public function formInfo($nid = NULL) {
     $formName = 'FormInfo';
     $subtitle = 'Build a form';
-    $breadcrumbs = $this->generateBreadcrumbs('home', 'Form info');
     $libraries = ['form_info'];
 
     if (!empty($nid)) {
@@ -259,6 +257,12 @@ class VaGovFormBuilderController extends ControllerBase {
       if (!$nodeFound) {
         throw new NotFoundHttpException();
       }
+
+      $breadcrumbs = $this->generateBreadcrumbs('layout', 'Form info');
+    }
+    else {
+      // This is a form creation.
+      $breadcrumbs = $this->generateBreadcrumbs('home', 'Form info');
     }
 
     return $this->getFormPage($formName, $subtitle, $breadcrumbs, $libraries);
@@ -325,7 +329,7 @@ class VaGovFormBuilderController extends ControllerBase {
       ],
     ];
     $subtitle = $this->digitalForm->getTitle();
-    $breadcrumbs = $this->generateBreadcrumbs('form_info', 'Layout');
+    $breadcrumbs = $this->generateBreadcrumbs('home', $this->digitalForm->getTitle());
     $libraries = ['layout'];
 
     return $this->getPage($pageContent, $subtitle, $breadcrumbs, $libraries);

--- a/docroot/modules/custom/va_gov_form_builder/templates/components/breadcrumbs.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/components/breadcrumbs.html.twig
@@ -10,15 +10,30 @@
  *   'label' => string,
  *   'url' => string,
  * ]
- *
- * The `url` property may be empty, in which case the url
- * should be the current page.
  */
 #}
 <nav class="form-builder-breadcrumbs" aria-label="Breadcrumbs">
   <ol class="form-builder-breadcrumbs__list">
     {% for breadcrumb in breadcrumbs %}
-      <li class="form-builder-breadcrumbs__list-item"><a class="form-builder-breadcrumbs__link" href="{{breadcrumb.url}}">{{breadcrumb.label}}</a></li>
+        {% if loop.last %}
+          <li class="form-builder-breadcrumbs__list-item" aria-current="page">
+            <a
+              class="form-builder-breadcrumbs__link form-builder-breadcrumbs__link--current"
+              href="{{breadcrumb.url}}"
+            >
+              {{breadcrumb.label}}
+            </a>
+          </li>
+        {% else %}
+          <li class="form-builder-breadcrumbs__list-item">
+            <a
+              class="form-builder-breadcrumbs__link"
+              href="{{breadcrumb.url}}"
+            >
+              {{breadcrumb.label}}
+            </a>
+          </li>
+        {% endif %}
     {% endfor %}
   </ol>
 </nav>

--- a/docroot/modules/custom/va_gov_form_builder/templates/components/breadcrumbs.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/components/breadcrumbs.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Breadcrumbs used on VA.gov Form Builder pages.
+ *
+ * The data available to this template is passed when this
+ * template is included in another. The data is a list of
+ * breadcrumbs with the following structure:
+ * [
+ *   'label' => string,
+ *   'url' => string,
+ * ]
+ *
+ * The `url` property may be empty, in which case the url
+ * should be the current page.
+ */
+#}
+<nav class="form-builder-breadcrumbs" aria-label="Breadcrumbs">
+  <ol class="form-builder-breadcrumbs__list">
+    {% for breadcrumb in breadcrumbs %}
+      <li class="form-builder-breadcrumbs__list-item"><a class="form-builder-breadcrumbs__link" href="{{breadcrumb.url}}">{{breadcrumb.label}}</a></li>
+    {% endfor %}
+  </ol>
+</nav>

--- a/docroot/modules/custom/va_gov_form_builder/templates/page-content/page-content--va-gov-form-builder--home.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page-content/page-content--va-gov-form-builder--home.html.twig
@@ -24,7 +24,7 @@
         <li class="form-builder-content-section--recent-forms__form-list-item">
           <a
             class="form-builder-content-section--recent-forms__form-link"
-            href="/form-builder/{{form.nid}}/layout"
+            href="{{form.url}}"
           >
             {{ form.title }} (VA Form {{ form.formNumber }})
           </a>

--- a/docroot/modules/custom/va_gov_form_builder/templates/page/page--va-gov-form-builder.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page/page--va-gov-form-builder.html.twig
@@ -27,7 +27,7 @@
       } %}
     {% endif %}
 
-    <main class="page-content clearfix" role="main">
+    <main id="content" class="page-content clearfix" role="main">
       <div class="visually-hidden">
         <a id="main-content" tabindex="-1"></a>
       </div>

--- a/docroot/modules/custom/va_gov_form_builder/templates/page/page--va-gov-form-builder.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page/page--va-gov-form-builder.html.twig
@@ -21,6 +21,12 @@
   </header>
 
   <div class="form-builder-layout-container">
+    {% if page.form_builder_page_data.breadcrumbs is not empty %}
+      {% include '@va_gov_form_builder/components/breadcrumbs.html.twig' with {
+        'breadcrumbs': page.form_builder_page_data.breadcrumbs,
+      } %}
+    {% endif %}
+
     <main class="page-content clearfix" role="main">
       <div class="visually-hidden">
         <a id="main-content" tabindex="-1"></a>

--- a/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.routing.yml
+++ b/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.routing.yml
@@ -17,7 +17,7 @@ va_gov_form_builder.form_info.edit:
   requirements:
     nid: \d*
 va_gov_form_builder.layout:
-  path: "/form-builder/{nid}/layout"
+  path: "/form-builder/{nid}"
   defaults:
     _controller: '\Drupal\va_gov_form_builder\Controller\VaGovFormBuilderController::layout'
 va_gov_form_builder.name_and_dob:

--- a/tests/phpunit/va_gov_form_builder/Traits/TestPageLoads.php
+++ b/tests/phpunit/va_gov_form_builder/Traits/TestPageLoads.php
@@ -71,4 +71,30 @@ trait TestPageLoads {
     $this->assertEquals($subtitleElement->getText(), $expectedSubtitle);
   }
 
+  /**
+   * Test the page has the expected breadcrumbs.
+   *
+   * @param string $url
+   *   The  page to load.
+   * @param string[] $expectedBreadcrumbs
+   *   The expected breadcrumbs.
+   */
+  private function sharedTestPageHasExpectedBreadcrumbs($url, $expectedBreadcrumbs) {
+    // Log in a user with permission.
+    $this->loginFormBuilderUser();
+
+    // Navigate to page.
+    $this->drupalGet($url);
+
+    $page = $this->getSession()->getPage();
+    $breadcrumbLinks = $page->findAll('css', '.form-builder-breadcrumbs__link');
+    foreach ($breadcrumbLinks as $index => $breadcrumbLink) {
+      $label = $breadcrumbLink->getText();
+      $this->assertEquals($expectedBreadcrumbs[$index]['label'], $label);
+
+      $url = $breadcrumbLink->getAttribute('href');
+      $this->assertEquals($expectedBreadcrumbs[$index]['url'], $url);
+    }
+  }
+
 }

--- a/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
@@ -114,7 +114,7 @@ class FormInfoTest extends VaGovExistingSiteBase {
         ],
         [
           'label' => $title,
-          'url' => "/form-builder/{$node->id()}/layout",
+          'url' => "/form-builder/{$node->id()}",
         ],
         [
           'label' => 'Form info',
@@ -188,9 +188,9 @@ class FormInfoTest extends VaGovExistingSiteBase {
     ];
     $this->submitForm($formInput, 'Save and continue');
 
-    // Successful submission should take user to next page.
+    // Successful submission should take user to new form's layout page.
     $nextPageUrl = $this->getSession()->getCurrentUrl();
-    $this->assertStringContainsString('/layout', $nextPageUrl);
+    $this->assertMatchesRegularExpression('|/form-builder/\d+|', $nextPageUrl);
   }
 
   /**

--- a/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
@@ -71,10 +71,9 @@ class FormInfoTest extends VaGovExistingSiteBase {
   }
 
   /**
-   * Test that the page has the expected breadcrumbs.
+   * Test that the page has the expected breadcrumbs in create mode.
    */
-  public function testPageBreadcrumbs() {
-    // Home page should not have breadcrumbs.
+  public function testPageBreadcrumbsCreateMode() {
     $this->sharedTestPageHasExpectedBreadcrumbs(
       $this->getFormPageUrl(),
       [
@@ -84,7 +83,42 @@ class FormInfoTest extends VaGovExistingSiteBase {
         ],
         [
           'label' => 'Form info',
-          'url' => "",
+          'url' => "#content",
+        ],
+      ],
+    );
+  }
+
+  /**
+   * Test that the page has the expected breadcrumbs in edit mode.
+   */
+  public function testPageBreadcrumbsEditMode() {
+    $title = 'Test Digital Form ' . uniqid();
+    $formNumber = '99-9999';
+
+    // Create a new Digital Form node.
+    $node = $this->createNode([
+      'type' => 'digital_form',
+      'title' => $title,
+      'field_chapters' => [],
+      'field_va_form_number' => $formNumber,
+    ]);
+
+    // Ensure page loads.
+    $this->sharedTestPageHasExpectedBreadcrumbs(
+      $this->getFormPageUrl($node->id()),
+      [
+        [
+          'label' => 'Home',
+          'url' => '/form-builder/home',
+        ],
+        [
+          'label' => $title,
+          'url' => "/form-builder/{$node->id()}/layout",
+        ],
+        [
+          'label' => 'Form info',
+          'url' => "#content",
         ],
       ],
     );

--- a/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
@@ -71,6 +71,26 @@ class FormInfoTest extends VaGovExistingSiteBase {
   }
 
   /**
+   * Test that the page has the expected breadcrumbs.
+   */
+  public function testPageBreadcrumbs() {
+    // Home page should not have breadcrumbs.
+    $this->sharedTestPageHasExpectedBreadcrumbs(
+      $this->getFormPageUrl(),
+      [
+        [
+          'label' => 'Home',
+          'url' => '/form-builder/home',
+        ],
+        [
+          'label' => 'Form info',
+          'url' => "",
+        ],
+      ],
+    );
+  }
+
+  /**
    * Test that the page loads correctly in create mode.
    *
    * Ensure form fields are empty (not pre-populated).

--- a/tests/phpunit/va_gov_form_builder/functional/content-pages/HomeTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/content-pages/HomeTest.php
@@ -57,6 +57,16 @@ class HomeTest extends VaGovExistingSiteBase {
   }
 
   /**
+   * Test that the page has the expected breadcrumbs.
+   */
+  public function testPageBreadcrumbs() {
+    // Home page should not have breadcrumbs.
+    $this->drupalGet($this->getPageUrl());
+    $breadcrumbWrapper = $this->getSession()->getPage()->find('css', '.form-builder-breadcrumbs');
+    $this->assertEmpty($breadcrumbWrapper);
+  }
+
+  /**
    * Test the 'Build a form' button.
    */
   public function testButton() {

--- a/tests/phpunit/va_gov_form_builder/functional/content-pages/LayoutTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/content-pages/LayoutTest.php
@@ -111,6 +111,30 @@ class LayoutTest extends VaGovExistingSiteBase {
   }
 
   /**
+   * Test that the page has the expected breadcrumbs.
+   */
+  public function testPageBreadcrumbs() {
+    // Home page should not have breadcrumbs.
+    $this->sharedTestPageHasExpectedBreadcrumbs(
+      $this->getFormPageUrl(),
+      [
+        [
+          'label' => 'Home',
+          'url' => '/form-builder/home',
+        ],
+        [
+          'label' => 'Form info',
+          'url' => "/form-builder/{$this->digitalFormNode->id()}/form-info",
+        ],
+        [
+          'label' => 'Layout',
+          'url' => '',
+        ],
+      ],
+    );
+  }
+
+  /**
    * Test the "Form info" section.
    */
   public function testFormInfo() {

--- a/tests/phpunit/va_gov_form_builder/functional/content-pages/LayoutTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/content-pages/LayoutTest.php
@@ -123,12 +123,8 @@ class LayoutTest extends VaGovExistingSiteBase {
           'url' => '/form-builder/home',
         ],
         [
-          'label' => 'Form info',
-          'url' => "/form-builder/{$this->digitalFormNode->id()}/form-info",
-        ],
-        [
-          'label' => 'Layout',
-          'url' => '',
+          'label' => $this->digitalFormNode->getTitle(),
+          'url' => "#content",
         ],
       ],
     );

--- a/tests/phpunit/va_gov_form_builder/functional/content-pages/LayoutTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/content-pages/LayoutTest.php
@@ -30,7 +30,7 @@ class LayoutTest extends VaGovExistingSiteBase {
    * Returns the url for this page.
    */
   private function getFormPageUrl() {
-    return "/form-builder/{$this->digitalFormNode->id()}/layout";
+    return "/form-builder/{$this->digitalFormNode->id()}";
   }
 
   /**


### PR DESCRIPTION
## Description
- Adds a mechanism to define and render breadcrumbs on Form Builder pages.
- Defines those breadcrumbs for Form Info and Layout pages.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/101602

## Testing done
- Functional tests updated to add test cases for breadcrumbs.
- Manual tests done on breadcrumb functionality.

## Screenshots
### Form Info page
![image](https://github.com/user-attachments/assets/7da0343d-fd64-413c-9673-d294ef9c8d88)

### Layout page
![image](https://github.com/user-attachments/assets/b1f2d9b2-17f2-4842-86e9-0ba9c078f374)

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As any user that can access Form Builder:
1. Navigate to `/form-builder/home`
   - [x] Validate that there are no breadcrumbs displayed
2. Navigate to `/form-builder/form-info`
   - [x] Validate the following breadcrumbs exist and navigate appropriately:
      - [x] Home -> `/form-builder/home`
      - [x] Form info -> (current page with '#content' appended)
3. The rest of the validations require a Digital Form to exist. If needed, create one. Then locate the existing forms at the bottom of the Form Builder home page and click on one.
   - [x] Validate that you are taken to the Layout page. The url should be `form-builder/{nid}/layout`.
   - [x] Validate that the following breadcrumbs exist and navigate appropriately:
      - [x] Home -> `/form-builder/home`
      - [x] $FORM_NAME -> (current page with `#content` appended)
4. On the Layout page, click on the "View form info" link.
   - [x] Validate that you are taken to `form-builder/{nid}/form-info`
   - [x] Validate that the following breadcrumbs exist and navigate appropriately:
      - [x] Home -> `/form-builder/home`
      - [x] $FORM_NAME -> '/form-builder/{nid}/layout`
      - [x] Form info -> (current page with `#content` appended)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Engine`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
