### PR TITLE
VACMS-20738: Removes closed from facility operating status.

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/templates/page-content/step-layout.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/page-content/step-layout.html.twig
@@ -1,0 +1,27 @@
+{% extends '@va_gov_form_builder/page-content/base/single-column-with-buttons.html.twig' %}
+
+{% set page_id = 'step-layout' %}
+{# page_heading passed from controller #}
+
+{% block main_content %}
+  {% if supported_step_type %}
+    <div class="form-builder-step-layout__step_label"><strong>Step label:</strong> <a href="{{ step_label.url }}">{{ step_label.label }}</a></div>
+
+    {% for page in pages %}
+      <div class="form-builder-step-layout__page">
+        <a class="form-builder-step-layout__page_title" href="{{ page.url }}">{{ page.title }}</a>
+        {% if pages|length > 1 %}
+          <div class="form-builder-paragraph-sort-and-delete form-builder-step-layout__paragraph-sort-and-delete">
+            <i class="form-builder-paragraph-sort-and-delete__test">(Placeholder for sort-and-delete controls)</i>
+          </div>
+        {% endif %}
+      </div>
+    {% endfor %}
+
+    {% if pages|length == 0 %}
+      <p>There are no questions or responses added to this step.</p>
+    {% endif %}
+    <p>If you want to add a question to this step, select Add question.</p>
+    <p>If you are done with this step, select return to steps.</p>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Description

Relates to #20738

### Generated description

This pull request includes changes to update the operating status of facilities from "Closed" to "Temporary facility closure" and introduces a new script to automate this process. The most important changes include the removal of the "closed" status option, the addition of a new script for updating facility statuses, and the inclusion of a new update hook to execute the script.

Changes to operating status options:

* [`config/sync/field.storage.node.field_operating_status_facility.yml`](diffhunk://#diff-48ea2fa5ddc78c4f206e14c5b305d6233439745d6d6c890da14144ad389fb5f5L20-L22): Removed the "closed" status option from the list of operating statuses.

New script for updating facility statuses:

* [`docroot/modules/custom/va_gov_batch/src/cbo_scripts/MakeClosedFacilitiesTemporarilyClosed.php`](diffhunk://#diff-09fc65664ee1e2313caba3b35d93fc0e268a1c2db12e81d540a9c0046329fd51R1-R77): Added a new script to update facilities with a "Closed" status to "Temporary facility closure".

Update hook to execute the new script:

* [`docroot/modules/custom/va_gov_facilities/va_gov_facilities.install`](diffhunk://#diff-32a90ac1f43af96a9565e49eb4bc715ce663dbdd6da9b92994a032f587e3b57dR109-R116): Added a new update hook `va_gov_facilities_update_9003` to run the new script that updates facility statuses.

## Testing done
Manual
PHPUnit regression

## Screenshots
![Screenshot 2025-03-31 at 16 54 57](https://github.com/user-attachments/assets/5609e1b4-f919-47f5-a5b6-840a0224720d)


## QA steps
- [x] [Log in](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov) as an admin
- [x] Go to the [Codit Batch Operations log](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov/admin/config/development/batch_operations/log/8)
- [x] Confirm that ~124 items were updated
- [x] Spot check the following (Closed in prod, Temporary facility closure in PR env):
  - [ ] Jupiter Vet Center - Okeechobee ([prod](https://prod.cms.va.gov/jupiter-vet-center/community-access-point/jupiter-vet-center-okeechobee), [Tugboat](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov/jupiter-vet-center/community-access-point/jupiter-vet-center-okeechobee))
    - [ ] Confirm that the Tugboat facility is changed
    - [ ] Confirm that revision log message explains the change
  - [ ] Bay County Vet Center - Marianna ([prod](https://prod.cms.va.gov/node/49012/), [Tugboat](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov/node/49012/))
    - [ ] Confirm that the Tugboat facility is changed
    - [ ] Confirm that revision log message explains the change
  - [ ] Little Rock Vet Center - Batesville ([prod](https://prod.cms.va.gov/node/43416/), [Tugboat](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov/node/43416/))
    - [ ] Confirm that the Tugboat facility is changed
    - [ ] Confirm that revision log message explains the change
  - [ ] Danbury Vet Center - Putnam County NY ([prod](https://prod.cms.va.gov/node/41969/), [Tugboat](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov/node/41969/))
    - [ ] Confirm that the Tugboat facility is changed
    - [ ] Confirm that revision log message explains the change

# Confirm removal of "Closed"
- [ ] Edit [Little Rock Vet Center - Batesville](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov/node/43416/edit)
- [ ] Check the Operating status options
- [ ] Confirm that "Closed" is not among them
- [ ] Go to the [Facility status report](https://pr21048-wwboetaa6hgutix316ovvbgm23t0hxee.ci.cms.va.gov/admin/content/facilities/facility-status)
- [ ] Click on the **Operating status** dropdown
- [ ] Confirm that "Closed" is not an available status


### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`


