### PR TITLE
Correct test step in CLP tests 

### DIFF
--- a/tests/cypress/integration/features/content_type/campaign_landing_page/clp_connect_with_us.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/clp_connect_with_us.feature
@@ -6,6 +6,6 @@ Feature: Content Type: Campaign Landing Page
     When I am at "node/add/campaign_landing_page"
     And I click to expand "Connect with us"
     Then I should see an option with the text "NCA" from dropdown with selector "#edit-field-connect-with-us"
-    And I should see an option with the text "Veteran Affairs" from dropdown with selector "#edit-field-connect-with-us"
+    And I should see an option with the text "Veterans Affairs" from dropdown with selector "#edit-field-connect-with-us"
     And I should see an option with the text "VBA" from dropdown with selector "#edit-field-connect-with-us"
     And I should see an option with the text "VHA" from dropdown with selector "#edit-field-connect-with-us"

--- a/tests/cypress/integration/features/content_type/campaign_landing_page/clp_connect_with_us.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/clp_connect_with_us.feature
@@ -6,6 +6,5 @@ Feature: Content Type: Campaign Landing Page
     When I am at "node/add/campaign_landing_page"
     And I click to expand "Connect with us"
     Then I should see an option with the text "NCA" from dropdown with selector "#edit-field-connect-with-us"
-    And I should see an option with the text "VACO" from dropdown with selector "#edit-field-connect-with-us"
     And I should see an option with the text "VBA" from dropdown with selector "#edit-field-connect-with-us"
     And I should see an option with the text "VHA" from dropdown with selector "#edit-field-connect-with-us"

--- a/tests/cypress/integration/features/content_type/campaign_landing_page/clp_connect_with_us.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/clp_connect_with_us.feature
@@ -6,5 +6,6 @@ Feature: Content Type: Campaign Landing Page
     When I am at "node/add/campaign_landing_page"
     And I click to expand "Connect with us"
     Then I should see an option with the text "NCA" from dropdown with selector "#edit-field-connect-with-us"
+    And I should see an option with the text "Veteran Affairs" from dropdown with selector "#edit-field-connect-with-us"
     And I should see an option with the text "VBA" from dropdown with selector "#edit-field-connect-with-us"
     And I should see an option with the text "VHA" from dropdown with selector "#edit-field-connect-with-us"

--- a/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
@@ -20,7 +20,7 @@ Scenario: Log in and create VAMC Facility Health Service as a Lovell editor
   Then I select option "----Lovell - TRICARE" from dropdown "Section"
   And I wait "2" seconds
   Then I select option "Captain James A. Lovell Federal Health Care Center | Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-facility-location"
-  Then I select option "Cardiology at Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-regional-health-service"
+  Then I select option "Homeless Veteran care at Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-regional-health-service"
 
 # Phone number AJAX test
   Then I click to expand "Appointments"


### PR DESCRIPTION
## Description

#21069 

This corrects a failing test step in the CLP 'Connect with us' tests.

### Generated description
This pull request includes a small change to the Cypress test file for the Campaign Landing Page feature. The change updates the expected text for one of the dropdown options in the "Connect with us" section.

* [`tests/cypress/integration/features/content_type/campaign_landing_page/clp_connect_with_us.feature`](diffhunk://#diff-8a0a7070716cf9f6b1582e70a9b87fb2f62c4765d3114c471738263f78a0b548L9-R9): Updated the expected text from "VACO" to "Veteran Affairs" for the dropdown option with selector `#edit-field-connect-with-us`.

## Testing done
Cypress tests must pass.

