### PR TITLE
VACMS-20923: Homepage news spotlight block automation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -410,6 +410,9 @@
                 "3228798 - Make revisions overview page accessible": "patches/3228798-make-revisions-overview-page-accessible.patch",
                 "2834253 - Missing column headings in Revisions list": "patches/2834253-missing-column-headers.patch"
             },
+            "drupal/eca": {
+                "3515195 - Add migration_id token to migrate events": "patches/3515195-add-migration_id-token-to-migrate-events.patch"
+            },
             "drupal/entity_browser": {
                 "2856138 - Entity browser cardinality validation": "patches/2856138-entity-browser-cardinality-validation.patch",
                 "3191302 - Make modal iframe tab accessible": "patches/3191302-make-modal-iframe-tab-accessible.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fb1b41b25fd6b89004e81caa724e0f2",
+    "content-hash": "4f1bf8e8d1c8bd415b72c4ecada400ec",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -28148,7 +28148,6 @@
         "drupal/fieldhelptext": 10,
         "drupal/flag": 10,
         "drupal/graphql_menu": 15,
-        "drupal/html_tag_usage": 10,
         "drupal/image_style_warmer": 5,
         "drupal/jsonapi_resources": 10,
         "drupal/limited_field_widgets": 15,
@@ -28167,12 +28166,13 @@
         "drupal/simplesamlphp_auth": 5,
         "drupal/styleguide": 10,
         "drupal/user_history": 15,
-        "drupal/viewfield": 10
+        "drupal/viewfield": 10,
+        "drupal/html_tag_usage": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.1.30"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f1bf8e8d1c8bd415b72c4ecada400ec",
+    "content-hash": "9f6c0d7f4d511eea99093632c4dec998",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -28148,6 +28148,7 @@
         "drupal/fieldhelptext": 10,
         "drupal/flag": 10,
         "drupal/graphql_menu": 15,
+        "drupal/html_tag_usage": 10,
         "drupal/image_style_warmer": 5,
         "drupal/jsonapi_resources": 10,
         "drupal/limited_field_widgets": 15,
@@ -28166,13 +28167,12 @@
         "drupal/simplesamlphp_auth": 5,
         "drupal/styleguide": 10,
         "drupal/user_history": 15,
-        "drupal/viewfield": 10,
-        "drupal/html_tag_usage": 10
+        "drupal/viewfield": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.30"
     },

--- a/config/sync/core.entity_form_display.block_content.news_promo.default.yml
+++ b/config/sync/core.entity_form_display.block_content.news_promo.default.yml
@@ -79,6 +79,7 @@ content:
       maxlength: 55
       counter_position: after
       js_prevent_submit: false
+      count_only_mode: false
       count_html_characters: true
       textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
     third_party_settings: {  }
@@ -89,9 +90,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-      maxlength: 125
+      maxlength: 160
       counter_position: after
       js_prevent_submit: false
+      count_only_mode: false
       count_html_characters: true
       textcount_status_message: '<span class="remaining_count">@remaining_count</span> characters remaining'
     third_party_settings: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -62,6 +62,7 @@ module:
   eca_base: 0
   eca_cm: 0
   eca_content: 0
+  eca_migrate: 0
   eca_ui: 0
   eca_views: 0
   eca_workflow: 0

--- a/config/sync/eca.eca.aging_content_expired_news_promo.yml
+++ b/config/sync/eca.eca.aging_content_expired_news_promo.yml
@@ -1,6 +1,6 @@
 uuid: 1f258e15-5c8f-4645-bc99-42d7c6ab772e
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - views.view.aging_content_content_block

--- a/config/sync/eca.eca.aging_content_warn_news_promo.yml
+++ b/config/sync/eca.eca.aging_content_warn_news_promo.yml
@@ -1,6 +1,6 @@
 uuid: e0b9a4d3-1d5d-46ca-8652-2eeeb2ffb21c
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - views.view.aging_content_content_block

--- a/config/sync/eca.eca.home_page_news_spotlight_block.yml
+++ b/config/sync/eca.eca.home_page_news_spotlight_block.yml
@@ -13,7 +13,7 @@ dependencies:
 id: home_page_news_spotlight_block
 modeller: core
 label: 'Home page: News Spotlight Block'
