### PR TITLE
Disable workflow-on-push for build docs.

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -7,10 +7,10 @@
 name: Build and Deploy Docs
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - "READMES/**"
+  # push:
+  #   branches: ["main"]
+  #   paths:
+  #     - "READMES/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -39,10 +39,10 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7' # Not needed with a .ruby-version file
+          ruby-version: "2.7" # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-          working-directory: '${{ github.workspace }}/READMES'
+          working-directory: "${{ github.workspace }}/READMES"
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Description

This just disables automatic run of the build docs workflow for the time being, since the version on `main` is not ready.

