### PR TITLE
VACMS-21396: drush cleanup

### DIFF
--- a/docroot/modules/custom/va_gov_migrate/drush.services.yml
+++ b/docroot/modules/custom/va_gov_migrate/drush.services.yml
@@ -2,11 +2,6 @@ services:
   va_gov_migrate.commands:
     class: \Drupal\va_gov_migrate\Commands\Commands
     arguments:
-      - '@database'
-      - '@entity_type.manager'
-      - '@va_gov_workflow.flagger'
-      - '@plugin.manager.migrate_plus.data_fetcher'
-      - '@logger.channel.va_gov_migrate'
-      - '@va_gov_notifications.notifications_manager'
+      - '@va_gov_migrate.va_gov_migrate_service'
     tags:
       - { name: drush.command }

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -59,7 +59,15 @@ class Commands extends DrushCommands {
    * @aliases va-gov-flag-missing-facilities
    */
   public function flagMissingFacilities() {
-    $this->vaGovMigrateService->flagMissingFacilities();
+    $messages = $this->vaGovMigrateService->flagMissingFacilities();
+    if (!empty($messages)) {
+      foreach ($messages as $message) {
+        $this->logger->log('success', $message);
+      }
+    }
+    else {
+      $this->logger->log('info', 'No facilities were flagged.');
+    }
   }
 
 }

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -2,102 +2,32 @@
 
 namespace Drupal\va_gov_migrate\Commands;
 
-use Drupal\Core\Database\Connection;
-use Drupal\Core\Entity\EntityStorageException;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\migrate_plus\DataFetcherPluginManager;
-use Drupal\migrate_plus\Entity\Migration;
-use Drupal\node\NodeInterface;
-use Drupal\va_gov_facilities\FacilityOps;
-use Drupal\va_gov_notifications\Service\NotificationsManager;
-use Drupal\va_gov_workflow\Service\Flagger;
 use Drush\Commands\DrushCommands;
