### PR TITLE
Flagged facility updates: LH CSV and other process updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/runbook-facility-url-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-facility-url-change.md
@@ -18,37 +18,19 @@ When does this request need to be live:
 (Note: This issue will be used from initial request through implementation to ensure all individuals working on this are notified of status updates.  Please do not create multiple issues to track different steps.)
 - [ ] Notify VA stakeholders as appropriate.
 - [ ] Link the related facility closure / rename issue.
+- [ ] Verify that the new URL for the facility is published and accessible on VA.gov.
 - [ ] Create a URL redirect in the [vsp-platform-revproxy](https://github.com/department-of-veterans-affairs/vsp-platform-revproxy) repo in `template-rendering/revproxy-vagov/vars/redirects.yml`
-- [ ] Add the "Awaiting redirect" flag to the facility node with a revision log message that includes a link to this ticket, preserving the node's current moderation state.
+- [ ] Add the "Awaiting redirect" flag to the facility node with a revision log message that includes a link to this ticket, preserving the node's current moderation state. (may not be necessary if redirects deploy quickly)
 - [ ] Redirects deploy daily except Friday at 10am ET, or by requesting OOB deploy (of the revproxy job to prod) in #vfs-platform-support. After deploy, validate that the URL redirect is deployed. 
 - [ ] Update this ticket with a comment that the redirect has been deployed.
-- [ ] Remove the "Awaiting redirect" flag on the facility node with a revision log message that includes a link to this ticket, preserving the node's current moderation state.
-- [ ] Notify helpdesk via comment on ticket or Slack message in #cms-support that changes are ready for review.
+- [ ] Remove the "Awaiting redirect" flag if it was added on the facility node, with a revision log message that includes a link to this ticket, preserving the node's current moderation state.
+- [ ] Notify helpdesk via comment on ticket that redirect has deployed.
 
 #### URL Redirect
 | Current URL  |  Redirect Destination or New URL |
 | ---  |  --- |
-| current URL | new URL |
+| `old URL` | `new URL` |
 
-## Use one of the following:
-### 1. Canonical URL change
-
-**Note: Canonical URL changes do not block the completion of the parent ticket. Once the URL redirect above has been deployed, the value to the Veteran is delivered. This ticket should be kept open until the URL change is verified, except in the case of a removal (as described below).**
-
-### Instructions for canonical URL change
-- [ ] Verify that the new URL for the facility is published and accessible on VA.gov.
-
-#### After next nightly Facilities migration to Lighthouse
-- [ ] Validate that the change has deployed by checking that the Facility Locator has been updated with the new url.
-
-#### URL change example (update with actual ID and URL)
-| Facility API ID  |  Full VA.gov URL |
-| ---  |  --- |
-| vha_691GM | https://www.va.gov/greater-los-angeles-health-care/locations/oxnard-va-clinic/ |
-
-### 2. Canonical URL removal (if removed from VAST)
-### Instructions for canonical URL removal
-- [ ] Try to find the facility via the Facility Locator, using the Facility API ID (e.g. https://va.gov/find-locations/facility/"facility_api_id"). If it is not available, close this ticket.
-
-**Note: there's no check to see if it's not returning anything, as it should already be not showing anything in the Facility Locator.**
-
+#### If the Facility is an unpublished NCA facility
+After next nightly Facilities migration to Lighthouse:
+- [ ] Validate that the change has deployed by checking that the Facility Locator search result for the facility has been updated and uses the new url

--- a/.github/ISSUE_TEMPLATE/runbook-nca-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-nca-facility-name-change.md
@@ -17,7 +17,8 @@ Facility API ID: <insert_facility_API_ID>
 
 ## Acceptance criteria
 
-## NCA Facility name change
+## NCA Facility name change: if in Draft
+_As of creation of this runbook, NCA facilities are not published via Drupal. If that changes, revisit this runbook and update the necessary steps._
 
 ### Drupal Admin steps
 - [ ] Edit the node and update the alias to match the new facility name, lowercase with dashes.

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-facility-name-change.md
@@ -31,29 +31,26 @@ Facility API ID: <insert_facility_API_ID>
 #### CMS help desk steps
 **Note: If the help desk is waiting on information from the facility staff or editor, add the "Awaiting editor" flag to the facility with a log message that includes a link to this ticket. Remove the flag when the ticket is ready to be worked by the Facilities team. Be sure to preserve the current moderation state of the node when adding or removing the flag.**
 What happens: The name change is made in VAST, that syncs to Lighthouse which syncs to Drupal.
-- [ ] 1. Check that the title change in name field on the VAMC node has shown up in Drupal.
-- [ ] 2. Create a [URL change request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&template=runbook-facility-url-change.md&title=URL+Change+for%3A+%3Cinsert+facility+name%3E), changing the entry from the old facility URL to the new facility URL. (**Note: The URL change request ticket blocks the completion of this ticket.**)
+- [ ] Check that the title change in name field on the VAMC node has shown up in Drupal.
+- [ ] Create a [URL change request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&template=runbook-facility-url-change.md&title=URL+Change+for%3A+%3Cinsert+facility+name%3E), changing the entry from the old facility URL to the new facility URL. **URL changes no longer block the remaining steps in this ticket.**
 
 <insert_url_change_request_link>
 
-
-#### CMS Engineer steps
-- [ ] 3. Execute the steps of the URL change request ticket from step 2 above.
-
-(Redirects deploy daily except Friday at 10am ET, or by requesting OOB deploy (of the revproxy job to prod) in #vfs-platform-support. Coordinate the following items below and canonical URL change after URL change ticket is merged, deployed, and verified in prod.)
-
 #### Drupal Admin steps (CMS Engineer or Help desk)
 _Help desk will complete these steps or escalate to request help from CMS engineering._
-- [ ] 4. Locate the newly renamed VAMC Facility (https://prod.cms.va.gov/admin/content/bulk) Search by new name
-- [ ] 5. Updates URL alias for this facility
-- [ ] 6. Resave this facility
-- [ ] 7. Make bulk alias changes to facility service nodes. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service)
-- [ ] 8. Bulk save fixed titles to facility service nodes. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service)
-- [ ] 9. Update menu title for facility
-- [ ] 10. May also need to directly edit the VAMC System menu to alpha sort the menu item after the title changes
-- [ ] 11. Update Alt text for facility image, if relevant
-- [ ] 12. Update Meta description (TBD: some backwards compatibility for SEM, by including something like ", formerly known as [previous name]".
-- [ ] 13. Edit facility node and remove flag `Changed name` then save node (with moderation state = published)
+- [ ] Locate the newly renamed VAMC Facility (https://prod.cms.va.gov/admin/content/bulk) Search by new name
+- [ ] Change all data for the facility, in order to ensure changes ship together in the same content release:
+    - [ ] Edit facility:
+        - [ ] Update URL alias for this facility
+        - [ ] Update menu title for the facility to use the new name
+        - [ ] Update Meta description use the new name after "at", and add ", formerly known as [previous name]".
+        - [ ] Remove flag `Changed name`
+        - [ ] Save node (and preserve moderation state)
+    - [ ] [Bulk edit](https://prod.cms.va.gov/admin/content/bulk), perform the Action: update URL alias for all facility service nodes on this facility. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service)
+    - [ ] [Bulk edit](https://prod.cms.va.gov/admin/content/bulk), Action: Resave content, on all facility service nodes for this facility, to fix the title. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service)
+     - [ ] May also need to directly edit the VAMC System menu to alpha sort the menu item after the title changes
+     - [ ] Under [Media](https://prod.cms.va.gov/admin/content/media/images): Find the image for this facility (using the old facility name or Section), and update Alt text and name for facility image, if relevant
+- [ ] After the next content release: verify that the new URL for the facility is published and accessible on VA.gov
 
 #### CMS Help desk (wrap up)
 - [ ] 14. Notify editor and any other stakeholders. Ask editor to validate that the photo of the facility does not contain the old name in any signage, etc. and to replace if necessary.

--- a/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vamc-system-name-change.md
@@ -24,25 +24,27 @@ System API ID: <insert_facility_API_ID>
 ## Steps before proceeding
 **Note: If the help desk is waiting on information from the facility staff or editor, add the "Awaiting editor" flag to the facility with a log message that includes a link to this ticket. Remove the flag when the ticket is ready to be worked by the Facilities team. Be sure to preserve the current moderation state of the node when adding or removing the flag.**
 - [ ] Check with Facilities team Product Owner to get approval of name change.
-- [ ] Check with VHA Digital Media.
+- [ ] Check with VHA Digital Media to confirm approval
 
 ## VAMC system name change
+Timing around these is critical and VHA DM / VA PO will help determine timing and priority.  **It may be advisable to perform all the changes listed below in a Tugboat in order to get stakeholder signoff before making changes in production.**
 
-Timing around these is critical and we may need more detail here.
-
-#### CMS help desk steps
-- [ ] 1. Create a [URL change request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&template=runbook-facility-url-change.md&title=URL+Change+for%3A+%3Cinsert+facility+name%3E), changing the entry from the old facility URL to the new facility URL. (**Note: The URL change request ticket blocks the completion of this ticket.**)
+### CMS help desk steps
+- [ ] 1. Create a [URL change request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&template=runbook-facility-url-change.md&title=URL+Change+for%3A+%3Cinsert+facility+name%3E), changing the entry from the old facility URL to the new facility URL. **Redirects no longer block remaining steps in this ticket.** Create the ticket, then proceed with remaining steps.
 
 <insert_url_change_request_link>
 
-(Redirects deploy daily except Friday at 10am ET, or by requesting OOB deploy (of the revproxy job to prod) in #vfs-platform-support. Coordinate the items below and canonical URL change after URL change ticket is merged, deployed, and verified in prod.)
+### Drupal Admin steps (CMS Engineer or Help desk)
+- [ ] Update the Section name to new VAMC System name.
+- [ ] [Bulk edit](https://prod.cms.va.gov/admin/content/bulk), perform the Action: update URL alias: for all nodes within the system. (https://prod.cms.va.gov/admin/content/bulk)
+- [ ] [Bulk edit](https://prod.cms.va.gov/admin/content/bulk), Action: Resave content, for all nodes within system.
+- [ ] After next content release, verify that all content presents correctly in production.
 
-#### CMS engineer steps
-- [ ] 2. Execute the steps of the URL change request ticket from step 1.
-- [ ] 3. Update the Section name.
-- [ ] 3. Bulk alias change all nodes within the system. (https://prod.cms.va.gov/admin/content/bulk)
-- [ ] 4. Bulk save to fix titles for all nodes within system. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service)
-- [ ] 5. Create a PR to rename the menu for the system accordingly.  (In the future, they may need to rebuild the menu so that name and machine name match.)
 
-#### CMS Help desk (wrap up)
-- [ ] 6. Notify editor and any other stakeholders.
+### CMS engineer
+- [ ] Create a PR to rename the menu for the system accordingly.  (In the future, they may need to rebuild the menu so that name and machine name match.)
+- [ ] Build the front-end from a Tugboat and verify that all pages within the system still correctly use the menu and link correctly, before merge.
+- [ ] Merge & verify after deploy in production
+
+### CMS Help desk (wrap up)
+- [ ] Notify editor and any other stakeholders that changes are complete

--- a/.github/ISSUE_TEMPLATE/runbook-vba-facility-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vba-facility-name-change.md
@@ -22,11 +22,27 @@ Facility API ID: <insert_facility_API_ID>
 
 ## VBA Facility name change
 
+### CMS help desk steps
+**Note: If the help desk is waiting on information from the facility staff or editor, add the "Awaiting editor" flag to the facility with a log message that includes a link to this ticket. Remove the flag when the ticket is ready to be worked by the Facilities team. Be sure to preserve the current moderation state of the node when adding or removing the flag.**
+What happens: The name change is made in Sandy's DB, that syncs to Lighthouse which syncs to Drupal.
+- [ ] Check that the title change in name field on the VBA node has shown up in Drupal.
+- [ ] If the node is published: Create a [URL change request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&template=runbook-facility-url-change.md&title=URL+Change+for%3A+%3Cinsert+facility+name%3E), changing the entry from the old facility URL to the new facility URL. **URL changes no longer block the remaining steps in this ticket.**
 
-### Drupal Admin steps
-- [ ] Edit the node and update the alias to match the new facility name, lowercase with dashes.
-- [ ] Edit the facility node, remove the `Changed name` flag, save the node with revision log
+<insert_url_change_request_link>
 
-If this facility is a Regional Office
-- [ ] Go to [Sections taxonomy]( https://prod.cms.va.gov/admin/structure/taxonomy/manage/administration/overview), VBA > Rename the term that matches the old Facility name to use the new Facility name
-    * If this process gets automated, this runbook can be retired.
+#### Drupal Admin steps (CMS Engineer or Help desk)
+_Help desk will complete these steps or escalate to request help from CMS engineering._
+- [ ] Locate the newly renamed VBA Facility (https://prod.cms.va.gov/admin/content/bulk) Search by new name
+- [ ] Change all data for the facility, in order to ensure changes ship together in the same content release:
+    - [ ] Edit facility:
+        - [ ] Update URL alias for this facility to match the new facility name, lowercase with dashes.
+        - [ ] Remove flag `Changed name`
+        - [ ] Save node (and preserve moderation state)
+    - [ ] [Bulk edit](https://prod.cms.va.gov/admin/content/bulk), perform the Action: update URL alias for all facility service nodes on this facility. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service)
+    - [ ] [Bulk edit](https://prod.cms.va.gov/admin/content/bulk), Action: Resave content, on all facility service nodes for this facility, to fix the title. (https://prod.cms.va.gov/admin/content/bulk?type=health_care_local_health_service)
+     - [ ] Under [Media](https://prod.cms.va.gov/admin/content/media/images): Find the image for this facility (using the old facility name or Section), and update Alt text and name for facility image, if relevant
+     - [ ] If this facility is a Regional Office: Go to [Sections taxonomy]( https://prod.cms.va.gov/admin/structure/taxonomy/manage/administration/overview), VBA > Rename the term that matches the old Facility name to use the new Facility name
+- [ ] After the next content release: verify that the new URL for the facility is published and accessible on VA.gov
+
+#### CMS Help desk (wrap up)
+- [ ] Notify editor and any other stakeholders. Ask editor to validate that the photo of the facility does not contain the old name in any signage, etc. and to replace if necessary.

--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-name-change.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-name-change.md
@@ -32,20 +32,15 @@ Facility API ID: <insert_facility_API_ID>
 ### CMS help desk steps
 **Note: If the help desk is waiting on information from the facility staff or editor, add the "Awaiting editor" flag to the facility** with a log message that includes a link to this ticket. Remove the flag when the ticket is ready to be worked by the Facilities team. **Be sure to preserve the current moderation state of the node when adding or removing the flag.**
 - [ ] The title (Name of Vet Center field) change comes from Lighthouse to Drupal & is flagged
-- [ ] If the Vet Center published and is NOT an Outstation/MVC, create a [URL change request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&template=runbook-facility-url-change.md&title=URL+Change+for%3A+%3Cinsert+facility+name%3E), changing the entry from the old facility URL to the new facility URL. (**Note: The URL change request ticket blocks the completion of this ticket.**)
+- [ ] If the Vet Center published and is NOT an Outstation/MVC, create a [URL change request](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new?assignees=&template=runbook-facility-url-change.md&title=URL+Change+for%3A+%3Cinsert+facility+name%3E), changing the entry from the old facility URL to the new facility URL. **URL changes no longer block the remaining steps in this ticket.**
 
 <insert_redirect_request_link>
-
-### CMS engineer steps - Vet Center only (not Outstation/MVC)
-- [ ] Execute the steps of the URL change request ticket from step 2.
-
-(Redirects deploy daily except Friday at 10am ET, or by requesting OOB deploy (of the revproxy job to prod) in #vfs-platform-support. Coordinate the items below and canonical URL change after URL change ticket is merged, deployed, and verified in prod.)
 
 ### Drupal Admin steps (CMS Engineer or Help desk)
 _Help desk will complete these steps or escalate to request help from CMS engineering._
 
 **If a Mobile Vet Center or Outstation**
-- [ ] Verify which Vet Center it belongs to, and confirm that the "Main Vet Center Location" field is set correctly.
+- [ ] Verify which Vet Center the Outstation belongs to, and confirm that the "Main Vet Center Location" field is set correctly.
 
 **If a Vet Center**
 
@@ -77,4 +72,7 @@ _Help desk will complete these steps or escalate to request help from CMS engine
 - [ ] Edit the Vet Center node by removing flag `Changed name`, and saves the node (with moderation state = published)
 
 #### CMS Help desk (wrap up)
+- [ ] After the next content release, verify that your changes took place on VA.gov:
+    - [ ] Vet center name is correct
+    - [ ] Vet center URLs are correct
 - [ ] Notify editor and any other stakeholders.


### PR DESCRIPTION
## Description

Relates to #20676 

We realized more runbook changes as a result of https://dsva.slack.com/archives/C02730UEZPS/p1740432213877859 LIghthouse removing their CSV as source of truth for Facility URLs. 

Updates include: 
* URL change ticket is no longer a blocker to any Facility name change processes. Drupal changes will drive URL changes in the UI for new visits, and the URL redirect is now only a correction for folks who may have the old URLs bookmarked and encounter a 404. 
* Updated steps for VBA name change to be more comprehensive now that some facilities are published with images, services, etc.
* Added verification steps to several runbooks, to ensure we're verifying our changes before notifying stakeholders.