### PR TITLE
VACMS-20698: Adds VBA Facility Service to VBA Facility Draft ECA Workflow

### DIFF
--- a/config/sync/eca.eca.workflow_vba_facility_as_draft.yml
+++ b/config/sync/eca.eca.workflow_vba_facility_as_draft.yml
@@ -59,13 +59,14 @@ dependencies:
     - field.field.node.vha_facility_nonclinical_service.field_last_saved_by_an_editor
     - field.storage.node.field_last_saved_by_an_editor
     - node.type.vba_facility
+    - node.type.vba_facility_service
   module:
     - eca_workflow
     - va_gov_eca
 id: workflow_vba_facility_as_draft
 modeller: core
 label: 'Workflow: VBA Facility as Draft'
-version: null
+version: ''
 weight: 0
 events:
   workflow_transition:
@@ -73,6 +74,17 @@ events:
     label: 'Workflow: state transition'
     configuration:
       type: 'node vba_facility'
+      from_state: ''
+      to_state: draft
+    successors:
+      -
+        id: create_advancedqueue_job
+        condition: null
+  workflow_transition_1:
+    plugin: 'workflow:transition'
+    label: 'Workflow: state transition'
+    configuration:
+      type: 'node vba_facility_service'
       from_state: ''
       to_state: draft
     successors:


### PR DESCRIPTION
## Description
Adds VBA Facility Service to the existing ECA workflow that sends email notifications for content moving into the draft workflow state.

Relates to #20698

### Generated description
This pull request includes changes to the `config/sync/eca.eca.workflow_vba_facility_as_draft.yml` file to update dependencies and events for a new workflow transition. The most important changes include adding a new node type to the dependencies and defining a new workflow transition event.

Updates to dependencies:

* Added `node.type.vba_facility_service` to the list of dependencies.

Updates to events:

* Added a new `workflow_transition_1` event with a state transition configuration for `node vba_facility_service` from an empty state to `draft`.
## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