-version: null
+version: ''
 weight: 0
 events:
   migrate_post_import:
@@ -32,7 +32,7 @@ events:
     successors:
       -
         id: entityqueue_add_item
-        condition: null
+        condition: entityqueue_entity_is_in_subqueu
 conditions:
   news_spotlight_block_migration:
     plugin: eca_scalar
@@ -43,6 +43,12 @@ conditions:
       type: value
       case: false
       negate: false
+  entityqueue_entity_is_in_subqueu:
+    plugin: entityqueue_entity_is_in_subqueue
+    configuration:
+      subqueue: home_page_news_spotlight
+      negate: true
+      entity: entity
 gateways: {  }
 actions:
   eca_views_query_news_block:

--- a/config/sync/eca.eca.home_page_news_spotlight_block.yml
+++ b/config/sync/eca.eca.home_page_news_spotlight_block.yml
@@ -1,0 +1,75 @@
+uuid: ba7d481a-3a13-4a24-822a-27269e14b4af
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.news_spotlight_blocks
+  module:
+    - eca_base
+    - eca_content
+    - eca_migrate
+    - eca_views
+    - entityqueue
+id: home_page_news_spotlight_block
+modeller: core
+label: 'Home page: News Spotlight Block'
+version: null
+weight: 0
+events:
+  migrate_post_import:
+    plugin: 'migrate:post_import'
+    label: 'Migration import finished'
+    configuration: {  }
+    successors:
+      -
+        id: eca_views_query_news_block
+        condition: news_spotlight_block_migration
+  home_page_news_block_event:
+    plugin: 'content_entity:custom'
+    label: 'Content  Aware Event: News Spotlight Block'
+    configuration:
+      event_id: home_page_news_spotlight_block_event
+    successors:
+      -
+        id: entityqueue_add_item
+        condition: null
+conditions:
+  news_spotlight_block_migration:
+    plugin: eca_scalar
+    configuration:
+      left: '[migration_id]'
+      right: news_spotlight_blocks
+      operator: equal
+      type: value
+      case: false
+      negate: false
+gateways: {  }
+actions:
+  eca_views_query_news_block:
+    plugin: eca_views_query
+    label: 'Views: Home page news spotlight block'
+    configuration:
+      token_name: results
+      view_id: news_spotlight_blocks
+      display_id: default
+      arguments: ''
+    successors:
+      -
+        id: home_page_news_block_eca_trigger
+        condition: null
+  home_page_news_block_eca_trigger:
+    plugin: eca_trigger_content_entity_custom_event
+    label: 'Trigger Custom Event: News Spotlight Block'
+    configuration:
+      event_id: home_page_news_spotlight_block_event
+      tokens: ''
+      object: results
+    successors: {  }
+  entityqueue_add_item:
+    plugin: entityqueue_add_item
+    label: 'Add Item to a Subqueue'
+    configuration:
+      subqueue: home_page_news_spotlight
+      object: entity
+      replace_tokens: false
+    successors: {  }

--- a/config/sync/eca.eca.home_page_news_spotlight_block.yml
+++ b/config/sync/eca.eca.home_page_news_spotlight_block.yml
@@ -33,6 +33,14 @@ events:
       -
         id: entityqueue_add_item
         condition: entityqueue_entity_is_in_subqueu
+  migrate_post_rollback:
+    plugin: 'migrate:post_rollback'
+    label: 'Migration rollback finished'
+    configuration: {  }
+    successors:
+      -
+        id: eca_views_query_news_block
+        condition: news_spotlight_block_migration
 conditions:
   news_spotlight_block_migration:
     plugin: eca_scalar

--- a/config/sync/eca.eca.home_page_news_spotlight_block.yml
+++ b/config/sync/eca.eca.home_page_news_spotlight_block.yml
@@ -10,6 +10,7 @@ dependencies:
     - eca_migrate
     - eca_views
     - entityqueue
+    - va_gov_eca
 id: home_page_news_spotlight_block
 modeller: core
 label: 'Home page: News Spotlight Block'
@@ -41,6 +42,21 @@ events:
       -
         id: eca_views_query_news_block
         condition: news_spotlight_block_migration
