### PR TITLE
VACMS-21097: Adds root-restricted condition to .htaccess

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -168,7 +168,7 @@ AddEncoding gzip svgz
   # because Drupal may be located in a subdirectory. To further improve
   # security, you can replace '!/' with '!^/'.
   # Allow access to PHP files in /core (like authorize.php or install.php):
-  RewriteCond %{REQUEST_URI} !/core/[^/]*\.php$
+  RewriteCond %{REQUEST_URI} !^/core/[^/]*\.php$
   # Allow access to test-specific PHP files:
   RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?.php
   # Allow access to Statistics module's custom front controller.


### PR DESCRIPTION
## Description

Relates to #21097

This change makes it so that any non-core .php file is returns a 403.

### Generated description
This pull request includes a minor adjustment to the `.htaccess` file to improve the accuracy of a rewrite condition.

* [`docroot/.htaccess`](diffhunk://#diff-97a20696a8f6a925104f5174167c8c6f73dd7606b1f7f263dea1f1d9e23969cbL171-R171): Updated the regular expression in a `RewriteCond` directive to use `^/core/` instead of `/core/` for more precise matching of PHP files in the `/core` directory.

## Testing done
Manual

## QA steps
- [x] Go to the [terminal](https://tugboat.vfs.va.gov/tush/681e498e09d190440b25416e)
- [x] Make a directory under files:  `mkdir docroot/sites/default/files/core`
- [x] Create a .php file: `vi docroot/sites/default/files/core/test.php`
Add the following lines:
```
<?php
phpinfo();
```
- [x] Save the file
- [x] Go to the file: https://pr21334-ik7fw9rn5ciwub9layzsis6db7d1lqoj.ci.cms.va.gov/sites/default/core/test.php
- [x] Confirm that you receive a 403 response.

### Confirm that you can add and get to another non-php file
- [x] Go to https://pr21334-ik7fw9rn5ciwub9layzsis6db7d1lqoj.ci.cms.va.gov/media/add/document
- [x] Add a pdf 
- [x] Save it
- [x] Go to the pdf
- [x] Confirm that it loads without issue

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

