### PR TITLE
VACMS-21834: Adds users per section view

### DIFF
--- a/config/sync/views.view.users_per_section.yml
+++ b/config/sync/views.view.users_per_section.yml
@@ -158,7 +158,7 @@ display:
           entity_type: section_association
           entity_field: section_id
           plugin_id: workbench_access_section_id
-          label: 'Section Name'
+          label: 'Section name'
           exclude: false
           alter:
             alter_text: false
@@ -410,7 +410,20 @@ display:
           query_tags: {  }
       relationships: {  }
       group_by: true
-      header: {  }
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: 'A <b>Section name</b> of "N/A" is  a replacement for that field when there are no results. Any such sections can be ignored.'
+            format: rich_text
+          tokenize: false
       footer: {  }
       display_extenders:
         jsonapi_views:


### PR DESCRIPTION
## Description

Relates to #21834 

## Testing done
Manually

## Screenshots
<img width="1766" height="1137" alt="Screenshot 2025-08-18 at 10 59 43 AM" src="https://github.com/user-attachments/assets/4c8289a1-43c0-4046-9906-b372dc9457a1" />



## QA steps

As user _uid_ with _user_role_
1. Log in as an admin
2. Go to the [Users per section view](https://pr22025-79ztr6hzqwpysaktoidweqszkrcz8dnt.ci.cms.va.gov/admin/people/users_per_section) (This can also be accessed under the People menu)
3. Click the linked items in the "Section name" column
4. Click the linked items in the "Users per section" column
5. Click "Download CSV"
6. Confirm that the CSV matches the page

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

