### PR TITLE
VAGOV-TEAM-108810 add plain language title to form builder ui flow

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/css/form-info.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/form-info.css
@@ -8,6 +8,7 @@
 
 .form-builder-content-section {
   border-bottom: 1px solid var(--vads-color-base-light);
+  margin: var(--units-2) 0;
 }
 
 h3.form-builder-content-section__header {

--- a/docroot/modules/custom/va_gov_form_builder/src/Form/FormInfo.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Form/FormInfo.php
@@ -53,6 +53,13 @@ class FormInfo extends FormBuilderFormBase {
       '#default_value' => $this->getDigitalFormFieldValue('field_va_form_number'),
     ];
 
+    $form['plain_language_title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t("Plain language sentence of this form's purpose to use as a header on all pages"),
+      '#required' => TRUE,
+      '#default_value' => $this->getDigitalFormFieldValue('field_plain_language_title'),
+    ];
+
     $form['omb_number'] = [
       '#type' => 'textfield',
       '#title' => $this->t('OMB number'),
@@ -100,6 +107,7 @@ class FormInfo extends FormBuilderFormBase {
   protected function setDigitalFormFromFormState(FormStateInterface $form_state) {
     $title = $form_state->getValue('title');
     $vaFormNumber = $form_state->getValue('va_form_number');
+    $plainLanguageTitle = $form_state->getValue('plain_language_title');
     $ombNumber = $form_state->getValue('omb_number');
     $respondentBurden = $form_state->getValue('respondent_burden');
     $expirationDate = $form_state->getValue('expiration_date');
@@ -113,6 +121,7 @@ class FormInfo extends FormBuilderFormBase {
       $this->digitalForm = $this->digitalFormsService->createDigitalForm([
         'title' => $title,
         'field_va_form_number' => $vaFormNumber,
+        'field_plain_language_title' => $plainLanguageTitle,
         'field_omb_number' => $ombNumber,
         'field_respondent_burden' => $respondentBurden,
         'field_expiration_date' => $expirationDate,
@@ -132,6 +141,7 @@ class FormInfo extends FormBuilderFormBase {
        */
       $this->digitalForm->set('title', $title);
       $this->digitalForm->set('field_va_form_number', $vaFormNumber);
+      $this->digitalForm->set('field_plain_language_title', $plainLanguageTitle);
       $this->digitalForm->set('field_omb_number', $ombNumber);
       $this->digitalForm->set('field_respondent_burden', $respondentBurden);
       $this->digitalForm->set('field_expiration_date', $expirationDate);
@@ -149,6 +159,7 @@ class FormInfo extends FormBuilderFormBase {
       self::setFormErrors($form_state, $violations, [
         'title' => $form['title'],
         'field_va_form_number' => $form['va_form_number'],
+        'field_plain_language_title' => $form['plain_language_title'],
         'field_omb_number' => $form['omb_number'],
         'field_respondent_burden' => $form['respondent_burden'],
         'field_expiration_date' => $form['expiration_date'],

--- a/docroot/modules/custom/va_gov_form_builder/templates/form/form-info.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/form/form-info.html.twig
@@ -10,6 +10,11 @@
     {{ form.title }}
     {{ form.va_form_number }}
   </section>
+  <section class="form-builder-content-section">
+    <p>Provide the header that tells the user what the form will do, such as: <em>Register for this program...</em>, or <em>Provide your documentation</em>, etc.'),</p>
+
+    {{ form.plain_language_title }}
+  </section>
   <section class="form-builder-content-section form-builder-content-section--omb-info">
     <h3 class="form-builder-content-section__header form-builder-content-section--omb-info__header">OMB information</h3>
     {{ form.omb_number }}
@@ -23,6 +28,7 @@
     'status_messages',
     'title',
     'va_form_number',
+    'plain_language_title',
     'omb_number',
     'respondent_burden',
     'expiration_date',

--- a/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/FormInfoTest.php
@@ -182,6 +182,7 @@ class FormInfoTest extends VaGovExistingSiteBase {
     $formInput = [
       'title' => 'Test Title',
       'va_form_number' => self::getUniqueVaFormNumber(),
+      'plain_language_title' => 'A title for testing',
       'omb_number' => '1111-1111',
       'respondent_burden' => '15',
       'expiration_date' => '2024-10-03',
@@ -201,6 +202,7 @@ class FormInfoTest extends VaGovExistingSiteBase {
     $formInput = [
       'title' => 'Test Title',
       'va_form_number' => self::getUniqueVaFormNumber(),
+      'plain_language_title' => 'A title for testing',
       'omb_number' => '1111-1111',
       'respondent_burden' => '15',
       // 'expiration_date' is required but missing


### PR DESCRIPTION
## Description

Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/108810


## Testing done
Verified the field was present on the FormInfo step & that it prefilled properly if already saved on a digital form node via normal drupal node operations.

## Screenshots

![Screenshot 2025-05-01 at 10 43 48 AM](https://github.com/user-attachments/assets/961b1e2f-b538-47e3-a4e5-64fa02dfe68f)


## QA steps

Visit the FormInfo page via the Form Builder UI for any form and note that the field is present (and auto-filled, if checking the employment questionnaire form)
