### PR TITLE
VACMS-21017: News release API test

### DIFF
--- a/tests/cypress/integration/features/api/press_release.feature
+++ b/tests/cypress/integration/features/api/press_release.feature
@@ -1,0 +1,5 @@
+Feature: API
+
+  Scenario: JSON API consumer can access press_release nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "jsonapi/node/press_release?page[limit]=1&filter[status]=1&include=field_press_release_downloads%2Cfield_press_release_contact%2Cfield_press_release_contact.field_telephone%2Cfield_listing%2Cfield_administration"


### PR DESCRIPTION
## Description

Relates to #21017

### Generated description
This pull request introduces a new feature test for the JSON API consumer to verify access to `press_release` nodes.

Testing additions:

* [`tests/cypress/integration/features/api/press_release.feature`](diffhunk://#diff-ef71364bf7972820c478a53f0900ee4473013e27ea241a791c594119e4bb98a3R1-R5): Added a new feature test scenario to ensure anonymous users can access `press_release` nodes through the JSON API, receiving a status code of 200 for valid requests.

## Testing done
Cypres

## Screenshots
![Screenshot 2025-06-30 at 11 46 27 AM](https://github.com/user-attachments/assets/1efac55a-583c-48b7-a12d-bc10e7743bf0)


## QA steps
- [ ] Run Cypress tests

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

