### PR TITLE
VACMS-21936: add permissions to apache container gha

### DIFF
--- a/.github/workflows/build-apache-container.yml
+++ b/.github/workflows/build-apache-container.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: 0 12 * * 4
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Relates to #21936 

### Generated description

This pull request makes a small but important update to the GitHub Actions workflow configuration. The change sets explicit permissions for the workflow, allowing it to request a JWT and read repository contents. This improves security and ensures the workflow has the necessary access to perform its tasks.

* Workflow permissions: Added `id-token: write` and `contents: read` permissions to the `.github/workflows/build-apache-container.yml` workflow to enable JWT requests and repository checkout.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?
If this passes automated testing it should be good.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
