### PR TITLE
VACMS-21855: adding currently active users metric

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
+++ b/docroot/modules/custom/va_gov_backend/src/Plugin/MetricsCollector/ActiveUserCount.php
@@ -103,7 +103,7 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
    * This should return the users who are not administrators, API users, or
    * "ghost" users (users with duplicate accounts).
    *
-   * @return \Drupal\Core\Entity\Query\QueryInterface
+   * @return \Drupal\Core\Database\Query\Insert|\Drupal\Core\Database\Query\SelectInterface
    *   A query, not yet completed.
    */
   protected function getRealUserQuery() {
@@ -144,6 +144,24 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
   }
 
   /**
+   * Show a count of currently active users within the last hour.
+   *
+   * @return int
+   *   The count of currently active users.
+   */
+  protected function getCurrentlyActiveUsers(): int {
+    $now = time();
+    // Current time minus one hour.
+    $timestamp = $now - (60 * 60);
+    // Count within the last hour, how many users are active on the website.
+    $query_count = $this->database->select('sessions', 's');
+    $query_count->condition('s.timestamp', $timestamp, '>=');
+    $count_rc = $query_count->countQuery()->execute()->fetchField();
+
+    return $count_rc;
+  }
+
+  /**
    * Gets a count of users active since a specified time.
    *
    * @param int $timestamp
@@ -152,7 +170,8 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
    * @return int
    *   The count of active users in the specified time interval.
    */
-  protected function getCountSinceTime($timestamp) {
+  protected function getCountSinceTime(int $timestamp): int {
+    /* @var \Drupal\Core\Database\Query\Select $query */
     $query = $this->getRealUserQuery();
     $query
       ->condition('access', $timestamp, '>=');
@@ -163,7 +182,7 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
   /**
    * {@inheritdoc}
    */
-  public function collectMetrics() {
+  public function collectMetrics(): array {
     $now = time();
     $gauge = new Gauge($this->getNamespace(), 'total', $this->getDescription());
     $sessionWriteInterval = $this->settingsService->get('session_write_interval', 180);
@@ -173,6 +192,7 @@ class ActiveUserCount extends BaseMetricsCollector implements ContainerFactoryPl
     // 180 days in seconds
     $sixMonthsAgoTimestamp = $now - (180 * 86400);
     $gauge->set($this->getCount());
+    $gauge->set($this->getCurrentlyActiveUsers(), ['currently' => 'active']);
     $gauge->set($this->getCountSinceTime($sessionWriteIntervalTimestamp), ['last' => 'session_write_interval']);
     $gauge->set($this->getCountSinceTime($sixtyDaysAgoTimestamp), ['last' => '60days']);
     $gauge->set($this->getCountSinceTime($sixMonthsAgoTimestamp), ['last' => '180days']);

--- a/docroot/sites/default/services.yml
+++ b/docroot/sites/default/services.yml
@@ -9,7 +9,7 @@ parameters:
     # @default 1
     gc_probability: 1
     # @default 100
-    gc_divisor: 100
+    gc_divisor: 1
     #
     # Set session lifetime (in seconds), i.e. the time from the user's last
     # visit to the active session may be deleted by the session garbage

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -308,3 +308,5 @@ $settings['state_cache'] = TRUE;
 
 // Disable the use of insecure uploads.
 $config['system.file']['allow_insecure_uploads'] = FALSE;
+
+$settings['session_write_interval'] = 1;


### PR DESCRIPTION
## Description

Relates to #21855 

### Generated description
This pull request introduces improvements to the active user metrics collection in the `ActiveUserCount` plugin and adjusts session management settings to support more accurate and frequent user activity tracking. The changes include a new method for counting currently active users, stricter typing and return types, and configuration updates for session garbage collection and write intervals.

**Active User Metrics Enhancements:**

* Added a new method `getCurrentlyActiveUsers()` to count users active within the last hour and included this metric in `collectMetrics()` reporting. [[1]](diffhunk://#diff-0e59120646e5d72cf812bd70d1cdc597785c1081ddca9a9836f6b19525224414R146-R163) [[2]](diffhunk://#diff-0e59120646e5d72cf812bd70d1cdc597785c1081ddca9a9836f6b19525224414R195)
* Improved type hinting and return types in methods such as `getCountSinceTime` and `collectMetrics` for better code reliability and clarity. [[1]](diffhunk://#diff-0e59120646e5d72cf812bd70d1cdc597785c1081ddca9a9836f6b19525224414L155-R174) [[2]](diffhunk://#diff-0e59120646e5d72cf812bd70d1cdc597785c1081ddca9a9836f6b19525224414L166-R185)
* Updated the return type annotation for `getRealUserQuery()` to accurately reflect the possible query types returned.

**Session Management Configuration:**

* Changed `gc_divisor` from 100 to 1 in `services.yml`, increasing the frequency of session garbage collection for more up-to-date session data.
* Set `$settings['session_write_interval'] = 1` in `settings.php` to ensure session activity is written every second, further improving the accuracy of active user metrics.
## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?



### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
