### PR TITLE
Next preview fix

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -206,7 +206,7 @@ services:
       - ln -snf "${TUGBOAT_ROOT}/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
 
       # Update the .env file for the next build preview server
-      - sed -i 's|https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g' "${TUGBOAT_ROOT}/next/envs/.env.tugboat"
+      - sed -i "s|https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"
 
       # https://www.drush.org/latest/deploycommand/ (updatedb, cache:rebuild, config:import, deploy:hook)
       - bash -lc 'drush deploy'

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -205,6 +205,9 @@ services:
       - mkdir -p "${TUGBOAT_ROOT}/next/public"
       - ln -snf "${TUGBOAT_ROOT}/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
 
+      # Update the .env file for the next build preview server
+      - sed -i 's|https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g' "${TUGBOAT_ROOT}/next/envs/.env.tugboat"
+
       # https://www.drush.org/latest/deploycommand/ (updatedb, cache:rebuild, config:import, deploy:hook)
       - bash -lc 'drush deploy'
 

--- a/config/sync/simple_oauth.oauth2_scope.administrator.yml
+++ b/config/sync/simple_oauth.oauth2_scope.administrator.yml
@@ -1,0 +1,22 @@
+uuid: 2e8e2d03-6190-4040-9b8d-33dea0073c27
+langcode: en
+status: true
+dependencies: {  }
+id: administrator
+name: administrator
+description: administrator
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.admnistrator_users.yml
+++ b/config/sync/simple_oauth.oauth2_scope.admnistrator_users.yml
@@ -1,0 +1,22 @@
+uuid: b9cb23b4-6c3f-4473-aba8-8484c4f3fdc3
+langcode: en
+status: true
+dependencies: {  }
+id: admnistrator_users
+name: admnistrator_users
+description: admnistrator_users
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.content_admin.yml
+++ b/config/sync/simple_oauth.oauth2_scope.content_admin.yml
@@ -1,0 +1,22 @@
+uuid: ffbb0815-bac4-46c4-a90c-759a9afcc2e0
+langcode: en
+status: true
+dependencies: {  }
+id: content_admin
+name: content_admin
+description: content_admin
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.content_creator_benefits_hubs.yml
+++ b/config/sync/simple_oauth.oauth2_scope.content_creator_benefits_hubs.yml
@@ -1,0 +1,22 @@
+uuid: 87a444fe-4d74-4674-8954-9fd56dc3e9aa
+langcode: en
+status: true
+dependencies: {  }
+id: content_creator_benefits_hubs
+name: content_creator_benefits_hubs
+description: content_creator_benefits_hubs
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.content_creator_vba.yml
+++ b/config/sync/simple_oauth.oauth2_scope.content_creator_vba.yml
@@ -1,0 +1,22 @@
+uuid: e2055878-770b-4314-9082-ab9abaa69e5b
+langcode: en
+status: true
+dependencies: {  }
+id: content_creator_vba
+name: content_creator_vba
+description: content_creator_vba
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.content_creator_vet_center.yml
+++ b/config/sync/simple_oauth.oauth2_scope.content_creator_vet_center.yml
@@ -1,0 +1,22 @@
+uuid: af9ef6b9-7b98-4b84-a458-79ce0eba8738
+langcode: en
+status: true
+dependencies: {  }
+id: content_creator_vet_center
+name: content_creator_vet_center
+description: content_creator_vet_center
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.content_editor.yml
+++ b/config/sync/simple_oauth.oauth2_scope.content_editor.yml
@@ -1,0 +1,22 @@
+uuid: 9c7aad88-e496-4d52-8044-78a0909098c3
+langcode: en
+status: true
+dependencies: {  }
+id: content_editor
+name: content_editor
+description: content_editor
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.content_publisher.yml
+++ b/config/sync/simple_oauth.oauth2_scope.content_publisher.yml
@@ -1,0 +1,22 @@
+uuid: 8c129e9d-1149-497e-a973-64e07774901d
+langcode: en
+status: true
+dependencies: {  }
+id: content_publisher
+name: content_publisher
+description: content_publisher
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.content_reviewer.yml
+++ b/config/sync/simple_oauth.oauth2_scope.content_reviewer.yml
@@ -1,0 +1,22 @@
+uuid: 7acbac6c-ff4a-4532-aa6b-2cfca42277f4
+langcode: en
+status: true
+dependencies: {  }
+id: content_reviewer
+name: content_reviewer
+description: content_reviewer
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.next_js.yml
+++ b/config/sync/simple_oauth.oauth2_scope.next_js.yml
@@ -6,13 +6,17 @@ id: next_js
 name: next_js
 description: Next.js
 grant_types:
+  refresh_token:
+    status: false
+    description: ''
   authorization_code:
-    status: true
+    status: false
+    description: ''
   client_credentials:
     status: true
-  refresh_token:
-    status: true
+    description: ''
 umbrella: false
-parent: null
-granularity_id: null
-granularity_configuration: {  }
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js

