### PR TITLE
VACMS-21194: HOTFIX-cypress-test

### DIFF
--- a/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature
@@ -14,13 +14,13 @@ Scenario: Log in and create VAMC Facility Health Service as a Lovell editor
   And I select option "----Lovell - VA" from dropdown "Section"
   And I wait "2" seconds
   Then I select option "Captain James A. Lovell Federal Health Care Center | Lovell Federal health care - VA" from dropdown with selector "#edit-field-facility-location"
-  Then I select option "Cardiology at Lovell Federal health care - VA" from dropdown with selector "#edit-field-regional-health-service"
+  Then I select option "Cardiology at Lovell Federal health care - VA" from dropdown with selector "select[data-drupal-selector*='edit-field-regional-health-service']"
 
 # Lovell TRICARE test
   Then I select option "----Lovell - TRICARE" from dropdown "Section"
   And I wait "2" seconds
   Then I select option "Captain James A. Lovell Federal Health Care Center | Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-facility-location"
-  Then I select option "Homeless Veteran care at Lovell Federal health care - TRICARE" from dropdown with selector "#edit-field-regional-health-service"
+  Then I select option "Homeless Veteran care at Lovell Federal health care - TRICARE" from dropdown with selector "select[data-drupal-selector*='edit-field-regional-health-service']"
 
 # Phone number AJAX test
   Then I click to expand "Appointments"
@@ -44,7 +44,7 @@ Scenario: Log in and create VAMC Facility Health Service as a non-Lovell editor
   And I wait "2" seconds
   Then I click the button with selector "#edit-group-health-service-and-facilit"
   Then I select option "Brockton VA Medical Center | VA Boston health care" from dropdown with selector "#edit-field-facility-location"
-  Then I select option "Audiology and speech at VA Boston health care" from dropdown with selector "#edit-field-regional-health-service"
+  Then I select option "Audiology and speech at VA Boston health care" from dropdown with selector "select[data-drupal-selector*='edit-field-regional-health-service']"
 
 Scenario: Editors should not be able to rename a VAMC Facility Health Service
   Given I am logged in as a user with the roles "vamc_content_creator, content_publisher, content_editor, content_admin"


### PR DESCRIPTION
Updated cypress test to better find dropdown element

## Description

Closes to #21194. (or closes?)

### Generated description
Instead of using the element id,(**edit-field-regional-health-service**) which is dynamically modified, changed the test to use the element's attribute **data-drupal-selector** value (which happens to match the base id value).

## Testing done
Run `npm run test:cypress:interactive`

Select test content_type > facilities > vamc > health_care_local_health_service
3 tests should pass

## Screenshots
<img width="1507" alt="Screenshot 2025-04-16 at 16 40 57" src="https://github.com/user-attachments/assets/83f1a9f3-f521-4eb4-b0db-45c7fbfaf464" />


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As admin
1. Do this
   - [ ] run cypress test on **tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_health_service.feature ** and make sure it passes


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ X] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [X ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
