### PR TITLE
VACMS-21936: update gha for caching a cleaner tagging script

### DIFF
--- a/.github/workflows/build-apache-container.yml
+++ b/.github/workflows/build-apache-container.yml
@@ -34,7 +34,7 @@ jobs:
           REPO_NAME="dsva/cms-apache"
           LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
 
-          if [ -z "$LAST_TAG" ]; then
+          if [ -z "$LAST_TAG" ] || [ "$LAST_TAG" = "None" ]; then
             NEW_TAG="1.0.0" # Initial tag if no images exist
           else
             # Example: Incrementing a semantic version tag (e.g., 1.0.1 -> 1.0.2)

--- a/.github/workflows/build-apache-container.yml
+++ b/.github/workflows/build-apache-container.yml
@@ -32,7 +32,7 @@ jobs:
         id: get_next_tag
         run: |
           REPO_NAME="dsva/cms-apache"
-          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' --output text)
+          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
 
           if [ -z "$LAST_TAG" ]; then
             NEW_TAG="1.0.0" # Initial tag if no images exist

--- a/.github/workflows/build-apache-container.yml
+++ b/.github/workflows/build-apache-container.yml
@@ -32,13 +32,19 @@ jobs:
         id: get_next_tag
         run: |
           REPO_NAME="dsva/cms-apache"
-          # Logic to fetch latest tag and increment (e.g., using aws cli and jq)
-          # For simplicity, let's assume a basic increment here
-          LATEST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' --output text || echo "0.0.0")
-          IFS='.' read -r major minor patch <<< "$LATEST_TAG"
-          NEW_PATCH=$((patch + 1))
-          NEW_TAG="${major}.${minor}.${NEW_PATCH}"
-          echo "new_tag=${NEW_TAG}" >> $GITHUB_OUTPUT
+          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' --output text)
+
+          if [ -z "$LAST_TAG" ]; then
+            NEW_TAG="1.0.0" # Initial tag if no images exist
+          else
+            # Example: Incrementing a semantic version tag (e.g., 1.0.1 -> 1.0.2)
+            MAJOR=$(echo $LAST_TAG | awk -F'.' '{print $1}')
+            MINOR=$(echo $LAST_TAG | awk -F'.' '{print $2}')
+            PATCH=$(echo $LAST_TAG | awk -F'.' '{print $3}')
+            PATCH=$((PATCH + 1))
+            NEW_TAG="${MAJOR}.${MINOR}.${PATCH}"
+          fi
+          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -50,4 +56,9 @@ jobs:
           platforms: linux/amd64
           file: ./docker/apache/Dockerfile
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/dsva/cms-apache:${{ steps.get_next_tag.outputs.new_tag }}
+          provenance: false
+          tags: ${{ steps.login-ecr.outputs.registry }}/dsva/cms-apache:${{ env.NEW_TAG }}
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/dsva/cms-apache:cache
+          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ steps.login-ecr.outputs.registry }}/dsva/cms-apache:cache
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1


### PR DESCRIPTION
## Description

Relates to #21936 

### Generated description

This pull request updates the GitHub Actions workflow for building and publishing the Apache container image. The changes focus on improving the tagging logic for Docker images and optimizing the build process with caching and provenance settings.

**Build Tagging Improvements:**

* Refactored the logic for determining the next Docker tag: now checks if an existing tag is present and starts at `1.0.0` if none exists, otherwise increments the patch version of the latest tag. The new tag is set in the environment variable `NEW_TAG` for use in subsequent steps.

**Docker Build Process Optimization:**

* Updated the Docker build step to:
  - Use the new `NEW_TAG` environment variable for tagging the image.
  - Disable provenance metadata generation for the build.
  - Add registry-based build cache configuration (`cache-from` and `cache-to`) to speed up future builds.
  - Include the `BUILDKIT_INLINE_CACHE` build argument for improved caching with BuildKit.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If this pases automated testing it should be good. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