+  eca_base_eca_cron:
+    plugin: 'eca_base:eca_cron'
+    label: 'ECA cron event'
+    configuration:
+      frequency: '15 0 * * *'
+    successors:
+      -
+        id: execute_news_spotlight_images_mi
+        condition: null
+      -
+        id: execute_news_spotlight_media_mi
+        condition: null
+      -
+        id: execute_news_spotlight_blocks_mi
+        condition: null
 conditions:
   news_spotlight_block_migration:
     plugin: eca_scalar
@@ -86,4 +102,34 @@ actions:
       subqueue: home_page_news_spotlight
       object: entity
       replace_tokens: false
+    successors: {  }
+  execute_news_spotlight_images_mi:
+    plugin: execute_migration_import
+    label: 'Execute news_spotlight_images migration'
+    configuration:
+      migration: news_spotlight_images
+      update: false
+      force: false
+      limit: ''
+      idlist: ''
+    successors: {  }
+  execute_news_spotlight_media_mi:
+    plugin: execute_migration_import
+    label: 'Execute news_spotlight_media migration'
+    configuration:
+      migration: news_spotlight_media
+      update: false
+      force: false
+      limit: ''
+      idlist: ''
+    successors: {  }
+  execute_news_spotlight_blocks_mi:
+    plugin: execute_migration_import
+    label: 'Execute news_spotlight_blocks migration'
+    configuration:
+      migration: news_spotlight_blocks
+      update: false
+      force: false
+      limit: ''
+      idlist: ''
     successors: {  }

--- a/config/sync/eca.settings.yml
+++ b/config/sync/eca.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: crbLzxE1culnNNbMcnjEQy5F_PmdYkkXBTvemcgc2kg
 log_level: 3
 documentation_domain: 'https://ecaguide.org'
-user: ''
+user: '1'
 dependency_calculation:
   - bundle
   - field_storage

--- a/config/sync/entityqueue.entity_queue.home_page_news_spotlight.yml
+++ b/config/sync/entityqueue.entity_queue.home_page_news_spotlight.yml
@@ -22,5 +22,5 @@ entity_settings:
 queue_settings:
   min_size: 1
   max_size: 1
-  act_as_queue: false
+  act_as_queue: true
   reverse: false

--- a/config/sync/entityqueue.entity_queue.home_page_news_spotlight.yml
+++ b/config/sync/entityqueue.entity_queue.home_page_news_spotlight.yml
@@ -21,6 +21,6 @@ entity_settings:
     auto_create_bundle: ''
 queue_settings:
   min_size: 1
-  max_size: 1
-  act_as_queue: true
-  reverse: false
+  max_size: null
+  act_as_queue: false
+  reverse: true

--- a/config/sync/entityqueue.entity_queue.home_page_news_spotlight.yml
+++ b/config/sync/entityqueue.entity_queue.home_page_news_spotlight.yml
@@ -21,6 +21,6 @@ entity_settings:
     auto_create_bundle: ''
 queue_settings:
   min_size: 1
-  max_size: null
-  act_as_queue: false
-  reverse: true
+  max_size: 1
+  act_as_queue: true
+  reverse: false

--- a/config/sync/migrate_plus.migration.news_spotlight_blocks.yml
+++ b/config/sync/migrate_plus.migration.news_spotlight_blocks.yml
@@ -66,7 +66,7 @@ process:
     default_value: news_promo
   moderation_state:
     plugin: default_value
-    default_value: draft
+    default_value: published
   status:
     plugin: default_value
     default_value: 0
@@ -81,6 +81,9 @@ process:
   revision_log:
     plugin: default_value
     default_value: 'Block created from news_spotlight_blocks migration'
+  revision_user:
+    plugin: default_value
+    default_value: 1317
 destination:
   plugin: 'entity:block_content'
 migration_dependencies:

--- a/config/sync/migrate_plus.migration.news_spotlight_blocks.yml
+++ b/config/sync/migrate_plus.migration.news_spotlight_blocks.yml
@@ -37,7 +37,7 @@ source:
     -
       name: excerpt
       label: 'Promo text'
-      selector: excerpt/rendered
+      selector: meta_box/standfirst
     -
       name: link
       label: Link

