### PR TITLE
added openID connect module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,7 @@
         "drupal/openapi_jsonapi": "^3.0",
         "drupal/openapi_ui": "^1.0@RC",
         "drupal/openapi_ui_swagger": "^1.0",
+        "drupal/openid_connect": "^1.4",
         "drupal/override_node_options": "^2.4",
         "drupal/paragraphs": "^1.5",
         "drupal/paragraphs_browser": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95f644fa78a487f97eeff754c5e96f16",
+    "content-hash": "15da7f8dca9432bb40110578e329724b",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "598cbf9b245759a9a06970a91ad4cd69",
+    "content-hash": "95f644fa78a487f97eeff754c5e96f16",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11431,6 +11431,75 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/openapi_ui_swagger",
                 "issues": "http://drupal.org/project/issues/openapi_ui_swagger"
+            }
+        },
+        {
+            "name": "drupal/openid_connect",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/openid_connect.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/openid_connect-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "9bdbfa6365d10b2029bdaee9fbd82265aa6d4fa4"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10",
+                "ext-json": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1698170385",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bojanz",
+                    "homepage": "https://www.drupal.org/user/86106"
+                },
+                {
+                    "name": "jcnventura",
+                    "homepage": "https://www.drupal.org/user/122464"
+                },
+                {
+                    "name": "mstrelan",
+                    "homepage": "https://www.drupal.org/user/314289"
+                },
+                {
+                    "name": "pfrilling",
+                    "homepage": "https://www.drupal.org/user/169695"
+                },
+                {
+                    "name": "pjcdawkins",
+                    "homepage": "https://www.drupal.org/user/1025236"
+                },
+                {
+                    "name": "sanduhrs",
+                    "homepage": "https://www.drupal.org/user/28074"
+                }
+            ],
+            "description": "A pluggable client implementation for the OpenID Connect protocol.",
+            "homepage": "https://www.drupal.org/project/openid_connect",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/openid_connect",
+                "issues": "https://www.drupal.org/project/issues/openid_connect"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -190,6 +190,7 @@ module:
   openapi_jsonapi: 0
   openapi_ui: 0
   openapi_ui_swagger: 0
+  openid_connect: 0
   options: 0
   override_node_options: 0
   page_cache: 0

--- a/config/sync/openid_connect.settings.facebook.yml
+++ b/config/sync/openid_connect.settings.facebook.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: XE2MqevnEK7g2Hi3bBsxJUUcbYQBm9AjQR6foDyycRY
+enabled: false
+settings:
+  client_id: null
+  client_secret: null
+  api_version: null

--- a/config/sync/openid_connect.settings.generic.yml
+++ b/config/sync/openid_connect.settings.generic.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: FJ7FfwlYzcbFfG0AqVPlqsLJIRhkzS1Rv6eO1vssSkM
+enabled: false
+settings:
+  client_id: null
+  client_secret: null
+  authorization_endpoint: 'https://example.com/oauth2/authorize'
+  token_endpoint: 'https://example.com/oauth2/token'
+  userinfo_endpoint: 'https://example.com/oauth2/UserInfo'

--- a/config/sync/openid_connect.settings.github.yml
+++ b/config/sync/openid_connect.settings.github.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: h0ctmI-lSknN6e9qvO8PKjAPEeopeDR4FnxTYhGcD1k
+enabled: false
+settings:
+  client_id: null
+  client_secret: null

--- a/config/sync/openid_connect.settings.google.yml
+++ b/config/sync/openid_connect.settings.google.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: h0ctmI-lSknN6e9qvO8PKjAPEeopeDR4FnxTYhGcD1k
+enabled: false
+settings:
+  client_id: null
+  client_secret: null

--- a/config/sync/openid_connect.settings.linkedin.yml
+++ b/config/sync/openid_connect.settings.linkedin.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: h0ctmI-lSknN6e9qvO8PKjAPEeopeDR4FnxTYhGcD1k
+enabled: false
+settings:
+  client_id: null
+  client_secret: null

--- a/config/sync/openid_connect.settings.okta.yml
+++ b/config/sync/openid_connect.settings.okta.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: 7F1ngE9fiONEo0Nk1cfez_GTGzhHBLuPaHlrDqYI_hg
+enabled: false
+settings:
+  client_id: null
+  client_secret: null
+  okta_domain: null

--- a/config/sync/openid_connect.settings.yml
+++ b/config/sync/openid_connect.settings.yml
@@ -1,0 +1,8 @@
+_core:
+  default_config_hash: YpBA3MmDuJpZ9SM3DE4kR0lTY89bf2y3g0sS7s3TQ4k
+always_save_userinfo: true
+connect_existing_users: false
+override_registration_settings: false
+user_login_display: hidden
+userinfo_mappings:
+  timezone: zoneinfo


### PR DESCRIPTION
## Description

This PR adds the module openID connect, that we intend to use for Okta integration. It has been tested in a tugboat environment, but this PR simply adds and enables the module with no config. Config and setup will occur in follow up tickets. 

Closes #20699

### Generated description

This pull request adds support for the OpenID Connect module to the project. The most important changes include adding the OpenID Connect dependency in `composer.json`, updating the module configuration in `core.extension.yml`, and adding default settings for various OpenID Connect providers.

### Adding OpenID Connect support:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R152): Added the `drupal/openid_connect` dependency.
* [`config/sync/core.extension.yml`](diffhunk://#diff-c74373ec0d30209248deac631a2a6db007924814cb51f9a620a807fbcb30de1dR193): Enabled the `openid_connect` module.

### Configuration for OpenID Connect providers:

* [`config/sync/openid_connect.settings.facebook.yml`](diffhunk://#diff-7f274ad19b8ebe0f642358b2550fc84b8ee96d08e26ab54e7eb33390b604c845R1-R7): Added default settings for Facebook OpenID Connect.
* [`config/sync/openid_connect.settings.generic.yml`](diffhunk://#diff-c86c168ca59a9c2c9739d672522366029f23ad73bd0f387e8ae4fd652b1beb7dR1-R9): Added default settings for a generic OpenID Connect provider.
* [`config/sync/openid_connect.settings.github.yml`](diffhunk://#diff-0cdb44771b5835cb94f3a6be4ee34e849a8e7809445f29aae502a432cc288678R1-R6): Added default settings for GitHub OpenID Connect.
* [`config/sync/openid_connect.settings.google.yml`](diffhunk://#diff-0cdb44771b5835cb94f3a6be4ee34e849a8e7809445f29aae502a432cc288678R1-R6): Added default settings for Google OpenID Connect.
* [`config/sync/openid_connect.settings.linkedin.yml`](diffhunk://#diff-0cdb44771b5835cb94f3a6be4ee34e849a8e7809445f29aae502a432cc288678R1-R6): Added default settings for LinkedIn OpenID Connect.
* [`config/sync/openid_connect.settings.okta.yml`](diffhunk://#diff-2aeb36cf1ab11bc27e3b5b98bb4c999994f166876a9bbe6f6f1c47cd2c7c37c7R1-R7): Added default settings for Okta OpenID Connect.
* [`config/sync/openid_connect.settings.yml`](diffhunk://#diff-dc5b32e1604409d5c66f2ab0b85f1e7eef5bcc93a97aadf7537950b463262638R1-R8): Added general OpenID Connect settings.

## Testing done

Tested in tugboat with dev Okta


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
