### PR TITLE
updates content-build to 0.0.3708

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,7 +230,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "0.0.3702",
+        "va-gov/content-build": "v0.0.3708",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15da7f8dca9432bb40110578e329724b",
+    "content-hash": "4a1baf8e26716508edfe1dc84412b231",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27028,16 +27028,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3702",
+            "version": "v0.0.3708",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "24c2a0d823f8c3e4f7b3cfba9a1fb9bd8393c475"
+                "reference": "1e4f6d09f7dcbe8a50bbd2a09003ec63345c316b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/24c2a0d823f8c3e4f7b3cfba9a1fb9bd8393c475",
-                "reference": "24c2a0d823f8c3e4f7b3cfba9a1fb9bd8393c475",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/1e4f6d09f7dcbe8a50bbd2a09003ec63345c316b",
+                "reference": "1e4f6d09f7dcbe8a50bbd2a09003ec63345c316b",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27064,9 +27064,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3702"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3708"
             },
-            "time": "2025-03-11T17:57:14+00:00"
+            "time": "2025-03-19T17:49:16+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description
updates content-build to 0.0.3708

Closes to #20899. 

### Generated description

This pull request includes a small change to the `composer.json` file. The change updates the version of the `va-gov/content-build` dependency from `0.0.3702` to `v0.0.3708`.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

