### PR TITLE
VACMS-21936: added gha to build drupal container

### DIFF
--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           REPO_NAME="dsva/cms-apache"
           LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
+          if [ -z "$LAST_TAG" ] || [ "$LAST_TAG" = "None" ]; then
+            echo "No tagged images found in $REPO_NAME. Using fallback tag '1.0.0'."
+            LAST_TAG="1.0.0" # Initial tag if no images exist
+          fi
 
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
 

--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -1,0 +1,56 @@
+name: Build and Push Drupal Container to ECR
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.2.1
+        with:
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-vagov-next-build-githubaction
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Get last Apache image tag
+        id: get_last_apache_tag
+        run: |
+          REPO_NAME="dsva/cms-apache"
+          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
+
+          echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          file: ./Dockerfile
+          push: true
+          provenance: false
+          tags: ${{ steps.login-ecr.outputs.registry }}/dsva/cms-drupal:${{ github.sha }}
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/dsva/cms-drupal:cache
+          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ steps.login-ecr.outputs.registry }}/dsva/cms-drupal:cache
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE_TAG=${{ env.LAST_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=latest
+ARG BASE_IMAGE_TAG=1.0.0
 FROM 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cms-apache:${BASE_IMAGE_TAG}
 
 # https://www.drupal.org/node/3060/release


### PR DESCRIPTION
## Description

Relates to #21936 

### Generated description

This pull request introduces a new GitHub Actions workflow for building and pushing the Drupal container to Amazon ECR, and updates the `Dockerfile` to use a specific base image tag. The workflow automates the build and deployment process, integrates with AWS for authentication, and improves image caching and tagging.

**CI/CD Workflow Automation:**
* Added `.github/workflows/build-drupal-container.yml` to automate building and pushing the Drupal Docker image to ECR on pushes to `main` or via manual dispatch. The workflow includes AWS authentication, Docker Buildx setup, image caching, and dynamic base image tagging.

**Dockerfile Update:**
* Changed the default `BASE_IMAGE_TAG` in `Dockerfile` from `latest` to `1.0.0` to ensure consistent and predictable base image usage for Drupal builds.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
