### PR TITLE
bring phpunit test up to psr4 standard

### DIFF
--- a/tests/phpunit/Deploy/DeployServiceTest.php
+++ b/tests/phpunit/Deploy/DeployServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\phpunit\Deploy;
+namespace Tests\Deploy;
 
 use Drupal\Core\Site\Settings;
 use Drupal\va_gov_backend\Deploy\DeployService;

--- a/tests/phpunit/Deploy/Plugins/HealthCheckTest.php
+++ b/tests/phpunit/Deploy/Plugins/HealthCheckTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\phpunit\Deploy\Plugins;
+namespace Tests\Deploy\Plugins;
 
 use Drupal\va_gov_backend\Deploy\Plugin\HealthCheck;
 use Drupal\va_gov_backend\Deploy\SuccessHTTPException;

--- a/tests/phpunit/Logging/DatadogApmProcessorTest.php
+++ b/tests/phpunit/Logging/DatadogApmProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\phpunit\Deploy;
+namespace Tests\Logging;
 
 use Drupal\va_gov_backend\Logger\Processor\DatadogApmProcessor;
 use Drupal\va_gov_backend\Service\DatadogContextProviderInterface;

--- a/tests/phpunit/va_gov_form_builder/functional/Form/IntroductionTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/IntroductionTest.php
@@ -12,7 +12,6 @@ use Drupal\va_gov_form_builder\EntityWrapper\DigitalForm;
  *
  * @group functional
  * @group all
- * @group disabled
  *
  * @coversDefaultClass \Drupal\va_gov_form_builder\Form\FormInfo
  */

--- a/tests/phpunit/va_gov_form_builder/functional/Form/IntroductionTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/Form/IntroductionTest.php
@@ -12,6 +12,8 @@ use Drupal\va_gov_form_builder\EntityWrapper\DigitalForm;
  *
  * @group functional
  * @group all
+ * @group disabled
+ * @group test
  *
  * @coversDefaultClass \Drupal\va_gov_form_builder\Form\FormInfo
  */

--- a/tests/phpunit/va_gov_form_builder/functional/pages/AddressInfoTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/AddressInfoTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
- * Functional test of the Name-and-date-of-birth page.
+ * Functional test of the Address-information page.
  *
  * @group functional
  * @group all
  */
-class NameAndDobTest extends VaGovExistingSiteBase {
+class AddressInfoTest extends VaGovExistingSiteBase {
   use TestPageLoads;
 
   /**
@@ -30,7 +30,7 @@ class NameAndDobTest extends VaGovExistingSiteBase {
    * Returns the url for this page.
    */
   private function getPageUrl() {
-    return "/form-builder/{$this->digitalFormNode->id()}/name-and-dob";
+    return "/form-builder/{$this->digitalFormNode->id()}/address-info";
   }
 
   /**
@@ -73,7 +73,7 @@ class NameAndDobTest extends VaGovExistingSiteBase {
    */
   public function testPageLoads() {
     // Ensure page loads.
-    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting Name and Date of birth');
+    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting address information');
   }
 
   /**
@@ -111,7 +111,7 @@ class NameAndDobTest extends VaGovExistingSiteBase {
           'url' => "/form-builder/{$this->digitalFormNode->id()}",
         ],
         [
-          'label' => 'Personal information',
+          'label' => 'Address information',
           'url' => "#content",
         ],
       ],
@@ -125,15 +125,6 @@ class NameAndDobTest extends VaGovExistingSiteBase {
     $this->drupalGet($this->getPageUrl());
     $this->click('a#form-builder-primary-button');
     $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}");
-  }
-
-  /**
-   * Test the secondary button.
-   */
-  public function testSecondaryButton() {
-    $this->drupalGet($this->getPageUrl());
-    $this->click('a#form-builder-secondary-button-1');
-    $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}/identification-info");
   }
 
 }

--- a/tests/phpunit/va_gov_form_builder/functional/pages/ContactInfoTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/ContactInfoTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
- * Functional test of the Identification-information page.
+ * Functional test of the Contact-information page.
  *
  * @group functional
  * @group all
  */
