### PR TITLE
VACMS-21385: Adds patch to fix bulk publish and archive

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -162,6 +162,9 @@
         "drupal/views_bulk_edit": {
             "3024419 - Fix Required fields to really not be required": "patches/3024419-views-bulk-edit-fix-required-fields.patch"
         },
+        "drupal/views_bulk_operations": {
+            "3272580 - Fix bulk publishing and archiving": "patches/call-to-member-3272580-10.patch"
+        },
         "drupal/views_data_export": {
             "3189135 - Use relative URL for export button": "patches/3189135-use-relative-url-for-export.patch"
         }

--- a/patches/call-to-member-3272580-10.patch
+++ b/patches/call-to-member-3272580-10.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Service/ViewsBulkOperationsActionProcessor.php b/src/Service/ViewsBulkOperationsActionProcessor.php
+index 9d04fe7..69a8de3 100644
+--- a/src/Service/ViewsBulkOperationsActionProcessor.php
++++ b/src/Service/ViewsBulkOperationsActionProcessor.php
+@@ -419,7 +419,7 @@ class ViewsBulkOperationsActionProcessor implements ViewsBulkOperationsActionPro
+     // Check access.
+     foreach ($this->queue as $delta => $entity) {
+       $accessResult = $this->action->access($entity, $this->currentUser, TRUE);
+-      if ($accessResult->isAllowed() === FALSE) {
++      if ($accessResult instanceof AccessResultInterface && $accessResult->isAllowed() === FALSE) {
+         $result = [
+           'message' => (string) $this->t('Access denied'),
+           'type' => 'warning',


### PR DESCRIPTION
There are was fair bit of discussion around this issue by @ndouglas and @swirt in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14851\#issue-1857084554, but instead of going with the fix that @ndouglas suggested, one that involved a new workflow, I grabbed a patch from https://www.drupal.org/project/views_bulk_operations/issues/3272580 to fix the immediate issue with no UX change.

## Description

Relates to #21385, #14851

### Generated description
This pull request introduces a new patch to fix an issue with bulk publishing and archiving in the `drupal/views_bulk_operations` module. The patch ensures proper type checking for access results.

### Added patch for `drupal/views_bulk_operations`:

* Updated `composer.patches.json` to include a new patch (`call-to-member-3272580-10.patch`) for fixing bulk publishing and archiving issues in the `drupal/views_bulk_operations` module.

### Code fix for access result type checking:

* Modified `ViewsBulkOperationsActionProcessor.php` to add a type check ensuring `$accessResult` is an instance of `AccessResultInterface` before calling `isAllowed()`. This prevents potential errors when the access result is not of the expected type.

## Testing done
Manually

## Screenshots


## QA steps
### Set up test user
- [x] Log in as an admin
- [x] Set the QA Content Publisher to the "Content admin" role

### Bulk archive
- [x] Go to the [bulk edit page](https://pr21469-vdkn4ea4zjgcsdbtrtrjhdc9zqmixwxb.ci.cms.va.gov/admin/content/bulk?title=Mobile+Medical+Unit&type=health_care_local_facility&moderation_state=draft&taxonomy_entity_index_tid_depth=All), searching for "Mobile Medical Units" in draft
- [x] Select all on the first page
- [x] Archive them
- [x] Change the filter to look for archived
- [x] Confirm that you have 25 facilities archived just now

### Bulk publish
- [x] [Log in](https://pr21469-vdkn4ea4zjgcsdbtrtrjhdc9zqmixwxb.ci.cms.va.gov) as QA Content Publisher
- [x] Select these 25 draft facilities
- [x] Publish them
- [x] Change the filter to look for published facilities
- [x] Confirm that you have 25 facilities published just now

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

