### PR TITLE
VACMS-21591: Update content build version 26 June 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,7 +231,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "0.0.3774",
+        "va-gov/content-build": "^0.0.3777",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "450aa4baa2e3aee2c6a7f642a29eb599",
+    "content-hash": "93fbaf819c895d1837da1404f5de2672",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27373,16 +27373,16 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3774",
+            "version": "v0.0.3777",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
-                "reference": "843b4d8b7931e946cdec2db31c17830379bd4283"
+                "reference": "3b4a304e9ceda3706f6460ce41ba4defd4b9301d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/843b4d8b7931e946cdec2db31c17830379bd4283",
-                "reference": "843b4d8b7931e946cdec2db31c17830379bd4283",
+                "url": "https://api.github.com/repos/department-of-veterans-affairs/content-build/zipball/3b4a304e9ceda3706f6460ce41ba4defd4b9301d",
+                "reference": "3b4a304e9ceda3706f6460ce41ba4defd4b9301d",
                 "shasum": ""
             },
             "type": "node-project",
@@ -27409,9 +27409,9 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3774"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3777"
             },
-            "time": "2025-06-23T13:48:37+00:00"
+            "time": "2025-06-24T17:39:34+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
## Description

Relates to #[21591](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21591). (or closes?)

### Generated description
This pull request includes a version update for the `va-gov/content-build` dependency in the `composer.json` file. The version constraint has been changed from `0.0.3774` to `^0.0.3777` to allow for greater flexibility in adopting newer patch versions.