-use League\Csv\Reader;
-use League\Csv\Statement;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
+use Drupal\va_gov_migrate\Service\VaGovMigrateService;
 
 /**
  * Drush commands related to migrations.
  */
 class Commands extends DrushCommands {
 
-  // The UID of the CMS Help Desk account subscribing to facility messages.
-  const USER_CMS_HELP_DESK_NOTIFICATIONS = 4050;
-
   /**
-   * EntityTypemanager.
+   * The VA gov Migrate Service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var \Drupal\va_gov_migrate\Service\VaGovMigrateService
    */
-  protected $entityTypeManager;
-
-  /**
-   * The database connection.
-   *
-   * @var \Drupal\Core\Database\Connection
-   */
-  protected $database;
-
-  /**
-   * Migrate plus datafetcher plugin manager.
-   *
-   * @var \Drupal\migrate_plus\DataFetcherPluginManager
-   */
-  protected $dataFetcherPluginManager;
-
-  /**
-   * The logger channel for va_gov_migrate.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected $migrateChannelLogger;
-
-  /**
-   * Workflow flagger service.
-   *
-   * @var \Drupal\va_gov_workflow\Service\Flagger
-   */
-  protected $flagger;
-
-  /**
-   * The VA gov NotificationsManager.
-   *
-   * @var \Drupal\va_gov_notifications\Service\NotificationsManager
-   */
-  protected $notificationsManager;
+  protected $vaGovMigrateService;
 
   /**
    * Constructor for this set of drush commands.
    *
-   * @param \Drupal\Core\Database\Connection $data_base
-   *   Core database connection.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager.
-   * @param \Drupal\va_gov_workflow\Service\Flagger $flaggerservice
-   *   Workflow flagger service.
-   * @param \Drupal\migrate_plus\DataFetcherPluginManager $data_fetcher_plugin_manager
-   *   DataFetcherPluginManager.
-   * @param \Psr\Log\LoggerInterface $migrate_channel_logger
-   *   LoggerChannel for va_gov_migrate.
-   * @param \Drupal\va_gov_notifications\Service\NotificationsManager $notifications_manager
-   *   VA gov NotificationsManager service.
+   * @param \Drupal\va_gov_migrate\Service\VaGovMigrateService $va_gov_migrate_service
+   *   VA gov VaGovMigrateService service.
    */
   public function __construct(
-    Connection $data_base,
-    EntityTypeManagerInterface $entity_type_manager,
-    Flagger $flaggerservice,
-    DataFetcherPluginManager $data_fetcher_plugin_manager,
-    LoggerInterface $migrate_channel_logger,
-    NotificationsManager $notifications_manager,
+    VaGovMigrateService $va_gov_migrate_service,
   ) {
     parent::__construct();
-    $this->database = $data_base;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->flagger = $flaggerservice;
-    $this->dataFetcherPluginManager = $data_fetcher_plugin_manager;
-    $this->migrateChannelLogger = $migrate_channel_logger;
-    $this->notificationsManager = $notifications_manager;
+    $this->vaGovMigrateService = $va_gov_migrate_service;
   }
 
   /**
@@ -107,37 +37,9 @@ class Commands extends DrushCommands {
    * @aliases vg-cr,va-gov-clean-revs
    */
   public function cleanRevs() {
-    $time = 1572551719;
-
-    $query = $this->database->select('node_revision', 'nr');
-    $query->condition('revision_timestamp', $time);
-    $query->fields('nr', ['vid']);
-    $vids = $query->execute()->fetchCol();
-
-    $query = $this->database->select('node_revision', 'nr');
-    $query->condition('revision_log', 'Update of status by migration.');
-    $query->condition('nid', 1884);
-    $query->fields('nr', ['vid']);
-    $more_vids = $query->execute()->fetchCol();
-
-    $vids = array_merge($vids, $more_vids);
-    $this->migrateChannelLogger->info('Attempting to Delete ' . count($vids) . ' node revisions');
-    $missed_vids = [];
-    foreach ($vids as $vid) {
-      try {
-        $this->migrateChannelLogger->info('Deleting: ' . $vid);
-        $this->entityTypeManager->getStorage('node')->deleteRevision($vid);
-      }
-      catch (EntityStorageException $e) {
-        $this->migrateChannelLogger->warning('Vid ' . $vid . ' could not be deleted: ' . $e->getMessage());
-        $missed_vids[] = $vid;
-      }
-    }
-
-    $count = count($vids) - count($missed_vids);
-    // @phpstan-ignore-next-line
-    $this->logger->success("Deleted {$count} revision(s).");
-    $this->logger->warning('The following revisions were not deleted: ' . implode(', ', $missed_vids));
+    $messages = $this->vaGovMigrateService->cleanRevs();
+    $this->logger->success($messages['success']);
+    $this->logger->warning($messages['warning']);
   }
 
   /**
@@ -145,58 +47,9 @@ class Commands extends DrushCommands {
    *
    * @command va_gov_migrate:archive-intranet-only-forms
    * @aliases va-gov-archive-intranet-only-forms
-   *
-   * @throws \League\Csv\UnavailableStream
-   *   Thrown when the file is not available.
-   * @throws \League\Csv\Exception
-   *   Thrown if the offset is a negative integer.
-   * @throws \League\Csv\InvalidArgument
-   *   Thrown by enclosure or delimiter arguments are more than one character.
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   *   Thrown if the entity type doesn't exist.
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   *   Thrown if the storage handler couldn't be loaded.
    */
   public function archiveIntranetOnlyForms() {
-    $csv = Reader::createFromPath(DRUPAL_ROOT . '/sites/default/files/migrate_source/va_forms_data.csv', 'r');
-    $csv->setHeaderOffset(0);
-    $csv->setEnclosure('"');
-    $csv->setDelimiter(',');
-
-    // Create a Statement.
-    $stmt = (new Statement())
-      ->select('rowid')
-    // Start from first record.
-      ->offset(0)
-      ->limit(-1)
-      ->andWhere('IntranetOnly', '=', '1')
-    // Get all records.
-      ->orderByAsc('rowid');
-
-    // Process the CSV with the statement and filter for IntranetOnly = 1.
-    $records = $stmt->process($csv);
-
-    $intranet_only = [];
-    foreach ($records as $record) {
-      // Make an array of the rowids.
-      $intranet_only[] = $record['rowid'];
-    }
-    // Get all the non-archived forms in the CMS that are IntranetOnly.
-    $select = $this->database->select('node__field_va_form_row_id', 'nfvfri');
-    $select->join('content_moderation_state_field_data', 'cmsfd', 'nfvfri.entity_id = cmsfd.content_entity_id');
-    $select->fields('nfvfri', ['entity_id'])
-      ->condition('nfvfri.field_va_form_row_id_value', $intranet_only, 'IN')
-      ->condition('cmsfd.moderation_state', 'archived', '<>');
-    $nids = $select->execute()->fetchCol();
-
-    $forms_to_archive = $this->entityTypeManager->getStorage('node')->loadMultiple(array_values($nids));
-    $message = 'Archived due to being set IntranetOnly in Forms CSV.';
-
-    // Archive the nodes.
-    foreach ($forms_to_archive as $form_to_archive) {
-      $this->archiveNode($form_to_archive, $message);
-    }
-
+    $this->vaGovMigrateService->archiveIntranetOnlyForms();
   }
 
   /**
@@ -206,274 +59,7 @@ class Commands extends DrushCommands {
    * @aliases va-gov-flag-missing-facilities
    */
   public function flagMissingFacilities() {
-    $facilities_in_fapi = $this->getFapiList();
-    // Make the two-dimensional array one dimension.
-    $facilities_flat = array_reduce($facilities_in_fapi, function ($carry, $item) {
-      return array_merge($carry, $item);
-    }, []);
-    $count_fapi = count($facilities_flat);
-    // Make sure facilities in fapi makes sense or we will flag all facilities.
-    if ($this->facilityCountSeemsFaulty($count_fapi)) {
-      $vars = [
-        '%count' => $count_fapi,
-      ];
-
-      $this->migrateChannelLogger->log(LogLevel::WARNING, 'The facility API returned %count facilities, which seems suspicious. Flagging aborted.', $vars);
-      return;
-    }
-    $facilities_to_flag = $this->getFacilitiesToFlag($facilities_flat);
-    $count_flagged = count($facilities_to_flag);
-    $count_archived = 0;
-    if ($count_flagged) {
-      $facility_nodes_to_flag = $this->entityTypeManager->getStorage('node')->loadMultiple(array_values($facilities_to_flag));
-      foreach ($facility_nodes_to_flag as $facility_node_to_flag) {
-        if (!FacilityOps::isAutoArchiveFacility($facility_node_to_flag)) {
-          $this->addNodeRevision($facility_node_to_flag);
-          $this->flagger->setFlag('removed_from_source', $facility_node_to_flag);
-          // Send email to CMS Help Desk for follow-up steps.
-          $message_fields = $this->notificationsManager->buildMessageFields($facility_node_to_flag, 'Facility removed:');
-          $this->notificationsManager->send('va_facility_removed_from_source', self::USER_CMS_HELP_DESK_NOTIFICATIONS, $message_fields);
-          // Log amount to be processed.
-        }
-        else {
-          $this->archiveRemovedFacility($facility_node_to_flag);
-          $count_flagged--;
-          $count_archived++;
-        }
-      }
-      $vars = [
-        '%count_flagged' => $count_flagged,
-        '%count_archived' => $count_archived,
-      ];
-
-      if ($vars['%count_flagged'] > 0) {
-        $msg = 'Flagged %count_flagged facilities as removed from Facility API.';
-        $this->migrateChannelLogger->log(LogLevel::INFO, $msg, $vars);
-        // Create drush output.
-        // @phpstan-ignore-next-line
-        $this->logger->success("Flagged {$count_flagged} facilities as removed from Facility API.");
-      }
-      if ($vars['%count_archived'] > 0) {
-        $msg = 'Archived %count_archived facilities due to removal from Facility API.';
-        $this->migrateChannelLogger->log(LogLevel::INFO, $msg, $vars);
-        // Create drush output.
-        // @phpstan-ignore-next-line
-        $this->logger->success("Archived {$count_archived} facilities due to removal from Facility API.");
-      }
-    }
-  }
-
-  /**
-   * Archive a facility.
-   *
-   * @param \Drupal\node\NodeInterface $facility
-   *   The facility to archive.
-   */
-  protected function archiveRemovedFacility(NodeInterface $facility) {
-    $this->clearStatusData($facility);
-    $message = 'Archived due to removal from Facility API.';
-    $this->archiveNode($facility, $message);
-  }
-
-  /**
-   * Archive a node.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node to archive.
-   * @param string $message
-   *   The revision message.
-   */
-  protected function archiveNode(NodeInterface $node, string $message) {
-    $node->set('moderation_state', 'archived');
-    $node->setRevisionLogMessage($message);
-    $node->setNewRevision(TRUE);
-    $node->setUnpublished();
-    // Assign to CMS Migrator user.
-    $node->setRevisionUserId(1317);
-    // Prevents some other actions.
-    $node->setSyncing(TRUE);
-    $node->setChangedTime(time());
-    $node->isDefaultRevision(TRUE);
-    $node->setRevisionCreationTime(time());
-    $node->save();
-  }
-
-  /**
-   * Clear out a facility's status data.
-   *
-   * @param \Drupal\node\NodeInterface $facility
-   *   The facility to clean.
-   */
-  protected function clearStatusData(NodeInterface &$facility) {
-    if ($facility->hasField('field_operating_status_facility')) {
-      $facility->field_operating_status_facility->value = 'closed';
-    }
-    if ($facility->hasField('field_operating_status_more_info')) {
-      $facility->field_operating_status_more_info->value = '';
-    }
-    $facility->save();
-  }
-
-  /**
-   * Add a revision to a node to log what happened.
-   *
-   * @param \Drupal\node\NodeInterface $facility
-   *   The facility node to be updated.
-   */
-  protected function addnodeRevision(NodeInterface $facility): void {
-    $facility->setRevisionCreationTime(time());
-    $facility->setChangedTime(time());
-    $msg = "No longer appears in the Facility API.";
-    $facility->setRevisionLogMessage($msg);
-    // New revision will inherit content moderation status from default rev.
-    $facility->setNewRevision(TRUE);
-    $facility->isDefaultRevision(TRUE);
-    // Setting revision as CMS migrator.
-    $facility->setRevisionUserId(1317);
-    $facility->save();
-  }
-
-  /**
-   * Get array of facilities that need flagging for removal.
-   *
-   * @param array $facilities_in_fapi
-   *   An array of facility api ids as keys.
-   *
-   * @return array
-   *   Array of facility_api-id => nid pairs that need flagging.
-   */
-  protected function getFacilitiesToFlag(array $facilities_in_fapi): array {
-    // Remove any facilities that are in the API.
-    $missing_facilities = array_diff_key($this->getFacilitiesInCms(), $facilities_in_fapi);
-    // Remove any facilities that are already flagged.
-    $facilities_to_flag = array_diff($missing_facilities, $this->getFlaggedRemovedFromSource());
-    // Remove any facilities that are already archived.
-    $facilities_to_flag = array_diff($facilities_to_flag, $this->getArchivedFacilities());
-
-    return $facilities_to_flag;
-  }
-
-  /**
-   * Get all facilities present from the facility API.
-   *
-   * @return array
-   *   Array of facility id keys for all facilities in FAPI.
-   */
-  protected function getFapiList(): array {
-    // Will end up keyed <fapi_id> => <n>.
-    $facilities = [];
-    // Use settings from facility migration to get data.
-    /** @var \Drupal\migrate_plus\Entity\MigrationInterface $facility_migration */
-    $facility_migration = Migration::load('va_node_health_care_local_facility');
-    if ($facility_migration) {
-      $source = $facility_migration->get('source');
-      // We can only get a 1000 facilities at a time, so need to loop through.
-      foreach ($source['urls'] as $url) {
-        $headers = $source['headers'];
-        $fetcher = $this->dataFetcherPluginManager->createInstance('http', ['headers' => $headers]);
-        $data = $fetcher->getResponseContent($url);
-        // Convert objects to associative arrays.
-        $source_data = json_decode($data, TRUE);
-        $ids = array_map([__CLASS__, 'extractId'], $source_data['data']);
-        $facilities[] = array_flip($ids);
-      }
-    }
-
-    return $facilities;
-  }
-
-  /**
-   * Extracts the facility API id from the row.
-   *
-   * @param array $facility
-   *   Array of data for a single row.
-   *
-   * @return string
-   *   The facility api id.
-   */
-  protected static function extractId(array $facility) {
-    return $facility['id'];
-  }
-
-  /**
-   * Get all facility locator api ids in the CMS.
-   *
-   * @return array
-   *   Array of facility data key value pairs of <fapi_id> => <nid>.
-   */
-  protected function getFacilitiesInCms(): array {
-    // Will end up keyed <fapi_id> => nid.
-    $facilities = [];
-    $query = $this->database->select('node__field_facility_locator_api_id', 'fapi');
-    // For now we are excluding CAPs, they are not in the facility API.
-    $query->condition('field_facility_locator_api_id_value', '%CAP%', 'NOT LIKE');
-    $query->condition('field_facility_locator_api_id_value', '%tricare%', 'NOT LIKE');
-    $query->fields('fapi', ['field_facility_locator_api_id_value', 'entity_id']);
-    $facility_fields = $query->execute()->fetchAll();
-    if ($facility_fields) {
-      foreach ($facility_fields as $facility) {
-        $facilities[$facility->field_facility_locator_api_id_value] = $facility->entity_id;
-      }
-    }
-
-    return $facilities;
-  }
-
-  /**
-   * Get all archived facilities.
-   *
-   * @return array
-   *   Array of facility node ids.
-   */
-  protected function getArchivedFacilities(): array {
-    $facility_bundles = [
-      'health_care_local_facility',
-      'nca_facility',
-      'vba_facility',
-      'vet_center_mobile_vet_center',
-      'vet_center_outstation',
-      'vet_center',
-    ];
-    $storage = $this->entityTypeManager->getStorage('node');
-    $query = $storage->getQuery();
-    $query->condition('type', $facility_bundles, 'IN');
-    $query->condition('moderation_state', 'archived');
-    $query->accessCheck(FALSE);
-    $archived_facilities = array_values($query->execute());
-    return (array) $archived_facilities;
-  }
-
-  /**
-   * Get all facilities in the CMS already flagged removed_from_source.
-   *
-   * @return array
-   *   Array of facility node ids.
-   */
-  protected function getFlaggedRemovedFromSource(): array {
-    $query = $this->database->select('flagging', 'flagging');
-    $query->condition('entity_type', 'node', '=');
-    $query->condition('flag_id', 'removed_from_source', '=');
-    $query->fields('flagging', ['entity_id']);
-    $facilities_flagged = $query->execute()->fetchCol();
-    return (array) $facilities_flagged;
-  }
-
-  /**
-   * Performs a sanity count on the facility api data.
-   *
-   * @param int $count_fapi
-   *   A count of the facility api data returned.
-   *
-   * @return bool
-   *   TRUE if suspicious, FALSE otherwise.
-   */
-  protected function facilityCountSeemsFaulty($count_fapi): bool {
-    // We are always calling at least 1000 facilities, but have less than 5000.
-    if ($count_fapi < 1000 || $count_fapi > 5000) {
-      // Something is suspicious.
-      return TRUE;
-    }
-    return FALSE;
+    $this->vaGovMigrateService->flagMissingFacilities();
   }
 
 }

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -38,7 +38,7 @@ class Commands extends DrushCommands {
    */
   public function cleanRevs() {
     $messages = $this->vaGovMigrateService->cleanRevs();
-    $this->logger->success($messages['success']);
+    $this->logger->log('success', $messages['success']);
     $this->logger->warning($messages['warning']);
   }
 

--- a/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
@@ -67,7 +67,7 @@ class VaGovMigrateService {
   protected $notificationsManager;
 
   /**
-   * Constructs a new flagMissingFacilities object.
+   * Constructs a new VaGovMigrateService object.
    *
    * @param \Drupal\Core\Database\Connection $data_base
    *   Core database connection.
@@ -214,6 +214,7 @@ class VaGovMigrateService {
     $facilities_to_flag = $this->getFacilitiesToFlag($facilities_flat);
     $count_flagged = count($facilities_to_flag);
     $count_archived = 0;
+    $status = [];
     if ($count_flagged) {
       $facility_nodes_to_flag = $this->entityTypeManager->getStorage('node')->loadMultiple(array_values($facilities_to_flag));
       foreach ($facility_nodes_to_flag as $facility_node_to_flag) {
@@ -235,22 +236,18 @@ class VaGovMigrateService {
         '%count_flagged' => $count_flagged,
         '%count_archived' => $count_archived,
       ];
-
       if ($vars['%count_flagged'] > 0) {
         $msg = 'Flagged %count_flagged facilities as removed from Facility API.';
         $this->migrateChannelLogger->log(LogLevel::INFO, $msg, $vars);
-        // Create drush output.
-        // @phpstan-ignore-next-line
-        $this->logger->success("Flagged {$count_flagged} facilities as removed from Facility API.");
+        array_push($status, "Flagged {$count_flagged} facilities as removed from Facility API.");
       }
       if ($vars['%count_archived'] > 0) {
         $msg = 'Archived %count_archived facilities due to removal from Facility API.';
         $this->migrateChannelLogger->log(LogLevel::INFO, $msg, $vars);
-        // Create drush output.
-        // @phpstan-ignore-next-line
-        $this->logger->success("Archived {$count_archived} facilities due to removal from Facility API.");
+        array_push($status, "Archived {$count_archived} facilities due to removal from Facility API.");
       }
     }
+    return $status;
   }
 
   /**

--- a/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
@@ -131,8 +131,10 @@ class VaGovMigrateService {
 
     $count = count($vids) - count($missed_vids);
     // @phpstan-ignore-next-line
-    $this->migrateChannelLogger->success("Deleted {$count} revision(s).");
-    $this->migrateChannelLogger->warning('The following revisions were not deleted: ' . implode(', ', $missed_vids));
+    return [
+      'success' => "Deleted {$count} revision(s).",
+      'warning' => 'The following revisions were not deleted: ' . implode(', ', $missed_vids),
+    ];
   }
 
   /**


### PR DESCRIPTION
## Description

Drush commands are now using service in va_gov_migrate

Relates to #21395

### Generated description
This pull request refactors the `va_gov_migrate` module to streamline service dependencies and improve the handling of migration-related logs. The most important changes include replacing multiple service dependencies with a single custom service and modifying the `cleanRevs` method to return structured data instead of logging messages directly.

### Refactoring service dependencies:

* [`docroot/modules/custom/va_gov_migrate/drush.services.yml`](diffhunk://#diff-4cb3441df16425d519a585a554b5f908d33ef9eec87579a4d35e5e57f555ac9aL5-R5): Replaced multiple service dependencies with a single custom service, `@va_gov_migrate.va_gov_migrate_service`, simplifying the configuration of the `va_gov_migrate.commands` class.

### Improving log handling:

* [`docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php`](diffhunk://#diff-4b371100d1c098ced540796966059d7f365e2f4118b0ac7cfe35f2c9c892d243L134-R137): Modified the `cleanRevs` method to return structured data containing success and warning messages instead of directly logging them, making the method more flexible for downstream usage.

## Testing done
Manual testing in tugboat

## QA steps
 - [ ] Test drush commands in this tugboat
 - [ ] view watchdog logs to verify there are no errors

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

