### PR TITLE
VAGOV-TEAM-106493: Custom/additional Step Status

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
@@ -447,12 +447,9 @@ class VaGovFormBuilderController extends ControllerBase {
         'steps' => array_map(function ($step) {
           $stepParagraphId = $step['fields']['id'][0]['value'];
           return [
-            // If an additional step exists, it's complete.
-            // @todo This logic needs to be updated to accommodate custom
-            // steps that are not complete by default.
             'type' => $step['type'],
             'title' => $step['fields']['field_title'][0]['value'],
-            'status' => 'complete',
+            'status' => $this->digitalForm->getStepStatus('custom', $step['paragraph']),
             'url' => Url::fromRoute('va_gov_form_builder.step.layout', [
               'nid' => $this->digitalForm->id(),
               'stepParagraphId' => $stepParagraphId,

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -19,7 +19,7 @@ use Drupal\va_gov_form_builder\Traits\EntityReferenceRevisionsOperations;
  * The following line is included because the public method `addStep`
  * makes dynamic calls to otherwise uncalled private methods, and those
  * private methods trigger unused-method warnings when they are, in fact,
- * not unused:
+ * unused:
  * @phpcs:disable DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod
  */
 class DigitalForm {

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -14,6 +14,7 @@ use Drupal\va_gov_form_builder\Traits\EntityReferenceRevisionsOperations;
  * @method int id()
  * @method string getTitle()
  * @method \Drupal\Core\Field\FieldItemListInterface get(string $field_name)
+ * @method \Symfony\Component\Validator\ConstraintViolationListInterface validate()
  * @method int save() Saves the entity and returns the save status
  * @method NodeInterface set(string $field_name, mixed $value, bool $notify = TRUE) Sets a field value
  *
@@ -178,14 +179,14 @@ class DigitalForm {
    *
    * @param string $stepName
    *   The step name of the step in question.
-   * @param mixed|\Drupal\paragraphs\ParagraphInterface $paragraph
+   * @param null|\Drupal\paragraphs\ParagraphInterface $paragraph
    *   Optional paragraph entity for this step.
    *
    * @return string
    *   Returns 'complete' if step is complete. Returns 'incomplete' if step is
    *   incomplete or if the step name does not exist.
    */
-  public function getStepStatus(string $stepName, mixed $paragraph = NULL) {
+  public function getStepStatus(string $stepName, null|ParagraphInterface $paragraph = NULL) {
     if ($stepName === 'form_info') {
       // If the node exists, this will necessarily be complete.
       return 'complete';

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -4,16 +4,16 @@ namespace Drupal\va_gov_form_builder\EntityWrapper;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
+use Drupal\va_gov_form_builder\Traits\EntityReferenceRevisionsOperations;
 
 /**
  * A wrapper class around Digital Form nodes.
  *
  * @method int id()
  * @method string getTitle()
- * @method \Drupal\Core\Field\FieldItemListInterface get(string $field_name)
- * @method \Symfony\Component\Validator\ConstraintViolationListInterface validate()
  * @method int save() Saves the entity and returns the save status
- * @method \Drupal\node\NodeInterface set(string $field_name, mixed $value, bool $notify = TRUE) Sets a field value
+ * @method NodeInterface set(string $field_name, mixed $value, bool $notify = TRUE) Sets a field value
  *
  * The following line is included because the public method `addStep`
  * makes dynamic calls to otherwise uncalled private methods, and those
@@ -22,6 +22,9 @@ use Drupal\node\NodeInterface;
  * @phpcs:disable DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod
  */
 class DigitalForm {
+
+  use EntityReferenceRevisionsOperations;
+
   /**
    * The standard steps of a Digital Form.
    */
@@ -105,6 +108,7 @@ class DigitalForm {
         if ($paragraph) {
           $steps[] = [
             'type' => $paragraph->bundle(),
+            'paragraph' => $paragraph,
             'fields' => array_map(function ($field) {
               return $field->getValue();
             }, $paragraph->getFields()),
@@ -172,13 +176,14 @@ class DigitalForm {
    *
    * @param string $stepName
    *   The step name of the step in question.
+   * @param \Drupal\paragraphs\ParagraphInterface|null $paragraph
+   *   Optional paragraph entity for this step.
    *
-   * @return 'complete'|'incomplete'
-   *   Returns 'complete' if step is complete.
-   *   Returns 'incomplete if step is incomplete
-   *   or if the step name does not exist.
+   * @return string
+   *   Returns 'complete' if step is complete. Returns 'incomplete' if step is
+   *   incomplete or if the step name does not exist.
    */
-  public function getStepStatus($stepName) {
+  public function getStepStatus(string $stepName, ParagraphInterface|\NULL $paragraph = \NULL) {
     if ($stepName === 'form_info') {
       // If the node exists, this will necessarily be complete.
       return 'complete';
@@ -204,6 +209,17 @@ class DigitalForm {
       return $this->hasChapterOfType($paragraphName)
         ? 'complete'
         : 'incomplete';
+    }
+
+    // Use recursive entity validation to determine custom step status. Any
+    // violation in the custom step paragraph or descendent paragraphs will
+    // cause the status to be incomplete. This method is used to reduce
+    // technical debt if the custom step content model, or the content model of
+    // its children, is updated. This could also support future enhancements to
+    // display _why_ the step is not complete.
+    if ($paragraph instanceof ParagraphInterface && $stepName === 'custom') {
+      $violations = $this->recursiveEntityReferenceRevisionValidator($paragraph);
+      return $violations->count() > 0 ? 'incomplete' : 'complete';
     }
 
     return 'incomplete';

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -13,13 +13,14 @@ use Drupal\va_gov_form_builder\Traits\EntityReferenceRevisionsOperations;
  *
  * @method int id()
  * @method string getTitle()
+ * @method \Drupal\Core\Field\FieldItemListInterface get(string $field_name)
  * @method int save() Saves the entity and returns the save status
  * @method NodeInterface set(string $field_name, mixed $value, bool $notify = TRUE) Sets a field value
  *
  * The following line is included because the public method `addStep`
  * makes dynamic calls to otherwise uncalled private methods, and those
  * private methods trigger unused-method warnings when they are, in fact,
- * unused:
+ * used:
  * @phpcs:disable DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod
  */
 class DigitalForm {

--- a/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/EntityWrapper/DigitalForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\va_gov_form_builder\EntityWrapper;
 
+use Drupal\Core\Entity\EntityConstraintViolationList;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\ParagraphInterface;
@@ -176,14 +177,14 @@ class DigitalForm {
    *
    * @param string $stepName
    *   The step name of the step in question.
-   * @param \Drupal\paragraphs\ParagraphInterface|null $paragraph
+   * @param mixed|\Drupal\paragraphs\ParagraphInterface $paragraph
    *   Optional paragraph entity for this step.
    *
    * @return string
    *   Returns 'complete' if step is complete. Returns 'incomplete' if step is
    *   incomplete or if the step name does not exist.
    */
-  public function getStepStatus(string $stepName, ParagraphInterface|\NULL $paragraph = \NULL) {
+  public function getStepStatus(string $stepName, mixed $paragraph = NULL) {
     if ($stepName === 'form_info') {
       // If the node exists, this will necessarily be complete.
       return 'complete';
@@ -218,7 +219,7 @@ class DigitalForm {
     // its children, is updated. This could also support future enhancements to
     // display _why_ the step is not complete.
     if ($paragraph instanceof ParagraphInterface && $stepName === 'custom') {
-      $violations = $this->recursiveEntityReferenceRevisionValidator($paragraph);
+      $violations = $this->recursiveEntityReferenceRevisionValidator($paragraph, new EntityConstraintViolationList($paragraph));
       return $violations->count() > 0 ? 'incomplete' : 'complete';
     }
 

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
@@ -20,7 +20,7 @@ trait EntityReferenceRevisionsOperations {
    * @param \Drupal\Core\Entity\EntityConstraintViolationList $violations
    *   Violations to add to the list.
    *
-   * @return \Drupal\Core\Entity\EntityConstraintViolationListInterface
+   * @return \Drupal\Core\Entity\EntityConstraintViolationList
    *   The comprehensive violations list for referenced the referenced entity.
    */
   public function recursiveEntityReferenceRevisionValidator(ContentEntityInterface $entity, EntityConstraintViolationList $violations): EntityConstraintViolationList {

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
@@ -15,13 +15,13 @@ trait EntityReferenceRevisionsOperations {
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity to validate recursively.
-   * @param mixed<EntityConstraintViolationList> $violations
+   * @param \Drupal\Core\Entity\EntityConstraintViolationList $violations
    *   Violations to add to the list.
    *
    * @return \Drupal\Core\Entity\EntityConstraintViolationListInterface
    *   The comprehensive violations list for referenced the referenced entity.
    */
-  public function recursiveEntityReferenceRevisionValidator(ContentEntityInterface $entity, mixed $violations = []): EntityConstraintViolationList {
+  public function recursiveEntityReferenceRevisionValidator(ContentEntityInterface $entity, EntityConstraintViolationList $violations): EntityConstraintViolationList {
     $violations->addAll($entity->validate());
     foreach ($entity->getFields() as $field) {
       // Skip base fields.

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\va_gov_form_builder\Traits;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityConstraintViolationList;
+
+/**
+ * Traits for Entity Reference Revisions (paragraphs) operations.
+ */
+trait EntityReferenceRevisionsOperations {
+
+  /**
+   * Returns violations for single or nested entity reference revision entities.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to validate recursively.
+   * @param mixed<EntityConstraintViolationList> $violations
+   *   Violations to add to the list.
+   *
+   * @return \Drupal\Core\Entity\EntityConstraintViolationListInterface
+   *   The comprehensive violations list for referenced the referenced entity.
+   */
+  public function recursiveEntityReferenceRevisionValidator(ContentEntityInterface $entity, mixed $violations = []): EntityConstraintViolationList {
+    $violations->addAll($entity->validate());
+    foreach ($entity->getFields() as $field) {
+      // Skip base fields.
+      if ($field->getFieldDefinition()->getFieldStorageDefinition()->isBaseField()) {
+        continue;
+      }
+      // Check if it's an entity reference field.
+      if ($field->getFieldDefinition()->getType() === 'entity_reference_revisions') {
+        // Now recursively check referenced entities (e.g., Paragraphs).
+        foreach ($field->referencedEntities() as $referenced_entity) {
+          // Only recurse if it's a content entity.
+          if ($referenced_entity instanceof ContentEntityInterface) {
+            $this->recursiveEntityReferenceRevisionValidator($referenced_entity, $violations);
+          }
+        }
+      }
+    }
+
+    return $violations;
+  }
+
+}

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/EntityReferenceRevisionsOperations.php
@@ -13,6 +13,8 @@ trait EntityReferenceRevisionsOperations {
   /**
    * Returns violations for single or nested entity reference revision entities.
    *
+   * This method could have performance impacts depending on entity tree depth.
+   *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity to validate recursively.
    * @param \Drupal\Core\Entity\EntityConstraintViolationList $violations

--- a/tests/phpunit/va_gov_form_builder/unit/Traits/EntityReferenceRevisionsOperationsTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/Traits/EntityReferenceRevisionsOperationsTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Drupal\Tests\va_gov_form_builder\Unit\Traits;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityConstraintViolationList;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\va_gov_form_builder\Traits\EntityReferenceRevisionsOperations;
+use Symfony\Component\Validator\ConstraintViolation;
+
+/**
+ * Tests the EntityReferenceRevisionsOperations trait.
+ *
+ * @group va_gov_form_builder
+ * @group unit
+ */
+class EntityReferenceRevisionsOperationsTest extends UnitTestCase {
+
+  /**
+   * A class that uses the trait for testing.
+   *
+   * @var object
+   */
+  protected $traitObject;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->traitObject = new class() {
+      use EntityReferenceRevisionsOperations;
+    };
+  }
+
+  /**
+   * Tests the recursiveEntityReferenceRevisionValidator method.
+   */
+  public function testRecursiveEntityReferenceRevisionValidator() {
+    // Create a mock entity with no violations.
+    $entity = $this->prophesize(ContentEntityInterface::class);
+    $entity->validate()->willReturn(new EntityConstraintViolationList($entity->reveal(), []));
+
+    // Create a mock field definition for a non-entity reference field.
+    $field_definition = $this->prophesize(FieldDefinitionInterface::class);
+    $field_storage = $this->prophesize(FieldStorageDefinitionInterface::class);
+    $field_storage->isBaseField()->willReturn(FALSE);
+    $field_definition->getFieldStorageDefinition()->willReturn($field_storage->reveal());
+    $field_definition->getType()->willReturn('string');
+
+    // Create a mock field item list.
+    $field = $this->prophesize(FieldItemListInterface::class);
+    $field->getFieldDefinition()->willReturn($field_definition->reveal());
+
+    // Set up the entity to return our mock field.
+    $entity->getFields()->willReturn(['test_field' => $field->reveal()]);
+
+    $violations = new EntityConstraintViolationList($entity->reveal(), []);
+    $result = $this->traitObject->recursiveEntityReferenceRevisionValidator($entity->reveal(), $violations);
+
+    $this->assertInstanceOf(EntityConstraintViolationList::class, $result);
+    $this->assertCount(0, $result);
+  }
+
+  /**
+   * Tests recursiveEntityReferenceRevisionValidator with nested entities.
+   */
+  public function testRecursiveEntityReferenceRevisionValidatorWithNestedEntities() {
+    // Create a mock deeply nested entity with no violations.
+    $deeply_nested_entity = $this->prophesize(ContentEntityInterface::class);
+    $deeply_nested_entity->validate()->willReturn(new EntityConstraintViolationList($deeply_nested_entity->reveal(), []));
+    $deeply_nested_entity->getFields()->willReturn([]);
+
+    // Create a mock nested entity with no violations that references the deeply
+    // nested entity.
+    $nested_entity = $this->prophesize(ContentEntityInterface::class);
+    $nested_entity->validate()->willReturn(new EntityConstraintViolationList($nested_entity->reveal(), []));
+
+    // Create a mock field definition for an entity reference revisions field.
+    $field_definition = $this->prophesize(FieldDefinitionInterface::class);
+    $field_storage = $this->prophesize(FieldStorageDefinitionInterface::class);
+    $field_storage->isBaseField()->willReturn(FALSE);
+    $field_definition->getFieldStorageDefinition()->willReturn($field_storage->reveal());
+    $field_definition->getType()->willReturn('entity_reference_revisions');
+
+    // Create a mock field item list that returns our deeply nested entity.
+    $nested_field = $this->prophesize(EntityReferenceFieldItemListInterface::class);
+    $nested_field->getFieldDefinition()->willReturn($field_definition->reveal());
+    $nested_field->referencedEntities()->willReturn([$deeply_nested_entity->reveal()]);
+
+    // Set up the nested entity to return our mock field.
+    $nested_entity->getFields()->willReturn(['nested_field' => $nested_field->reveal()]);
+
+    // Create a mock field item list that returns our nested entity.
+    $field = $this->prophesize(EntityReferenceFieldItemListInterface::class);
+    $field->getFieldDefinition()->willReturn($field_definition->reveal());
+    $field->referencedEntities()->willReturn([$nested_entity->reveal()]);
+
+    // Create a mock parent entity with no violations.
+    $parent_entity = $this->prophesize(ContentEntityInterface::class);
+    $parent_entity->validate()->willReturn(new EntityConstraintViolationList($parent_entity->reveal(), []));
+    $parent_entity->getFields()->willReturn(['test_field' => $field->reveal()]);
+
+    $violations = new EntityConstraintViolationList($parent_entity->reveal(), []);
+    $result = $this->traitObject->recursiveEntityReferenceRevisionValidator($parent_entity->reveal(), $violations);
+
+    $this->assertInstanceOf(EntityConstraintViolationList::class, $result);
+    $this->assertCount(0, $result);
+  }
+
+  /**
+   * Tests the recursiveEntityReferenceRevisionValidator method with violations.
+   */
+  public function testRecursiveEntityReferenceRevisionValidatorWithViolations() {
+    // Create a mock entity with violations.
+    $entity = $this->prophesize(ContentEntityInterface::class);
+    $violation = $this->prophesize(ConstraintViolation::class)->reveal();
+    $violation_list = new EntityConstraintViolationList($entity->reveal(), [$violation]);
+    $entity->validate()->willReturn($violation_list);
+
+    // Create a mock field definition for a non-entity reference field.
+    $field_definition = $this->prophesize(FieldDefinitionInterface::class);
+    $field_storage = $this->prophesize(FieldStorageDefinitionInterface::class);
+    $field_storage->isBaseField()->willReturn(FALSE);
+    $field_definition->getFieldStorageDefinition()->willReturn($field_storage->reveal());
+    $field_definition->getType()->willReturn('string');
+
+    // Create a mock field item list.
+    $field = $this->prophesize(FieldItemListInterface::class);
+    $field->getFieldDefinition()->willReturn($field_definition->reveal());
+
+    // Set up the entity to return our mock field.
+    $entity->getFields()->willReturn(['test_field' => $field->reveal()]);
+
+    $violations = new EntityConstraintViolationList($entity->reveal(), []);
+    $result = $this->traitObject->recursiveEntityReferenceRevisionValidator($entity->reveal(), $violations);
+
+    $this->assertInstanceOf(EntityConstraintViolationList::class, $result);
+    $this->assertCount(1, $result);
+  }
+
+  /**
+   * Tests recursiveEntityReferenceRevisionValidator method with base fields.
+   */
+  public function testRecursiveEntityReferenceRevisionValidatorWithBaseFields() {
+    // Create a mock entity with no violations.
+    $entity = $this->prophesize(ContentEntityInterface::class);
+    $entity->validate()->willReturn(new EntityConstraintViolationList($entity->reveal(), []));
+
+    // Create a mock field definition for a base field.
+    $field_definition = $this->prophesize(FieldDefinitionInterface::class);
+    $field_storage = $this->prophesize(FieldStorageDefinitionInterface::class);
+    $field_storage->isBaseField()->willReturn(TRUE);
+    $field_definition->getFieldStorageDefinition()->willReturn($field_storage->reveal());
+
+    // Create a mock field item list.
+    $field = $this->prophesize(FieldItemListInterface::class);
+    $field->getFieldDefinition()->willReturn($field_definition->reveal());
+
+    // Set up the entity to return our mock field.
+    $entity->getFields()->willReturn(['test_field' => $field->reveal()]);
+
+    $violations = new EntityConstraintViolationList($entity->reveal(), []);
+    $result = $this->traitObject->recursiveEntityReferenceRevisionValidator($entity->reveal(), $violations);
+
+    $this->assertInstanceOf(EntityConstraintViolationList::class, $result);
+    $this->assertCount(0, $result);
+  }
+
+}


### PR DESCRIPTION
## Description

Relates to: department-of-veterans-affairs/va.gov-team#106493

### Generated description

This pull request introduces several changes to enhance the functionality and validation of digital forms in the `va_gov_form_builder` module. The most significant updates include adding a new trait for entity reference revisions operations, updating the logic for determining step status, and modifying the `DigitalForm` class to incorporate these changes.

### Enhancements to Digital Form functionality:

* **Step Status Logic Update:**
  - Updated the logic for determining the status of custom steps using the `getStepStatus` method in the `DigitalForm` class. This now includes recursive entity validation to check for any violations in the custom step paragraph or its descendant paragraphs. [[1]](diffhunk://#diff-9dffa0f8b39e9a7ba0a5c28ef2b99bd9a06ca95b1f77852efd1896d10e9b920cL450-R452) [[2]](diffhunk://#diff-66168129b5c4f6b7bf146b4a0d6471d519f281139944ddd5ec43376c30cf6139R180-R187) [[3]](diffhunk://#diff-66168129b5c4f6b7bf146b4a0d6471d519f281139944ddd5ec43376c30cf6139R215-R225)

* **Entity Reference Revisions Operations Trait:**
  - Introduced a new trait `EntityReferenceRevisionsOperations` to handle recursive validation of entity reference revisions. This trait is used to validate nested entities and ensure comprehensive validation.

### Codebase modifications:

* **DigitalForm Class:**
  - Added the `EntityReferenceRevisionsOperations` trait to the `DigitalForm` class to utilize its recursive validation functionality.
  - Included the `paragraph` field in the `getAllSteps` method to pass the paragraph entity along with the step details.
  - Updated method signatures and docblocks to reflect the changes in validation and step status logic. [[1]](diffhunk://#diff-66168129b5c4f6b7bf146b4a0d6471d519f281139944ddd5ec43376c30cf6139R5-R17) [[2]](diffhunk://#diff-66168129b5c4f6b7bf146b4a0d6471d519f281139944ddd5ec43376c30cf6139R180-R187)

## Testing done
Manual and PHPUnit

## Screenshots

## QA steps
As a Form Engine user:
- [ ] Visit /form-builder/76353
- [ ] Validate that the step "Step 4: Veteran's employment history" status is "COMPLETE"
- [ ] Click the 'Add a Step' button
- [ ] Fill in the label and click 'Save and Continue'
- [ ] Select the 'Add single question' button
- [ ] Click the 'Return to steps' button
- [ ] Validate the new step status is "INCOMPLETE"
- [ ] Visit /node/76353/edit
- [ ] Find the new step you added under the 'Steps' section.
- [ ] Fill out the rest of the step by adding a page and any component
- [ ] Save the node
- [ ] Visit /form-builder/76353
- [ ] Validate the new step status is "COMPLETE"

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
