### PR TITLE
VACMS-21484: update content-build to v0.0.3769

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,7 +231,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3767",
+        "va-gov/content-build": "^0.0.3769",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45ca5f4cc06154a92a5790cf8c75ca89",
+    "content-hash": "a16e555118625ee6bd3475fb8825d033",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27373,16 +27373,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3767",
+            "version": "v0.0.3769",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "9caa492bc49fc5a3f227f3e3cd68d92525281e78"
+                "reference": "0a5b0ab4db49c212b77ff2e54d8da78b29fcf55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/9caa492bc49fc5a3f227f3e3cd68d92525281e78",
-                "reference": "9caa492bc49fc5a3f227f3e3cd68d92525281e78",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/0a5b0ab4db49c212b77ff2e54d8da78b29fcf55d",
+                "reference": "0a5b0ab4db49c212b77ff2e54d8da78b29fcf55d",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27409,9 +27409,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3767"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3769"
             },
-            "time": "2025-06-11T00:53:33+00:00"
+            "time": "2025-06-13T13:40:47+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description

Closes #21484 

### Generated description

This pull request includes a minor update to the `composer.json` file. The change updates the version constraint for the `va-gov/content-build` package from `^0.0.3767` to `^0.0.3769`.

## Testing done


## Screenshots


## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

This should be good as long as automated testing passes. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
