### PR TITLE
VAGOV-TEAM-106494 index iteration

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/css/repeatable-field-groups.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/repeatable-field-groups.css
@@ -1,0 +1,14 @@
+#edit-add-item {
+  background-color: unset;
+  box-shadow: unset;
+  color: var(--vads-color-primary);
+  padding-left: var(--units-1);
+  text-transform: uppercase;
+}
+
+/* input elements don't support pseudo elements so put the icon on the wrapper */
+.form-builder-add-item-wrapper::before {
+  align-self: center;
+  content: url("data:image/svg+xml,%3Csvg width='17' height='17' viewBox='0 0 17 17' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M16.96 7.32364V9.63636C16.96 10.2748 16.442 10.7927 15.8036 10.7927H10.7927V15.8036C10.7927 16.442 10.2748 16.96 9.63636 16.96H7.32364C6.68523 16.96 6.16727 16.442 6.16727 15.8036V10.7927H1.15636C0.517955 10.7927 0 10.2748 0 9.63636V7.32364C0 6.68523 0.517955 6.16727 1.15636 6.16727H6.16727V1.15636C6.16727 0.517955 6.68523 0 7.32364 0H9.63636C10.2748 0 10.7927 0.517955 10.7927 1.15636V6.16727H15.8036C16.442 6.16727 16.96 6.68523 16.96 7.32364Z' fill='%23005EA2'/%3E%3C/svg%3E%0A");
+  display: inline-block;
+}

