### PR TITLE
New VAMC Facility runbook: Replace URL example with placeholder content

### DIFF
--- a/.github/ISSUE_TEMPLATE/runbook-vamc-facility-new.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-facility-new.md
@@ -62,8 +62,8 @@ Please let us know when your draft content is complete, so that we can wrap up t
 - [ ] Update the facility **Meta description** field, using the following format: "Get address and hours, parking and transportation information, and health services offered at [facility name]."
 - [ ] Move the facility link in the health care system menu to its place in the alphabetized list (medical centers first, then clinics).
 - [ ] Drupal Admin bulk publishes nodes and facility.
-- [ ] Contact Lighthouse via Slack at #cms-lighthouse channel that this facility requires a canonical link in the following format (replacing the placeholder data with the actual API Id and VA.gov URL):
-  - `vha_691GM,https://www.va.gov/greater-los-angeles-health-care/locations/oxnard-va-clinic/`
+- [ ] Contact Lighthouse via Slack at #cms-lighthouse channel that this facility requires a canonical link in the following format (replace the placeholder data with the actual API Id and VA.gov URL):
+  - `vha_XXX`,https://www.va.gov/SYSTEM-health-care/locations/PATH/`
 - [ ] Add the "Awaiting CSV" flag to the facility node with a revision log message that includes a link to this ticket.
 - [ ] Let Help desk know this has been done, if not done by Help desk.
 


### PR DESCRIPTION
## Description
**ISSUE TEMPLATE change only.**

The example URL is confusing and not clearly an example. This can lead to confusion if we actually use that example to ask for canonical URL changes. Updated the example to use placeholder text / variables, to more clearly demonstrate that it's an example.