### PR TITLE
VACMS-20902: Content-build-dependency_20250331

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,7 +230,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3710",
+        "va-gov/content-build": "^0.0.3714",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edae178e62fcee994888a369b44aee33",
+    "content-hash": "b7b4a596d432cbc1551ec58162d36bfd",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27104,16 +27104,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3710",
+            "version": "v0.0.3714",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "aa6f503fa396ea5d90a4f9f1bc670552829e9d77"
+                "reference": "76da738bf0003bc94d5dba5493821113f61a8fc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/aa6f503fa396ea5d90a4f9f1bc670552829e9d77",
-                "reference": "aa6f503fa396ea5d90a4f9f1bc670552829e9d77",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/76da738bf0003bc94d5dba5493821113f61a8fc6",
+                "reference": "76da738bf0003bc94d5dba5493821113f61a8fc6",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27140,9 +27140,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3710"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3714"
             },
-            "time": "2025-03-21T23:54:26+00:00"
+            "time": "2025-03-28T14:04:14+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description
 Update content-build to version 0.0.3714

Closes #20902.

### Generated description
 Update content-build to version 0.0.3714 from 0.0.3710

## Testing done
Ran the command `ddev composer show 'va-gov/content-build'` to check the version

## Screenshots
<img width="1327" alt="Screenshot 2025-03-31 at 08 29 09" src="https://github.com/user-attachments/assets/a52bb93c-eba8-4cbf-b2cf-985f283462ed" />


## QA steps
As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that the content build version is 0.0.3714
2. Then
   - [ ] Validate that the version matches the latest version on [packagist](https://packagist.org/packages/va-gov/content-build)


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [x ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
