### PR TITLE
VACMS-21021: news_story JSON api test

### DIFF
--- a/tests/cypress/integration/features/api/news_story.feature
+++ b/tests/cypress/integration/features/api/news_story.feature
@@ -1,0 +1,8 @@
+Feature: API
+
+  Scenario: JSON API consumer can access route translation for a given news_story
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care%2Fstories%2F600-volunteers-45000-hours-one-inspiring-week"
+  Scenario: JSON API consumer can access news_story nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/jsonapi/node/news_story?page[limit]=1&include=field_media%2Cfield_media.image%2Cfield_author%2Cfield_listing%2Cfield_administration"

--- a/tests/cypress/integration/features/api/news_story.feature
+++ b/tests/cypress/integration/features/api/news_story.feature
@@ -1,8 +1,5 @@
 Feature: API
 
-  Scenario: JSON API consumer can access route translation for a given news_story
-    Given I am an anonymous user
-    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care%2Fstories%2F600-volunteers-45000-hours-one-inspiring-week"
   Scenario: JSON API consumer can access news_story nodes
     Given I am an anonymous user
     And I should receive status code 200 when I request "/jsonapi/node/news_story?page[limit]=1&include=field_media%2Cfield_media.image%2Cfield_author%2Cfield_listing%2Cfield_administration"


### PR DESCRIPTION
## Description
Adds a simple JSON API test for the news_story endpoint with the relevant includes

Relates to #21021 

### Generated description
This pull request adds new test scenarios to verify the functionality of the JSON API for `news_story` routes and nodes.

### Added API test scenarios:

* [`tests/cypress/integration/features/api/news_story.feature`](diffhunk://#diff-1fb6d570ad166fede16792c6de0194620db18016a09a1e5a5bde9e7de7b017f5R1-R8): Added a scenario to test that an anonymous user can access `news_story` nodes with specific fields and relationships included, and receive a 200 status code.
## Testing done
Adds a test.

## QA steps

 - [ ] Test passes in CI


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

