### PR TITLE
VACMS-21845: entra va gov login

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -62,3 +62,4 @@ features:
   feature_banner_use_alternative_banners: FEATURE_BANNER_USE_ALTERNATIVE_BANNERS
   feature_rum_family_caregiver_hub: FEATURE_RUM_FAMILY_CAREGIVER_HUB
   feature_vet_center_outstation_enhancements: FEATURE_VET_CENTER_OUTSTATION_ENHANCEMENTS
+  feature_use_entraid_for_piv_login: FEATURE_USE_ENTRAID_FOR_PIV_LOGIN

--- a/docroot/modules/custom/va_gov_login/src/Controller/VaGovLoginController.php
+++ b/docroot/modules/custom/va_gov_login/src/Controller/VaGovLoginController.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Drupal\va_gov_login\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Url;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Controller for handling Microsoft Entra ID.
+ *
+ * Social authentication redirects and callbacks.
+ */
+class VaGovLoginController extends ControllerBase {
+
+  /**
+   * HTTP client service for making external requests.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * Messenger service for displaying messages.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Logger factory service for logging errors.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * Constructs a VaGovLoginController object.
+   *
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   HTTP client service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   Logger factory service.
+   */
+  public function __construct(
+    ClientInterface $http_client,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $logger_factory,
+  ) {
+    $this->httpClient = $http_client;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $logger_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('http_client'),
+      $container->get('messenger'),
+      $container->get('logger.factory')
+    );
+  }
+
+  /**
+   * Redirects the user to the Microsoft Entra ID login page.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse
+   *   A trusted redirect response to the Microsoft Entra ID login URL.
+   */
+  public function redirectToMicrosoft() {
+    $client_id = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
+    $tenant_id = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');
+
+    // Use Url::fromRoute() to generate the redirect URI.
+    $redirect_uri = Url::fromRoute('va_gov_login.callback', [], ['absolute' => TRUE])->toString();
+    $scopes = 'openid profile email User.Read';
+
+    // Construct the URL for the Microsoft login.
+    $url = "https://login.microsoftonline.com/$tenant_id/oauth2/v2.0/authorize?" . http_build_query([
+      'client_id' => $client_id,
+      'response_type' => 'code',
+      'redirect_uri' => $redirect_uri,
+      'scope' => $scopes,
+    ]);
+
+    // Redirect the user to Microsoft login using TrustedRedirectResponse.
+    return new TrustedRedirectResponse($url);
+  }
+
+  /**
+   * Handles the callback from Microsoft Entra ID after user authorization.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The incoming request object.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   A redirect response to the front page after processing the callback.
+   */
+  public function handleMicrosoftCallback(Request $request) {
+    $code = $request->query->get('code');
+
+    if ($code) {
+      // Retrieve settings from environment variables.
+      $client_id = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
+      $client_secret = getenv('MICROSOFT_ENTRA_ID_CLIENT_SECRET');
+      $tenant_id = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');
+      $redirect_uri = Url::fromRoute('va_gov_login.callback', [], ['absolute' => TRUE])->toString();
+
+      try {
+        // Exchange the code for an access token.
+        $response = $this->httpClient->post("https://login.microsoftonline.com/$tenant_id/oauth2/v2.0/token", [
+          'form_params' => [
+            'client_id' => $client_id,
+            'client_secret' => $client_secret,
+            'code' => $code,
+            'redirect_uri' => $redirect_uri,
+            'grant_type' => 'authorization_code',
+          ],
+        ]);
+        $data = json_decode($response->getBody()->getContents(), TRUE);
+
+        // Check if access_token exists in response.
+        if (isset($data['access_token'])) {
+          $profile_response = $this->httpClient->get('https://graph.microsoft.com/v1.0/me', [
+            'headers' => ['Authorization' => 'Bearer ' . $data['access_token']],
+          ]);
+          $profile_data = json_decode($profile_response->getBody()->getContents(), TRUE);
+
+          if (isset($profile_data['mail'])) {
+            $user_email = $profile_data['mail'];
+
+            $existing_user = user_load_by_name($user_email);
+
+            if ($existing_user) {
+              user_login_finalize($existing_user);
+              $this->messenger->addStatus($this->t('Logged in successfully.'));
+            }
+            else {
+              $this->messenger->addError($this->t('Login failed. The account does not exist.'));
+              return new RedirectResponse(Url::fromRoute('<front>')->toString());
+            }
+          }
+          else {
+            throw new \Exception('User email not found.');
+          }
+        }
+        else {
+          throw new \Exception('Access token missing.');
+        }
+      }
+      catch (\Exception $e) {
+        $this->messenger->addError($this->t('An error occurred.'));
+        $this->loggerFactory->get('va_gov_login')->error($e->getMessage());
+      }
+    }
+    else {
+      $this->messenger->addError($this->t('Authorization code missing.'));
+    }
+
+    // Redirect to the front page after handling callback or errors.
+    return new RedirectResponse(Url::fromRoute('<front>')->toString());
+  }
+
+}

