### PR TITLE
VACMS-20606: Adds VA Manila health care menu

### DIFF
--- a/config/sync/menu_breadcrumb.settings.yml
+++ b/config/sync/menu_breadcrumb.settings.yml
@@ -69,11 +69,6 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  home-page-hub-list:
-    enabled: 0
-    weight: 0
-    taxattach: 0
-    langhandle: 0
   lovell-federal-health-care:
     enabled: 1
     weight: 0
@@ -95,6 +90,11 @@ menu_breadcrumb_menus:
     taxattach: 0
     langhandle: 0
   popular-on-va-gov:
+    enabled: 0
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  home-page-hub-list:
     enabled: 0
     weight: 0
     taxattach: 0
@@ -275,6 +275,11 @@ menu_breadcrumb_menus:
     taxattach: 0
     langhandle: 0
   va-madison-health-care:
+    enabled: 1
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  va-manila-health-care:
     enabled: 1
     weight: 0
     taxattach: 0
@@ -489,11 +494,6 @@ menu_breadcrumb_menus:
     weight: 9
     taxattach: 0
     langhandle: 0
-  account:
-    enabled: 0
-    weight: 10
-    taxattach: 0
-    langhandle: 0
   admin:
     enabled: 0
     weight: 10
@@ -505,11 +505,6 @@ menu_breadcrumb_menus:
     taxattach: 0
     langhandle: 0
   footer:
-    enabled: 0
-    weight: 10
-    taxattach: 0
-    langhandle: 0
-  footer-bottom-rail:
     enabled: 0
     weight: 10
     taxattach: 0
@@ -529,12 +524,22 @@ menu_breadcrumb_menus:
     weight: 10
     taxattach: 0
     langhandle: 0
-  pittsburgh-health-care:
+  sections:
     enabled: 1
     weight: 10
     taxattach: 0
     langhandle: 0
-  sections:
+  account:
+    enabled: 0
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  footer-bottom-rail:
+    enabled: 0
+    weight: 10
+    taxattach: 0
+    langhandle: 0
+  pittsburgh-health-care:
     enabled: 1
     weight: 10
     taxattach: 0

--- a/config/sync/node.type.event.yml
+++ b/config/sync/node.type.event.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.event_listing.yml
+++ b/config/sync/node.type.event_listing.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.health_care_local_facility.yml
+++ b/config/sync/node.type.health_care_local_facility.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.health_care_region_detail_page.yml
+++ b/config/sync/node.type.health_care_region_detail_page.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.health_care_region_page.yml
+++ b/config/sync/node.type.health_care_region_page.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.health_services_listing.yml
+++ b/config/sync/node.type.health_services_listing.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.leadership_listing.yml
+++ b/config/sync/node.type.leadership_listing.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.locations_listing.yml
+++ b/config/sync/node.type.locations_listing.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.news_story.yml
+++ b/config/sync/node.type.news_story.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.person_profile.yml
+++ b/config/sync/node.type.person_profile.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.press_release.yml
+++ b/config/sync/node.type.press_release.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.press_releases_listing.yml
+++ b/config/sync/node.type.press_releases_listing.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.publication_listing.yml
+++ b/config/sync/node.type.publication_listing.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.story_listing.yml
+++ b/config/sync/node.type.story_listing.yml
@@ -85,6 +85,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.vamc_operating_status_and_alerts.yml
+++ b/config/sync/node.type.vamc_operating_status_and_alerts.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.vamc_system_billing_insurance.yml
+++ b/config/sync/node.type.vamc_system_billing_insurance.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.vamc_system_medical_records_offi.yml
+++ b/config/sync/node.type.vamc_system_medical_records_offi.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.vamc_system_policies_page.yml
+++ b/config/sync/node.type.vamc_system_policies_page.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.vamc_system_register_for_care.yml
+++ b/config/sync/node.type.vamc_system_register_for_care.yml
@@ -84,6 +84,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/node.type.vamc_system_va_police.yml
+++ b/config/sync/node.type.vamc_system_va_police.yml
@@ -83,6 +83,7 @@ third_party_settings:
       - va-madison-health-care
       - va-maine-health-care
       - va-manchester-health-care
+      - va-manila-health-care
       - va-marion-health-care
       - va-martinsburg-health-care
       - va-maryland-health-care

