### PR TITLE
upgraded php to 8.4 in tugboat config

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,8 +1,8 @@
 services:
   # What to call the service hosting the site.
   php:
-    # Use PHP 8.1 with Apache; this syntax pulls in the latest version of PHP 8.1.
-    image: tugboatqa/php:8.1-apache-bookworm
+    # Use PHP 8.4 with Apache; this syntax pulls in the latest version of PHP 8.4.
+    image: tugboatqa/php:8.4-apache-bookworm
 
     aliases:
     - cms


### PR DESCRIPTION
## Description



### Generated description

This pull request updates the PHP version used in the Tugboat configuration to ensure compatibility with newer features and security updates.

Dependency update:

* [`.tugboat/config.yml`](diffhunk://#diff-fbd0812762ff8d2c67fa66a4956c3b55557ad0889505294f524192000b2ce50eL4-R5): Updated the PHP service image from `tugboatqa/php:8.1-apache-bookworm` to `tugboatqa/php:8.4-apache-bookworm`.

## Testing done

 will use this to test in Tugboat env
