### PR TITLE
VAGOV-TEAM-96557: Add default steps to digital form

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -243,7 +243,7 @@ class DigitalForm {
   }
 
   /**
-   * Adds a Address-information step to the Digital Form.
+   * Adds an Address-information step to the Digital Form.
    *
    * @param mixed $fields
    *   The field values to add. If needed values are not present,
@@ -261,6 +261,27 @@ class DigitalForm {
     ]);
 
     $this->node->get('field_chapters')->appendItem($addressInformation);
+  }
+
+  /**
+   * Adds a Contact-information step to the Digital Form.
+   *
+   * @param mixed $fields
+   *   The field values to add. If needed values are not present,
+   *   they take defaults as defined in the code.
+   */
+  private function addContactInfoStep($fields = NULL) {
+    if (!$this->node) {
+      throw new \Exception('Digital Form is not set. Cannot add steps to an empty Digital Form object.');
+    }
+
+    $contactInformation = $this->entityTypeManager->getStorage('paragraph')->create([
+      'type' => 'digital_form_phone_and_email',
+      'field_title' => $fields['field_title'] ?? 'Phone and email address',
+      'field_include_email' => $fields['field_include_email'] ?? TRUE,
+    ]);
+
+    $this->node->get('field_chapters')->appendItem($contactInformation);
   }
 
   /**

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -243,6 +243,27 @@ class DigitalForm {
   }
 
   /**
+   * Adds a Address-information step to the Digital Form.
+   *
+   * @param mixed $fields
+   *   The field values to add. If needed values are not present,
+   *   they take defaults as defined in the code.
+   */
+  private function addAddressInfoStep($fields = NULL) {
+    if (!$this->node) {
+      throw new \Exception('Digital Form is not set. Cannot add steps to an empty Digital Form object.');
+    }
+
+    $addressInformation = $this->entityTypeManager->getStorage('paragraph')->create([
+      'type' => 'digital_form_address',
+      'field_title' => $fields['field_title'] ?? 'Mailing address',
+      'field_military_address_checkbox' => $fields['field_military_address_checkbox'] ?? TRUE,
+    ]);
+
+    $this->node->get('field_chapters')->appendItem($addressInformation);
+  }
+
+  /**
    * Adds a step to the Digital Form.
    *
    * @param string $stepName

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -14,6 +14,12 @@ use Drupal\node\NodeInterface;
  * @method \Symfony\Component\Validator\ConstraintViolationListInterface validate()
  * @method int save() Saves the entity and returns the save status
  * @method \Drupal\node\NodeInterface set(string $field_name, mixed $value, bool $notify = TRUE) Sets a field value
+ *
+ * The following line is included because the public method `addStep`
+ * makes dynamic calls to otherwise uncalled private methods, and those
+ * private methods trigger unused-method warnings when they are, in fact,
+ * not unused:
+ * @phpcs:disable DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod
  */
 class DigitalForm {
   /**
@@ -201,6 +207,63 @@ class DigitalForm {
     }
 
     return 'incomplete';
+  }
+
+  /**
+   * Adds a Your-personal-information step to the Digital Form.
+   *
+   * @param mixed $fields
+   *   The field values to add. If needed values are not present,
+   *   they take defaults as defined in the code.
+   */
+  private function addYourPersonalInfoStep($fields = NULL) {
+    if (!$this->node) {
+      throw new \Exception('Digital Form is not set. Cannot add steps to an empty Digital Form object.');
+    }
+
+    $nameAndDob = $this->entityTypeManager->getStorage('paragraph')->create([
+      'type' => 'digital_form_name_and_date_of_bi',
+      'field_title' => $fields['field_name_and_date_of_birth']['field_title'] ?? 'Name and date of birth',
+      'field_include_date_of_birth' => $fields['field_name_and_date_of_birth']['field_include_date_of_birth'] ?? TRUE,
+    ]);
+
+    $identificationInfo = $this->entityTypeManager->getStorage('paragraph')->create([
+      'type' => 'digital_form_identification_info',
+      'field_title' => $fields['field_identification_information']['field_title'] ?? 'Identifying information',
+      'field_include_veteran_s_service' => $fields['field_identification_information']['field_include_veteran_s_service'] ?? TRUE,
+    ]);
+
+    $yourPersonalInformation = $this->entityTypeManager->getStorage('paragraph')->create([
+      'type' => 'digital_form_your_personal_info',
+      'field_name_and_date_of_birth' => $nameAndDob,
+      'field_identification_information' => $identificationInfo,
+    ]);
+
+    $this->node->get('field_chapters')->appendItem($yourPersonalInformation);
+  }
+
+  /**
+   * Adds a step to the Digital Form.
+   *
+   * @param string $stepName
+   *   The name of the step to add.
+   * @param array<string,mixed> $fields
+   *   The field values. If not passed, defaults
+   *   are used in the underlying calls.
+   */
+  public function addStep($stepName, $fields = NULL) {
+    if (!$this->node) {
+      throw new \Exception('Digital Form is not set. Cannot add steps to an empty Digital Form object.');
+    }
+
+    // Ex: 'your_personal_info' => 'addYourPersonalInfoStep'.
+    $methodName = 'add' . str_replace('_', '', ucwords($stepName, '_')) . 'Step';
+
+    if (method_exists($this, $methodName)) {
+      return $this->$methodName($fields);
+    }
+
+    throw new \InvalidArgumentException("Method $methodName does not exist.");
   }
 
 }

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -229,7 +229,7 @@ class DigitalForm {
 
     $identificationInfo = $this->entityTypeManager->getStorage('paragraph')->create([
       'type' => 'digital_form_identification_info',
-      'field_title' => $fields['field_identification_information']['field_title'] ?? 'Identifying information',
+      'field_title' => $fields['field_identification_information']['field_title'] ?? 'Identification information',
       'field_include_veteran_s_service' => $fields['field_identification_information']['field_include_veteran_s_service'] ?? TRUE,
     ]);
 

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -230,7 +230,7 @@ class DigitalForm {
     $identificationInfo = $this->entityTypeManager->getStorage('paragraph')->create([
       'type' => 'digital_form_identification_info',
       'field_title' => $fields['field_identification_information']['field_title'] ?? 'Identification information',
-      'field_include_veteran_s_service' => $fields['field_identification_information']['field_include_veteran_s_service'] ?? TRUE,
+      'field_include_veteran_s_service' => $fields['field_identification_information']['field_include_veteran_s_service'] ?? FALSE,
     ]);
 
     $yourPersonalInformation = $this->entityTypeManager->getStorage('paragraph')->create([

--- a/docroot/modules/custom/va_gov_form_builder/src/Form/FormInfo.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Form/FormInfo.php
@@ -135,15 +135,18 @@ class FormInfo extends FormBuilderBase {
        *
        * Create the new Digital Form with the fields from this form.
        */
-      $node = $this->entityTypeManager->getStorage('node')->create([
-        'type' => 'digital_form',
+      $this->digitalForm = $this->digitalFormsService->createDigitalForm([
         'title' => $title,
         'field_va_form_number' => $vaFormNumber,
         'field_omb_number' => $ombNumber,
         'field_respondent_burden' => $respondentBurden,
         'field_expiration_date' => $expirationDate,
       ]);
-      $this->digitalForm = $this->digitalFormsService->wrapDigitalForm($node);
+
+      // Add default standard steps.
+      $this->digitalForm->addStep('your_personal_info');
+      $this->digitalForm->addStep('address_info');
+      $this->digitalForm->addStep('contact_info');
     }
     else {
       /*

--- a/docroot/modules/custom/va_gov_form_builder/src/Service/DigitalFormsService.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Service/DigitalFormsService.php
@@ -63,13 +63,36 @@ class DigitalFormsService {
   }
 
   /**
-   * Retrieves a Digital Form node by node id.
+   * Creates a Digital Form node and wraps it.
+   *
+   * @param array<string,mixed> $fields
+   *   The field values.
+   *
+   * @return \Drupal\va_gov_form_builder\EntityWrapper\DigitalForm|null
+   *   A DigitalForm object wrapping the created node, or NULL if not created.
+   */
+  public function createDigitalForm($fields) {
+    try {
+      $node = $this->entityTypeManager->getStorage('node')->create([
+        'type' => 'digital_form',
+      ] + $fields);
+
+      return $this->wrapDigitalForm($node);
+    }
+    catch (\Exception $e) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Retrieves a Digital Form node by node id and wraps it.
    *
    * @param bool $nid
    *   The node id.
    *
-   * @return \Drupal\node\NodeInterface|null
-   *   A node object of type 'digital_form', or NULL if not found.
+   * @return \Drupal\va_gov_form_builder\EntityWrapper\DigitalForm|null
+   *   A DigitalForm object wrapping the fetched 'digital_form' node,
+   *   or NULL if not found.
    */
   public function getDigitalForm($nid) {
     $node = $this->entityTypeManager->getStorage('node')->load($nid);
@@ -83,8 +106,8 @@ class DigitalFormsService {
    * @param \Drupal\node\NodeInterface $node
    *   The `digital_form` node to wrap.
    *
-   * @return \Drupal\va_gov_form_builder\EntityWrapper\DigitalForm
-   *   The DigitalForm object wrapping the passed-in $node.
+   * @return \Drupal\va_gov_form_builder\EntityWrapper\DigitalForm|null
+   *   The DigitalForm object wrapping the passed-in $node, or NULL.
    */
   public function wrapDigitalForm($node) {
     if (!$node) {

--- a/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
@@ -397,6 +397,67 @@ class DigitalFormTest extends VaGovUnitTestBase {
   }
 
   /**
+   * Helper function to set up a test for addStep with `address_info`.
+   *
+   * @param mixed $expectedValues
+   *   The expected values passed to the paragraph creation calls.
+   */
+  private function setUpAddStepAddressInfoTest($expectedValues) {
+    $addressInfo = $this->createMockParagraph('digital_form_address');
+
+    $mockParagraphEntityStorage = $this->createMock(EntityStorageInterface::class);
+    $mockParagraphEntityStorage
+      ->expects($this->exactly(1))
+      ->method('create')
+      ->with(
+        $this->callback(fn($params) =>
+          isset($params['type']) &&
+          $params['type'] === 'digital_form_address' &&
+          isset($params['field_title']) &&
+          $params['field_title'] === $expectedValues['field_title'] &&
+          isset($params['field_military_address_checkbox']) &&
+          $params['field_military_address_checkbox'] === $expectedValues['field_military_address_checkbox']
+        ),
+      )
+      ->willReturn($addressInfo);
+
+    $this->setUpAddStepTest($mockParagraphEntityStorage);
+    $this->expectAppendedParagraph('digital_form_address');
+  }
+
+  /**
+   * Tests addStep() with `address_info` and default values.
+   */
+  public function testAddStepAddressInfoWithDefaults() {
+    // Expect the default values.
+    $this->setUpAddStepAddressInfoTest([
+      'field_title' => 'Mailing address',
+      'field_military_address_checkbox' => TRUE,
+    ]);
+
+    /* Call the method under test */
+    $this->digitalForm->addStep('address_info');
+  }
+
+  /**
+   * Tests addStep() with `address_info` and non-default values.
+   */
+  public function testAddStepAddressInfo() {
+    $addressInfoTitle = 'My address-info title';
+    $includeMilitaryAddressCheckbox = FALSE;
+
+    $fields = [
+      'field_title' => $addressInfoTitle,
+      'field_military_address_checkbox' => $includeMilitaryAddressCheckbox,
+    ];
+
+    $this->setUpAddStepAddressInfoTest($fields);
+
+    /* Call the method under test */
+    $this->digitalForm->addStep('address_info', $fields);
+  }
+
+  /**
    * Tests addStep() with non-existent step name.
    */
   public function testAddStepNonExistentStep() {

--- a/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
@@ -45,18 +45,50 @@ class DigitalFormTest extends VaGovUnitTestBase {
   }
 
   /**
+   * Creates a mock node of a given type.
+   *
+   * Defaults to `digital_form`.
+   *
+   * @param string $type
+   *   The node type.
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The mock digital_form node.
+   */
+  private function createMockNode($type = 'digital_form') {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('getType')
+      ->willReturn($type);
+
+    return $node;
+  }
+
+  /**
+   * Creates a mock paragraph of a given type (bundle).
+   *
+   * @param string $type
+   *   The paragraph bundle type.
+   *
+   * @return \Drupal\paragraphs\Entity\Paragraph
+   *   The mock paragraph.
+   */
+  private function createMockParagraph($type) {
+    $paragraph = $this->createMock(Paragraph::class);
+    $paragraph->method('bundle')->willReturn($type);
+
+    return $paragraph;
+  }
+
+  /**
    * Test the constructor with wrong node type passed in.
    *
    * Ensures that passing in a node that is not a
    * DigitalForm node thorws an error.
    */
   public function testConstructorWrongNodeType() {
-    $node = $this->createMock(NodeInterface::class);
-
-    // Configure the mock to return something other
-    // than 'digital_form' when getType() is called.
-    $node->method('getType')
-      ->willReturn('article');
+    // Create a mock node that is some type
+    // other than 'digital_form'.
+    $node = $this->createMockNode('article');
 
     $this->expectException(\InvalidArgumentException::class);
     $this->digitalForm = new DigitalForm($this->entityTypeManager, $node);
@@ -71,9 +103,7 @@ class DigitalFormTest extends VaGovUnitTestBase {
     $field = $this->createMock(FieldItemListInterface::class);
     $field->value = 'Some field value';
 
-    $node = $this->createMock(NodeInterface::class);
-    $node->method('getType')
-      ->willReturn('digital_form');
+    $node = $this->createMockNode();
     $node->method('getTitle')
       ->willReturn($title);
     $node->method('id')
@@ -102,9 +132,9 @@ class DigitalFormTest extends VaGovUnitTestBase {
   }
 
   /**
-   * Helper function to set up a mock query for paragraphs.
+   * Helper function to set up a test for hasChapterOfType.
    */
-  private function setUpMockQueryParagraph() {
+  private function setUpHasChapterOfTypeTest() {
     // Mock the paragraph.
     $mockParagraph = $this->createMock(Paragraph::class);
     $mockParagraph->expects($this->once())
@@ -124,12 +154,7 @@ class DigitalFormTest extends VaGovUnitTestBase {
       ->method('getStorage')
       ->with('paragraph')
       ->willReturn($entityStorage);
-  }
 
-  /**
-   * Helper function to create and return a mock a node with a paragraph.
-   */
-  private function createMockNodeWithParagraph() {
     // Mock the field_chapters field.
     $mockField = $this->createMock(FieldItemListInterface::class);
     $mockField->expects($this->once())
@@ -155,18 +180,8 @@ class DigitalFormTest extends VaGovUnitTestBase {
       ->method('getType')
       ->willReturn('digital_form');
 
-    return $mockNode;
-  }
-
-  /**
-   * Helper function to set up a test for hasChapterOfType.
-   */
-  private function setUpHasChapterOfTypeTest() {
-    $this->setUpMockQueryParagraph();
-    $node = $this->createMockNodeWithParagraph();
-
     // Instantiate an object to test.
-    $this->digitalForm = new DigitalForm($this->entityTypeManager, $node);
+    $this->digitalForm = new DigitalForm($this->entityTypeManager, $mockNode);
   }
 
   /**
@@ -241,6 +256,157 @@ class DigitalFormTest extends VaGovUnitTestBase {
     // Note: `address_info` step = `digital_form_address` paragraph.
     $result = $this->digitalForm->getStepStatus('address_info');
     $this->assertEquals('incomplete', $result);
+  }
+
+  /**
+   * Helper function to DRY up expectations for appendItem.
+   *
+   * @param string $paragraphType
+   *   The type of paragraph expected to be passed to appendItem.
+   */
+  private function expectAppendedParagraph($paragraphType) {
+    $mockChaptersField = $this->createMock(FieldItemListInterface::class);
+
+    $mockChaptersField->expects($this->once())
+      ->method('appendItem')
+      ->with($this->callback(function ($paragraph) use ($paragraphType) {
+        return method_exists($paragraph, 'bundle') && $paragraph->bundle() === $paragraphType;
+      }));
+
+    $this->digitalForm->expects($this->once())
+      ->method('get')
+      ->with('field_chapters')
+      ->willReturn($mockChaptersField);
+  }
+
+  /**
+   * Helper function to set up a test for addStep.
+   *
+   * @param \Drupal\Core\Entity\EntityStorageInterface $mockParagraphEntityStorage
+   *   The mock paragraph entity storage.
+   */
+  private function setUpAddStepTest($mockParagraphEntityStorage) {
+    // Mock the entity type manager.
+    $this->entityTypeManager
+      ->method('getStorage')
+      ->with('paragraph')
+      ->willReturn($mockParagraphEntityStorage);
+
+    $mockNode = $this->createMockNode();
+
+    // Instantiate an object to test.
+    $this->digitalForm = new DigitalForm($this->entityTypeManager, $mockNode);
+  }
+
+  /**
+   * Helper function to set up a test for addStep with `your_personal_info`.
+   *
+   * @param mixed $expectedValues
+   *   The expected values passed to the paragraph creation calls.
+   */
+  private function setUpAddStepYourPersonalInfoTest($expectedValues) {
+    $nameAndDob = $this->createMockParagraph('digital_form_name_and_date_of_bi');
+    $identificationInfo = $this->createMockParagraph('digital_form_identification_info');
+    $yourPersonalInformation = $this->createMockParagraph('digital_form_your_personal_info');
+
+    $mockParagraphEntityStorage = $this->createMock(EntityStorageInterface::class);
+    $mockParagraphEntityStorage
+      ->expects($this->exactly(3))
+      ->method('create')
+      ->withConsecutive(
+        [
+          $this->callback(fn($params) =>
+            isset($params['type']) &&
+            $params['type'] === 'digital_form_name_and_date_of_bi' &&
+            isset($params['field_title']) &&
+            $params['field_title'] === $expectedValues['field_name_and_date_of_birth']['field_title'] &&
+            isset($params['field_include_date_of_birth']) &&
+            $params['field_include_date_of_birth'] === $expectedValues['field_name_and_date_of_birth']['field_include_date_of_birth']
+          ),
+        ],
+        [
+          $this->callback(fn($params) =>
+            isset($params['type']) &&
+            $params['type'] === 'digital_form_identification_info' &&
+            isset($params['field_title']) &&
+            $params['field_title'] === $expectedValues['field_identification_information']['field_title'] &&
+            isset($params['field_include_veteran_s_service']) &&
+            $params['field_include_veteran_s_service'] === $expectedValues['field_identification_information']['field_include_veteran_s_service']
+          ),
+        ],
+        [
+          $this->callback(fn($params) =>
+            isset($params['type']) && $params['type'] === 'digital_form_your_personal_info'
+          ),
+        ]
+      )
+      ->willReturnOnConsecutiveCalls(
+          $nameAndDob,
+          $identificationInfo,
+          $yourPersonalInformation,
+      );
+
+    $this->setUpAddStepTest($mockParagraphEntityStorage);
+    $this->expectAppendedParagraph('digital_form_your_personal_info');
+  }
+
+  /**
+   * Tests addStep() with `your_personal_info` and default values.
+   */
+  public function testAddStepYourPersonalInfoWithDefaults() {
+    // Expect the default values.
+    $this->setUpAddStepYourPersonalInfoTest([
+      'field_name_and_date_of_birth' => [
+        'field_title' => 'Name and date of birth',
+        'field_include_date_of_birth' => TRUE,
+      ],
+      'field_identification_information' => [
+        'field_title' => 'Identifying information',
+        'field_include_veteran_s_service' => TRUE,
+      ],
+    ]);
+
+    /* Call the method under test */
+    $this->digitalForm->addStep('your_personal_info');
+  }
+
+  /**
+   * Tests addStep() with `your_personal_info` and non-default values.
+   */
+  public function testAddStepYourPersonalInfo() {
+    $nameAndDobTitle = 'My name-and-dob title';
+    $includeDob = FALSE;
+    $identificationInfoTitle = 'My identification-info title';
+    $includeVeteranService = FALSE;
+
+    $fields = [
+      'field_name_and_date_of_birth' => [
+        'field_title' => $nameAndDobTitle,
+        'field_include_date_of_birth' => $includeDob,
+      ],
+      'field_identification_information' => [
+        'field_title' => $identificationInfoTitle,
+        'field_include_veteran_s_service' => $includeVeteranService,
+      ],
+    ];
+
+    $this->setUpAddStepYourPersonalInfoTest($fields);
+
+    /* Call the method under test */
+    $this->digitalForm->addStep('your_personal_info', $fields);
+  }
+
+  /**
+   * Tests addStep() with non-existent step name.
+   */
+  public function testAddStepNonExistentStep() {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('getType')
+      ->willReturn('digital_form');
+
+    $this->digitalForm = new DigitalForm($this->entityTypeManager, $node);
+    $this->expectException(\InvalidArgumentException::class);
+    $this->digitalForm->addStep('some_non_existent_step_name');
   }
 
 }

--- a/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
@@ -361,7 +361,7 @@ class DigitalFormTest extends VaGovUnitTestBase {
         'field_include_date_of_birth' => TRUE,
       ],
       'field_identification_information' => [
-        'field_title' => 'Identifying information',
+        'field_title' => 'Identification information',
         'field_include_veteran_s_service' => TRUE,
       ],
     ]);

--- a/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
@@ -458,6 +458,67 @@ class DigitalFormTest extends VaGovUnitTestBase {
   }
 
   /**
+   * Helper function to set up a test for addStep with `contact_info`.
+   *
+   * @param mixed $expectedValues
+   *   The expected values passed to the paragraph creation calls.
+   */
+  private function setUpAddStepContactInfoTest($expectedValues) {
+    $addressInfo = $this->createMockParagraph('digital_form_phone_and_email');
+
+    $mockParagraphEntityStorage = $this->createMock(EntityStorageInterface::class);
+    $mockParagraphEntityStorage
+      ->expects($this->exactly(1))
+      ->method('create')
+      ->with(
+        $this->callback(fn($params) =>
+          isset($params['type']) &&
+          $params['type'] === 'digital_form_phone_and_email' &&
+          isset($params['field_title']) &&
+          $params['field_title'] === $expectedValues['field_title'] &&
+          isset($params['field_include_email']) &&
+          $params['field_include_email'] === $expectedValues['field_include_email']
+        ),
+      )
+      ->willReturn($addressInfo);
+
+    $this->setUpAddStepTest($mockParagraphEntityStorage);
+    $this->expectAppendedParagraph('digital_form_phone_and_email');
+  }
+
+  /**
+   * Tests addStep() with `contact_info` and default values.
+   */
+  public function testAddStepContactInfoWithDefaults() {
+    // Expect the default values.
+    $this->setUpAddStepContactInfoTest([
+      'field_title' => 'Phone and email address',
+      'field_include_email' => TRUE,
+    ]);
+
+    /* Call the method under test */
+    $this->digitalForm->addStep('contact_info');
+  }
+
+  /**
+   * Tests addStep() with `contact_info` and non-default values.
+   */
+  public function testAddStepContactInfo() {
+    $contactInfoTitle = 'My contact-info title';
+    $includeEmail = FALSE;
+
+    $fields = [
+      'field_title' => $contactInfoTitle,
+      'field_include_email' => $includeEmail,
+    ];
+
+    $this->setUpAddStepContactInfoTest($fields);
+
+    /* Call the method under test */
+    $this->digitalForm->addStep('contact_info', $fields);
+  }
+
+  /**
    * Tests addStep() with non-existent step name.
    */
   public function testAddStepNonExistentStep() {

--- a/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/EntityWrapper/DigitalFormTest.php
@@ -362,7 +362,7 @@ class DigitalFormTest extends VaGovUnitTestBase {
       ],
       'field_identification_information' => [
         'field_title' => 'Identification information',
-        'field_include_veteran_s_service' => TRUE,
+        'field_include_veteran_s_service' => FALSE,
       ],
     ]);
 
@@ -377,7 +377,7 @@ class DigitalFormTest extends VaGovUnitTestBase {
     $nameAndDobTitle = 'My name-and-dob title';
     $includeDob = FALSE;
     $identificationInfoTitle = 'My identification-info title';
-    $includeVeteranService = FALSE;
+    $includeVeteranService = TRUE;
 
     $fields = [
       'field_name_and_date_of_birth' => [

--- a/tests/phpunit/va_gov_form_builder/unit/Service/DigitalFormsServiceTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/Service/DigitalFormsServiceTest.php
@@ -315,4 +315,64 @@ class DigitalFormsServiceTest extends VaGovUnitTestBase {
     $this->assertEmpty($digitalForm);
   }
 
+  /**
+   * Helper function to DRY up expectation setup for createDigitalForm.
+   *
+   * @param array|null $fields
+   *   The fields that should be on the call to `create`.
+   */
+  private function setUpMockQueryCreateDigitalForm($fields = NULL) {
+    // Mock the entity storage.
+    $entityStorage = $this->createMock(EntityStorageInterface::class);
+    if (empty($fields)) {
+      $entityStorage->expects($this->once())
+        ->method('create')
+        ->willReturn(NULL);
+    }
+    else {
+      $node = $this->createMock('Drupal\node\NodeInterface');
+      $node->method('getType')
+        ->willReturn('digital_form');
+
+      $entityStorage->expects($this->once())
+        ->method('create')
+        ->with($this->equalTo(['type' => 'digital_form'] + $fields))
+        ->willReturn($node);
+    }
+
+    // Mock the entity type manager.
+    $this->entityTypeManager->expects($this->once())
+      ->method('getStorage')
+      ->with('node')
+      ->willReturn($entityStorage);
+  }
+
+  /**
+   * Tests createDigitalForm() with good data.
+   */
+  public function testCreateDigitalFormGoodData() {
+    $fields = [
+      'title' => 'My title',
+      'field_va_form_number' => '99-1234',
+    ];
+    $this->setUpMockQueryCreateDigitalForm($fields);
+
+    $digitalForm = $this->digitalFormsService->createDigitalForm($fields);
+    $this->assertNotEmpty($digitalForm);
+  }
+
+  /**
+   * Tests createDigitalForm() catches exception.
+   */
+  public function testCreateDigitalFormCatchesException() {
+    $fields = [
+      'some_field' => 'Some value',
+    ];
+    // Mock query will throw an exception if we don't pass in any fields.
+    $this->setUpMockQueryCreateDigitalForm();
+
+    $digitalForm = $this->digitalFormsService->createDigitalForm($fields);
+    $this->assertEmpty($digitalForm);
+  }
+
 }


### PR DESCRIPTION
## Description
- Implements functionality for adding steps of these types:
  1. Your personal information
  2. Address information
  3. Contact information
- Implements the creation of default steps of each of the three types listed above.
- Creates default steps of the three types listed above upon initial form creation on the Form Info page. 

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/96557

## Testing done
- Unit tests added for the creation of each of the three step types.
- Manual tests creating a new form and confirming the existence of the three default steps.

## Screenshots
The three steps are marked as "Complete" immediately upon form creation:
![image](https://github.com/user-attachments/assets/02e60f86-3347-4ccf-827d-5942fa74ec17)


## QA steps
As a Form Builder user:
1. Create a new Digital Form at `/form-builder/form-info`.
   - [x] Fill in all the fields and click "Save and continue".
   - [x] Validate that you are taken to the "Layout" page (`/form-builder/{nid}`)
1. On the "Layout" page:
   - [x] Validate that the three default steps are all marked as "Complete" as shown in the above screenshot.
1. Note the nid from the url and navigate to `/node/{nid}/edit`:
   - [ ] Validate that the following values are present on the added paragraphs:
      - [x] Your Personal Information
          - [x] Name and Date of Birth:
              - [x] Title: "Name and date of birth"
              - [x] Include date of birth?: True (checked)
          - [x] Identification Information
              - [x] Title: "Identification information"
              - [x] Include Veteran's Service Number?: False (not checked)
      - [x] Address Information
          - [x] Title: "Mailing address"
          - [x] Include military address checkbox?: True (checked)
      - [x] Contact Information
          - [x] Title: "Phone and email address"
          - [x] Include email address?: True (checked)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [ ] `Form Engine`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
