### PR TITLE
VACMS-21854: adding prometheus and queue container building

### DIFF
--- a/.github/workflows/build-drupal-container.yml
+++ b/.github/workflows/build-drupal-container.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main # Only triggers on PRs targeting main branch
 
+# Add concurrency to prevent parallel executions
+concurrency:
+  group: drupal-container-build
+  cancel-in-progress: false
+
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -200,7 +200,7 @@ php-fpm -D\n\
 # Start rsyslog\n\
 rsyslogd\n\
 # Start Prometheus\n\
-/opt/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml --web.listen-address=0.0.0.0:9090\n\
+/opt/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml &\n\
 apache2-foreground' > /usr/local/bin/start-services.sh && \
 chmod +x /usr/local/bin/start-services.sh
 

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -200,7 +200,7 @@ php-fpm -D\n\
 # Start rsyslog\n\
 rsyslogd\n\
 # Start Prometheus\n\
-/opt/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml --web.listen\n\
+/opt/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml --web.listen-address=0.0.0.0:9090\n\
 apache2-foreground' > /usr/local/bin/start-services.sh && \
 chmod +x /usr/local/bin/start-services.sh
 

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -121,6 +121,16 @@ RUN install-va-certs.sh
 RUN apt update && apt install -y ca-certificates
 RUN update-ca-certificates
 
+# Install and cnfigure prometheus
+RUN mkdir -p /opt/prometheus && \
+    cd /opt/prometheus && \
+    wget https://github.com/prometheus/prometheus/releases/download/v2.47.0/prometheus-2.47.0.linux-amd64.tar.gz && \
+    tar -xvf prometheus-2.47.0.linux-amd64.tar.gz --strip-components=1 && \
+    rm prometheus-2.47.0.linux-amd64.tar.gz
+
+# Create Prometheus config
+RUN mkdir -p /etc/prometheus
+COPY ./docker-conf-files/prometheus.yml /etc/prometheus/prometheus.yml
 
 # Configure rsyslog
 COPY ./docker-conf-files/drupal.conf ${RSYSLOG_CONF_DIR}/drupal.conf
@@ -182,13 +192,15 @@ RUN rm -rf /opt/drupal
 
 ENV BUILD_ENV=eks
 
-EXPOSE 80
+EXPOSE 80 9090
 
 # Create startup script to run both Apache and PHP-FPM
 RUN echo '#!/bin/bash\n\
 php-fpm -D\n\
 # Start rsyslog\n\
 rsyslogd\n\
+# Start Prometheus\n\
+/opt/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml --web.listen\n\
 apache2-foreground' > /usr/local/bin/start-services.sh && \
 chmod +x /usr/local/bin/start-services.sh
 

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -121,7 +121,7 @@ RUN install-va-certs.sh
 RUN apt update && apt install -y ca-certificates
 RUN update-ca-certificates
 
-# Install and cnfigure prometheus
+# Install and configure prometheus
 RUN mkdir -p /opt/prometheus && \
     cd /opt/prometheus && \
     wget https://github.com/prometheus/prometheus/releases/download/v2.47.0/prometheus-2.47.0.linux-amd64.tar.gz && \

--- a/docker/apache/docker-conf-files/prometheus.yml
+++ b/docker/apache/docker-conf-files/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'apache'
+    static_configs:
+      - targets: ['localhost:9117']
+
+  - job_name: 'php-fpm'
+    static_configs:
+      - targets: ['localhost:9253']


### PR DESCRIPTION
## Description

Relates to #21854 

### Generated description
This pull request introduces Prometheus monitoring to the Drupal Apache Docker container and improves the CI workflow by preventing parallel builds. The main changes include installing and configuring Prometheus, exposing the necessary port, updating the container startup script, and adding a Prometheus configuration file.

**Prometheus Integration:**

* Added installation steps for Prometheus in the `docker/apache/Dockerfile`, including downloading, extracting, and cleaning up the Prometheus binary. Also, added a step to copy the Prometheus configuration file into the container.
* Added a new Prometheus configuration file `prometheus.yml` with scrape jobs for Prometheus itself, Apache, and PHP-FPM.
* Modified the container startup script to launch Prometheus alongside Apache, PHP-FPM, and rsyslog.
* Exposed port 9090 in the Dockerfile to allow Prometheus web UI access.

**CI/CD Workflow Improvement:**

* Added a `concurrency` group to the GitHub Actions workflow to prevent parallel executions of the Drupal container build process.
## Testing done
Built a container locally to check the build. 

## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
