### PR TITLE
VACMS-21062: Updates content-build to latest version on packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,7 +230,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3714",
+        "va-gov/content-build": "^0.0.3716",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7b4a596d432cbc1551ec58162d36bfd",
+    "content-hash": "4fb1b41b25fd6b89004e81caa724e0f2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27104,16 +27104,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3714",
+            "version": "v0.0.3716",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "76da738bf0003bc94d5dba5493821113f61a8fc6"
+                "reference": "141a63959179f2d2831f3dd1c7f8e379d3583d33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/76da738bf0003bc94d5dba5493821113f61a8fc6",
-                "reference": "76da738bf0003bc94d5dba5493821113f61a8fc6",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/141a63959179f2d2831f3dd1c7f8e379d3583d33",
+                "reference": "141a63959179f2d2831f3dd1c7f8e379d3583d33",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27140,9 +27140,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3714"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3716"
             },
-            "time": "2025-03-28T14:04:14+00:00"
+            "time": "2025-03-31T17:39:42+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description
 Update content-build to version 0.0.3716

Closes #21062.

### Generated description
 Update content-build to version 0.0.3714 from 0.0.3716

## Testing done
Ran the command `ddev composer show 'va-gov/content-build'` to check the version

## Screenshots
![Screenshot 2025-04-01 at 06 38 26](https://github.com/user-attachments/assets/6db9d34c-1122-4f40-8f20-1741962fb82d)



## QA steps
As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that the content build version is 0.0.3716
2. Then
   - [ ] Validate that the version matches the latest version on [packagist](https://packagist.org/packages/va-gov/content-build)


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