--- a/config/sync/simple_oauth.oauth2_scope.vamc_content_creator.yml
+++ b/config/sync/simple_oauth.oauth2_scope.vamc_content_creator.yml
@@ -1,0 +1,22 @@
+uuid: 445eefe8-effd-4ba8-a947-c213ea3b7d51
+langcode: en
+status: true
+dependencies: {  }
+id: vamc_content_creator
+name: vamc_content_creator
+description: vamc_content_creator
+grant_types:
+  refresh_token:
+    status: false
+    description: ''
+  authorization_code:
+    status: false
+    description: ''
+  client_credentials:
+    status: true
+    description: ''
+umbrella: false
+parent: _none
+granularity_id: role
+granularity_configuration:
+  role: next_js


### PR DESCRIPTION
## Description
This PR adds a scope for each role that may need to use next preview. This is due to Drupal module updates for Next and simple_oauth. This combined with a change to the consumer entity on prod after this is merged will restore the preview for pages built with Next.

Also included is an enhancement for tugboat that will allow previews to work in PR tugboats and link the next & Drupal that are built with Tugboat.

Relates to #21229

### Generated description
This pull request introduces updates to the Tugboat configuration and adds several new OAuth2 scopes for improved role-based access control. The most significant changes include modifying the `.env` file for the Tugboat build preview server and defining new OAuth2 scopes for various user roles, which standardize the granularity configuration for Next.js roles.

### Tugboat Configuration Updates:
* Updated the `.env` file for the Tugboat build preview server to replace a hardcoded URL with the default service URL dynamically. This ensures the configuration is more adaptable across environments. (`.tugboat/config.yml`, [.tugboat/config.ymlR208-R210](diffhunk://#diff-fbd0812762ff8d2c67fa66a4956c3b55557ad0889505294f524192000b2ce50eR208-R210))

### OAuth2 Scope Additions:
* Added new OAuth2 scopes for the following roles: `administrator`, `admnistrator_users`, `content_admin`, `content_creator_benefits_hubs`, `content_creator_vba`, `content_creator_vet_center`, `content_editor`, `content_publisher`, `content_reviewer`, and `vamc_content_creator`. These configurations define role-based access with `client_credentials` as the active grant type. (`config/sync/simple_oauth.oauth2_scope.*.yml`, [[1]](diffhunk://#diff-74439a60482b22b368c0451e08599528fca8f2f4c05345adc2c5822173bd0d8cR1-R22) [[2]](diffhunk://#diff-0e0566ce590f3fa6097f409719907bf23251a7f7d878410b3b99c7f6d0a12797R1-R22) [[3]](diffhunk://#diff-c15d17f52b34ba5b422e9cd1a332239178871b988f46a90cfc109d4544493669R1-R22) [[4]](diffhunk://#diff-ec56c4e5a30eac11e2de02d28a7a64bb7d63bca1e800f83ae0af9e8e2684b7bbR1-R22) [[5]](diffhunk://#diff-af8360d92a34f1921a6dacf1e4cb8e780c7577cd8f28a79b788cb4a5fd4800f0R1-R22) [[6]](diffhunk://#diff-892a47d552986263b62b2d55211b7440e718eef47c23faa9c48bfe80084db552R1-R22) [[7]](diffhunk://#diff-272f1aa70f9b228265c7c5b30ad84327800378d14cdd926a8237fb74bd570c92R1-R22) [[8]](diffhunk://#diff-1999e98d2798362f623cfa821944fdebf7323211951fc9a9c529e7e53f918255R1-R22) [[9]](diffhunk://#diff-7e3c8a1be5d6b1d09b44c0a42db8f9f9ab0d37ee3598703922749253a347a392R1-R22) [[10]](diffhunk://#diff-d4d0481341123589346ccabb7d2a32c11852dab75fe7fd2a97251e0398acb0c7R1-R22)
* Updated the existing `next_js` OAuth2 scope to align its granularity configuration with the new scopes, specifying `role: next_js` and deactivating the `authorization_code` and `refresh_token` grant types. (`config/sync/simple_oauth.oauth2_scope.next_js.yml`, [config/sync/simple_oauth.oauth2_scope.next_js.ymlR9-R22](diffhunk://#diff-2ee05506548126a4681874786cad5113ccf7603e2abb1c7e045c9ffc640da7adR9-R22))

## Testing done
Manual testing in local environments and Tugboat enviroments.

## QA steps
 - log into tugboat: https://pr21240-16oxej9ellvyegabr2xxylysk5b4xr6d.ci.cms.va.gov/
 - navigate to content https://pr21240-16oxej9ellvyegabr2xxylysk5b4xr6d.ci.cms.va.gov/admin/content
 - filter to events
 - click the title of any event
 - once the page loads, click the Preview button
 - verify that the preview loads in the Next environment built by this tugboat (https://next-16oxej9ellvyegabr2xxylysk5b4xr6d.ci.cms.va.gov/)
 - go back to Drupal and edit an event, then save as Draft
 - now click the Preview button from the draft
 - verify that the draft version loads in the Next environment built by this tugboat 
 - navigate over to users https://pr21240-16oxej9ellvyegabr2xxylysk5b4xr6d.ci.cms.va.gov/admin/people
 - find a user with the role of `Content creator` or `Content admin`
 - edit this user to have a password like `drupal8`
 - in an incognito tab, log in as this user
 - repeat the steps for viewing current event preview and draft preview

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