--- a/config/sync/views.view.news_spotlight_blocks.yml
+++ b/config/sync/views.view.news_spotlight_blocks.yml
@@ -1,0 +1,400 @@
+uuid: 10c617a1-e4f6-4206-9dfc-b3ffd5dd9746
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.news_promo
+    - user.role.authenticated
+  module:
+    - block_content
+    - options
+    - user
+id: news_spotlight_blocks
+label: 'News Spotlight Blocks'
+module: views
+description: 'Home page news spotlight block'
+tag: ''
+base_table: block_content_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Home page news spotlight block'
+      fields:
+        info:
+          id: info
+          table: block_content_field_data
+          field: info
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: info
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          pagination_heading_level: h2
+          items_per_page: 1
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            authenticated: authenticated
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        revision_created:
+          id: revision_created
+          table: block_content_revision
+          field: revision_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: revision_created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: block_content_field_data
+          field: status
+          entity_type: block_content
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        reusable:
+          id: reusable
+          table: block_content_field_data
+          field: reusable
+          entity_type: block_content
+          entity_field: reusable
+          plugin_id: boolean
+          value: '1'
+        type:
+          id: type
+          table: block_content_field_data
+          field: type
+          entity_type: block_content
+          entity_field: type
+          plugin_id: bundle
+          value:
+            news_promo: news_promo
+        field_image_target_id:
+          id: field_image_target_id
+          table: block_content__field_image
+          field: field_image_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_link_uri:
+          id: field_link_uri
+          table: block_content__field_link
+          field: field_link_uri
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_promo_headline_value:
+          id: field_promo_headline_value
+          table: block_content__field_promo_headline
+          field: field_promo_headline_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_link_label_value:
+          id: field_link_label_value
+          table: block_content__field_link_label
+          field: field_link_label_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: list_field
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        field_promo_text_value:
+          id: field_promo_text_value
+          table: block_content__field_promo_text
+          field: field_promo_text_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_comment: 'This View is responsible for containing a single V2 Home Page News Spotlight block for the purpose of placement on the VA.gov home page. This View should only ever return the most recently created V2 Home Page News Spotlight block.'
+      display_extenders:
+        jsonapi_views:
+          enabled: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.roles
+      tags: {  }

