### PR TITLE
VACMS-21650: Banner API cache

### DIFF
--- a/docroot/modules/custom/va_gov_api/src/Controller/BannerAlertsController.php
+++ b/docroot/modules/custom/va_gov_api/src/Controller/BannerAlertsController.php
@@ -45,7 +45,8 @@ class BannerAlertsController extends ControllerBase {
     SerializerInterface $serializer,
     PathMatcherInterface $path_matcher,
     PathValidatorInterface $path_validator,
-    EntityTypeManagerInterface $entity_type_manager) {
+    EntityTypeManagerInterface $entity_type_manager,
+  ) {
     $this->serializer = $serializer;
     $this->pathMatcher = $path_matcher;
     $this->pathValidator = $path_validator;
@@ -134,7 +135,7 @@ class BannerAlertsController extends ControllerBase {
 
     // Add the banners to the response.
     $banner_data = [];
-    $cache_tags = [];
+    $cache_tags = ['node_list:banner'];
     foreach ($banners as $entity) {
       $banner_data[] = $this->serializer->normalize($entity);
       $cache_tags = array_merge($cache_tags, $entity->getCacheTags());
@@ -178,7 +179,7 @@ class BannerAlertsController extends ControllerBase {
 
     // Add the promo_banners to the response.
     $promo_banner_data = [];
-    $cache_tags = [];
+    $cache_tags = ['node_list:promo_banner'];
     foreach ($promo_banners as $entity) {
       $promo_banner_data[] = $this->serializer->normalize($entity);
       $cache_tags = array_merge($cache_tags, $entity->getCacheTags());
@@ -250,7 +251,7 @@ class BannerAlertsController extends ControllerBase {
 
     // Add the banners to the response.
     $full_width_banner_alert_data = [];
-    $cache_tags = [];
+    $cache_tags = ['node_list:full_width_banner_alert'];
     foreach ($facility_banners as $entity) {
       $normalized_data = $this->serializer->normalize($entity);
 


### PR DESCRIPTION
## Description
Adds node_list cache tags to invalidate the cache for the path anytime a banner, promo_banner, or  full_width_banner_alert is updated, created, or deleted. Alternatively a custom cache tag could have been created for each cached path, and then invalidated once that value is used in the field of a banner. I felt like this simpler option was better since these don't get heavy use.

Closes to #21650.

### Generated description
This pull request makes updates to the `BannerAlertsController` class in the `va_gov_api` module to improve cache tagging for banner-related data and refactors the constructor for better readability.

### Cache Tagging Improvements:
* Updated cache tags for banner data collection methods to include specific tags for `node_list:banner`, `node_list:promo_banner`, and `node_list:full_width_banner_alert` to enhance cache management and ensure more granular control. (`[[1]](diffhunk://#diff-a7135d760bf735a5b023ba0c522fc27b57fbaf65e6938e120a390e6bd1ef294aL137-R138)`, `[[2]](diffhunk://#diff-a7135d760bf735a5b023ba0c522fc27b57fbaf65e6938e120a390e6bd1ef294aL181-R182)`, `[[3]](diffhunk://#diff-a7135d760bf735a5b023ba0c522fc27b57fbaf65e6938e120a390e6bd1ef294aL253-R254)`)

### Constructor Refactoring:
* Refactored the `__construct` method to improve readability by adding a trailing comma in the parameter list. (`[docroot/modules/custom/va_gov_api/src/Controller/BannerAlertsController.phpL48-R49](diffhunk://#diff-a7135d760bf735a5b023ba0c522fc27b57fbaf65e6938e120a390e6bd1ef294aL48-R49)`)

## Testing done
tugboat testing

## QA steps
 - [ ] visit this api endpoint in tugboat: https://cms-cdfx9qn1e87pe4mztnqbt9hnojcewicg.ci.cms.va.gov/api/v1/banner-alerts?path=/boston-health-care/staff-profiles/vincent-ng/
 - [ ] it should be empty, and this empty value should now be cached
 - [ ] create a new Full Width Alert -> https://cms-cdfx9qn1e87pe4mztnqbt9hnojcewicg.ci.cms.va.gov/node/add/banner
 - [ ] add `/boston-health-care/staff-profiles/vincent-ng/` as a path
 - [ ] you can set the section to `Sitewide Content Team`
 - [ ] Save & Publish the alert
 - [ ] re-visit https://cms-cdfx9qn1e87pe4mztnqbt9hnojcewicg.ci.cms.va.gov/api/v1/banner-alerts?path=/boston-health-care/staff-profiles/vincent-ng/
 - [ ] verify that there is data now, this value should now be cached
 - [ ] go back to the alert that you created in the CMS, and delete it
 - [ ] re-visit https://cms-cdfx9qn1e87pe4mztnqbt9hnojcewicg.ci.cms.va.gov/api/v1/banner-alerts?path=/boston-health-care/staff-profiles/vincent-ng/
 - [ ] verify that there is no data
 - [ ] you can pull this branch locally and run xdebug to verify that the cache hits when it is supposed to, to verify that caching is still working when there are no changes or new nodes.
 
### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

