### PR TITLE
VACMS-21936: need to get last not first because aws ecr quuery reverses sort duh!

### DIFF
--- a/.github/workflows/build-apache-container.yml
+++ b/.github/workflows/build-apache-container.yml
@@ -32,7 +32,16 @@ jobs:
         id: get_next_tag
         run: |
           REPO_NAME="dsva/cms-apache"
-          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
+          # Get all images sorted by push date (newest first)
+          LAST_TAG="1.0.0"  # Default fallback
+          IMAGES_JSON=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(reverse(imageDetails),& imagePushedAt)' --output json)
+          SEMVER_TAG=$(echo "$IMAGES_JSON" | jq -r '
+            [.[] | select(.imageTags != null) |
+             .imageTags[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] |
+            last
+          ')
+
+          LAST_TAG="$SEMVER_TAG"
 
           if [ -z "$LAST_TAG" ] || [ "$LAST_TAG" = "None" ]; then
             NEW_TAG="1.0.0" # Initial tag if no images exist

--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -33,11 +33,16 @@ jobs:
         id: get_last_apache_tag
         run: |
           REPO_NAME="dsva/cms-apache"
-          LAST_TAG=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(imageDetails[?imageTags!=null],& imagePushedAt)[-1].imageTags[0]' --output text)
-          if [ -z "$LAST_TAG" ] || [ "$LAST_TAG" = "None" ]; then
-            echo "No tagged images found in $REPO_NAME. Using fallback tag '1.0.0'."
-            LAST_TAG="1.0.0" # Initial tag if no images exist
-          fi
+          # Get all images sorted by push date (newest first)
+          LAST_TAG="1.0.0"  # Default fallback
+          IMAGES_JSON=$(aws ecr describe-images --repository-name $REPO_NAME --query 'sort_by(reverse(imageDetails),& imagePushedAt)' --output json)
+          SEMVER_TAG=$(echo "$IMAGES_JSON" | jq -r '
+            [.[] | select(.imageTags != null) |
+             .imageTags[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] |
+            last
+          ')
+
+          LAST_TAG="$SEMVER_TAG"
 
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Description

Relates to #21936 
### Generated description

This pull request updates the logic for retrieving the latest semantic version tag from the ECR repository in both the Apache and Drupal container build workflows. The changes improve reliability by ensuring only valid semantic version tags are selected and providing a consistent fallback mechanism.

**Tag retrieval improvements:**

* Updated the tag selection logic in `.github/workflows/build-apache-container.yml` to use `jq` for extracting the latest semantic version tag from the ECR image list, with a fallback to `"1.0.0"` if no valid tags are found.
* Applied the same semantic version tag extraction and fallback logic in `.github/workflows/build-drupal-container.yml`, replacing the previous approach and ensuring consistency between both workflows.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
