### PR TITLE
Make step color in KB articles higher contrast.

### DIFF
--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_process_list.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_process_list.scss
@@ -9,7 +9,7 @@
     padding-left: 1.94em;
 
     > li {
-      border-left: 8px solid var(--va-gray-lightest);
+      border-left: 8px solid var(--va-blue-dark);
       counter-increment: process-counter;
       line-height: 1.5;
       list-style: none;
@@ -21,7 +21,7 @@
       }
 
       &::before {
-        background: var(--va-gray-lightest);
+        background: var(--va-blue-dark);
         border: 4px solid var(--va-white);
         border-radius: 4em;
         color: var(--va-white);


### PR DESCRIPTION
## Description

Just makes step style in kb articles higher contrast. 


## QA steps

1. Visit `/node/9421/edit`
2. Add a Process List component in the content. Make sure to add at least 3 steps. The content doesn't matter. Save as published.
3. Check the look of the numbers and the border connecting them. They should be dark blue. See screenshots below.

Before:
<img width="301" alt="image" src="https://github.com/user-attachments/assets/69e0560c-bacf-427f-8afa-adf781861002" />

After:
<img width="272" alt="image" src="https://github.com/user-attachments/assets/8bd9738c-0aaf-43e4-88cb-c2873f70bb26" />


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

