### PR TITLE
VACMS-21323: Cypress API test of person_profile (Staff profile)

### DIFF
--- a/tests/cypress/integration/features/api/person_profile.feature
+++ b/tests/cypress/integration/features/api/person_profile.feature
@@ -1,0 +1,5 @@
+Feature: API
+
+  Scenario: JSON API consumer can access event nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "jsonapi/node/person_profile?page[limit]=1&include=field_media%2Cfield_media.image&filter[status]=1"

--- a/tests/cypress/integration/features/api/person_profile.feature
+++ b/tests/cypress/integration/features/api/person_profile.feature
@@ -1,5 +1,5 @@
 Feature: API
 
-  Scenario: JSON API consumer can access event nodes
+  Scenario: JSON API consumer can access person_profile nodes
     Given I am an anonymous user
     And I should receive status code 200 when I request "jsonapi/node/person_profile?page[limit]=1&include=field_media%2Cfield_media.image&filter[status]=1"

--- a/tests/cypress/integration/features/api/person_profile.feature
+++ b/tests/cypress/integration/features/api/person_profile.feature
@@ -2,4 +2,4 @@ Feature: API
 
   Scenario: JSON API consumer can access person_profile nodes
     Given I am an anonymous user
-    And I should receive status code 200 when I request "jsonapi/node/person_profile?page[limit]=1&include=field_media%2Cfield_media.image&filter[status]=1"
+    And I should receive status code 200 when I request "jsonapi/node/person_profile?page[limit]=1&filter[status]=1&include=field_media%2Cfield_media.image%2Cfield_office%2Cfield_complete_biography%2Cfield_telephone%2Cfield_administration"


### PR DESCRIPTION
## Description

Relates to #21323

### Generated description
This pull request introduces a new feature test for the API, specifically targeting the `person_profile` nodes. The test ensures that anonymous users can access these nodes via the JSON API and validates the response status code.

Testing additions:

* [`tests/cypress/integration/features/api/person_profile.feature`](diffhunk://#diff-185d8d88c7ffbd56d28cafa91374a681a25f3d6bb23054e04077b9af1f49ecd6R1-R5): Added a feature test to verify that anonymous users receive a status code of 200 when accessing `person_profile` nodes through the JSON API with specific filters and included fields.

## Testing done
Cypress

## Screenshots
![Screenshot 2025-06-24 at 8 20 30 AM](https://github.com/user-attachments/assets/f4656c95-9877-4eb9-94bc-49ff7eb39db3)


## QA steps
- [ ] Cypress tests need to pass
- [ ] The fields in the test should include those included in the query


