### PR TITLE
VACMS-21491: Updates content-build to 0.0.3767

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,7 +231,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3766",
+        "va-gov/content-build": "^0.0.3767",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "536dd967d181b19341dcf78b0b557c91",
+    "content-hash": "45ca5f4cc06154a92a5790cf8c75ca89",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27387,16 +27387,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3766",
+            "version": "v0.0.3767",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "770521c4c19fa33c0088f9562eb848b7f4943dd6"
+                "reference": "9caa492bc49fc5a3f227f3e3cd68d92525281e78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/770521c4c19fa33c0088f9562eb848b7f4943dd6",
-                "reference": "770521c4c19fa33c0088f9562eb848b7f4943dd6",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/9caa492bc49fc5a3f227f3e3cd68d92525281e78",
+                "reference": "9caa492bc49fc5a3f227f3e3cd68d92525281e78",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27423,9 +27423,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3766"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3767"
             },
-            "time": "2025-06-10T15:55:00+00:00"
+            "time": "2025-06-11T00:53:33+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description

Relates to #21491 

### Generated description
This pull request updates the dependency version for `va-gov/content-build` in the `composer.json` file. The version has been incremented from `^0.0.3766` to `^0.0.3767`.

