### PR TITLE
Add default settings for Next Build git form.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -126,6 +126,8 @@ $settings['va_gov_path_to_composer'] = '/usr/local/bin/composer';
 $settings['va_gov_web_root'] = '/var/www/cms/web';
 $settings['va_gov_app_root'] = '/var/www/cms';
 $settings['va_gov_vets_website_root'] = '/var/www/cms/docroot/vendor/va-gov/vets-website';
+$settings['va_gov_next_build_root'] = getenv('TUGBOAT_ROOT')  . '/var/www/cms/next';
+$settings['va_gov_next_build_vets_website_root'] = getenv('TUGBOAT_ROOT') . '/var/www/cms/vets-website';
 
 // Defaults (should only be local that doesn't set these), default to dev for config_split
 $config['config_split.config_split.dev']['status'] = TRUE;


### PR DESCRIPTION
## Description

#21660 

This is in response to phpunit tests failing on Staging. See for example http://jenkins.vfs.va.gov/job/testing/job/cms-post-deploy-tests-staging/3296/consoleFull:
```
18:13:27    1) tests\phpunit\va_gov_git\functional\Repository\Settings\RepositorySettingsTest::testList
18:13:27    Drupal\va_gov_git\Exception\RepositoryPathNotSetException: Path not set for repository: next-build (va_gov_next_build_root)
18:13:27    
18:13:27    /var/www/cms/docroot/modules/custom/va_gov_git/src/Repository/Settings/RepositorySettings.php:62
18:13:27    /var/www/cms/docroot/modules/custom/va_gov_git/src/Repository/Settings/RepositorySettings.php:74
18:13:27    /var/www/cms/docroot/modules/custom/va_gov_git/src/Repository/Settings/RepositorySettings.php:76
18:13:27    /var/www/cms/tests/phpunit/va_gov_git/functional/Repository/Settings/RepositorySettingsTest.php:82
18:13:27    /var/www/cms/docroot/vendor/phpunit/phpunit/src/Framework/TestResult.php:729
18:13:27    /var/www/cms/docroot/vendor/phpunit/phpunit/src/Framework/TestSuite.php:685
18:13:27    /var/www/cms/docroot/vendor/phpunit/phpunit/src/Framework/TestSuite.php:685
18:13:27    /var/www/cms/docroot/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:651
18:13:27    /var/www/cms/docroot/vendor/phpunit/phpunit/src/TextUI/Command.php:146
18:13:27    /var/www/cms/docroot/vendor/phpunit/phpunit/src/TextUI/Command.php:99
18:13:27    /var/www/cms/bin/phpunit:122
```

## QA steps

PHPUnit tests must pass. This will not be properly testable until after merge, as it needs to pass on Staging.

