### PR TITLE
VAGOV-TEAM-109413: Removes access checks on paragraph base class.

### DIFF
--- a/docroot/modules/custom/va_gov_form_builder/src/Entity/Paragraph/FormBuilderParagraphBase.php
+++ b/docroot/modules/custom/va_gov_form_builder/src/Entity/Paragraph/FormBuilderParagraphBase.php
@@ -107,12 +107,7 @@ abstract class FormBuilderParagraphBase extends Paragraph implements FormBuilder
     // If this is a new Paragraph, it has not been saved, therefore there is no
     // parent node or paragraph to persist changes made by the action.
     $result = AccessResult::allowedIf(!$this->isNew());
-    // Check delete access if needed.
-    if ($action->getKey() === 'delete') {
-      $result = $result->andIf($this->access(operation: 'delete', return_as_object: TRUE));
-    }
-    // Prevent action if parent cannot be updated.
-    $result = $result->andIf($this->getParentEntity()->access(operation:'update', return_as_object: TRUE));
+
     // Ensure this Paragraph has this action in its ActionCollection.
     return $result->andIf(AccessResult::allowedIf($this->actionCollection->has($action->getKey())));
   }


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/109413

Removes access checks so non-admin Form Builder users can see paragraph-action controls.

## Testing done
- Ensures the paragraph actions appear for both admins and non-admin users.

## Screenshots
![image](https://github.com/user-attachments/assets/de95f2b6-a6f7-4492-9b10-e5b6bf75667b)


## QA steps

As a *non-admin* Form Builder user:
1. View form-layout page of a form with multiple steps, or step-layout page of a step with multiple pages:
   - [ ] Validate that paragraph actions are displayed.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
- [ ] `Form Engine`

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