--- a/docroot/modules/custom/va_gov_login/va_gov_login.module
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.module
@@ -23,6 +23,8 @@ function va_gov_login_form_user_login_form_alter(&$form, FormStateInterface $for
   if (!$config->get('activate') || (!$config->get('login_link_show'))) {
     return;
   }
+  $feature_service = \Drupal::service('feature_toggle.feature_status');
+  $useEntra = $feature_service->getStatus('feature_use_entraid_for_piv_login');
 
   // Create PIV login & container.
   $form['simplesamlphp_auth_login_link'] = [
@@ -37,7 +39,7 @@ function va_gov_login_form_user_login_form_alter(&$form, FormStateInterface $for
   $form['simplesamlphp_auth_login_link']['link'] = [
     '#title' => 'Log in with PIV',
     '#type' => 'link',
-    '#url' => Url::fromRoute('simplesamlphp_auth.saml_login'),
+    '#url' => $useEntra ? Url::fromRoute('va_gov_login.redirect') : Url::fromRoute('simplesamlphp_auth.saml_login'),
     '#attributes' => [
       'title' => 'Follow this link to login using your PIV or other smartcard.',
       'class' => ['simplesamlphp-auth-login-link', 'button', 'button--primary'],

--- a/docroot/modules/custom/va_gov_login/va_gov_login.routing.yml
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.routing.yml
@@ -1,0 +1,17 @@
+va_gov_login.redirect:
+  path: '/user/login/entra-id'
+  defaults:
+    _controller: '\Drupal\va_gov_login\Controller\VaGovLoginController::redirectToMicrosoft'
+    _title: 'Redirect to Microsoft Login'
+  requirements:
+   # Note: Explicitly allow access to all users, This route must be accessible to anonymous users to initiate the Microsoft Entra ID login process.
+    _access: 'TRUE'
+
+va_gov_login.callback:
+  path: '/user/login/entra-id/callback'
+  defaults:
+    _controller: '\Drupal\va_gov_login\Controller\VaGovLoginController::handleMicrosoftCallback'
+    _title: 'Microsoft Callback'
+  requirements:
+   # Note: Explicitly allow access to all users, This route must be accessible to anonymous users to initiate the Microsoft Entra ID login process.
+    _access: 'TRUE'

--- a/docroot/modules/custom/va_gov_login/va_gov_login.services.yml
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.services.yml
@@ -1,0 +1,4 @@
+services:
+  va_gov_login.controller:
+    class: Drupal\va_gov_login\Controller\VaGovLoginController
+    arguments: ['@http_client', '@messenger', '@logger.factory']

--- a/docroot/modules/custom/va_gov_login/va_gov_login.services.yml
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.services.yml
@@ -1,4 +1,4 @@
 services:
   va_gov_login.controller:
     class: Drupal\va_gov_login\Controller\VaGovLoginController
-    arguments: ['@http_client', '@messenger', '@logger.factory']
+    arguments: ['@http_client', '@messenger', '@logger.factory', '@settings']

--- a/docroot/sites/default/settings/settings.dev.php
+++ b/docroot/sites/default/settings/settings.dev.php
@@ -49,3 +49,8 @@ $settings['github_actions_deploy_env'] = 'dev';
 
 // Public asset S3 location
 $public_asset_s3_base_url = "https://dsva-vagov-staging-cms-files.s3.us-gov-west-1.amazonaws.com";
+
+// Entra ID settings
+$settings['microsoft_entra_id_client_id'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
+$settings['microsoft_entra_id_client_secret'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_SECRET');
+$settings['microsoft_entra_id_tenant_id'] = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');

--- a/docroot/sites/default/settings/settings.eks.php
+++ b/docroot/sites/default/settings/settings.eks.php
@@ -39,3 +39,8 @@ $settings['trusted_host_patterns'] = [
 
 $settings['va_gov_frontend_build_type'] = 'eks';
 $settings['va_gov_frontend_url'] = 'http://localhost:8080';
+
+// Entra ID settings
+$settings['microsoft_entra_id_client_id'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
+$settings['microsoft_entra_id_client_secret'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_SECRET');
+$settings['microsoft_entra_id_tenant_id'] = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');

--- a/docroot/sites/default/settings/settings.prod.php
+++ b/docroot/sites/default/settings/settings.prod.php
@@ -65,3 +65,8 @@ $public_asset_s3_base_url = "https://dsva-vagov-prod-cms-files.s3.us-gov-west-1.
   $settings['s3fs.use_s3_for_public'] = FALSE;
   $settings['s3fs.use_s3_for_private'] = FALSE;
   $settings['s3fs.upload_as_private'] = TRUE;
+
+// Entra ID settings
+$settings['microsoft_entra_id_client_id'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
+$settings['microsoft_entra_id_client_secret'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_SECRET');
+$settings['microsoft_entra_id_tenant_id'] = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');

--- a/docroot/sites/default/settings/settings.staging.php
+++ b/docroot/sites/default/settings/settings.staging.php
@@ -62,3 +62,8 @@ $public_asset_s3_base_url = "https://dsva-vagov-staging-cms-files.s3.us-gov-west
   $settings['s3fs.use_s3_for_public'] = FALSE;
   $settings['s3fs.use_s3_for_private'] = FALSE;
   $settings['s3fs.upload_as_private'] = TRUE;
+
+// Entra ID settings
+$settings['microsoft_entra_id_client_id'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
+$settings['microsoft_entra_id_client_secret'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_SECRET');
+$settings['microsoft_entra_id_tenant_id'] = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');


### PR DESCRIPTION
## Description
Adds integration with EntraID to the va_gov_login custom module

Closes to #21845 

### Generated description

This pull request introduces Microsoft Entra ID (formerly Azure AD) as an alternative authentication method for PIV login, controlled by a new feature flag. It adds a new controller to handle the Entra ID OAuth flow, updates the login form to optionally use this flow, and configures environment-specific settings for the required Entra ID credentials. The implementation is gated by a feature toggle, ensuring backward compatibility with the existing SAML-based PIV login.

**Microsoft Entra ID integration for PIV login:**

* Added a new feature flag `feature_use_entraid_for_piv_login` to control whether Entra ID is used for PIV login (`config/sync/feature_toggle.features.yml`).
* Implemented `VaGovLoginController` to handle the Microsoft Entra ID OAuth redirect and callback, including user authentication and error handling (`docroot/modules/custom/va_gov_login/src/Controller/VaGovLoginController.php`).
* Registered two new routes for initiating the Entra ID login flow and handling the callback (`docroot/modules/custom/va_gov_login/va_gov_login.routing.yml`).
* Registered the controller as a service with necessary dependencies (`docroot/modules/custom/va_gov_login/va_gov_login.services.yml`).

**Login form logic and feature toggle:**

* Updated the login form alter hook to check the new feature flag and switch the PIV login link to use Entra ID when enabled (`docroot/modules/custom/va_gov_login/va_gov_login.module`). [[1]](diffhunk://#diff-339b0ee5551212443fcb97f4a5f40f605ce5027d0f9bb6cf43f466a509753969R26-R27) [[2]](diffhunk://#diff-339b0ee5551212443fcb97f4a5f40f605ce5027d0f9bb6cf43f466a509753969L40-R42)

**Configuration and environment settings:**

* Added Entra ID client ID, client secret, and tenant ID to environment-specific settings files, sourcing them from environment variables (`docroot/sites/default/settings/settings.dev.php`, `docroot/sites/default/settings/settings.eks.php`, `docroot/sites/default/settings/settings.prod.php`, `docroot/sites/default/settings/settings.staging.php`). [[1]](diffhunk://#diff-696432ddb7c67ec35688c5b9e0d9c1ea74263b19274c54db2e616da1dd156a8bR52-R56) [[2]](diffhunk://#diff-0fb33aa6330e86d29479d473a0c2ad3fe6a91cca39ac77f65e2ad0a7dc088b47R42-R46) [[3]](diffhunk://#diff-a645c663929f44b13e5bd35e10cdf979c884ce6f7a5a608a861e98202048ff3aR68-R72) [[4]](diffhunk://#diff-44c6efd7dad5e50e90457020f2cc9312561fb3c07e244c1173d3801f35762656R65-R69)

## Testing done
Tested on https://test.staging.cms.va.gov


## QA steps
 - [x] visit https://test.staging.cms.va.gov
 - [x] click Log in with PIV, and follow any prompts
 - [x] verify that you are logged in
 - [x] navigate to https://test.staging.cms.va.gov/admin/config/system/feature_toggle
 - [x] turn off `FEATURE_USE_ENTRAID_FOR_PIV_LOGIN`
 - [x] flush cache
 - [x] logout
 - [x] return to https://test.staging.cms.va.gov
 - [x] verify Log in with PIV now uses SAML (inspect the button link to verify, SAML login won't work in this env)
 - [x] log back in with the developer login and navigate to https://test.staging.cms.va.gov/admin/config/system/feature_toggle
 - [x] turn on `FEATURE_USE_ENTRAID_FOR_PIV_LOGIN` in case others need to test
 - [x] flush cache

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