--- a/docroot/modules/custom/va_gov_eca/src/Plugin/Action/ExecuteMigrationImport.php
+++ b/docroot/modules/custom/va_gov_eca/src/Plugin/Action/ExecuteMigrationImport.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Drupal\va_gov_eca\Plugin\Action;
+
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\eca\Plugin\Action\ConfigurableActionBase;
+use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate\MigrateMessage;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Drupal\migrate_tools\MigrateTools;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Execute a migration import.
+ */
+#[Action(
+  id: 'execute_migration_import',
+  label: new TranslatableMarkup("Execute migration import.")
+)]
+class ExecuteMigrationImport extends ConfigurableActionBase {
+
+  /**
+   * The migration plugin manager service.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
+   */
+  protected MigrationPluginManagerInterface $migrationPluginManager;
+
+  /**
+   * The logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected LoggerChannelInterface $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->migrationPluginManager = $container->get('plugin.manager.migration');
+    $instance->logger = $container->get('logger.channel.eca');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'migration' => '',
+      'update' => FALSE,
+      'force' => FALSE,
+      'limit' => '',
+      'idlist' => '',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function execute() {
+    try {
+      // Get the migration instance.
+      $migration = $this->migrationPluginManager->createInstance($this->configuration['migration']);
+
+      // Check and set migration status.
+      $status = $migration->getStatus();
+      if ($status !== MigrationInterface::STATUS_IDLE) {
+        $migration->setStatus(MigrationInterface::STATUS_IDLE);
+      }
+      // Prepare the migration for update if needed.
+      $migration->getIdMap()->prepareUpdate();
+
+      // Create message handler and executable.
+      $message = new MigrateMessage();
+      $executable = new MigrateExecutable($migration, $message);
+
+      // Get the options for the migration.
+      $this->buildOptions($migration);
+
+      // Execute the migration.
+      $executable->import();
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Failed to execute migration @migration: @error', [
+        '@migration' => $this->configuration['migration'],
+        '@error' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  /**
+   * Builds options for migration execution.
+   */
+  protected function buildOptions(MigrationInterface $migration): void {
+    $options = [
+      'limit' => $this->configuration['limit'],
+      'update' => $this->configuration['update'],
+      'force' => $this->configuration['force'],
+    ];
+
+    if ($idlist = $this->configuration['idlist']) {
+      $options['idlist'] = $idlist;
+    }
+
+    if ($options['limit']) {
+      $migration->set('limit', $options['limit']);
+    }
+    if ($options['update']) {
+      if (!$options['idlist']) {
+        $migration->getIdMap()->prepareUpdate();
+      }
+      else {
+        $source_id_values_list = MigrateTools::buildIdList($options);
+        $keys = array_keys($migration->getSourcePlugin()->getIds());
+        foreach ($source_id_values_list as $source_id_values) {
+          $migration->getIdMap()->setUpdate(array_combine($keys, $source_id_values));
+        }
+      }
+    }
+    if ($options['force']) {
+      $migration->set('requirements', []);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    // Get all available migrations.
+    $migrations = $this->migrationPluginManager->createInstances([]);
+    $options = ['' => $this->t('- Select -')];
+    foreach ($migrations as $migration) {
+      $options[$migration->id()] = $migration->label();
+    }
+
+    $form['migration'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Migration'),
+      '#options' => $options,
+      '#default_value' => $this->configuration['migration'],
+      '#required' => TRUE,
+    ];
+
+    $form['update'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Update existing content'),
+      '#default_value' => $this->configuration['update'],
+      '#description' => $this->t('If checked, existing content will be updated.'),
+    ];
+
+    $form['force'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Force'),
+      '#default_value' => $this->configuration['force'],
+      '#description' => $this->t('Force an operation to run, even if all requirements are not met.'),
+    ];
+
+    $form['limit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Limit'),
+      '#default_value' => $this->configuration['limit'],
+      '#description' => $this->t('Limit the number of items to process. Leave empty for no limit.'),
+      '#min' => 1,
+    ];
+
+    $form['idlist'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('ID List'),
+      '#default_value' => $this->configuration['idlist'],
+      '#description' => $this->t('Comma-separated list of IDs to process.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitConfigurationForm($form, $form_state);
+
+    $this->configuration['migration'] = $form_state->getValue('migration');
+    $this->configuration['update'] = $form_state->getValue('update');
+    $this->configuration['force'] = $form_state->getValue('force');
+    $this->configuration['limit'] = $form_state->getValue('limit');
+    $this->configuration['idlist'] = $form_state->getValue('idlist');
+  }
+
+}

--- a/docroot/modules/custom/va_gov_eca/src/Plugin/Action/ExecuteMigrationImport.php
+++ b/docroot/modules/custom/va_gov_eca/src/Plugin/Action/ExecuteMigrationImport.php
@@ -11,6 +11,7 @@ use Drupal\migrate\MigrateExecutable;
 use Drupal\migrate\MigrateMessage;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Drupal\migrate\Plugin\Migration;
 use Drupal\migrate_tools\MigrateTools;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -95,9 +96,12 @@ class ExecuteMigrationImport extends ConfigurableActionBase {
   }
 
   /**
-   * Builds options for migration execution.
+   * Builds options for a migration plugin.
+   *
+   * @param \Drupal\migrate\Plugin\Migration $migration
+   *   The migration plugin to build options for.
    */
-  protected function buildOptions(MigrationInterface $migration): void {
+  protected function buildOptions(Migration $migration): void {
     $options = [
       'limit' => $this->configuration['limit'],
       'update' => $this->configuration['update'],

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.news_spotlight_blocks.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.news_spotlight_blocks.yml
@@ -36,7 +36,7 @@ source:
     -
       name: excerpt
       label: 'Promo text'
-      selector: excerpt/rendered
+      selector: meta_box/standfirst
     -
       name: link
       label: Link

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.news_spotlight_blocks.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.news_spotlight_blocks.yml
@@ -65,7 +65,7 @@ process:
     default_value: news_promo
   moderation_state:
     plugin: default_value
-    default_value: draft
+    default_value: published
   status:
     plugin: default_value
     default_value: 0
@@ -80,6 +80,9 @@ process:
   revision_log:
     plugin: default_value
     default_value: 'Block created from news_spotlight_blocks migration'
+  revision_user:
+    plugin: default_value
+    default_value: 1317
 destination:
   plugin: 'entity:block_content'
 migration_dependencies:

--- a/patches/3515195-add-migration_id-token-to-migrate-events.patch
+++ b/patches/3515195-add-migration_id-token-to-migrate-events.patch
@@ -1,0 +1,41 @@
+diff --git a/modules/migrate/src/Plugin/ECA/Event/MigrateEvent.php b/modules/migrate/src/Plugin/ECA/Event/MigrateEvent.php
+index b3636d4ab749e86a6a2a9d7587594ca5734a3f02..debb719adf58ed1fd32cd47ca1479e2b6f6c57a0 100644
+--- a/modules/migrate/src/Plugin/ECA/Event/MigrateEvent.php
++++ b/modules/migrate/src/Plugin/ECA/Event/MigrateEvent.php
+@@ -102,6 +102,17 @@ class MigrateEvent extends EventBase {
+       MigrateIdMapMessageEvent::class,
+     ]
+   )]
++  #[Token(
++    name: 'migration_id',
++    description: 'The migration plugin id being run.',
++    classes: [
++      MigrateImportEvent::class,
++      MigratePreRowSaveEvent::class,
++      MigrateRollbackEvent::class,
++      MigrateRowDeleteEvent::class,
++      MigrateIdMapMessageEvent::class,
++    ]
++  )]
+   #[Token(
+     name: 'map',
+     description: 'The map plugin that caused the event to fire.',
+@@ -176,6 +187,18 @@ class MigrateEvent extends EventBase {
+         }
+         break;
+ 
++      case 'migration_id':
++        if ($event instanceof MigrateImportEvent
++          || $event instanceof MigratePreRowSaveEvent
++          || $event instanceof MigrateRollbackEvent
++          || $event instanceof MigrateRowDeleteEvent
++          || $event instanceof MigrateIdMapMessageEvent
++        ) {
++          $migration = $event->getMigration();
++          return $migration->id();
++        }
++        break;
++
+       case 'map':
+         if ($event instanceof MigrateMapSaveEvent
+           || $event instanceof MigrateMapDeleteEvent


### PR DESCRIPTION
## Description

Relates to #20923

This PR completes end-to-end automation for homepage news spotlights. It adds a new ECA workflow that automates placing News Spotlight blocks into the home page entityqueue/subqueue, which the FE already pulls from to create the news block on the homepage. No further actions are necessary to automate the process.

## ECA Workflows

There are 4 "buckets" of workflows that run independently from each other, but work together to form the complete homepage news promo automation.

### Run Migrations
1. Drupal cron runs every ~15 minutes triggered by Jenkins
2. ECA Event: ECA cron event. At 12:15AM this event will trigger actions below (running the migrations)
   1. ECA Action: Execute migration import of news_spotlight_images
   2. ECA Action: Execute migration import of news_spotlight_media
   3. ECA Action: Execute migration import of news_spotlight_blocks. This ends this phase of the workflow.

#### Gather News Block
3. ECA Event: Migration import finished. Listens for migrations that have completed import.
   1. ECA Condition: Compare two scalar values. Uses the 'migration_id' token from the previous event and compares it to the text `news_spotlight_block` and returns true if they match.
   2. ECA Action: Views: Home page news spotlight block. This queries a new View that returns the most recently created block and creates a 'results' token which will be an array containing a single block entity.
   3. ECA Action: Trigger Custom Event: News Spotlight Block. This is a custom ECA event trigger that is 'entity aware'. It passes the block entity from Views to a Custom ECA Event which is also 'entity aware'.

#### Add Block to Subueue
4. ECA Event: Content Aware Event: News Spotlight Block. This is the event that step 3.iii triggered. The block entity is available as the 'entity' token.
   1. ECA Condition: Entity is in Subqueue. This condition checks to see if the current block from the 'entity' token is already in the entityqueue. If so, the next action is not taken.
   2. ECA Action: Add Item to a Subqueue. This action takes the block from the 'entity' token and places it in the `home_page_news_spotlight` entityqueue. This is the final action for automating homepage news spotlights.

#### Rollback Safeguard
**Without this workflow, a migration rollback would empty the entityqueue, since the entity in the subqueue would most likely be from a the migration, and that entity would be deleted as part of a rollback.**

5. ECA Event: Migration rollback finished. This listens for migrations that have completed rollback. 
   1. ECA Condition: Compare two scalar values. Uses the same condition from 3.i to only trigger following activities if the `news_spotlight_block` migration has completed a rollback.
   2. ECA Action: Views: Home page news spotlight block. Runs the same Views query from 3.ii.
   3. ECA Action: Trigger Custom Event: News Spotlight Block. This is the same event as 3.iii. This would then cause 4.i to fire, which would update the entityqueue with the most recently created block that remains, which should be the current news story created by an editor.

## ECA Workflow Diagram:
```mermaid
flowchart TD
    x@{shape: subproc, label: Drupal Cron}
    x -->xx(12:15AM Homepage cron: ECA Event)
    xx -->xxx(Migrations run:
    - news_spotlight_images
    - news_spotlight_media
    - news_spotlight_blocks:
    ECA Actions)

    A(Migration Import Finished: ECA Event)
    A --> mid[/migration id/]
    mid -->C{migration_id = home page migration?: ECA Condition}
    C -->|No| D([End])
    C -->|Yes| E[Get home page block from Views: ECA Action]
    E -->entity1[/block entity/] 
    entity1 -->A1(Trigger custom content event: ECA Action)

    y@{shape: subproc, label: "Migration Rollback Finished: ECA Event"}
    y --> mid[/migration id/]


    H@{ shape: subproc, label: "Custom content event: ECA Event" }
    H -->mid2[/block entity/] 
    mid2 -->entity2{entity exists in subqueue?: ECA Condition}
    entity2 -->|no|J([Add entity to subqueue])
```

## Additional Info
The ECA module needed a [patch](https://www.drupal.org/project/eca/issues/3515195) in order to pickup the migration_id as a token so that we could take actions if only the `news_spotlight_block` migration had fired. This has been merged into the 2.x dev branch, and will get added to the next ECA release. We should update ECA at that point and remove the patch.

## Testing done
Rigorous manual testing

## QA steps
As an administrator...

Change ECA Cron Frequency:
We need to change the frequency of the primary ECA Event that acts upon Drupal cron running. Currently it is set to only run nightly, and so without changing this to alway run, we would only be able to QA this PR once a day.
- [x] Edit the [ECA Cron event](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/config/workflow/eca/home_page_news_spotlight_block/event/eca_base_eca_cron/edit) and change the frequency to exactly `* * * * *`.

Validate Existing Subqueue:
- [x] Visit the '[V2 Home page news spotlight](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/structure/entityqueue/home_page_news_spotlight/home_page_news_spotlight)' subqueue page
- [x] Validate you see a single item, 'Homepage news promo'
- [x] On the [FE homepage](https://web-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/), in the news story section, validate you see a news story with the title "VA ends DEI, stops millions in DEI spending"

Run Cron:
- [x] Visit the [cron admin page](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/config/system/cron) and run cron.
- [x] Wait for cron to complete
- [x]  Visit the '[V2 Home page news spotlight](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/structure/entityqueue/home_page_news_spotlight/home_page_news_spotlight)' subqueue page
- [x] Validate you see the entity: 'Download the VA Health and Benefits App' as the sole item in the queue.

Validate home page is updated
- [x] Perform a [content release](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/content/deploy)
- [x] Wait until the release is complete
- [x] Validate the [home page](https://web-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/) news story is updated with the 'Download the VA Health and Benefits App' content

Regression/Rollback test
- [x] Visit the [News Spotlight block migration](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/structure/migrate/manage/homepage/migrations/news_spotlight_blocks/execute)
- [x] Select rollback and execute it
- [x] Visit the '[V2 Home page news spotlight](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/structure/entityqueue/home_page_news_spotlight/home_page_news_spotlight)' subqueue page
- [x] Validate you see a single item, 'Homepage news promo'
- [x] Perform a [content release](https://pr20976-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/admin/content/deploy)
- [x] Wait until the release is complete
- [x] Validate the [home page ](https://web-nzlooss8tayhmckamtarajqgtv7dbgev.ci.cms.va.gov/) news story is updated with the original 'Homepage news promo' content.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
