### PR TITLE
VACMS-21104: Admin Access Review

### DIFF
--- a/config/sync/eca.eca.administrative_users.yml
+++ b/config/sync/eca.eca.administrative_users.yml
@@ -1,0 +1,64 @@
+uuid: 883779b3-d5b5-44f2-b216-adf2b0990a4b
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.administrative_users
+  module:
+    - eca_base
+    - eca_content
+    - eca_views
+id: administrative_users
+modeller: core
+label: 'Administrative Users'
+version: '1.0'
+weight: 0
+events:
+  eca_base_eca_custom:
+    plugin: 'eca_base:eca_custom'
+    label: 'Administrative Users List'
+    configuration:
+      event_id: administrative_users_list
+    successors:
+      -
+        id: eca_views_query
+        condition: null
+  content_entity_custom:
+    plugin: 'content_entity:custom'
+    label: 'Parse Administrative Results'
+    configuration:
+      event_id: parse_administrative_results
+    successors:
+      -
+        id: action_message_action
+        condition: null
+conditions: {  }
+gateways: {  }
+actions:
+  eca_views_query:
+    plugin: eca_views_query
+    label: 'Views: Execute query'
+    configuration:
+      token_name: results
+      view_id: administrative_users
+      display_id: default
+      arguments: ''
+    successors:
+      -
+        id: eca_trigger_content_entity_custo
+        condition: null
+  action_message_action:
+    plugin: action_message_action
+    label: 'Display a message to the user'
+    configuration:
+      message: "This is the data we found:\r\nThis user named [entity:name] with an email of [entity:mail] has the roles [entity:roles]"
+      replace_tokens: true
+    successors: {  }
+  eca_trigger_content_entity_custo:
+    plugin: eca_trigger_content_entity_custom_event
+    label: 'Trigger a custom event (entity-aware)'
+    configuration:
+      event_id: parse_administrative_results
+      tokens: ''
+      object: results
+    successors: {  }

--- a/config/sync/node_link_report.settings.yml
+++ b/config/sync/node_link_report.settings.yml
@@ -9,9 +9,11 @@ domains_to_skip: |-
   acemapp.org
   agif-nvop.org
   ashevillerelief.org
+  aspr.hhs.gov
   bddy.me
   ccgov.org
   charlesajudge.com
+  county.milwaukee.gov
   dartfirststate.com
   databus.org
   dea.gov
@@ -22,9 +24,11 @@ domains_to_skip: |-
   ez-rider.org
   fcp.vetpro.org
   federalregister.gov
+  ffr.cnic.navy.mil
   hamptoninn3.hilton.com
   help.id.me
   hiltongardeninn3.hilton.com
+  https://aspr.hhs.gov/Pages/Home.aspx
   imablefoundation.org
   jobs.kontactintelligence.com
   journals.sagepub.com
@@ -84,6 +88,7 @@ domains_to_skip: |-
   www.militaryonesource.mil
   www.milvets.nc.gov
   www.music4veterans.org
+  www.mynavyhr.navy.mil
   www.onlinelibrary.wiley.com
   www.opm.gov
   www.portauthority.org

--- a/config/sync/views.view.administrative_users.yml
+++ b/config/sync/views.view.administrative_users.yml
@@ -1,0 +1,372 @@
+uuid: 82855561-b34d-43d0-8126-db0f9160c76a
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.admin
+    - user.role.administrator
+    - user.role.admnistrator_users
+    - user.role.content_admin
+    - user.role.redirect_administrator
+  module:
+    - user
+id: administrative_users
+label: 'Administrative Users'
+module: views
+description: 'Get users with administrative role'
+tag: ''
+base_table: users_field_data
+base_field: uid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Administrative Users'
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        mail:
+          id: mail
+          table: users_field_data
+          field: mail
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
+          label: Email
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+          label: Roles
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: separator
+          separator: ', '
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h2
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: users_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+          operator: or
+          value:
+            content_admin: content_admin
+            redirect_administrator: redirect_administrator
+            admnistrator_users: admnistrator_users
+            administrator: administrator
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            name: name
+          default: '-1'
+          info:
+            name:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        jsonapi_views:
+          enabled: true
+      path: admin/reports/administrative-users
+      menu:
+        type: normal
+        title: 'Administrative Users'
+        menu_name: admin
+        parent: system.admin_reports
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }


### PR DESCRIPTION
Set up a view for admin users that creates a report and a simple ECA model that uses the view

## Description

Closes #_21104_

### Generated description

This pull request introduces a new feature for managing administrative users and updates the list of domains to skip in link reports. The most important changes include the addition of a new ECA configuration for administrative users, a new view for displaying administrative user details, and updates to the `domains_to_skip` configuration.

### New Feature: Administrative Users Management
* Added a new ECA configuration in `config/sync/eca.eca.administrative_users.yml` to define events, actions, and workflows for managing administrative users. This includes custom events for querying and parsing administrative user data and displaying messages to users.
* Added a new view in `config/sync/views.view.administrative_users.yml` to retrieve and display users with administrative roles. This includes fields for user name, email, and roles, as well as filters for active users and specific roles.

### Updates to Link Report Configuration
* Updated the `domains_to_skip` list in `config/sync/node_link_report.settings.yml` to include additional domains such as `aspr.hhs.gov`, `county.milwaukee.gov`, `ffr.cnic.navy.mil`, and others. These domains will now be skipped during link validation. [[1]](diffhunk://#diff-b6ddd061e8b58a4b67dcd8118447fad5ecf86ad46aceef523d9aec603e227626R12-R16) [[2]](diffhunk://#diff-b6ddd061e8b58a4b67dcd8118447fad5ecf86ad46aceef523d9aec603e227626R27-R31) [[3]](diffhunk://#diff-b6ddd061e8b58a4b67dcd8118447fad5ecf86ad46aceef523d9aec603e227626R91)

## Testing done
1. On command line execute `ddev drush eca:trigger:custom_event administrative_users_list`
 - Should get a list of users with some sort of administrative role.
2. Navigate to Reports > Administrative Users
 - Should see a listing of users with some sort of administrative role.

## Screenshots
<img width="1500" alt="Screenshot 2025-04-30 at 14 58 51" src="https://github.com/user-attachments/assets/64a1b426-b453-417f-9582-ba4f7dc5930e" />
<img width="1498" alt="Screenshot 2025-04-30 at 14 59 16" src="https://github.com/user-attachments/assets/8536769e-677e-4c6f-9a94-525780e71fdd" />


## QA steps
As admin
1. Do this
   - [ ] Validate that Administrative Users report exists
2. Then
   - [ ] Validate that Administrative User Report produces a list of users with any sort of administrative role
3. Then
   - [ ] On command line execute command `ddev drush eca:trigger:custom_event administrative_users_list`
   - [ ] Validate a list of users with any sort of administrative role is produced

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [x ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ x] `DO NOT MERGE` Until you speak with Sofia Kirkman

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
