### PR TITLE
Fix the GHA trigger for building drupal container

### DIFF
--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types:
       - closed # Trigger when the pull request is closed
+    branches:
+      - main # Only triggers on PRs targeting main branch
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -2,9 +2,9 @@ name: Build and Push Drupal Container to ECR
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  pull_request:
+    types:
+      - closed # Trigger when the pull request is closed
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   build-and-push:
+    if: github.event.pull_request.merged == true # Only run if the PR was actually merged
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-and-push:
-    if: github.event.pull_request.merged == true # Only run if the PR was actually merged
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true # Allow manual runs and merged PRs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

This wasn't picking up the PR when the content-build dependency was getting updated at night. This should fix it. 

### Generated description

This pull request updates the GitHub Actions workflow for building and pushing the Drupal container. The workflow is now triggered only when a pull request is closed and merged, instead of on every push to the main branch. This change helps prevent unnecessary builds and deployments.

**Workflow trigger changes:**

* Changed the workflow trigger from `push` on the `main` branch to `pull_request` events of type `closed`, ensuring the workflow only runs when a pull request is closed.
* Added a conditional check to the `build-and-push` job so it only runs if the pull request was actually merged (`github.event.pull_request.merged == true`).

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
