### PR TITLE
Remove nvm from composer commands; set tugboat variables earlier so they can be picked up.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -235,6 +235,14 @@ services:
       - j2 "${TUGBOAT_ROOT}/.next/503-error-document.j2.html" -o "${TUGBOAT_ROOT}/.next/503-error-document.html"
 
       online:
+
+      # Put necessary env variables in place for next's Drupal Preview before building server
+      # Need to construct this way instead of TUGBOAT_DEFAULT_SERVICE_URL in order to drop the trailing /
+      - echo "NEXT_PUBLIC_DRUPAL_BASE_URL=https://cms-${TUGBOAT_SERVICE_TOKEN}.${TUGBOAT_SERVICE_CONFIG_DOMAIN}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
+      - echo "NEXT_IMAGE_DOMAIN=https://cms-${TUGBOAT_SERVICE_TOKEN}.${TUGBOAT_SERVICE_CONFIG_DOMAIN}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
+      - echo "DRUPAL_CLIENT_ID=${DRUPAL_CLIENT_ID}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
+      - echo "DRUPAL_CLIENT_SECRET=${DRUPAL_CLIENT_SECRET}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
+
       # Start the next build preview server
       - bash -lc 'composer va:next:build'
       - bash -lc 'composer va:next:start' &
@@ -249,14 +257,7 @@ services:
       - find -L "${DOCROOT}/vendor/va-gov/content-build/node_modules/.bin" -type f -exec chmod +x {} \+
       - find "${DOCROOT}/vendor/va-gov/content-build/script" -type f -exec chmod +x {} \+
 
-      # Put necessary env variables in place for next's Drupal Preview before building server
-      # Need to construct this way instead of TUGBOAT_DEFAULT_SERVICE_URL in order to drop the trailing /
-      - echo "NEXT_PUBLIC_DRUPAL_BASE_URL=https://cms-${TUGBOAT_SERVICE_TOKEN}.${TUGBOAT_SERVICE_CONFIG_DOMAIN}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
-      - echo "NEXT_IMAGE_DOMAIN=https://cms-${TUGBOAT_SERVICE_TOKEN}.${TUGBOAT_SERVICE_CONFIG_DOMAIN}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
-      - echo "DRUPAL_CLIENT_ID=${DRUPAL_CLIENT_ID}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
-      - echo "DRUPAL_CLIENT_SECRET=${DRUPAL_CLIENT_SECRET}" >> ${TUGBOAT_ROOT}/next/envs/.env.tugboat
-
-      # Build storybook and the frontends (web, next) in parallel
+      # Build storybook and the content-build frontend (web) in parallel
       - bash -lc 'time task --taskfile=tugboat.yml'
 
   memcache:

--- a/composer.json
+++ b/composer.json
@@ -445,12 +445,12 @@
         ],
         "va:ds:drupal": [
             "# Build the Drupal theme.",
-            "! ./scripts/should-run-directly.sh || (cd docroot/design-system && nvm use && npm install && npm run build:drupal)",
+            "! ./scripts/should-run-directly.sh || (cd docroot/design-system && npm install && npm run build:drupal)",
             "./scripts/should-run-directly.sh || ddev composer va:ds:drupal --"
         ],
         "va:ds:storybook": [
             "# Build the Storybook.",
-            "! ./scripts/should-run-directly.sh || (cd docroot/design-system && nvm use && npm install && npm run build:storybook)",
+            "! ./scripts/should-run-directly.sh || (cd docroot/design-system && npm install && npm run build:storybook)",
             "./scripts/should-run-directly.sh || ddev composer va:ds:storybook --"
         ],
         "va:migrate:sync": [


### PR DESCRIPTION
## Description

Relates to #20685

### Generated description
This pull request includes changes to the `.tugboat/config.yml` and `composer.json` files to update environment variable handling and simplify the build process. The most important changes include moving environment variable setup for Drupal Preview, and removing unnecessary `nvm use` commands.

Environment variable handling:

* [`.tugboat/config.yml`](diffhunk://#diff-fbd0812762ff8d2c67fa66a4956c3b55557ad0889505294f524192000b2ce50eR235-R242): Moved the setup of necessary environment variables for Next.js Drupal Preview to the `online` service section.
* [`.tugboat/config.yml`](diffhunk://#diff-fbd0812762ff8d2c67fa66a4956c3b55557ad0889505294f524192000b2ce50eL249-R257): Removed the setup of environment variables for Next.js Drupal Preview from the previous section.

Build process simplification:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L622-R627): Removed the `nvm use` command from the `va:ds:drupal` and `va:ds:storybook` script commands.

## Testing done
- confirm that storybook and content-build kick off
- confirm next-build starts


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

