### PR TITLE
VACMS-21936: add semver check to cms-apache repo tagging for both builds

### DIFF
--- a/.github/workflows/build-apache-container.yml
+++ b/.github/workflows/build-apache-container.yml
@@ -32,7 +32,21 @@ jobs:
         id: get_next_tag
         run: |
           REPO_NAME="dsva/cms-apache"
-          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
+          # Get all images sorted by push date (newest first)
+          LAST_TAG="1.0.0"  # Default fallback
+          IMAGES_JSON=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(reverse(imageDetails),& imagePushedAt)' --output json)
+          SEMVER_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+          # Loop through images from newest to oldest to find the first tag matching semantic versioning
+          echo "$IMAGES_JSON" | jq -c '.[]' | while read -r IMAGE; do
+            for TAG in $(echo "$IMAGE" | jq -r '.imageTags[]? // empty'); do
+              if [[ "$TAG" =~ $SEMVER_PATTERN ]]; then
+                LAST_TAG="$TAG"
+                echo "Found most recent semantic version tag: $LAST_TAG"
+                break 2
+              fi
+            done
+          done
 
           if [ -z "$LAST_TAG" ] || [ "$LAST_TAG" = "None" ]; then
             NEW_TAG="1.0.0" # Initial tag if no images exist

--- a/.github/workflows/build-apache-container.yml
+++ b/.github/workflows/build-apache-container.yml
@@ -35,18 +35,13 @@ jobs:
           # Get all images sorted by push date (newest first)
           LAST_TAG="1.0.0"  # Default fallback
           IMAGES_JSON=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(reverse(imageDetails),& imagePushedAt)' --output json)
-          SEMVER_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
+          SEMVER_TAG=$(echo "$IMAGES_JSON" | jq -r '
+            [.[] | select(.imageTags != null) |
+             .imageTags[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] |
+            first
+          ')
 
-          # Loop through images from newest to oldest to find the first tag matching semantic versioning
-          echo "$IMAGES_JSON" | jq -c '.[]' | while read -r IMAGE; do
-            for TAG in $(echo "$IMAGE" | jq -r '.imageTags[]? // empty'); do
-              if [[ "$TAG" =~ $SEMVER_PATTERN ]]; then
-                LAST_TAG="$TAG"
-                echo "Found most recent semantic version tag: $LAST_TAG"
-                break 2
-              fi
-            done
-          done
+          LAST_TAG="$SEMVER_TAG"
 
           if [ -z "$LAST_TAG" ] || [ "$LAST_TAG" = "None" ]; then
             NEW_TAG="1.0.0" # Initial tag if no images exist

--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -33,11 +33,21 @@ jobs:
         id: get_last_apache_tag
         run: |
           REPO_NAME="dsva/cms-apache"
-          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
-          if [ -z "$LAST_TAG" ] || [ "$LAST_TAG" = "None" ]; then
-            echo "No tagged images found in $REPO_NAME. Using fallback tag '1.0.0'."
-            LAST_TAG="1.0.0" # Initial tag if no images exist
-          fi
+          # Get all images sorted by push date (newest first)
+          LAST_TAG="1.0.0"  # Default fallback
+          IMAGES_JSON=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(reverse(imageDetails),& imagePushedAt)' --output json)
+          SEMVER_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+          # Loop through images from newest to oldest to find the first tag matching semantic versioning
+          echo "$IMAGES_JSON" | jq -c '.[]' | while read -r IMAGE; do
+            for TAG in $(echo "$IMAGE" | jq -r '.imageTags[]? // empty'); do
+              if [[ "$TAG" =~ $SEMVER_PATTERN ]]; then
+                LAST_TAG="$TAG"
+                echo "Found most recent semantic version tag: $LAST_TAG"
+                break 2
+              fi
+            done
+          done
 
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
 

--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -36,18 +36,13 @@ jobs:
           # Get all images sorted by push date (newest first)
           LAST_TAG="1.0.0"  # Default fallback
           IMAGES_JSON=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(reverse(imageDetails),& imagePushedAt)' --output json)
-          SEMVER_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
+          SEMVER_TAG=$(echo "$IMAGES_JSON" | jq -r '
+            [.[] | select(.imageTags != null) |
+             .imageTags[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] |
+            first
+          ')
 
-          # Loop through images from newest to oldest to find the first tag matching semantic versioning
-          echo "$IMAGES_JSON" | jq -c '.[]' | while read -r IMAGE; do
-            for TAG in $(echo "$IMAGE" | jq -r '.imageTags[]? // empty'); do
-              if [[ "$TAG" =~ $SEMVER_PATTERN ]]; then
-                LAST_TAG="$TAG"
-                echo "Found most recent semantic version tag: $LAST_TAG"
-                break 2
-              fi
-            done
-          done
+          LAST_TAG="$SEMVER_TAG"
 
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
 

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -167,6 +167,8 @@ RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
 
 RUN rm -rf /opt/drupal
 
+ENV BUILD_ENV=eks
+
 EXPOSE 80
 
 # Create startup script to run both Apache and PHP-FPM

--- a/scripts/compile-theme.sh
+++ b/scripts/compile-theme.sh
@@ -13,7 +13,10 @@ pushd ./bin
 ln -sf ../docroot/libraries/yarn/bin/yarn ./yarn
 popd
 
-export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+export NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt
+if [[ "${BUILD_ENV}" == "eks" ]]; then
+  export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+fi
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
 
 pushd ./docroot/core

--- a/scripts/web-install.sh
+++ b/scripts/web-install.sh
@@ -23,7 +23,10 @@ echo "Yarn $(yarn -v)"
 pushd "./web"
 nvm install
 yarn run install-repos
-export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+export NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt
+if [[ "${BUILD_ENV}" == "eks" ]]; then
+  export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+fi
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
 yarn install
 popd


### PR DESCRIPTION
## Description

Relates to #21936 

### Generated description

This pull request updates the logic for retrieving the most recent semantic version tag from the ECR repository in both the Apache and Drupal container build workflows. The new approach ensures that only tags following semantic versioning (e.g., `1.2.3`) are selected, improving reliability and consistency in tag selection.

**Improvements to ECR image tag selection:**

* Updated the logic in `.github/workflows/build-apache-container.yml` to iterate through image tags from newest to oldest and select the most recent tag that matches semantic versioning, defaulting to `1.0.0` if none are found.
* Applied the same semantic version tag selection logic to `.github/workflows/build-drupal-container.yml`, ensuring consistent behavior across both workflows.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
