### PR TITLE
VACMS-20981: Skipping the manila cypress tests until Manila revert launches.

### DIFF
--- a/tests/cypress/integration/features/content_type/facilities/manila.feature
+++ b/tests/cypress/integration/features/content_type/facilities/manila.feature
@@ -1,4 +1,4 @@
-@content_type__event, @content_editing_vamc_facility
+@content_type__event, @content_editing_vamc_facility @skip
 Feature: Content Types: Event, VAMC Facility
 
 Scenario: Log in and create Event as a Manila editor


### PR DESCRIPTION
## Description

Doesn't close #20981 but gets tests passing until launch.

Relates to #20981

## QA steps
Cypress tests pass.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
