### PR TITLE
VACMS-21274: update va-gov/content-build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,7 +231,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "0.0.3740",
+        "va-gov/content-build": "^0.0.3743",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84563859a4f74a4175e977e8e4ceac7c",
+    "content-hash": "c0bd6d1a54821284e4a48058aaf22b00",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27387,16 +27387,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3740",
+            "version": "v0.0.3743",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "6733e7aeb14ca017561068a7021d03340fa88b67"
+                "reference": "3a9167844741000dfd708d81b9de1087c4680b87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/6733e7aeb14ca017561068a7021d03340fa88b67",
-                "reference": "6733e7aeb14ca017561068a7021d03340fa88b67",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/3a9167844741000dfd708d81b9de1087c4680b87",
+                "reference": "3a9167844741000dfd708d81b9de1087c4680b87",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27423,9 +27423,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3740"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3743"
             },
-            "time": "2025-05-01T13:26:49+00:00"
+            "time": "2025-05-08T14:15:25+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description

Closes #21274

### Generated description

This pull request updates the version constraint for the `va-gov/content-build` dependency in the `composer.json` file to allow for newer versions.

Dependency update:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L234-R234): Updated `va-gov/content-build` from a fixed version (`0.0.3740`) to a flexible version constraint (`^0.0.3743`), enabling compatibility with newer versions starting from `0.0.3743`.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If this passes automated testing it should be good.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
