### PR TITLE
VACMS-21015: Adds tests for press release listings

### DIFF
--- a/tests/cypress/integration/features/api/press_release_listing.feature
+++ b/tests/cypress/integration/features/api/press_release_listing.feature
@@ -1,0 +1,8 @@
+Feature: API
+
+  Scenario: JSON API consumer can access route translation for a given press release listing
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care%2Fnews-releases"
+  Scenario: JSON API consumer can access press release nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/jsonapi/node/press_releases_listing?page[limit]=1&include=field_administration&sort=-created"


### PR DESCRIPTION
## Description

Relates to #21015 

### Generated description
This pull request adds new test scenarios for the API in the `press_release_listing.feature` file. These scenarios validate the accessibility of route translations and press release nodes for JSON API consumers.

API test additions:

* [`tests/cypress/integration/features/api/press_release_listing.feature`](diffhunk://#diff-df937cddbf92de96fc4a7f6b9dfe16c5ba422ab0bd27270e32292005adf9d4cbR1-R8): Added a scenario to ensure JSON API consumers can access route translations for a given press release listing.
* [`tests/cypress/integration/features/api/press_release_listing.feature`](diffhunk://#diff-df937cddbf92de96fc4a7f6b9dfe16c5ba422ab0bd27270e32292005adf9d4cbR1-R8): Added a scenario to validate that JSON API consumers can access press release nodes with specific query parameters.
## Testing done
Cypress

## Screenshots
![Screenshot 2025-07-01 at 3 03 57 PM](https://github.com/user-attachments/assets/10356234-3920-4e10-abab-134123fb1c5c)


## QA steps
- [ ] Run Cypress tests

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