--- a/docroot/modules/custom/va_gov_form_builder/css/repeatable-field-groups.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/repeatable-field-groups.css
@@ -1,4 +1,5 @@
-#edit-add-item {
+/* stylelint-disable-next-line selector-no-qualifying-type */
+input[type="submit"].form-builder-add-item  {
   background-color: unset;
   box-shadow: unset;
   color: var(--vads-color-primary);

--- a/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Controller/VaGovFormBuilderController.php
@@ -1184,6 +1184,7 @@ class VaGovFormBuilderController extends ControllerBase {
       'response_kind',
       'expanded_radio',
       'expanded_radio__help_text_optional_image',
+      'repeatable_field_groups',
     ];
 
     return $this->getFormPage($formName, $subtitle, $breadcrumbs, $libraries);
@@ -1373,6 +1374,7 @@ class VaGovFormBuilderController extends ControllerBase {
       'two_column_with_buttons',
       'expanded_radio',
       'custom_single_question_response',
+      'repeatable_field_groups',
     ];
 
     return $this->getFormPage($formName, $subtitle, $breadcrumbs, $libraries);
@@ -1439,6 +1441,7 @@ class VaGovFormBuilderController extends ControllerBase {
       'two_column_with_buttons',
       'expanded_radio',
       'custom_single_question_response',
+      'repeatable_field_groups',
     ];
 
     return $this->getFormPage($formName, $subtitle, $breadcrumbs, $libraries);

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
@@ -17,7 +17,7 @@ trait RepeatableFieldGroup {
    */
   public function addRepeatableFieldGroup(array &$form, FormStateInterface $form_state, string $element_name, array $field_definitions, int $startIndex = 1, int $max = 10, $button_name = 'Add another') {
     // If an additional item would be over the limit, bail early.
-    if ($startIndex >= $max) {
+    if ($startIndex > $max) {
       return;
     }
 
@@ -57,6 +57,9 @@ trait RepeatableFieldGroup {
     if ($num_items < $max) {
       $form[$element_name . '_fieldset']['actions'] = [
         '#type' => 'actions',
+        '#attributes' => [
+          'class' => ['form-builder-add-item-wrapper'],
+        ],
       ];
 
       $form[$element_name . '_fieldset']['actions']['add_item'] = [
@@ -67,6 +70,9 @@ trait RepeatableFieldGroup {
         '#ajax' => [
           'callback' => '::addMoreCallback',
           'wrapper' => $element_name . '-wrapper',
+        ],
+        '#attributes' => [
+          'class' => ['form-builder-add-item'],
         ],
         // Don't validate on ajax add, only on full page submission.
         '#limit_validation_errors' => [],

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
@@ -63,6 +63,8 @@ trait RepeatableFieldGroup {
           'callback' => '::addMoreCallback',
           'wrapper' => $element_name . '-wrapper',
         ],
+        // Don't validate on ajax add, only on full page submission.
+        '#limit_validation_errors' => [],
       ];
     }
   }

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
@@ -15,12 +15,17 @@ trait RepeatableFieldGroup {
   /**
    * Creates repeatable fields dynamically using AJAX.
    */
-  public function addRepeatableFieldGroup(array &$form, FormStateInterface $form_state, string $element_name, array $field_definitions, int $min = 1, int $max = 10) {
-    // Get the number of items in the form already.
+  public function addRepeatableFieldGroup(array &$form, FormStateInterface $form_state, string $element_name, array $field_definitions, int $startIndex = 1, int $max = 10) {
+    // If an additional item would be over the limit, bail early.
+    if ($startIndex >= $max) {
+      return;
+    }
+
+    // Get the number of ajax items in the form already.
     $num_items = $form_state->get($element_name . '_count');
     // We have to ensure that there is at least one item field.
     if ($num_items === NULL) {
-      $form_state->set($element_name . '_count', 1);
+      $form_state->set($element_name . '_count', $startIndex);
       $num_items = $form_state->get($element_name . '_count');
     }
 
@@ -33,7 +38,7 @@ trait RepeatableFieldGroup {
     // Fields get their own values instead of copying the first group.
     $form[$element_name . '_fieldset'][$element_name]['#tree'] = TRUE;
 
-    for ($i = 0; $i < $num_items; $i++) {
+    for ($i = $startIndex - 1; $i < $num_items; $i++) {
       // Create a new fields for each item.
       foreach ($field_definitions as $field_key => $definition) {
         $form[$element_name . '_fieldset'][$element_name][$i][$field_key] = $definition;

--- a/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Traits/RepeatableFieldGroup.php
@@ -15,7 +15,7 @@ trait RepeatableFieldGroup {
   /**
    * Creates repeatable fields dynamically using AJAX.
    */
-  public function addRepeatableFieldGroup(array &$form, FormStateInterface $form_state, string $element_name, array $field_definitions, int $startIndex = 1, int $max = 10) {
+  public function addRepeatableFieldGroup(array &$form, FormStateInterface $form_state, string $element_name, array $field_definitions, int $startIndex = 1, int $max = 10, $button_name = 'Add another') {
     // If an additional item would be over the limit, bail early.
     if ($startIndex >= $max) {
       return;
@@ -43,9 +43,14 @@ trait RepeatableFieldGroup {
       foreach ($field_definitions as $field_key => $definition) {
         $form[$element_name . '_fieldset'][$element_name][$i][$field_key] = $definition;
 
-        // Track given field title to iterate visible counter.
-        $label = $form[$element_name . '_fieldset'][$element_name][$i][$field_key]['#title'];
-        $form[$element_name . '_fieldset'][$element_name][$i][$field_key]['#title'] = $label . ' ' . $i + 1;
+        // Append index counter to the input label for a given set of fields.
+        // - Custom key isn't set, so hideIndex === FALSE.
+        // - Or if custom key exists and value isn't FALSE.
+        $hideIndex = isset($form[$element_name . '_fieldset'][$element_name][$i][$field_key]['#displayIndexCount']);
+        if ($hideIndex === FALSE || $form[$element_name . '_fieldset'][$element_name][$i][$field_key]['#displayIndexCount'] !== FALSE) {
+          $label = $form[$element_name . '_fieldset'][$element_name][$i][$field_key]['#title'];
+          $form[$element_name . '_fieldset'][$element_name][$i][$field_key]['#title'] = $label . ' ' . $i + 1;
+        }
       }
     }
 
@@ -57,7 +62,7 @@ trait RepeatableFieldGroup {
       $form[$element_name . '_fieldset']['actions']['add_item'] = [
         '#type' => 'submit',
         '#name' => $element_name . '_add_item',
-        '#value' => $this->t('Add another'),
+        '#value' => $this->t('@button', ['@button' => $button_name]),
         '#submit' => ['::addOne'],
         '#ajax' => [
           'callback' => '::addMoreCallback',

--- a/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.libraries.yml
+++ b/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.libraries.yml
@@ -85,3 +85,8 @@ expanded_radio__help_text_optional_image:
   css:
     theme:
       css/expanded-radio--help-text-optional-image.css: {}
+repeatable_field_groups:
+  version: 1.x
+  css:
+    theme:
+      css/repeatable-field-groups.css: {}


### PR DESCRIPTION
## Description

Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/106494

Updates the $min parameter to be a startingIndex instead. Updates logic to use this value instead of always starting at 0. This should allow the edit page to define how many objects exist already and then add ajax items from there.

Also updated the form validation to not trigger on the ajax add button, only the actual form submit for the page.


## Testing done
Add this Trait to the `FormInfo.php` for testing:
```php
use Drupal\va_gov_form_builder\Traits\RepeatableFieldGroup;

class FormInfo extends FormBuilderFormBase {

use RepeatableFieldGroup;
```

Added this code block to `FormInfo.php` for testing:
```php
    $field_definitions = [
      'label' => ['#type' => 'textfield', '#title' => 'Label for radio item', '#required' => TRUE],
      'description' => ['#type' => 'textfield', '#title' => 'Description for radio item'],
      'required' => [
        '#type' => 'checkbox',
        '#title' => $this->t('Required for the submitter'),
        '#displayIndexCount' => FALSE
      ],
    ];

    $this->addRepeatableFieldGroup($form, $form_state, 'dynamic_radio', $field_definitions, 1, 5, 'Radio Item');
```

Visit `/form-builder/76353/form-info` to see the repeatable fields + button


## Screenshots
Count starting at a higher index:
![Screenshot 2025-04-29 at 12 02 50 PM](https://github.com/user-attachments/assets/3b8956f6-6faf-440e-b0ce-223aa4f52371)

Button disappearing when max items reached:
![Screenshot 2025-04-29 at 12 02 53 PM](https://github.com/user-attachments/assets/6ddc6d6b-568c-414a-8e48-4b9cbd06aba3)

Validation only triggered when save & continue hit:
![Screenshot 2025-04-29 at 12 02 56 PM](https://github.com/user-attachments/assets/3fb6798f-fa96-4d5c-991e-c416962c7f1a)


## QA steps

- [ ] Checkout branch locally
- [ ] Add the code from above to the necessary file
- [ ] Verify functionality works as expected for 5 new items
- [ ] Update startIndex to `3` and `ddev drush cr`
- [ ] Refresh the page, see the item count start at 3 and add items.
- [ ] Verify form validation does not trigger on the ajax button, but on the `Save & Continue` button.
- [ ] Updated startIndex to `5` and `ddev drush cr`
- [ ] Verify no button appears on the page as the max limit has been reached already.
