### PR TITLE
Updated content-build to v0.0.3727

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,7 +230,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3716",
+        "va-gov/content-build": "^0.0.3727",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6f2b4df2b50a02edfe63113a204ee4f",
+    "content-hash": "ceb6976a0acd34806652508c73a45aed",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27335,16 +27335,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3716",
+            "version": "v0.0.3727",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "141a63959179f2d2831f3dd1c7f8e379d3583d33"
+                "reference": "bae3947f2532311258853d7d037350bc26506199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/141a63959179f2d2831f3dd1c7f8e379d3583d33",
-                "reference": "141a63959179f2d2831f3dd1c7f8e379d3583d33",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/bae3947f2532311258853d7d037350bc26506199",
+                "reference": "bae3947f2532311258853d7d037350bc26506199",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27371,9 +27371,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3716"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3727"
             },
-            "time": "2025-03-31T17:39:42+00:00"
+            "time": "2025-04-14T17:20:15+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description

Closes to #21009

### Generated description

This pull request includes an update to the `composer.json` file. The change updates the version of the `va-gov/content-build` package from `^0.0.3716` to `^0.0.3727`.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L233-R233): Updated the `va-gov/content-build` package version from `^0.0.3716` to `^0.0.3727`

## Testing done
Pipeline builds successfully, tests this.


## QA steps
  - verify Content-build is on latest
  
### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

