### PR TITLE
VACMS-21474: Adds virtual support

### DIFF
--- a/config/sync/views.view.service_locations_audit.yml
+++ b/config/sync/views.view.service_locations_audit.yml
@@ -4,18 +4,14 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_administration
-    - field.storage.node.field_hservice_appt_intro_select
-    - field.storage.node.field_hservice_appt_leadin
     - field.storage.node.field_last_saved_by_an_editor
-    - field.storage.node.field_online_scheduling_availabl
-    - field.storage.node.field_phone_numbers_paragraph
-    - field.storage.node.field_walk_ins_accepted
     - field.storage.paragraph.field_appt_intro_text_custom
     - field.storage.paragraph.field_appt_intro_text_type
     - field.storage.paragraph.field_office_visits
     - field.storage.paragraph.field_online_scheduling_avail
     - field.storage.paragraph.field_other_phone_numbers
     - field.storage.paragraph.field_use_facility_phone_number
+    - field.storage.paragraph.field_virtual_support
     - node.type.health_care_local_health_service
     - node.type.service_region
     - node.type.vba_facility_service
@@ -616,6 +612,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_virtual_support:
+          id: field_virtual_support
+          table: paragraph__field_virtual_support
+          field: field_virtual_support
+          relationship: field_service_location
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Virtual support'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         field_online_scheduling_avail:
           id: field_online_scheduling_avail
           table: paragraph__field_online_scheduling_avail
@@ -951,6 +1009,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 100
           total_pages: null
           id: 0
@@ -968,7 +1027,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -1472,6 +1530,7 @@ display:
         - 'config:field.storage.paragraph.field_online_scheduling_avail'
         - 'config:field.storage.paragraph.field_other_phone_numbers'
         - 'config:field.storage.paragraph.field_use_facility_phone_number'
+        - 'config:field.storage.paragraph.field_virtual_support'
   audit_service_locations:
     id: audit_service_locations
     display_title: 'Service locations audit'
@@ -1515,6 +1574,7 @@ display:
         - 'config:field.storage.paragraph.field_online_scheduling_avail'
         - 'config:field.storage.paragraph.field_other_phone_numbers'
         - 'config:field.storage.paragraph.field_use_facility_phone_number'
+        - 'config:field.storage.paragraph.field_virtual_support'
   service_location_audit_export:
     id: service_location_audit_export
     display_title: 'Service location audit export'
@@ -1774,69 +1834,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_administration:
-          id: field_administration
-          table: node__field_administration
-          field: field_administration
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: Section
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
-          settings:
-            link: true
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         revision_log:
           id: revision_log
           table: node_revision
@@ -1901,15 +1898,15 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_hservice_appt_intro_select:
-          id: field_hservice_appt_intro_select
-          table: node__field_hservice_appt_intro_select
-          field: field_hservice_appt_intro_select
+        field_administration:
+          id: field_administration
+          table: node__field_administration
+          field: field_administration
           relationship: none
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: 'OLD: Appointment intro text'
+          label: Section
           exclude: false
           alter:
             alter_text: false
@@ -1950,10 +1947,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: list_default
-          settings: {  }
-          group_column: value
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -2014,68 +2012,6 @@ display:
           hide_alter_empty: true
           click_sort_column: value
           type: list_default
-          settings: {  }
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        field_hservice_appt_leadin:
-          id: field_hservice_appt_leadin
-          table: node__field_hservice_appt_leadin
-          field: field_hservice_appt_leadin
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: 'OLD: Appointment lead-in text'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: basic_string
           settings: {  }
           group_column: value
           group_columns: {  }
@@ -2149,68 +2085,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_walk_ins_accepted:
-          id: field_walk_ins_accepted
-          table: node__field_walk_ins_accepted
-          field: field_walk_ins_accepted
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: 'OLD: Are walkins accepted?'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: list_default
-          settings: {  }
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         field_office_visits:
           id: field_office_visits
           table: paragraph__field_office_visits
