### PR TITLE
VACMS-20364: Updates select for Tippy

### DIFF
--- a/docroot/modules/custom/va_gov_backend/js/toolbar.es6.js
+++ b/docroot/modules/custom/va_gov_backend/js/toolbar.es6.js
@@ -8,40 +8,43 @@
       const loadingText =
         "<div style='height: 20px; width: 40px;' class='claro-spinner'></div>";
       $(once("content-release-status-icon", "body", context)).each(() => {
-        Tippy("#content-release-status-icon", {
-          content(reference) {
-            reference.removeAttribute("title");
-            return loadingText;
-          },
-          flipOnUpdate: true,
-          onCreate(instance) {
-            instance._isFetching = false;
-            instance._src = null;
-            instance._error = null;
-          },
-          onHidden(instance) {
-            instance.setContent(loadingText);
-          },
-          onShow(instance) {
-            if (instance._isFetching || instance._src || instance._error) {
-              return;
-            }
+        Tippy(
+          "#content-release-status-icon, #content-release-status-icon-prod",
+          {
+            content(reference) {
+              reference.removeAttribute("title");
+              return loadingText;
+            },
+            flipOnUpdate: true,
+            onCreate(instance) {
+              instance._isFetching = false;
+              instance._src = null;
+              instance._error = null;
+            },
+            onHidden(instance) {
+              instance.setContent(loadingText);
+            },
+            onShow(instance) {
+              if (instance._isFetching || instance._src || instance._error) {
+                return;
+              }
 
-            instance._isFetching = true;
+              instance._isFetching = true;
 
-            $.get("/admin/content/deploy/status", (data) => {
-              instance.setContent(data);
-            })
-              .fail((jqXHR, textStatus, errorThrown) => {
-                instance.setContent(`Request failed. ${errorThrown}`);
+              $.get("/admin/content/deploy/status", (data) => {
+                instance.setContent(data);
               })
-              .always(() => {
-                instance._isFetching = false;
-              });
-          },
-          theme: "tippy_popover tippy_popover_center",
-          allowHTML: true,
-        });
+                .fail((jqXHR, textStatus, errorThrown) => {
+                  instance.setContent(`Request failed. ${errorThrown}`);
+                })
+                .always(() => {
+                  instance._isFetching = false;
+                });
+            },
+            theme: "tippy_popover tippy_popover_center",
+            allowHTML: true,
+          }
+        );
       });
     },
   };

--- a/docroot/modules/custom/va_gov_backend/js/toolbar.js
+++ b/docroot/modules/custom/va_gov_backend/js/toolbar.js
@@ -9,7 +9,7 @@
     attach: function attach(context) {
       var loadingText = "<div style='height: 20px; width: 40px;' class='claro-spinner'></div>";
       $(once("content-release-status-icon", "body", context)).each(function () {
-        Tippy("#content-release-status-icon", {
+        Tippy("#content-release-status-icon, #content-release-status-icon-prod", {
           content: function content(reference) {
             reference.removeAttribute("title");
             return loadingText;


### PR DESCRIPTION
## Description

Restores the production time information available on hover in Production.

Relates to #20364 

### Generated description
This pull request updates the JavaScript code in the `va_gov_backend` module to enhance functionality for displaying tooltips. The changes primarily involve expanding the scope of tooltips to include an additional element.

### Tooltip functionality updates:

* [`docroot/modules/custom/va_gov_backend/js/toolbar.es6.js`](diffhunk://#diff-ca1c375605b7551e2fab6addf866828858b883943a684b6c523dfc33818ede96L11-R13): Modified the `Tippy` initialization to target both `#content-release-status-icon` and `#content-release-status-icon-prod`, allowing tooltips to be displayed for both elements. [[1]](diffhunk://#diff-ca1c375605b7551e2fab6addf866828858b883943a684b6c523dfc33818ede96L11-R13) [[2]](diffhunk://#diff-ca1c375605b7551e2fab6addf866828858b883943a684b6c523dfc33818ede96L44-R47)
* [`docroot/modules/custom/va_gov_backend/js/toolbar.js`](diffhunk://#diff-affc0a873217ca8c862703bd256a1a13ed5c2f2695c9bd117d343b62d63aa886L12-R12): Updated the `Tippy` initialization similarly to include the `#content-release-status-icon-prod` element, ensuring consistent behavior across compiled JavaScript.

## Testing done
- Manually

## Screenshots
<img width="2338" height="3054" alt="Screenshot 2025-07-28 at 9 42 46 AM" src="https://github.com/user-attachments/assets/c58b93d5-f185-48dd-b76a-652ccba73e10" />

## QA steps
- [ ] Deploy branch to test.prod.cms.va.gov
- [ ] Log into test.prod.cms.va.gov
- [ ] Hover over icon on the top right
- [ ] Confirm that the last updated time appears

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