-class IdentificationInfoTest extends VaGovExistingSiteBase {
+class ContactInfoTest extends VaGovExistingSiteBase {
   use TestPageLoads;
 
   /**
@@ -30,7 +30,7 @@ class IdentificationInfoTest extends VaGovExistingSiteBase {
    * Returns the url for this page.
    */
   private function getPageUrl() {
-    return "/form-builder/{$this->digitalFormNode->id()}/identification-info";
+    return "/form-builder/{$this->digitalFormNode->id()}/contact-info";
   }
 
   /**
@@ -73,7 +73,7 @@ class IdentificationInfoTest extends VaGovExistingSiteBase {
    */
   public function testPageLoads() {
     // Ensure page loads.
-    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting identifying information');
+    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting contact information');
   }
 
   /**
@@ -111,7 +111,7 @@ class IdentificationInfoTest extends VaGovExistingSiteBase {
           'url' => "/form-builder/{$this->digitalFormNode->id()}",
         ],
         [
-          'label' => 'Personal information',
+          'label' => 'Contact information',
           'url' => "#content",
         ],
       ],
@@ -125,15 +125,6 @@ class IdentificationInfoTest extends VaGovExistingSiteBase {
     $this->drupalGet($this->getPageUrl());
     $this->click('a#form-builder-primary-button');
     $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}");
-  }
-
-  /**
-   * Test the secondary button.
-   */
-  public function testSecondaryButton() {
-    $this->drupalGet($this->getPageUrl());
-    $this->click('a#form-builder-secondary-button-1');
-    $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}/name-and-dob");
   }
 
 }

--- a/tests/phpunit/va_gov_form_builder/functional/pages/HomeTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/HomeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;

--- a/tests/phpunit/va_gov_form_builder/functional/pages/IdentificationInfoTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/IdentificationInfoTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
- * Functional test of the Address-information page.
+ * Functional test of the Identification-information page.
  *
  * @group functional
  * @group all
  */
-class AddressInfoTest extends VaGovExistingSiteBase {
+class IdentificationInfoTest extends VaGovExistingSiteBase {
   use TestPageLoads;
 
   /**
@@ -30,7 +30,7 @@ class AddressInfoTest extends VaGovExistingSiteBase {
    * Returns the url for this page.
    */
   private function getPageUrl() {
-    return "/form-builder/{$this->digitalFormNode->id()}/address-info";
+    return "/form-builder/{$this->digitalFormNode->id()}/identification-info";
   }
 
   /**
@@ -73,7 +73,7 @@ class AddressInfoTest extends VaGovExistingSiteBase {
    */
   public function testPageLoads() {
     // Ensure page loads.
-    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting address information');
+    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting identifying information');
   }
 
   /**
@@ -111,7 +111,7 @@ class AddressInfoTest extends VaGovExistingSiteBase {
           'url' => "/form-builder/{$this->digitalFormNode->id()}",
         ],
         [
-          'label' => 'Address information',
+          'label' => 'Personal information',
           'url' => "#content",
         ],
       ],
@@ -125,6 +125,15 @@ class AddressInfoTest extends VaGovExistingSiteBase {
     $this->drupalGet($this->getPageUrl());
     $this->click('a#form-builder-primary-button');
     $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}");
+  }
+
+  /**
+   * Test the secondary button.
+   */
+  public function testSecondaryButton() {
+    $this->drupalGet($this->getPageUrl());
+    $this->click('a#form-builder-secondary-button-1');
+    $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}/name-and-dob");
   }
 
 }

--- a/tests/phpunit/va_gov_form_builder/functional/pages/LayoutTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/LayoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;

--- a/tests/phpunit/va_gov_form_builder/functional/pages/NameAndDobTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/NameAndDobTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
- * Functional test of the View-form page.
+ * Functional test of the Name-and-date-of-birth page.
  *
  * @group functional
  * @group all
  */
-class ViewFormTest extends VaGovExistingSiteBase {
+class NameAndDobTest extends VaGovExistingSiteBase {
   use TestPageLoads;
 
   /**
@@ -30,7 +30,7 @@ class ViewFormTest extends VaGovExistingSiteBase {
    * Returns the url for this page.
    */
   private function getPageUrl() {
-    return "/form-builder/{$this->digitalFormNode->id()}/view-form";
+    return "/form-builder/{$this->digitalFormNode->id()}/name-and-dob";
   }
 
   /**
@@ -73,7 +73,7 @@ class ViewFormTest extends VaGovExistingSiteBase {
    */
   public function testPageLoads() {
     // Ensure page loads.
-    $this->sharedTestPageLoads($this->getPageUrl(), 'Reviewing the form');
+    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting Name and Date of birth');
   }
 
   /**
@@ -95,7 +95,45 @@ class ViewFormTest extends VaGovExistingSiteBase {
     );
   }
 
-  // Cannot test these until we have the staging-url field.
-  // @todo test breadcrumbs.
-  // @todo test buttons.
+  /**
+   * Test that the page has the expected breadcrumbs.
+   */
+  public function testPageBreadcrumbs() {
+    $this->sharedTestPageHasExpectedBreadcrumbs(
+      $this->getPageUrl(),
+      [
+        [
+          'label' => 'Home',
+          'url' => '/form-builder/home',
+        ],
+        [
+          'label' => $this->digitalFormNode->getTitle(),
+          'url' => "/form-builder/{$this->digitalFormNode->id()}",
+        ],
+        [
+          'label' => 'Personal information',
+          'url' => "#content",
+        ],
+      ],
+    );
+  }
+
+  /**
+   * Test the primary button.
+   */
+  public function testPrimaryButton() {
+    $this->drupalGet($this->getPageUrl());
+    $this->click('a#form-builder-primary-button');
+    $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}");
+  }
+
+  /**
+   * Test the secondary button.
+   */
+  public function testSecondaryButton() {
+    $this->drupalGet($this->getPageUrl());
+    $this->click('a#form-builder-secondary-button-1');
+    $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}/identification-info");
+  }
+
 }