@@ -2273,15 +2147,15 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_online_scheduling_availabl:
-          id: field_online_scheduling_availabl
-          table: node__field_online_scheduling_availabl
-          field: field_online_scheduling_availabl
-          relationship: none
+        field_virtual_support:
+          id: field_virtual_support
+          table: paragraph__field_virtual_support
+          field: field_virtual_support
+          relationship: field_service_location
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: 'OLD: Is online scheduling available for this service?'
+          label: 'Virtual support'
           exclude: false
           alter:
             alter_text: false
@@ -2388,69 +2262,6 @@ display:
           type: list_default
           settings: {  }
           group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        field_phone_numbers_paragraph:
-          id: field_phone_numbers_paragraph
-          table: node__field_phone_numbers_paragraph
-          field: field_phone_numbers_paragraph
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: 'OLD: Phone number for appointments'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_revisions_entity_view
-          settings:
-            view_mode: default
-          group_column: ''
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -2754,14 +2565,10 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.node.field_administration'
-        - 'config:field.storage.node.field_hservice_appt_intro_select'
-        - 'config:field.storage.node.field_hservice_appt_leadin'
-        - 'config:field.storage.node.field_online_scheduling_availabl'
-        - 'config:field.storage.node.field_phone_numbers_paragraph'
-        - 'config:field.storage.node.field_walk_ins_accepted'
         - 'config:field.storage.paragraph.field_appt_intro_text_custom'
         - 'config:field.storage.paragraph.field_appt_intro_text_type'
         - 'config:field.storage.paragraph.field_office_visits'
         - 'config:field.storage.paragraph.field_online_scheduling_avail'
         - 'config:field.storage.paragraph.field_other_phone_numbers'
         - 'config:field.storage.paragraph.field_use_facility_phone_number'
+        - 'config:field.storage.paragraph.field_virtual_support'


### PR DESCRIPTION
Adds "Virtual support" to the Service locations audit and removes old fields from the CSV export.

## Description

Relates to #21474 

### Generated description
This pull request makes significant updates to the `config/sync/views.view.service_locations_audit.yml` file by introducing a new "Virtual Support" field and removing several outdated fields. These changes enhance the audit configuration for service locations by refining the structure and improving clarity.

### Additions and Enhancements:
* Added a new `field_virtual_support` to represent virtual support capabilities, including its configuration and display settings. [[1]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fR615-R676) [[2]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fL2276-R2158)
* Updated tags and dependencies to include `field_virtual_support`. [[1]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fR1533) [[2]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fL2757-R2574)

### Removals:
* Removed outdated fields such as `field_hservice_appt_intro_select`, `field_hservice_appt_leadin`, `field_walk_ins_accepted`, `field_online_scheduling_availabl`, and `field_phone_numbers_paragraph`. These fields were no longer relevant and have been cleaned up from the configuration. [[1]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fL7-R14) [[2]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fL2152-L2213) [[3]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fL2400-L2462)

### Adjustments:
* Reintroduced `field_administration` with updated settings, replacing its previous configuration.
* Pagination settings were refined to remove redundant configurations and ensure consistency. [[1]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fR1012) [[2]](diffhunk://#diff-57df4e5b781227911732e9d5877c39b1a3beba98f3c06ccabad1177bf966197fL971)

## Testing done


## Screenshots
![Screenshot 2025-06-18 at 9 38 04 AM](https://github.com/user-attachments/assets/bb9b2d51-be2f-4c39-b1a1-01d00add805c)


## QA steps
- [ ] [Log in](https://pr21547-yitxzvk1kzp38oxa5ecak3jqcyqztctv.ci.cms.va.gov/) as an admin
- [ ] Go to the [service locations audit](https://pr21547-yitxzvk1kzp38oxa5ecak3jqcyqztctv.ci.cms.va.gov/admin/content/audit/service-locations-detailed)
- [ ] Filter by the VA Alaska health care **Section** (Note: the display of these dropdown items is not ideal, but as this is how it is in prod and as I'm not sure the reason, I'm not addressing it now).
- [ ] Confirm that the results include information about Virtual support
- [ ] Down load the results
- [ ] Open the the downloaded CSV
- [ ] Confirm that the results include information about Virtual support
- [ ] Confirm that no fields with "OLD" in the column header appear
 
### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
