### PR TITLE
VAGOV-TEAM-101555 add plain language title field to digital form content type

### DIFF
--- a/config/sync/core.entity_form_display.node.digital_form.default.yml
+++ b/config/sync/core.entity_form_display.node.digital_form.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
+        - revision_log
       label: 'Editorial Workflow'
       region: content
       parent_name: ''

--- a/config/sync/core.entity_form_display.node.digital_form.default.yml
+++ b/config/sync/core.entity_form_display.node.digital_form.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_plain_language_title
     - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
@@ -29,7 +30,6 @@ third_party_settings:
     group_editorial_workflow:
       children:
         - moderation_state
-        - revision_log
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
@@ -50,7 +50,7 @@ third_party_settings:
       label: 'OMB info'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -109,7 +109,7 @@ content:
     third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -128,6 +128,21 @@ content:
       count_html_characters: true
       textcount_status_message: 'Characters Remaining: <span class="remaining_count">@remaining_count</span>'
     third_party_settings: {  }
+  field_plain_language_title:
+    type: string_textfield_with_counter
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+      use_field_maxlength: true
+      maxlength: 0
+      counter_position: after
+      js_prevent_submit: true
+      count_only_mode: false
+      count_html_characters: true
+      textcount_status_message: 'Characters Remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings: {  }
   field_respondent_burden:
     type: number
     weight: 7
@@ -137,7 +152,7 @@ content:
     third_party_settings: {  }
   field_va_form_number:
     type: string_textfield_with_counter
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -158,7 +173,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.digital_form.default.yml
+++ b/config/sync/core.entity_view_display.node.digital_form.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_plain_language_title
     - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
@@ -27,7 +28,7 @@ third_party_settings:
       label: 'OMB info'
       parent_name: ''
       region: content
-      weight: 1
+      weight: 2
       format_type: details
       format_settings:
         classes: ''
@@ -67,6 +68,14 @@ content:
     third_party_settings: {  }
     weight: 6
     region: content
+  field_plain_language_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_respondent_burden:
     type: number_integer
     label: inline
@@ -82,7 +91,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   breadcrumbs: true

--- a/config/sync/core.entity_view_display.node.digital_form.external_content.yml
+++ b/config/sync/core.entity_view_display.node.digital_form.external_content.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_plain_language_title
     - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
@@ -58,6 +59,7 @@ hidden:
   field_last_saved_by_an_editor: true
   field_meta_tags: true
   field_omb_number: true
+  field_plain_language_title: true
   field_respondent_burden: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.digital_form.teaser.yml
+++ b/config/sync/core.entity_view_display.node.digital_form.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.digital_form.field_last_saved_by_an_editor
     - field.field.node.digital_form.field_meta_tags
     - field.field.node.digital_form.field_omb_number
+    - field.field.node.digital_form.field_plain_language_title
     - field.field.node.digital_form.field_respondent_burden
     - field.field.node.digital_form.field_va_form_number
     - node.type.digital_form
@@ -50,6 +51,7 @@ hidden:
   field_last_saved_by_an_editor: true
   field_meta_tags: true
   field_omb_number: true
+  field_plain_language_title: true
   field_respondent_burden: true
   field_va_form_number: true
   langcode: true

--- a/config/sync/field.field.node.digital_form.field_plain_language_title.yml
+++ b/config/sync/field.field.node.digital_form.field_plain_language_title.yml
@@ -1,0 +1,24 @@
+uuid: c51b3c27-2cbb-43d9-8e93-97d4ca757367
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_plain_language_title
+    - node.type.digital_form
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.digital_form.field_plain_language_title
+field_name: field_plain_language_title
+entity_type: node
+bundle: digital_form
+label: "Plain language sentence of this form's purpose to use as a header on all pages"
+description: 'Provide the header that tells the user what this form will do, such as: <i>Register for this program...</i> or <i>Provide your documentation</i>, etc.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.digital_form.field_plain_language_title.yml
+++ b/config/sync/field.field.node.digital_form.field_plain_language_title.yml
@@ -14,11 +14,11 @@ id: node.digital_form.field_plain_language_title
 field_name: field_plain_language_title
 entity_type: node
 bundle: digital_form
-label: "Plain language sentence of this form's purpose to use as a header on all pages"
-description: 'Provide the header that tells the user what this form will do, such as: <i>Register for this program...</i> or <i>Provide your documentation</i>, etc.'
+label: "Plain-language title"
+description: "A sentence describing this form's purpose, used as a header on all pages."
 required: true
 translatable: false
-default_value: {  }
-default_value_callback: ''
-settings: {  }
+default_value: {}
+default_value_callback: ""
+settings: {}
 field_type: string

--- a/config/sync/field.storage.node.field_plain_language_title.yml
+++ b/config/sync/field.storage.node.field_plain_language_title.yml
@@ -1,0 +1,21 @@
+uuid: 27c2a9e0-9566-4418-a24c-83cd27874ac4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_plain_language_title
+field_name: field_plain_language_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/user.role.form_builder_user.yml
+++ b/config/sync/user.role.form_builder_user.yml
@@ -7,10 +7,10 @@ dependencies:
     - va_gov_form_builder
 third_party_settings:
   va_gov_backend:
-    vgb_description: "A user of the VA.gov Form Builder tool."
+    vgb_description: 'A user of the VA.gov Form Builder tool.'
 id: form_builder_user
-label: "Form Builder user"
+label: 'Form Builder user'
 weight: 14
 is_admin: null
 permissions:
-  - "access form builder"
+  - 'access form builder'

--- a/tests/phpunit/va_gov_content_types/functional/Entity/DigitalFormTest.php
+++ b/tests/phpunit/va_gov_content_types/functional/Entity/DigitalFormTest.php
@@ -22,6 +22,7 @@ class DigitalFormTest extends VaGovExistingSiteBase {
       'field_respondent_burden' => 5,
       'field_va_form_number' => '12345',
       'field_omb_number' => '1234-5678',
+      'field_plain_language_title' => 'Test plain-language title',
       'title' => 'Test Digital Form',
       'type' => 'digital_form',
     ];
@@ -44,6 +45,10 @@ class DigitalFormTest extends VaGovExistingSiteBase {
     $this->assertEquals(
       $node->get('field_respondent_burden')->getString(),
       $digital_form_attrs['field_respondent_burden']
+    );
+    $this->assertEquals(
+      $node->get('field_plain_language_title')->getString(),
+      $digital_form_attrs['field_plain_language_title']
     );
   }
 


### PR DESCRIPTION
## Description

Closes [VAGOV-TEAM-101555](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101555)

Adds plain-language title field to Digital Forms.

## Testing done

Verified that the new field was present when creating a Digital Form

## Screenshots
![image](https://github.com/user-attachments/assets/d23eaba1-e701-44de-a7a3-36640146c107)

## QA steps

- Create new `Digital Form` node
- Verify the plain language header field is present

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [x] `Form Engine`