--- a/tests/phpunit/va_gov_form_builder/functional/pages/ReviewAndSignTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/ReviewAndSignTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
- * Functional test of the Contact-information page.
+ * Functional test of the Review-and-sign page.
  *
  * @group functional
  * @group all
  */
-class ContactInfoTest extends VaGovExistingSiteBase {
+class ReviewAndSignTest extends VaGovExistingSiteBase {
   use TestPageLoads;
 
   /**
@@ -30,7 +30,7 @@ class ContactInfoTest extends VaGovExistingSiteBase {
    * Returns the url for this page.
    */
   private function getPageUrl() {
-    return "/form-builder/{$this->digitalFormNode->id()}/contact-info";
+    return "/form-builder/{$this->digitalFormNode->id()}/review-and-sign";
   }
 
   /**
@@ -73,7 +73,7 @@ class ContactInfoTest extends VaGovExistingSiteBase {
    */
   public function testPageLoads() {
     // Ensure page loads.
-    $this->sharedTestPageLoads($this->getPageUrl(), 'Collecting contact information');
+    $this->sharedTestPageLoads($this->getPageUrl(), 'Reviewing the submission');
   }
 
   /**
@@ -111,7 +111,7 @@ class ContactInfoTest extends VaGovExistingSiteBase {
           'url' => "/form-builder/{$this->digitalFormNode->id()}",
         ],
         [
-          'label' => 'Contact information',
+          'label' => 'Review page',
           'url' => "#content",
         ],
       ],

--- a/tests/phpunit/va_gov_form_builder/functional/pages/ViewFormTest.php
+++ b/tests/phpunit/va_gov_form_builder/functional/pages/ViewFormTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace tests\phpunit\va_gov_form_builder\functional\content_pages;
+namespace Tests\va_gov_form_builder\functional\pages;
 
 use tests\phpunit\va_gov_form_builder\Traits\TestPageLoads;
 use Tests\Support\Classes\VaGovExistingSiteBase;
 
 /**
- * Functional test of the Review-and-sign page.
+ * Functional test of the View-form page.
  *
  * @group functional
  * @group all
  */
-class ReviewAndSignTest extends VaGovExistingSiteBase {
+class ViewFormTest extends VaGovExistingSiteBase {
   use TestPageLoads;
 
   /**
@@ -30,7 +30,7 @@ class ReviewAndSignTest extends VaGovExistingSiteBase {
    * Returns the url for this page.
    */
   private function getPageUrl() {
-    return "/form-builder/{$this->digitalFormNode->id()}/review-and-sign";
+    return "/form-builder/{$this->digitalFormNode->id()}/view-form";
   }
 
   /**
@@ -73,7 +73,7 @@ class ReviewAndSignTest extends VaGovExistingSiteBase {
    */
   public function testPageLoads() {
     // Ensure page loads.
-    $this->sharedTestPageLoads($this->getPageUrl(), 'Reviewing the submission');
+    $this->sharedTestPageLoads($this->getPageUrl(), 'Reviewing the form');
   }
 
   /**
@@ -95,36 +95,7 @@ class ReviewAndSignTest extends VaGovExistingSiteBase {
     );
   }
 
-  /**
-   * Test that the page has the expected breadcrumbs.
-   */
-  public function testPageBreadcrumbs() {
-    $this->sharedTestPageHasExpectedBreadcrumbs(
-      $this->getPageUrl(),
-      [
-        [
-          'label' => 'Home',
-          'url' => '/form-builder/home',
-        ],
-        [
-          'label' => $this->digitalFormNode->getTitle(),
-          'url' => "/form-builder/{$this->digitalFormNode->id()}",
-        ],
-        [
-          'label' => 'Review page',
-          'url' => "#content",
-        ],
-      ],
-    );
-  }
-
-  /**
-   * Test the primary button.
-   */
-  public function testPrimaryButton() {
-    $this->drupalGet($this->getPageUrl());
-    $this->click('a#form-builder-primary-button');
-    $this->assertSession()->addressEquals("/form-builder/{$this->digitalFormNode->id()}");
-  }
-
+  // Cannot test these until we have the staging-url field.
+  // @todo test breadcrumbs.
+  // @todo test buttons.
 }

--- a/tests/phpunit/va_gov_form_builder/unit/Traits/EntityReferenceRevisionsOperationsTest.php
+++ b/tests/phpunit/va_gov_form_builder/unit/Traits/EntityReferenceRevisionsOperationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\va_gov_form_builder\Unit\Traits;
+namespace Tests\va_gov_form_builder\unit\Traits;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityConstraintViolationList;

--- a/tests/phpunit/va_gov_git/functional/Repository/RepositoryTest.php
+++ b/tests/phpunit/va_gov_git/functional/Repository/RepositoryTest.php
@@ -10,6 +10,7 @@ use Tests\Support\Classes\VaGovExistingSiteBase;
  *
  * @group functional
  * @group all
+ * @group test
  *
  * @coversDefaultClass \Drupal\va_gov_git\Repository\Repository
  */


### PR DESCRIPTION
## Description

Relates to #_issueid_. (or closes?)

### Generated description
This pull request refactors the namespace structure and file organization in the test suite to improve consistency and maintainability. It also includes minor updates to test metadata annotations.

### Namespace Refactoring:
* Updated namespaces across multiple test files to follow a consistent structure, such as changing `namespace test\phpunit\Deploy;` to `namespace Tests\Deploy;` in `DeployServiceTest.php` and similar updates in other files. [[1]](diffhunk://#diff-d0992daca20447a178c0f46fcdcc00127eded92a7b5e4ae67da8816b47c7f43eL3-R3) [[2]](diffhunk://#diff-526149aba1f3cfbe4b04d28069cc1c8089aae019c8fa9710204d794d8845ad6fL3-R3) [[3]](diffhunk://#diff-0be6a775930e05aadc27831faa7eb46f6eff43225e66e722b941d84dd77b0782L3-R3) [[4]](diffhunk://#diff-62fb4422c058366bdd70a93065d7088fe080341aee65ee4c94c6b5a6a827dd53L3-R3)

### File Renaming and Namespace Updates:
* Renamed files under `tests/phpunit/va_gov_form_builder/functional/content-pages/` to `tests/phpunit/va_gov_form_builder/functional/pages/` and updated their namespaces accordingly (e.g., `namespace tests\phpunit\va_gov_form_builder\functional\content_pages;` to `namespace Tests\va_gov_form_builder\functional\pages;`). Affected files include `AddressInfoTest.php`, `ContactInfoTest.php`, `HomeTest.php`, and others. [[1]](diffhunk://#diff-2fc8d96f4fde133cd4aab84709da71ae2a572bc75beb96e9ce7282f6817dda02L3-R3) [[2]](diffhunk://#diff-d3de5b507a4f1655fb9c0ccceb5f53ce68fc183f31cf3b37f3a6803c76d08c83L3-R3) [[3]](diffhunk://#diff-0e9250d910db2d4408b099afc5bb603d79c9d3b3c08afed61daf17d08bc29a4aL3-R3) [[4]](diffhunk://#diff-67d08ed1d7ad40786711fc2966d94d5a6eaf9cd010be54c75d4e0647f9439dabL3-R3) [[5]](diffhunk://#diff-78d1301daef447d9e28fbdf9ac068f58cad50507a035d51d4376af5ab49a207eL3-R3) [[6]](diffhunk://#diff-25681d9e29404ed27109f502bf812725526a1103a5bd02816c037cfaed9a75abL3-R3) [[7]](diffhunk://#diff-dcd27e28fd3d6048c742bcd34a14c77a78345aecbaf55506d221d3690328fff4L3-R3) [[8]](diffhunk://#diff-5c139f73593f8ea5c0b75355b2a89ef5edeeb81885509892c851658d7b83dfe8L3-R3)

### Test Metadata Updates:
* Added the `@group test` annotation to specific test files, such as `IntroductionTest.php` and `RepositoryTest.php`, to improve test categorization. [[1]](diffhunk://#diff-976e5615cb852ab824419da7749899f766a4fe64f6581090f97d99f8dfad3acaR16) [[2]](diffhunk://#diff-101b9884e0d4222e517b743e4e496e39bbd20a94ec9f11c117edca537fc80e4aR13)
## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If this passes automated testing, we should be good. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
