### PR TITLE
VACMS-21936: new update manifest workflow

### DIFF
--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -63,3 +63,11 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             BASE_IMAGE_TAG=${{ env.LAST_TAG }}
+
+  deploy-to-dev:
+    needs: build-and-push
+    uses: department-of-veterans-affairs/va.gov-cms/.github/workflows/update-manifest.yml@main
+    with:
+      image_tag: ${{ github.sha }}
+      app_name: cms
+      environment: dev

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -12,24 +12,16 @@ on:
         description: Image tag version (git sha)
         type: string
         required: true
-        default: "8f0bc0de7d3857f1d78acbce80bdba1d0527ac7c"
       app_name:
         description: App to target (cms)
         type: string
         required: true
         default: "cms"
-        options:
-          - cms
-          - cms-test
       environment:
         description: Deploy environment (dev, staging, prod)
         type: string
         required: true
         default: "dev"
-        options:
-          - dev
-          - staging
-          - prod
   # Used to trigger this workflow from another workflow
   workflow_call:
     inputs:
@@ -37,7 +29,6 @@ on:
         description: Image tag version (git sha)
         type: string
         required: true
-        default: "8f0bc0de7d3857f1d78acbce80bdba1d0527ac7c"
       app_name:
         description: App to target (cms)
         type: string

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -1,0 +1,94 @@
+name: Update infrastructure manifest
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+on:
+  # Triggered manually or by another workflow
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Image tag version (git sha)
+        type: string
+        required: true
+        default: "8f0bc0de7d3857f1d78acbce80bdba1d0527ac7c"
+      app_name:
+        description: App to target (cms)
+        type: string
+        required: true
+        default: "cms"
+        options:
+          - cms
+          - cms-test
+      environment:
+        description: Deploy environment (dev, staging, prod)
+        type: string
+        required: true
+        default: "dev"
+        options:
+          - dev
+          - staging
+          - prod
+  # Used to trigger this workflow from another workflow
+  workflow_call:
+    inputs:
+      image_tag:
+        description: Image tag version (git sha)
+        type: string
+        required: true
+        default: "8f0bc0de7d3857f1d78acbce80bdba1d0527ac7c"
+      app_name:
+        description: App to target (cms)
+        type: string
+        required: true
+        default: "cms"
+      environment:
+        description: Deploy environment (dev, staging, prod)
+        type: string
+        required: true
+        default: "dev"
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: ${{ inputs.image_tag }}
+    steps:
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.2.1
+        with:
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-vagov-next-build-githubaction
+
+      - name: Get bot token from Parameter Store
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Check out Manifest Repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: department-of-veterans-affairs/vsp-infra-application-manifests
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          fetch-depth: 1
+          path: vsp-infra-application-manifests
+
+      # If this is triggered manually, use the input values
+      - name: Update image and helm chart versions (dispatch)
+        run: |
+            cd vsp-infra-application-manifests/apps/${{ inputs.app_name }}/${{ inputs.environment }}
+            yq e -i '.deployment.container.image = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cms-drupal:${{ env.IMAGE_TAG }}"' values.yaml
+            git diff
+
+      - name: Add and Commit file (dispatch)
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        with:
+          add: '*.yaml'
+          cwd: vsp-infra-application-manifests/apps/${{ inputs.app_name }}/${{ inputs.environment }}
+          author_name: va-vsp-bot
+          author_email: 70344339+va-vsp-bot@users.noreply.github.com
+          message: 'Update ${{ inputs.app_name }} images and helm chart for ${{ inputs.environment }} environment with version ${{ env.IMAGE_TAG }}'


### PR DESCRIPTION
## Description

Relates to #21936

### Generated description

This pull request introduces a new workflow for updating infrastructure manifests and integrates automated deployment to the development environment after building and pushing the Drupal container. The key changes are the addition of a reusable workflow for manifest updates and the orchestration of deployment steps in the CI pipeline.

**CI/CD Pipeline Enhancements:**

* Added a new job `deploy-to-dev` to `.github/workflows/build-drupal-container.yml` that triggers deployment to the development environment using the new manifest update workflow.

**Infrastructure Manifest Update Workflow:**

* Created `.github/workflows/update-manifest.yml` to automate updating application manifests with new image tags, including permissions, input parameters, and steps for AWS authentication, secret retrieval, manifest repository checkout, manifest update, and commit.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
