### PR TITLE
VAGOV-TEAM-109371 add menu item for form builder

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.links.menu.yml
+++ b/docroot/modules/custom/va_gov_form_builder/va_gov_form_builder.links.menu.yml
@@ -1,0 +1,6 @@
+va_gov_form_builder.form_builder:
+  title: 'Form Builder'
+  description: 'Main hub for managing Digital Forms with Form Builder'
+  parent: system.admin_content
+  route_name: 'va_gov_form_builder.entry'
+  weight: 5


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/109371

## Testing done

Verified that a link to Form Builder was under the Content menu.

## Screenshots
![Screenshot 2025-05-08 at 11 07 28 AM](https://github.com/user-attachments/assets/d84662d2-40b1-4925-b2f3-5528d353409e)

Interestingly, `weight: 5` put it much higher on the list in my local environment. In tugboat, you can see the added `Form Builder` link above `Menus`

## QA steps

Log in, see `Form Builder` under the Content menu. Verify the link takes you to the Form Builder homepage.