### PR TITLE
VAGOV-TEAM-106482: Radio and checkbox improvements from walkthrough

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/css/custom-single-question-response.css
+++ b/docroot/modules/custom/va_gov_form_builder/css/custom-single-question-response.css
@@ -14,7 +14,6 @@
 }
 
 .form-builder-single-question-response__type {
-  margin-bottom: var(--units-6);
   margin-top: var(--units-1);
 }
 
@@ -23,6 +22,14 @@
   font-size: var(--font-size-h2);
   font-weight: var(--font-weight-bold);
   line-height: 3;
+}
+
+.form-builder-single-question-response__type #response-type {
+  font-family: var(--font-family-serif);
+  font-size: var(--font-size-h2);
+  font-weight: var(--font-weight-bold);
+  line-height: 3;
+  margin-bottom: var(--units-3);
 }
 
 .form-builder-single-question-response__preview {
@@ -61,3 +68,8 @@
 .form-builder-single-question-response__guidance-details p {
   line-height: .75;
 }
+
+.form-builder-single-question-response__preview img {
+  max-width: 600px;
+}
+

--- a/docroot/modules/custom/va_gov_form_builder/templates/form/custom-single-question-checkbox-response.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/form/custom-single-question-checkbox-response.html.twig
@@ -17,18 +17,19 @@
       <div id="page-title">{{ form['#page_title'] ?: 'None provided' }}</div>
     </div>
 
+    {{ form.checkbox_fields.0.required }}
+
     <div class="form-builder-single-question-response__page-body">
       <label for="page-body">Body content:</label>
       <div id="page-body">{{ form['#page_body'] ?: 'None provided' }}</div>
     </div>
 
     <div class="form-builder-single-question-response__type">
-      <label for="guidance">Checkbox</label>
-      <p id="guidance">Guidance for this choice</p>
+      <p id="response-type">Checkbox</p>
     </div>
 
     <div class="form-builder-single-question-response__components">
-      {{ form.checkbox_fields }}
+      {{ form.checkbox_fields.0|without('required') }}
     </div>
 
     <div class="form-builder-single-question-response__guidance">

--- a/docroot/modules/custom/va_gov_form_builder/templates/form/custom-single-question-radio-response.html.twig
+++ b/docroot/modules/custom/va_gov_form_builder/templates/form/custom-single-question-radio-response.html.twig
@@ -17,18 +17,19 @@
       <div id="page-title">{{ form['#page_title'] ?: 'None provided' }}</div>
     </div>
 
+    {{ form.radio_button_fields.0.required }}
+
     <div class="form-builder-single-question-response__page-body">
       <label for="page-body">Body content:</label>
       <div id="page-body">{{ form['#page_body'] ?: 'None provided' }}</div>
     </div>
 
     <div class="form-builder-single-question-response__type">
-      <label for="guidance">Radio Button</label>
-      <p id="guidance">Guidance for this choice</p>
+      <p id="response-type">Radio Button</p>
     </div>
 
     <div class="form-builder-single-question-response__components">
-      {{ form.radio_button_fields }}
+      {{ form.radio_button_fields.0|without('required') }}
     </div>
 
     <div class="form-builder-single-question-response__guidance">


### PR DESCRIPTION
## Description

Minor changes for radio and checkbox responses:
- Moves the 'required' field up next to the title
- Adds a maximum width to preview images (right sidebar) for consitency
- Remove guidance text
- Adjusts some styling due to removing guidance text

Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/106477

### Generated description
(Select this text, hit the Copilot button, and select "Generate".)

## Testing done
Tested radio and checkboxes in both new and edit response pages.

## Screenshots
<img width="724" alt="Screenshot 2025-05-07 at 11 43 01 AM" src="https://github.com/user-attachments/assets/0fe56936-cc66-4952-ab6b-6d8498b9e043" />


## QA steps
- [ ] Verify required field has been moved under the title for radio and checkbox responses
- [ ] Verify preview images for radio and checkbox responses are limited to 600px
- [ ] Verify guidance is gone
- [ ] Verify response type margin is acceptable (~24px)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
