### PR TITLE
VACMS-21096: Adds a test for insecure_uploads and a runtime setting.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -303,3 +303,6 @@ $databases['default']['default']['init_commands']['isolation_level'] = 'SET SESS
 
 
 $settings['state_cache'] = TRUE;
+
+// Disable the use of insecure uploads.
+$config['system.file']['allow_insecure_uploads'] = FALSE;

--- a/tests/phpunit/Security/AllowInsecureUploadsTest.php
+++ b/tests/phpunit/Security/AllowInsecureUploadsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace tests\phpunit\Security;
+
+use Tests\Support\Classes\VaGovExistingSiteBase;
+
+/**
+ * A test to confirm that allow_insecure_uploads is always set to false.
+ *
+ * @group functional
+ * @group security
+ */
+class AllowInsecureUploadsTest extends VaGovExistingSiteBase {
+
+  /**
+   * Test that allow_insecure_uploads is always set to false.
+   */
+  public function testAllowInsecureUploadsIsFalse() {
+    // Load the system.file configuration.
+    $config = $this->container->get('config.factory')->get('system.file');
+
+    // Assert that allow_insecure_uploads is set to false.
+    $this->assertFalse(
+      $config->get('allow_insecure_uploads'),
+      'The allow_insecure_uploads setting is not set to false.'
+    );
+  }
+
+}


### PR DESCRIPTION
## Description

Relates to #21096

### Generated description
This pull request focuses on improving security by disabling insecure file uploads and adding a corresponding test to ensure this configuration remains enforced.

### Security improvements:

* [`docroot/sites/default/settings.php`](diffhunk://#diff-b80b0a60af550f2090849fc9fd25fb09aa1022a91461c49e16fa1a2f0657ac54R306-R308): Added a configuration setting to disable insecure file uploads by setting `$config['system.file']['allow_insecure_uploads']` to `FALSE`.

### Testing enhancements:

* [`tests/phpunit/Security/AllowInsecureUploadsTest.php`](diffhunk://#diff-1dfb8b28a42ad880a3f5dcf6c9037f2783f9e1273cf08638ed3514d9d36d2721R1-R29): Introduced a new PHPUnit test class, `AllowInsecureUploadsTest`, to verify that the `allow_insecure_uploads` configuration is always set to `FALSE`. This ensures the security setting is not inadvertently changed.
## Testing done
PHPUnit
Manually

## QA steps
The following steps show that though the allow_insecure_uploads can be changed in the database (via drush), the settings.php file overrides this at runtime.

- [x] In the [Tugboat terminal](https://tugboat.vfs.va.gov/tush/681ca94609d190440b11abc4) the phpunit test: `phpunit --filter  testAllowInsecureUploadsIsFalse tests/phpunit/Security/AllowInsecureUploadsTest.php`
- [x] Confirm that the test passes
- [x] In the terminal run `drush cget system.file allow_insecure_uploads`
- [x] Confirm that the output is "'system.file:allow_insecure_uploads': false"
- [x] In the terminal, run `drush cset system.file allow_insecure_uploads true --input-format=yaml -y`
- [x] In the terminal run `drush cget system.file allow_insecure_uploads`
- [x] Confirm that the output is "'system.file:allow_insecure_uploads': true"
- [x] In the terminal run the phpunit test: `phpunit --filter  testAllowInsecureUploadsIsFalse tests/phpunit/Security/AllowInsecureUploadsTest.php`
- [x] Confirm that the test passes
- [x] In the terminal, run `drush php:eval "\$value = \Drupal::config('system.file')->get('allow_insecure_uploads'); var_dump(\$value);"`
- [x] Confirm that the output is "(bool)false"

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
