### PR TITLE
VACMS-21688: content-build version update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,7 +231,7 @@
         "symfony/phpunit-bridge": "^7.1",
         "symfony/process": "^6.3",
         "symfony/routing": "^6.3",
-        "va-gov/content-build": "^0.0.3794",
+        "va-gov/content-build": "^0.0.3795",
         "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "1.3.1",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1990ba50f05d5bf7ceabbd696b32d129",
+    "content-hash": "0abe0c56e1e2d02db5e4b70db8fa929f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -27373,7 +27373,7 @@
         },
         {
             "name": "va-gov/content-build",
-            "version": "v0.0.3794",
+            "version": "v0.0.3795",
             "source": {
                 "type": "git",
                 "url": "https://github.com/department-of-veterans-affairs/content-build.git",
@@ -27409,7 +27409,7 @@
             "description": "Front-end for VA.gov. This repository contains the code that generates the www.va.gov website. It contains a Metalsmith static site builder that uses a Drupal CMS for content. This file is here to publish releases to https://packagist.org/packages/va-gov/content-build, so that the CMS CI system can install it and update it using standard composer processes, and so that we can run tests across both systems. See https://github.com/department-of-veterans-affairs/va.gov-cms for the CMS repo, and stand by for more documentation.",
             "support": {
                 "issues": "https://github.com/department-of-veterans-affairs/content-build/issues",
-                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3794"
+                "source": "https://github.com/department-of-veterans-affairs/content-build/tree/v0.0.3795"
             },
             "time": "2025-07-17T21:10:00+00:00"
         },


### PR DESCRIPTION
## Description
bumped content-build to 0.0.3795 from 0.0.3794

Closes to #21688 

### Generated description
This pull request updates the version of the `va-gov/content-build` dependency in `composer.json` to ensure compatibility with the latest features and bug fixes.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L234-R234): Updated the `va-gov/content-build` dependency from version `^0.0.3794` to `^0.0.3795` to incorporate the latest changes.

## Testing done
CI tests

## QA steps

 - [ ] verify that version in composer and composer lock for content-build is `0.0.3795`


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`