--- a/config/sync/system.menu.va-manila-health-care.yml
+++ b/config/sync/system.menu.va-manila-health-care.yml
@@ -1,0 +1,8 @@
+uuid: 3691cd23-c25a-44b3-9667-f6b3e0a86081
+langcode: en
+status: true
+dependencies: {  }
+id: va-manila-health-care
+label: 'VA Manila health care'
+description: 'VISN 21 | va.gov/manila-health-care'
+locked: false


### PR DESCRIPTION
## Description

Relates to #20606

Adds "VA Manila health care" menu and adds the menu to the necessary content types.

## Testing done
Manually in tugboat
- [x] Content > Menus > All Menus > VA Manila health care
- [x] Event (event)
- [x] Events List (event_listing)
- [x] Health Services List (health_services_listing)
- [x] Leadership List (leadership_listing)
- [x] News Release (press_release)
- [x] News Releases List (press_releases_listing)
- [x] Publication Listing Page (publication_listing)
- [x] Staff Profile (person_profile)
- [x] Stories List (story_listing)
- [x] Story (news_story)
- [x] VAMC Detail Page (health_care_region_detail_page)
- [x] VAMC Facility (health_care_local_facility)
- [x] VAMC System (health_care_region_page)
- [x] VAMC System Billing and Insurance (vamc_system_billing_insurance)
- [x] VAMC System Locations List (locations_listing)
- [x] VAMC System Medical Records Office (vamc_system_medical_records_offi)
- [x] VAMC System Operating Status (vamc_operating_status_and_alerts)
- [x] VAMC System Policies Page (vamc_system_policies_page)
- [x] VAMC System Register for Care (vamc_system_register_for_care)
- [x] VAMC System VA Police page (vamc_system_va_police)
- [x] [Menu breadcrumb settings](https://pr20866-gxpfwogb0xkxlpqbbu0ktvnkeljcvw72.ci.cms.va.gov//admin/config/user-interface/menu-breadcrumb)

## Screenshots
### Menus list
![Screenshot 2025-03-12 at 07 49 03](https://github.com/user-attachments/assets/ea41b5e2-dde9-4b19-8d65-b83bd1249ba2)

### Events menu settings
![Screenshot 2025-03-12 at 07 49 51](https://github.com/user-attachments/assets/77bc20c4-fd8a-420c-ba7c-40c0fb9a6740)

### Menu breadcrumb settings
![Screenshot 2025-03-12 at 15 46 22](https://github.com/user-attachments/assets/33675d9e-a330-4fca-ae04-bfbdb6711636)


## QA steps
As a QA Content Publisher
1. Log into the [Tugboat](https://pr20866-gxpfwogb0xkxlpqbbu0ktvnkeljcvw72.ci.cms.va.gov/)
2. Go to Content > Menus > All Menus > [VA Manila health care](https://pr20866-gxpfwogb0xkxlpqbbu0ktvnkeljcvw72.ci.cms.va.gov/admin/structure/menu/manage/va-manila-health-care)
   - [x] Confirm VA Manila health care menu exists
3. Check that `<VA Manila health care>` appears in the Menu settings / Parent link drop down menu for each of these content types
  - [x] Event (event)
  - [x] Events List (event_listing)
  - [x] Health Services List (health_services_listing)
  - [x] Leadership List (leadership_listing)
  - [x] News Release (press_release)
  - [x] News Releases List (press_releases_listing)
  - [x] Publication Listing Page (publication_listing)
  - [x] Staff Profile (person_profile)
  - [x] Stories List (story_listing)
  - [x] Story (news_story)
  - [x] VAMC Detail Page (health_care_region_detail_page)
  - [x] VAMC Facility (health_care_local_facility)
  - [x] VAMC System (health_care_region_page)
  - [x] VAMC System Billing and Insurance (vamc_system_billing_insurance)
  - [x] VAMC System Locations List (locations_listing)
  - [x] VAMC System Medical Records Office (vamc_system_medical_records_offi)
  - [x] VAMC System Operating Status (vamc_operating_status_and_alerts)
  - [x] VAMC System Policies Page (vamc_system_policies_page)
  - [x] VAMC System Register for Care (vamc_system_register_for_care)
  - [x] VAMC System VA Police page (vamc_system_va_police)
  - [ ] [Menu breadcrumb settings](https://pr20866-gxpfwogb0xkxlpqbbu0ktvnkeljcvw72.ci.cms.va.gov//admin/config/user-interface/menu-breadcrumb)

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

