### PR TITLE
updated content-build to 0.0.3710

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,7 +230,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3708",
+        "va-gov/content-build": "^0.0.3710",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "addc41fa6a9dc53bdc8cd71c83e07d04",
+    "content-hash": "edae178e62fcee994888a369b44aee33",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27028,16 +27028,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3708",
+            "version": "v0.0.3710",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "1e4f6d09f7dcbe8a50bbd2a09003ec63345c316b"
+                "reference": "aa6f503fa396ea5d90a4f9f1bc670552829e9d77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/1e4f6d09f7dcbe8a50bbd2a09003ec63345c316b",
-                "reference": "1e4f6d09f7dcbe8a50bbd2a09003ec63345c316b",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/aa6f503fa396ea5d90a4f9f1bc670552829e9d77",
+                "reference": "aa6f503fa396ea5d90a4f9f1bc670552829e9d77",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27064,9 +27064,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3708"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3710"
             },
-            "time": "2025-03-19T17:49:16+00:00"
+            "time": "2025-03-21T23:54:26+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description

Updates content-build to 0.0.3710

### Generated description
This pull request includes a minor update to the `composer.json` file. The change updates the version of the `va-gov/content-build` dependency to a newer version.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L233-R233): Updated the `va-gov/content-build` dependency from version `^0.0.3708` to `^0.0.3710`.


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`



### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
