### PR TITLE
initial tests for JSON API

### DIFF
--- a/READMES/testing.md
+++ b/READMES/testing.md
@@ -286,6 +286,29 @@ set +o allexport
 
 This will rerun the Cypress tests one by one and may resolve any failures that were due to paralellization
  
+## Testing JSON API
+
+As part of building a page type with [next-build](https://github.com/department-of-veterans-affairs/next-build/) tests should be added to ensure that the queries required to build those pages are functional. These tests are located in `/tests/cypress/integration/features/api/`. They can be as simple as 
+```
+I should receive status code 200 when I request "[JSON API path with required includes and filters]"
+```
+
+For some more complex pages like listing pages, they should attempt to test the full cycle of requests. For example these are the requests for an event listing page:
+
+- GET /router/translate-path?path=%2Fboston-health-care%2Fevents
+
+The UUID returned as part of that response is then used here
+
+- GET /jsonapi/node/event_listing/82de8912-23ac-4e97-b504-744015e38683?include=field_office
+
+The UUIDs and condition values from that response are then used to fetch the event teasers below
+
+- GET /jsonapi/node/event?filter%5Boutreach_cal_group%5D%5Bgroup%5D%5Bconjunction%5D=OR&filter%5Bfield_listing.id%5D%5Bcondition%5D%5Bpath%5D=field_listing.id&filter%5Bfield_listing.id%5D%5Bcondition%5D%5Bvalue%5D=82de8912-23ac-4e97-b504-744015e38683&filter%5Bfield_listing.id%5D%5Bcondition%5D%5BmemberOf%5D=outreach_cal_group&include=field_listing%2Cfield_administration%2Cfield_facility_location&page%5Blimit%5D=50&page%5Boffset%5D=0&sort=-create
+
+- GET /jsonapi/node/event?filter%5Boutreach_cal_group%5D%5Bgroup%5D%5Bconjunction%5D=OR&filter%5Bfield_listing.id%5D%5Bcondition%5D%5Bpath%5D=field_listing.id&filter%5Bfield_listing.id%5D%5Bcondition%5D%5Bvalue%5D=82de8912-23ac-4e97-b504-744015e38683&filter%5Bfield_listing.id%5D%5Bcondition%5D%5BmemberOf%5D=outreach_cal_group&include=field_listing%2Cfield_administration%2Cfield_facility_location&page%5Blimit%5D=50&page%5Boffset%5D=50&sort=-created
+
+To do this, a single step definition could be created to intake the translate-path route and then assert the rest.
+
 ----
 
 [Table of Contents](../README.md)

--- a/tests/cypress/integration/features/api/event.feature
+++ b/tests/cypress/integration/features/api/event.feature
@@ -1,0 +1,5 @@
+Feature: API
+
+  Scenario: JSON API consumer can access event nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "jsonapi/node/event?page[limit]=1&include=field_media%2Cfield_media.image%2Cfield_listing%2Cfield_listing.field_office%2Cfield_administration%2Cfield_facility_location"

--- a/tests/cypress/integration/features/api/event_listing.feature
+++ b/tests/cypress/integration/features/api/event_listing.feature
@@ -1,0 +1,8 @@
+Feature: API
+
+  Scenario: JSON API consumer can access route translation for a given event_listing
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care%2Fevents"
+  Scenario: JSON API consumer can access event_listing nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/jsonapi/node/event_listing?page[limit]=1&include=field_administration&sort=-created"


### PR DESCRIPTION
## Description

This PR adds some simple JSON API tests to our cypress tests. Also the readme proposes a plan to expand upon these tests.

Relates to #21169

### Generated description

This pull request introduces documentation and test updates to ensure the functionality of JSON API endpoints for building page types with `next-build`. The key changes include adding a new section in the documentation for testing JSON APIs and creating Cypress tests for event and event listing endpoints.

### Documentation Updates:

* Added a new section in `READMES/testing.md` explaining how to test JSON API endpoints, including examples for basic and complex scenarios like event listing pages.

### Test Additions:

* Added a new Cypress test in `tests/cypress/integration/features/api/event.feature` to verify access to event nodes via the JSON API.
* Added a new Cypress test in `tests/cypress/integration/features/api/event_listing.feature` to validate route translation and access to event listing nodes via the JSON API.


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


