### PR TITLE
VACMS-21733: trigger content release for next build prod when certain actions are taken in drupal

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
@@ -37,6 +37,13 @@ class BRD extends EnvironmentPluginBase {
   protected $cbGitHubClient;
 
   /**
+   * Github API client for the `next-build` repository.
+   *
+   * @var \Drupal\va_gov_github\Api\Client\ApiClientInterface
+   */
+  protected $nbGitHubClient;
+
+  /**
    * {@inheritDoc}
    */
   public function __construct(
@@ -46,7 +53,8 @@ class BRD extends EnvironmentPluginBase {
     LoggerInterface $logger,
     FileSystemInterface $filesystem,
     Settings $settings,
-    ApiClientInterface $cbGitHubClient
+    ApiClientInterface $cbGitHubClient,
+    ApiClientInterface $nbGitHubClient,
   ) {
     parent::__construct(
       $configuration,
@@ -57,6 +65,7 @@ class BRD extends EnvironmentPluginBase {
     );
     $this->settings = $settings;
     $this->cbGitHubClient = $cbGitHubClient;
+    $this->nbGitHubClient = $nbGitHubClient;
   }
 
   /**
@@ -70,7 +79,8 @@ class BRD extends EnvironmentPluginBase {
       $container->get('logger.factory')->get('va_gov_build_trigger'),
       $container->get('file_system'),
       $container->get('settings'),
-      $container->get('va_gov_github.api_client.content_build')
+      $container->get('va_gov_github.api_client.content_build'),
+      $container->get('va_gov_github.api_client.next_build')
     );
   }
 
@@ -79,7 +89,7 @@ class BRD extends EnvironmentPluginBase {
    */
   public function triggerFrontendBuild() : void {
     try {
-      if ($this->pendingWorkflowRunExists()) {
+      if ($this->pendingContentBuildWorkflowRunExists()) {
         $vars = [
           '@job_link' => 'https://github.com/department-of-veterans-affairs/content-build/actions/workflows/content-release.yml',
         ];
@@ -90,7 +100,28 @@ class BRD extends EnvironmentPluginBase {
         $vars = [
           '@job_link' => 'https://github.com/department-of-veterans-affairs/content-build/actions/workflows/content-release.yml',
         ];
-        $message = $this->t('The system started the process of releasing this content to go live on VA.gov. <a href="@job_link">Check status</a>.', $vars);
+        $message = $this->t('The system started the process of releasing this content to go live on VA.gov. <a href="@job_link">Check content-build status</a>.', $vars);
+      }
+      $this->messenger()->addStatus($message);
+      $this->logger->info($message);
+    }
+    catch (\Throwable $exception) {
+      $this->handleBrdException($exception);
+    }
+    try {
+      if ($this->pendingNextBuildWorkflowRunExists()) {
+        $vars = [
+          '@job_link' => 'https://github.com/department-of-veterans-affairs/next-build/actions/workflows/content-release-prod.yml',
+        ];
+        $message = $this->t('Changes will be included in a content release to VA.gov that\'s already in progress. <a href="@job_link">Check status</a>.', $vars);
+      }
+      else {
+        // Trigger the next-build workflow as well.
+        $this->nbGitHubClient->triggerRepositoryDispatchEvent('content-release-prod');
+        $vars = [
+          '@job_link' => 'https://github.com/department-of-veterans-affairs/next-build/actions/workflows/content-release-prod.yml',
+        ];
+        $message = $this->t('The system started the process of releasing this content to go live on VA.gov. <a href="@cb_job_link">Check next-build status</a>.', $vars);
       }
       $this->messenger()->addStatus($message);
       $this->logger->info($message);
@@ -108,9 +139,9 @@ class BRD extends EnvironmentPluginBase {
   }
 
   /**
-   * Check for a pending content-release workflow run.
+   * Check for a pending Content Build content-release workflow run.
    */
-  protected function pendingWorkflowRunExists() : bool {
+  protected function pendingContentBuildWorkflowRunExists() : bool {
     try {
       // Check if there are any workflows pending that were created recently.
       $check_interval = 2 * 60 * 60;
@@ -120,6 +151,29 @@ class BRD extends EnvironmentPluginBase {
         'created' => '>=' . date('c', $check_time),
       ];
       $workflow_runs = $this->cbGitHubClient->getWorkflowRuns('content-release.yml', $workflow_run_params);
+
+      // A well-formed response will have `total_count` set.
+      return !empty($workflow_runs['total_count']) && $workflow_runs['total_count'] > 0;
+    }
+    catch (\Throwable $exception) {
+      $this->handleBrdException($exception);
+    }
+    return FALSE;
+  }
+
+  /**
+   * Check for a pending Next Build content-release workflow run.
+   */
+  protected function pendingNextBuildWorkflowRunExists() : bool {
+    try {
+      // Check if there are any workflows pending that were created recently.
+      $check_interval = 2 * 60 * 60;
+      $check_time = time() - $check_interval;
+      $workflow_run_params = [
+        'status' => 'pending',
+        'created' => '>=' . date('c', $check_time),
+      ];
+      $workflow_runs = $this->nbGitHubClient->getWorkflowRuns('content-release-prod.yml', $workflow_run_params);
 
       // A well-formed response will have `total_count` set.
       return !empty($workflow_runs['total_count']) && $workflow_runs['total_count'] > 0;

--- a/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.php
@@ -122,7 +122,7 @@ class BRD extends EnvironmentPluginBase {
         $vars = [
           '@job_link' => 'https://github.com/department-of-veterans-affairs/next-build/actions/workflows/content-release-prod.yml',
         ];
-        $message = $this->t('The system started the process of releasing this content to go live on VA.gov. <a href="@cb_job_link">Check next-build status</a>.', $vars);
+        $message = $this->t('The system started the process of releasing this content to go live on VA.gov. <a href="@job_link">Check next-build status</a>.', $vars);
       }
       $this->messenger()->addStatus($message);
       $this->logger->info($message);


### PR DESCRIPTION
## Description

Closes #21733 

### Generated description

This pull request enhances the `BRD` environment plugin in the `va_gov_build_trigger` module to support triggering and monitoring builds for an additional repository (`next-build`) alongside the existing `content-build` repository. The changes include adding a new GitHub client, updating build trigger logic, and improving error handling for both repositories.

### Support for `next-build` repository:
* Added a new protected property `nbGitHubClient` to the `BRD` class to interact with the `next-build` repository's GitHub API. Updated the constructor and dependency injection container to initialize this new client. (`[[1]](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14R40-R46)`, `[[2]](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14L49-R58)`, `[[3]](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14R69)`, `[[4]](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14L73-R84)`)

* Introduced a new method, `pendingNextBuildWorkflowRunExists()`, to check for pending workflow runs in the `next-build` repository. (`[docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.phpL128-R217](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14L128-R217)`)

* Updated the `triggerFrontendBuild()` method to trigger and log build workflows for both `content-build` and `next-build` repositories. (`[docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.phpL82-R93](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14L82-R93)`)

### Error handling improvements:
* Refactored the `handleBrdException()` method into `handleCbException()` (for `content-build`) and added a new `handleNbException()` method for `next-build` to handle errors specific to each repository. Both methods now use `Error::logException()` for consistent logging. (`[docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.phpL111-R145](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14L111-R145)`)

### Miscellaneous:
* Renamed the `pendingWorkflowRunExists()` method to `pendingContentBuildWorkflowRunExists()` for clarity. (`[docroot/modules/custom/va_gov_build_trigger/src/Plugin/VAGov/Environment/BRD.phpL111-R145](diffhunk://#diff-5d9813a56dfa01e1b80f602194be157badc68e9859487e5651f81fc95782cb14L111-R145)`)

## Testing done
Tested on prod by running:
`drush php-eval "\Drupal::service('va_gov_github.api_client.next_build')->triggerRepositoryDispatchEvent('content-release-staging');"`
This successfully kicked off a content release on next-build staging. 
<img width="1285" height="86" alt="CleanShot2025-08-01at08 15 25" src="https://github.com/user-attachments/assets/8f0c052e-8e12-45fe-8507-04e750baf911" />


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If this passes automated testing, it should be good. Unfortunately, it cannot be tested on lower environments. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
