### PR TITLE
VACMS-22068: Adds modal for entities with usage

### DIFF
--- a/config/sync/user.role.admnistrator_users.yml
+++ b/config/sync/user.role.admnistrator_users.yml
@@ -8,6 +8,7 @@ dependencies:
     - taxonomy.vocabulary.administration
   module:
     - actions_permissions
+    - entity_usage
     - filter
     - node_link_report
     - password_policy
@@ -25,6 +26,7 @@ label: 'CMS account admin'
 weight: 4
 is_admin: null
 permissions:
+  - 'access entity usage statistics'
   - 'administer users'
   - 'assign content_admin role'
   - 'assign content_api_consumer role'

--- a/config/sync/user.role.content_admin.yml
+++ b/config/sync/user.role.content_admin.yml
@@ -28,6 +28,7 @@ dependencies:
     - content_moderation
     - content_translation
     - entity_clone
+    - entity_usage
     - entityqueue
     - file
     - filter
@@ -61,6 +62,7 @@ permissions:
   - 'accept translation jobs'
   - 'access administration pages'
   - 'access block library'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'access media overview'
   - 'access taxonomy overview'

--- a/config/sync/user.role.content_creator_benefits_hubs.yml
+++ b/config/sync/user.role.content_creator_benefits_hubs.yml
@@ -9,6 +9,7 @@ dependencies:
     - node.type.support_service
   module:
     - block_content
+    - entity_usage
     - file
     - node
     - node_link_report
@@ -22,6 +23,7 @@ weight: -7
 is_admin: null
 permissions:
   - 'access block library'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'create landing_page content'
   - 'create page content'

--- a/config/sync/user.role.content_creator_resources_and_support.yml
+++ b/config/sync/user.role.content_creator_resources_and_support.yml
@@ -13,6 +13,7 @@ dependencies:
     - node.type.support_resources_detail_page
   module:
     - block_content
+    - entity_usage
     - file
     - node
     - node_link_report
@@ -26,6 +27,7 @@ weight: -6
 is_admin: null
 permissions:
   - 'access block library'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'create checklist content'
   - 'create faq_multiple_q_a content'

--- a/config/sync/user.role.content_creator_vba.yml
+++ b/config/sync/user.role.content_creator_vba.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - node.type.vba_facility_service
   module:
+    - entity_usage
     - node
     - va_gov_backend
 third_party_settings:
@@ -15,5 +16,6 @@ label: 'Content creator - VBA'
 weight: -3
 is_admin: null
 permissions:
+  - 'access entity usage statistics'
   - 'create vba_facility_service content'
   - 'view node link report'

--- a/config/sync/user.role.content_creator_vet_center.yml
+++ b/config/sync/user.role.content_creator_vet_center.yml
@@ -6,6 +6,7 @@ dependencies:
     - node.type.vet_center_cap
     - node.type.vet_center_facility_health_servi
   module:
+    - entity_usage
     - node
     - node_link_report
     - va_gov_backend
@@ -17,6 +18,7 @@ label: 'Content creator - Vet Center'
 weight: -2
 is_admin: null
 permissions:
+  - 'access entity usage statistics'
   - 'create vet_center_cap content'
   - 'create vet_center_facility_health_servi content'
   - 'view node link report'

--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -72,6 +72,7 @@ dependencies:
     - block_diff_ui
     - content_lock
     - content_moderation
+    - entity_usage
     - file
     - filter
     - media
@@ -97,6 +98,7 @@ permissions:
   - 'access administration pages'
   - 'access block library'
   - 'access content overview'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'access media overview'
   - 'access user profiles'

--- a/config/sync/user.role.content_publisher.yml
+++ b/config/sync/user.role.content_publisher.yml
@@ -75,6 +75,7 @@ dependencies:
     - block_diff_ui
     - content_lock
     - content_moderation
+    - entity_usage
     - file
     - filter
     - flag
@@ -101,6 +102,7 @@ permissions:
   - 'access administration pages'
   - 'access block library'
   - 'access content overview'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'access media overview'
   - 'access user profiles'

--- a/config/sync/user.role.content_reviewer.yml
+++ b/config/sync/user.role.content_reviewer.yml
@@ -72,6 +72,7 @@ dependencies:
     - block_diff_ui
     - content_lock
     - content_moderation
+    - entity_usage
     - file
     - filter
     - media
@@ -96,6 +97,7 @@ permissions:
   - 'access administration pages'
   - 'access block library'
   - 'access content overview'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'access media overview'
   - 'access user profiles'

--- a/config/sync/user.role.form_builder_user.yml
+++ b/config/sync/user.role.form_builder_user.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - entity_usage
     - va_gov_backend
     - va_gov_form_builder
 third_party_settings:
@@ -13,4 +14,5 @@ label: 'Form Builder user'
 weight: 14
 is_admin: null
 permissions:
+  - 'access entity usage statistics'
   - 'access form builder'

--- a/config/sync/user.role.homepage_manager.yml
+++ b/config/sync/user.role.homepage_manager.yml
@@ -16,6 +16,7 @@ dependencies:
     - block_content
     - block_diff_ui
     - content_moderation
+    - entity_usage
     - entityqueue
     - node
     - system
@@ -29,6 +30,7 @@ weight: 6
 is_admin: null
 permissions:
   - 'access block library'
+  - 'access entity usage statistics'
   - 'create banner content'
   - 'create benefit_promo block content'
   - 'create cta_with_link block content'

--- a/config/sync/user.role.office_content_creator.yml
+++ b/config/sync/user.role.office_content_creator.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.outreach_asset
   module:
     - block_content
+    - entity_usage
     - file
     - node
     - node_link_report
@@ -21,6 +22,7 @@ weight: -5
 is_admin: null
 permissions:
   - 'access block library'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'create event content'
   - 'create outreach_asset content'

--- a/config/sync/user.role.rates_editor.yml
+++ b/config/sync/user.role.rates_editor.yml
@@ -14,6 +14,7 @@ dependencies:
   module:
     - content_lock
     - content_moderation
+    - entity_usage
     - file
     - filter
     - media
@@ -35,6 +36,7 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access content'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'access media overview'
   - 'break content lock'

--- a/config/sync/user.role.redirect_administrator.yml
+++ b/config/sync/user.role.redirect_administrator.yml
@@ -6,6 +6,7 @@ dependencies:
     - taxonomy.vocabulary.type_of_redirect
   module:
     - actions_permissions
+    - entity_usage
     - path
     - pathauto
     - redirect
@@ -22,6 +23,7 @@ weight: 3
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access entity usage statistics'
   - 'administer redirect settings'
   - 'administer redirects'
   - 'administer url aliases'

--- a/config/sync/user.role.translation_manager.yml
+++ b/config/sync/user.role.translation_manager.yml
@@ -9,6 +9,7 @@ dependencies:
     - config_translation
     - content_moderation
     - content_translation
+    - entity_usage
     - locale
     - node
     - tmgmt
@@ -19,6 +20,7 @@ is_admin: null
 permissions:
   - 'accept translation jobs'
   - 'access content overview'
+  - 'access entity usage statistics'
   - 'administer nodes'
   - 'bypass node access'
   - 'create content translations'

--- a/config/sync/user.role.vamc_content_creator.yml
+++ b/config/sync/user.role.vamc_content_creator.yml
@@ -15,6 +15,7 @@ dependencies:
     - node.type.vha_facility_nonclinical_service
   module:
     - block_content
+    - entity_usage
     - file
     - node
     - node_link_report
@@ -28,6 +29,7 @@ weight: -4
 is_admin: null
 permissions:
   - 'access block library'
+  - 'access entity usage statistics'
   - 'access files overview'
   - 'create event content'
   - 'create full_width_banner_alert content'

--- a/docroot/modules/custom/va_gov_workflow/js/modal.js
+++ b/docroot/modules/custom/va_gov_workflow/js/modal.js
@@ -1,0 +1,26 @@
+(function (Drupal, drupalSettings, $) {
+  'use strict';
+
+  Drupal.behaviors.vaGovWorkflowModal = {
+    attach: function (context, settings) {
+      // Wire up any archive modal action buttons rendered by the server.
+      // Use the global once() function provided by the core/drupal.once
+      // library. It returns a list of elements that have not yet been
+      // processed for the provided key.
+      var processed = once('vaGovWorkflowModal', '.va-gov-workflow-modal-actions .va-gov-workflow-archive', context);
+      Array.prototype.forEach.call(processed, function (el) {
+        el.addEventListener('click', function (e) {
+          e.preventDefault();
+          var submitSelector = el.getAttribute('data-submit-selector') || (drupalSettings.vaGovWorkflow && drupalSettings.vaGovWorkflow.submitSelector) || '#edit-submit';
+          // Trigger the configured submit element so the modal action flows
+          // through Drupal form submission (and the AJAX callback).
+          var submitEl = document.querySelector(submitSelector);
+          if (submitEl) {
+            submitEl.click();
+          }
+        });
+      });
+    }
+  };
+
+})(Drupal, drupalSettings, jQuery);

--- a/docroot/modules/custom/va_gov_workflow/js/restore-scroll.js
+++ b/docroot/modules/custom/va_gov_workflow/js/restore-scroll.js
@@ -1,0 +1,58 @@
+(function (Drupal, drupalSettings, $) {
+  'use strict';
+
+  // Small behavior to save and restore window scroll position around
+  // AJAX updates. This helps avoid a page "jump" when ReplaceCommand
+  // or other DOM-replacing commands run.
+  Drupal.behaviors.vaGovWorkflowRestoreScroll = {
+    attach: function (context, settings) {
+      // Ensure we bind handlers only once.
+      if (this._bound) {
+        return;
+      }
+      this._bound = true;
+
+      var saved = null;
+
+      // Save scroll position when any ajax request starts.
+      $(document).on('ajaxSend.vaGovWorkflowRestoreScroll', function (event, jqXHR, ajaxOptions) {
+        // Only capture for standard XHR requests originating from Drupal Ajax
+        // calls. We keep this generic so it helps the moderation-state ReplaceCommand
+        // without being tightly coupled to the module.
+        saved = {
+          x: (window.scrollX || window.pageXOffset || 0),
+          y: (window.scrollY || window.pageYOffset || 0)
+        };
+      });
+
+      // Restore scroll position after the ajax request completes and DOM
+      // changes have been applied. Use requestAnimationFrame to let the
+      // browser paint the updated DOM first.
+      $(document).on('ajaxComplete.vaGovWorkflowRestoreScroll', function (event, jqXHR, ajaxOptions) {
+        if (!saved) {
+          return;
+        }
+        // Use rAF so we restore after DOM updates/paint. Also guard with a
+        // small timeout for environments where rAF may not be sufficient.
+        var restore = function () {
+          try {
+            window.scrollTo(saved.x, saved.y);
+          } finally {
+            saved = null;
+          }
+        };
+
+        if (typeof window.requestAnimationFrame === 'function') {
+          window.requestAnimationFrame(function () {
+            // Slight timeout after rAF to be extra safe for complex layouts.
+            setTimeout(restore, 0);
+          });
+        }
+        else {
+          setTimeout(restore, 0);
+        }
+      });
+    }
+  };
+
+})(Drupal, drupalSettings, jQuery);

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -153,8 +153,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
     $form_id = $event->getFormId();
-    // Add entities have usage, we need to alert editors upon archiving.
-    $this->addModalForEntitiesWithUsage($form, $form_state, $form_id);
+    // If entities have usage, we need to alert editors upon archiving.
+    $this->addModalForEntitiesWithUsage($form, $form_state);
     // Keep existing behavior for removing archive option and revision message.
     if ($form_state->getFormObject() instanceof EntityFormInterface) {
       $this->removeArchiveOption($event);
@@ -413,16 +413,19 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Add ajax call.
+   * Adds a modal dialog to the form for entities that have usage.
+   *
+   * This function modifies the form to include an AJAX modal dialog
+   * when the entity being edited or deleted is referenced elsewhere.
+   * The modal informs the user about the entity's usage before allowing
+   * further actions.
    *
    * @param array $form
    *   The form array by reference.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state object.
-   * @param string $form_id
-   *   The form id.
    */
-  private function addModalForEntitiesWithUsage(array &$form, FormStateInterface $form_state, $form_id) {
+  private function addModalForEntitiesWithUsage(array &$form, FormStateInterface $form_state) {
     $formObject = $form_state->getFormObject();
     if (!($formObject instanceof EntityFormInterface)) {
       return;

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -153,7 +153,7 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
     $form_id = $event->getFormId();
-    // Add modal for entities with usage.
+    // Add entities have usage, we need to alert editors upon archiving.
     $this->addModalForEntitiesWithUsage($form, $form_state, $form_id);
     // Keep existing behavior for removing archive option and revision message.
     if ($form_state->getFormObject() instanceof EntityFormInterface) {
@@ -319,7 +319,6 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    *   The form state.
    */
   protected function bypassRevisionLogValidationOnIef(array &$form, FormStateInterface $form_state): void {
-    /** @var \Drupal\node\NodeInterface $node **/
     /** @var \Drupal\Core\Entity\EntityFormInterface|null $form_object */
     $form_object = $form_state->getFormObject();
     $node = $form_object->getEntity();

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityDeleteEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
@@ -18,12 +19,15 @@ use Drupal\va_gov_notifications\Service\NotificationsManager;
 use Drupal\va_gov_user\Service\UserPermsService;
 use Drupal\va_gov_workflow\Service\Flagger;
 use Drupal\va_gov_workflow\Service\WorkflowContentControl;
+use Drupal\entity_usage_addons\Service\Usage;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * VA.gov Workflow Entity Event Subscriber.
  */
 class EntityEventSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
 
   /**
    * The entity manager.
@@ -62,6 +66,13 @@ class EntityEventSubscriber implements EventSubscriberInterface {
   protected $workflowContentControl;
 
   /**
+   * The form alter service.
+   *
+   * @var \Drupal\entity_usage_addons\Service\Usage
+   */
+  protected $usage;
+
+  /**
    * {@inheritdoc}
    */
   public static function getSubscribedEvents(): array {
@@ -89,6 +100,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    *   The vagov workflow flagger service.
    * @param \Drupal\va_gov_notifications\Service\NotificationsManager $notifications_manager
    *   VA gov NotificationsManager service.
+   * @param \Drupal\entity_usage_addons\Service\Usage $usage
+   *   The entity usage service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -96,12 +109,14 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     WorkflowContentControl $workflow_content_control,
     Flagger $flagger,
     NotificationsManager $notifications_manager,
+    Usage $usage,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->userPermsService = $user_perms_service;
     $this->workflowContentControl = $workflow_content_control;
     $this->flagger = $flagger;
     $this->notificationsManager = $notifications_manager;
+    $this->usage = $usage;
   }
 
   /**
@@ -138,6 +153,9 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
     $form_id = $event->getFormId();
+    // Add modal for entities with usage.
+    $this->addModalForEntitiesWithUsage($form, $form_state, $form_id);
+    // Keep existing behavior for removing archive option and revision message.
     if ($form_state->getFormObject() instanceof EntityFormInterface) {
       $this->removeArchiveOption($event);
     }
@@ -197,8 +215,10 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
     if ($form_state->getFormObject() instanceof ContentEntityForm) {
+      /** @var \Drupal\Core\Entity\ContentEntityForm|null $form_object */
+      $form_object = $form_state->getFormObject();
       /** @var \Drupal\Core\Entity\EntityInterface $entity */
-      $entity = $form_state->getFormObject()->getEntity();
+      $entity = $form_object->getEntity();
       $entity_type = $entity->getEntityType()->id();
       $bundle = $entity->bundle();
       $is_admin = $this->userPermsService->hasAdminRole();
@@ -300,7 +320,9 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    */
   protected function bypassRevisionLogValidationOnIef(array &$form, FormStateInterface $form_state): void {
     /** @var \Drupal\node\NodeInterface $node **/
-    $node = $form_state->getFormObject()->getEntity();
+    /** @var \Drupal\Core\Entity\EntityFormInterface|null $form_object */
+    $form_object = $form_state->getFormObject();
+    $node = $form_object->getEntity();
     if (!$node instanceof NodeInterface) {
       return;
     }
@@ -389,6 +411,81 @@ class EntityEventSubscriber implements EventSubscriberInterface {
     $target_type = $field_definition->getItemDefinition()->getSettings()['target_type'] ?? '';
 
     return (in_array($fieldType, $field_types_for_ief)) && ($target_type === "node" || $target_type === "block_content");
+  }
+
+  /**
+   * Add ajax call.
+   *
+   * @param array $form
+   *   The form array by reference.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state object.
+   * @param string $form_id
+   *   The form id.
+   */
+  private function addModalForEntitiesWithUsage(array &$form, FormStateInterface $form_state, $form_id) {
+    $formObject = $form_state->getFormObject();
+    if (!($formObject instanceof EntityFormInterface)) {
+      return;
+    }
+    $entity = $formObject->getEntity();
+    if ($entity->getEntityTypeId() !== 'node') {
+      return;
+    }
+    $entity_type = $entity->getEntityTypeId();
+    $entity_id = $entity->id();
+    $usage_total = $this->usage->getUsageTotal($entity_type, $entity_id);
+    if ($usage_total < 1) {
+      return;
+    }
+
+    // Attach core AJAX support.
+    if (!empty($form['#attached']['library'])) {
+      $form['#attached']['library'][] = 'core/drupal.ajax';
+    }
+    else {
+      $form['#attached']['library'] = ['core/drupal.ajax'];
+    }
+
+    // Add ajax to the moderation state dropdown. Prefer the widget/state
+    // element path used by core content moderation widgets if present.
+    if (isset($form['moderation_state']['widget'][0]['state'])) {
+      $elem = &$form['moderation_state']['widget'][0]['state'];
+      // Ensure the element has a wrapper ID so ReplaceCommand can target it.
+      $elem['#prefix'] = '<div id="moderation-state-wrapper">';
+      $elem['#suffix'] = '</div>';
+
+      $elem['#ajax'] = [
+        'callback' => 'va_gov_workflow_moderation_state_ajax_callback',
+        'event' => 'change',
+        'wrapper' => 'moderation-state-wrapper',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => $this->t('Updating...'),
+        ],
+      ];
+      $elem['#attributes']['class'][] = 'use-ajax';
+    }
+    elseif (isset($form['moderation_state'])) {
+      // Fallback for variations where moderation_state is a simple element.
+      $form['moderation_state']['#prefix'] = '<div id="moderation-state-wrapper">';
+      $form['moderation_state']['#suffix'] = '</div>';
+
+      // Attach #ajax to the element. Use change event for selects.
+      $form['moderation_state']['#ajax'] = [
+        'callback' => 'va_gov_workflow_moderation_state_ajax_callback',
+        'event' => 'change',
+        'wrapper' => 'moderation-state-wrapper',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => $this->t('Updating...'),
+        ],
+      ];
+
+      // Ensure Drupal behaviors pick up AJAX-enabled elements.
+      $form['moderation_state']['#attributes']['class'][] = 'use-ajax';
+    }
+
   }
 
   /**

--- a/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_workflow/src/EventSubscriber/EntityEventSubscriber.php
@@ -431,9 +431,26 @@ class EntityEventSubscriber implements EventSubscriberInterface {
       return;
     }
     $entity = $formObject->getEntity();
+    // Defensive guards: bail out early for missing, new, or id-less entities so
+    // we never call the usage service with a NULL id (which triggers an
+    // assertion in entity storage).
+    if (!$entity) {
+      return;
+    }
+    if (method_exists($entity, 'isNew') && $entity->isNew()) {
+      return;
+    }
+    $maybe_id = NULL;
+    if (method_exists($entity, 'id')) {
+      $maybe_id = $entity->id();
+    }
+    if (empty($maybe_id)) {
+      return;
+    }
     if ($entity->getEntityTypeId() !== 'node') {
       return;
     }
+
     $entity_type = $entity->getEntityTypeId();
     $entity_id = $entity->id();
     $usage_total = $this->usage->getUsageTotal($entity_type, $entity_id);

--- a/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
+++ b/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
@@ -113,7 +113,11 @@ class WorkflowContentControl {
   public function hasLinkedEntities(EntityInterface $entity): bool {
     $entity_type = $entity->getEntityTypeId();
     $entity_id = $entity->id();
-    if ($this->entityUsageService->getUsageTotal($entity_type, $entity_id) > 0) {
+    $cache_key = $entity_type . ':' . $entity_id;
+    if (!isset($this->usageTotalCache[$cache_key])) {
+      $this->usageTotalCache[$cache_key] = $this->entityUsageService->getUsageTotal($entity_type, $entity_id);
+    }
+    if ($this->usageTotalCache[$cache_key] > 0) {
       return TRUE;
     }
     return FALSE;

--- a/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
+++ b/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
@@ -26,6 +26,13 @@ class WorkflowContentControl {
   protected $entityUsageService;
 
   /**
+   * Cache for usage totals.
+   *
+   * @var array
+   */
+  protected $usageTotalCache = [];
+
+  /**
    * Constructs the EventSubscriber object.
    *
    * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service

--- a/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
+++ b/docroot/modules/custom/va_gov_workflow/src/Service/WorkflowContentControl.php
@@ -3,6 +3,8 @@
 namespace Drupal\va_gov_workflow\Service;
 
 use Drupal\va_gov_user\Service\UserPermsService;
+use Drupal\entity_usage_addons\Service\Usage;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Service used for controlling entity workflow transitions.
@@ -17,15 +19,26 @@ class WorkflowContentControl {
   protected $userPermsService;
 
   /**
+   * The Entity Usage Service.
+   *
+   * @var \Drupal\entity_usage_addons\Service\Usage
+   */
+  protected $entityUsageService;
+
+  /**
    * Constructs the EventSubscriber object.
    *
    * @param \Drupal\va_gov_user\Service\UserPermsService $user_perms_service
    *   The user perms service.
+   * @param \Drupal\entity_usage_addons\Service\Usage $entity_usage_service
+   *   The entity usage service.
    */
   public function __construct(
     UserPermsService $user_perms_service,
+    Usage $entity_usage_service,
   ) {
     $this->userPermsService = $user_perms_service;
+    $this->entityUsageService = $entity_usage_service;
   }
 
   /**
@@ -86,6 +99,24 @@ class WorkflowContentControl {
    */
   public function isBundleArchiveableByNonAdmins(string $bundle, string $entity_type = 'node') {
     return in_array($bundle, $this->getBundlesArchiveableByAdmins($entity_type)) ? FALSE : TRUE;
+  }
+
+  /**
+   * Determine whether the given entity has linked (used) entities.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to check for linked usage.
+   *
+   * @return bool
+   *   TRUE if the entity has linked usages, FALSE otherwise.
+   */
+  public function hasLinkedEntities(EntityInterface $entity): bool {
+    $entity_type = $entity->getEntityTypeId();
+    $entity_id = $entity->id();
+    if ($this->entityUsageService->getUsageTotal($entity_type, $entity_id) > 0) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
 }

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.info.yml
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.info.yml
@@ -4,6 +4,7 @@ description: 'Provides customizations for publishing workflow.'
 package: 'Custom'
 core_version_requirement: ^9 || ^10
 dependencies:
+  - entity_usage_addons
   - flag
   - message
   - message_notify

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.install
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.install
@@ -21,7 +21,8 @@
 function _va_gov_workflow_change_content_type_workflow(
   string $contentType,
   string $oldWorkflow,
-  string $newWorkflow) {
+  string $newWorkflow,
+) {
   // Get the content type nids.
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
   $query = $node_storage->getQuery();

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.libraries.yml
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.libraries.yml
@@ -6,6 +6,7 @@ modal:
   dependencies:
     - core/jquery
     - core/drupal
+    - core/drupal.once
     - core/drupal.dialog
     - core/drupal.dialog.ajax
     - core/jquery.ui.dialog

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.libraries.yml
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.libraries.yml
@@ -1,7 +1,11 @@
 modal:
   version: 1.0
+  js:
+    js/modal.js: {}
+    js/restore-scroll.js: {}
   dependencies:
     - core/jquery
     - core/drupal
     - core/drupal.dialog
+    - core/drupal.dialog.ajax
     - core/jquery.ui.dialog

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.libraries.yml
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.libraries.yml
@@ -1,0 +1,7 @@
+modal:
+  version: 1.0
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupal.dialog
+    - core/jquery.ui.dialog

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -97,7 +97,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
       // If this form has an entity and that entity has linked content, show
       // a warning modal with a link to the usage tab so the user can review
       // related items before archiving.
-      $title = t('Address related content');
+      $title = t('Review related content');
       $entity = NULL;
       try {
         /** @var \Drupal\Core\Entity\ContentEntityForm|null $form_object */
@@ -190,8 +190,11 @@ function va_gov_workflow_moderation_state_ajax_callback(
           '#type' => 'container',
           'message' => [
             '#type' => 'markup',
-            '#markup' => '<p style="hyphens:none;">' . t('This content has @usage. Review these references and refer to the <a href="@url" target="_blank" rel="noopener">knowledge base article</a> to make sure archiving this content will not create broken links.',
+            '#markup' => '<p>' . t('This content has @usage. Review these references and refer to the <a href="@url" target="_blank" rel="noopener">knowledge base article</a> to make sure archiving this content will not create broken links.',
                           ['@usage' => $usage_text, '@url' => $kb_url]) . '</p>',
+            '#attributes' => [
+              'class' => ['va-gov-workflow-modal-message'],
+            ],
           ],
           'actions' => [
             '#type' => 'container',

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -118,7 +118,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
       $show_usage_warning = FALSE;
       $usage_total = 0;
       $usage_link_html = '';
-      $kb_link_html = '';
+      $kb_url = '';
 
       // Use the workflow content control service which knows about linked
       // entities.
@@ -164,20 +164,13 @@ function va_gov_workflow_moderation_state_ajax_callback(
           $usage_link_html = Link::fromTextAndUrl(t('View related content'), $url)->toString();
 
           // Build a button to the knowledge base article.
-          $kb_url = Url::fromRoute('entity.node.canonical', ['node' => $kb_id])->setOptions([
-            'attributes' => [
-              'target' => '_blank',
-              'rel' => 'noopener',
-              'class' => ['button', 'button--primary', 'button--outline'],
-            ],
-          ]);
-          $kb_link_html = Link::fromTextAndUrl(t('See related knowledge base article'), $kb_url)->toString();
+          $kb_url = '/node/' . $kb_id;
         }
         catch (\Throwable $e) {
           // If route generation fails, fallback to a simple path link.
           $path = '/' . $entity_type . '/' . $entity_id . '/usage';
           $usage_link_html = '<a href="' . $path . '" target="_blank" rel="noopener" class="button button--primary">' . t('View related content') . '</a>';
-          $kb_link_html = '<a href="/node/' . $kb_id . '" target="_blank" rel="noopener" class="button button--primary button--outline">' . t('See related knowledge base article') . '</a>';
+          $kb_url = '/node/' . $kb_id;
         }
 
       }
@@ -197,7 +190,8 @@ function va_gov_workflow_moderation_state_ajax_callback(
           '#type' => 'container',
           'message' => [
             '#type' => 'markup',
-            '#markup' => '<p>' . t('This content has @usage. Review and address the related content before archiving.', ['@usage' => $usage_text]) . '</p>',
+            '#markup' => '<p style="hyphens:none;">' . t('This content has @usage. Review these references and refer to the <a href="@url" target="_blank" rel="noopener">knowledge base article</a> to make sure archiving this content will not create broken links.',
+                          ['@usage' => $usage_text, '@url' => $kb_url]) . '</p>',
           ],
           'actions' => [
             '#type' => 'container',
@@ -205,10 +199,6 @@ function va_gov_workflow_moderation_state_ajax_callback(
             'usage_link' => [
               '#type' => 'markup',
               '#markup' => $usage_link_html,
-            ],
-            'kb_link' => [
-              '#type' => 'markup',
-              '#markup' => $kb_link_html,
             ],
           ],
           '#attached' => [

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -110,14 +110,16 @@ function va_gov_workflow_moderation_state_ajax_callback(
         // Ignore — we'll treat as no entity found.
         $entity = NULL;
       }
-
-      $show_usage_warning = FALSE;
-      $usage_total = 0;
-      $usage_link_html = '';
       // No point in proceeding without an entity.
       if (!$entity) {
         return;
       }
+
+      $show_usage_warning = FALSE;
+      $usage_total = 0;
+      $usage_link_html = '';
+      $kb_link_html = '';
+
       // Use the workflow content control service which knows about linked
       // entities.
       try {
@@ -133,7 +135,8 @@ function va_gov_workflow_moderation_state_ajax_callback(
         $entity_id = $entity->id();
         $route = "entity.{$entity_type}.entity_usage";
         // Build a link to the knowledge base article.
-        $kba_id = '82190';
+        // Use the node id of the relevant knowledge base article.
+        $kb_id = '82190';
 
         try {
           // Get the usage total for display.
@@ -161,7 +164,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
           $usage_link_html = Link::fromTextAndUrl(t('View related content'), $url)->toString();
 
           // Build a button to the knowledge base article.
-          $kb_url = Url::fromRoute('entity.node.canonical', ['node' => $kba_id])->setOptions([
+          $kb_url = Url::fromRoute('entity.node.canonical', ['node' => $kb_id])->setOptions([
             'attributes' => [
               'target' => '_blank',
               'rel' => 'noopener',

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -97,7 +97,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
       // If this form has an entity and that entity has linked content, show
       // a warning modal with a link to the usage tab so the user can review
       // related items before archiving.
-      $title = t('Review related content');
+      $title = t('View linked pages');
       $entity = NULL;
       try {
         /** @var \Drupal\Core\Entity\ContentEntityForm|null $form_object */
@@ -182,7 +182,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
 
       if ($show_usage_warning) {
         // Build pluralized usage text and include it inline in the warning.
-        $usage_text = \Drupal::translation()->formatPlural($usage_total, '1 related item', '@count related items', ['@count' => $usage_total]);
+        $usage_text = \Drupal::translation()->formatPlural($usage_total, '1 page', '@count pages', ['@count' => $usage_total]);
 
         // Build a render array for the modal content so we can attach a
         // library that provides safe behaviors instead of inline JS handlers.
@@ -190,8 +190,8 @@ function va_gov_workflow_moderation_state_ajax_callback(
           '#type' => 'container',
           'message' => [
             '#type' => 'markup',
-            '#markup' => '<p>' . t('This content has @usage. Review these references and refer to the <a href="@url" target="_blank" rel="noopener">knowledge base article</a> to make sure archiving this content will not create broken links.',
-                          ['@usage' => $usage_text, '@url' => $kb_url]) . '</p>',
+            '#markup' => '<p>' . t('This content is linked on @usage. Review the page(s) and refer to the <a href="@url" target="_blank" rel="noopener">Knowledge Base article</a> to make sure that archiving this content will not create broken links.',
+              ['@usage' => $usage_text, '@url' => $kb_url]) . '</p>',
             '#attributes' => [
               'class' => ['va-gov-workflow-modal-message'],
             ],

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -177,7 +177,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
           // If route generation fails, fallback to a simple path link.
           $path = '/' . $entity_type . '/' . $entity_id . '/usage';
           $usage_link_html = '<a href="' . $path . '" target="_blank" rel="noopener" class="button button--primary">' . t('View related content') . '</a>';
-          $kb_link_html = '<a href="/node/' . $kba_id . '" target="_blank" rel="noopener" class="button button--primary button--outline">' . t('See related knowledge base article') . '</a>';
+          $kb_link_html = '<a href="/node/' . $kb_id . '" target="_blank" rel="noopener" class="button button--primary button--outline">' . t('See related knowledge base article') . '</a>';
         }
 
       }

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -97,7 +97,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
       // If this form has an entity and that entity has linked content, show
       // a warning modal with a link to the usage tab so the user can review
       // related items before archiving.
-      $title = \Drupal::translation()->translate('Address related content');
+      $title = t('Address related content');
       $entity = NULL;
       try {
         /** @var \Drupal\Core\Entity\ContentEntityForm|null $form_object */
@@ -112,60 +112,62 @@ function va_gov_workflow_moderation_state_ajax_callback(
       }
 
       $show_usage_warning = FALSE;
+      $usage_total = 0;
       $usage_link_html = '';
-      if ($entity) {
-        // Use the workflow content control service which knows about linked
-        // entities.
+      // No point in proceeding without an entity.
+      if (!$entity) {
+        return;
+      }
+      // Use the workflow content control service which knows about linked
+      // entities.
+      try {
+        $workflow_control = \Drupal::service('va_gov_workflow.workflow_content_control');
+        $show_usage_warning = $workflow_control->hasLinkedEntities($entity);
+        // No usage warning needed.
+        if (!$show_usage_warning) {
+          return;
+        }
+        // Build a link to the entity usage page (entity_usage_addons
+        // exposes a route like entity.{entity_type}.entity_usage).
+        $entity_type = $entity->getEntityTypeId();
+        $entity_id = $entity->id();
+        $route = "entity.{$entity_type}.entity_usage";
         try {
-          $workflow_control = \Drupal::service('va_gov_workflow.workflow_content_control');
-          if (
-            method_exists($workflow_control, 'hasLinkedEntities')
-            && $workflow_control->hasLinkedEntities($entity)
-          ) {
-            $show_usage_warning = TRUE;
-            // Build a link to the entity usage page (entity_usage_addons
-            // exposes a route like entity.{entity_type}.entity_usage).
-            $entity_type = $entity->getEntityTypeId();
-            $entity_id = $entity->id();
-            $route = "entity.{$entity_type}.entity_usage";
-            try {
-              // Get the usage total for display.
-              $usage_total = 0;
-              try {
-                $usage_service = \Drupal::service('entity_usage_addons.usage');
-                $usage_total = (int) $usage_service->getUsageTotal(
-                  $entity_type,
-                  $entity_id
-                );
-              }
-              catch (\Throwable $e) {
-                $usage_total = 0;
-              }
-              // Build a URL to the usage page and ensure it opens in a new tab.
-              $url = Url::fromRoute(
-                $route,
-                [$entity_type => $entity_id]
-              )->setOptions([
-                'attributes' => [
-                  'target' => '_blank',
-                  'rel' => 'noopener',
-                  'class' => ['button', 'button--primary'],
-                ],
-              ]);
-              $usage_link_html = Link::fromTextAndUrl(\Drupal::translation()->translate('View related content'), $url)->toString();
-            }
-            catch (\Throwable $e) {
-              // If route generation fails, fallback to a simple path link.
-              $path = '/' . $entity_type . '/' . $entity_id . '/usage';
-              $usage_link_html = '<a href="' . $path . '" target="_blank" rel="noopener" class="button button--primary">' . \Drupal::translation()->translate('View related content') . '</a>';
-            }
+          // Get the usage total for display.
+          try {
+            $usage_service = \Drupal::service('entity_usage_addons.usage');
+            $usage_total = $usage_service->getUsageTotal(
+              $entity_type,
+              $entity_id
+            );
           }
+          catch (\Throwable $e) {
+            $usage_total = 0;
+          }
+          // Build a URL to the usage page and ensure it opens in a new tab.
+          $url = Url::fromRoute(
+            $route,
+            [$entity_type => $entity_id]
+          )->setOptions([
+            'attributes' => [
+              'target' => '_blank',
+              'rel' => 'noopener',
+              'class' => ['button', 'button--primary'],
+            ],
+          ]);
+          $usage_link_html = Link::fromTextAndUrl(t('View related content'), $url)->toString();
         }
         catch (\Throwable $e) {
-          // If the service isn't available or throws, don't block archive
-          // behavior — fall through to the normal confirm modal below.
-          $show_usage_warning = FALSE;
+          // If route generation fails, fallback to a simple path link.
+          $path = '/' . $entity_type . '/' . $entity_id . '/usage';
+          $usage_link_html = '<a href="' . $path . '" target="_blank" rel="noopener" class="button button--primary">' . t('View related content') . '</a>';
         }
+
+      }
+      catch (\Throwable $e) {
+        // If the service isn't available or throws, don't block archive
+        // behavior — fall through to the normal confirm modal below.
+        $show_usage_warning = FALSE;
       }
 
       if ($show_usage_warning) {
@@ -178,7 +180,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
           '#type' => 'container',
           'message' => [
             '#type' => 'markup',
-            '#markup' => '<p>' . \Drupal::translation()->translate('This content has @usage. Review and address the related content before archiving.', ['@usage' => $usage_text]) . '</p>',
+            '#markup' => '<p>' . t('This content has @usage. Review and address the related content before archiving.', ['@usage' => $usage_text]) . '</p>',
           ],
           'actions' => [
             '#type' => 'container',
@@ -233,8 +235,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
     }
   }
   catch (\Throwable $e) {
-    // Swallow exceptions to avoid breaking AJAX responses. Consider logging
-    // during development to help debug issues.
+    // Swallow exceptions to avoid breaking AJAX responses.
     \Drupal::logger('va_gov_workflow')->error($e->getMessage());
   }
   return $response;

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -132,6 +132,9 @@ function va_gov_workflow_moderation_state_ajax_callback(
         $entity_type = $entity->getEntityTypeId();
         $entity_id = $entity->id();
         $route = "entity.{$entity_type}.entity_usage";
+        // Build a link to the knowledge base article.
+        $kba_id = '82190';
+
         try {
           // Get the usage total for display.
           try {
@@ -156,6 +159,16 @@ function va_gov_workflow_moderation_state_ajax_callback(
             ],
           ]);
           $usage_link_html = Link::fromTextAndUrl(t('View related content'), $url)->toString();
+
+          // Build a button to the knowledge base article.
+          $kb_url = Url::fromRoute('entity.node.canonical', ['node' => $kba_id])->setOptions([
+            'attributes' => [
+              'target' => '_blank',
+              'rel' => 'noopener',
+              'class' => ['button', 'button--primary', 'button--outline'],
+            ],
+          ]);
+          $kb_link_html = Link::fromTextAndUrl(t('See related knowledge base article'), $kb_url)->toString();
         }
         catch (\Throwable $e) {
           // If route generation fails, fallback to a simple path link.
@@ -189,6 +202,10 @@ function va_gov_workflow_moderation_state_ajax_callback(
               '#type' => 'markup',
               '#markup' => $usage_link_html,
             ],
+            'kb_link' => [
+              '#type' => 'markup',
+              '#markup' => $kb_link_html,
+            ],
           ],
           '#attached' => [
             'library' => ['va_gov_workflow/modal'],
@@ -196,6 +213,12 @@ function va_gov_workflow_moderation_state_ajax_callback(
         ];
 
         $rendered = \Drupal::service('renderer')->renderRoot($modal_build);
+        // Ensure libraries and drupalSettings attached to the modal are sent in
+        // the AjaxResponse so clients that didn't previously load the library
+        // (for example non-admin pages) will receive the JS behavior.
+        if (!empty($modal_build['#attached'])) {
+          $response->setAttachments($modal_build['#attached']);
+        }
         $response->addCommand(new OpenModalDialogCommand($title, $rendered, ['width' => '600']));
       }
     }
@@ -207,7 +230,16 @@ function va_gov_workflow_moderation_state_ajax_callback(
         if (!empty($form['#id'])) {
           try {
             $rendered_form = \Drupal::service('renderer')->renderRoot($form);
+            // Ensure our modal library (containing scroll-restore behavior)
+            // is available after the AJAX replace so behaviors re-attach.
+            $attachments = !empty($form['#attached']) ? $form['#attached'] : [];
+            if (empty($attachments['library']) || !in_array('va_gov_workflow/modal', $attachments['library'])) {
+              $attachments['library'][] = 'va_gov_workflow/modal';
+            }
+            $response->setAttachments($attachments);
             $response->addCommand(new ReplaceCommand('#' . $form['#id'], $rendered_form));
+            // No explicit focus commands; scroll-restore behavior will preserve
+            // the user's position after AJAX updates.
           }
           catch (\Throwable $e) {
             // Fallback to rendering only the moderation element.
@@ -218,6 +250,13 @@ function va_gov_workflow_moderation_state_ajax_callback(
               $to_render = $form['moderation_state'];
             }
             $rendered = \Drupal::service('renderer')->renderRoot($to_render);
+            // Include any attachments from the rendered form so behaviors are
+            // re-applied on the client and ensure our modal library is present.
+            $attachments = !empty($form['#attached']) ? $form['#attached'] : [];
+            if (empty($attachments['library']) || !in_array('va_gov_workflow/modal', $attachments['library'])) {
+              $attachments['library'][] = 'va_gov_workflow/modal';
+            }
+            $response->setAttachments($attachments);
             $response->addCommand(new ReplaceCommand('#moderation-state-wrapper', $rendered));
           }
         }
@@ -229,7 +268,16 @@ function va_gov_workflow_moderation_state_ajax_callback(
             $to_render = $form['moderation_state'];
           }
           $rendered = \Drupal::service('renderer')->renderRoot($to_render);
+          // Merge any attachments from the element and ensure our library is
+          // included so the restore-scroll behavior is sent to the client.
+          $attachments = !empty($to_render['#attached']) ? $to_render['#attached'] : [];
+          if (empty($attachments['library']) || !in_array('va_gov_workflow/modal', $attachments['library'])) {
+            $attachments['library'][] = 'va_gov_workflow/modal';
+          }
+          $response->setAttachments($attachments);
           $response->addCommand(new ReplaceCommand('#moderation-state-wrapper', $rendered));
+          // No explicit focus commands; scroll-restore behavior will preserve
+          // the user's position after AJAX updates.
         }
       }
     }

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -174,6 +174,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
           // If route generation fails, fallback to a simple path link.
           $path = '/' . $entity_type . '/' . $entity_id . '/usage';
           $usage_link_html = '<a href="' . $path . '" target="_blank" rel="noopener" class="button button--primary">' . t('View related content') . '</a>';
+          $kb_link_html = '<a href="/node/' . $kba_id . '" target="_blank" rel="noopener" class="button button--primary button--outline">' . t('See related knowledge base article') . '</a>';
         }
 
       }

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -75,7 +75,6 @@ function va_gov_workflow_moderation_state_ajax_callback(
     // Try to detect the moderation state value from form_state or the form
     // structure. The widget value can be nested; extract the first string we
     // find.
-    $value = NULL;
     if ($form_state->hasValue('moderation_state')) {
       $selected_value = $form_state->getValue('moderation_state');
     }

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -5,9 +5,14 @@
  * Contains va_gov_workflow.module.
  */
 
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Ajax\OpenModalDialogCommand;
 
 /**
  * Implements hook_help().
@@ -56,4 +61,182 @@ function va_gov_workflow_entity_base_field_info_alter(&$fields, ContentEntityTyp
       ->setRequired(TRUE)
       ->setDisplayOptions('form', $form_options);
   }
+}
+
+/**
+ * AJAX callback for moderation state changes.
+ */
+function va_gov_workflow_moderation_state_ajax_callback(
+  array &$form,
+  FormStateInterface $form_state,
+) {
+  $response = new AjaxResponse();
+  try {
+    // Try to detect the moderation state value from form_state or the form
+    // structure. The widget value can be nested; extract the first string we
+    // find.
+    $value = NULL;
+    if ($form_state->hasValue('moderation_state')) {
+      $selected_value = $form_state->getValue('moderation_state');
+    }
+    elseif (isset($form['moderation_state'])) {
+      $selected_value = $form['moderation_state'];
+    }
+    else {
+      $selected_value = NULL;
+    }
+
+    // Get the selected moderation state.
+    $value = NULL;
+    if ($selected_value !== NULL
+        && is_array($selected_value)
+        && !empty($selected_value[0]['value'])) {
+      $value = $selected_value[0]['value'];
+    }
+
+    if ($value !== NULL && strtolower($value) === 'archived') {
+      // If this form has an entity and that entity has linked content, show
+      // a warning modal with a link to the usage tab so the user can review
+      // related items before archiving.
+      $title = \Drupal::translation()->translate('Address related content');
+      $entity = NULL;
+      try {
+        /** @var \Drupal\Core\Entity\ContentEntityForm|null $form_object */
+        $form_object = $form_state->getFormObject();
+        if ($form_object && method_exists($form_object, 'getEntity')) {
+          $entity = $form_object->getEntity();
+        }
+      }
+      catch (\Throwable $e) {
+        // Ignore — we'll treat as no entity found.
+        $entity = NULL;
+      }
+
+      $show_usage_warning = FALSE;
+      $usage_link_html = '';
+      if ($entity) {
+        // Use the workflow content control service which knows about linked
+        // entities.
+        try {
+          $workflow_control = \Drupal::service('va_gov_workflow.workflow_content_control');
+          if (
+            method_exists($workflow_control, 'hasLinkedEntities')
+            && $workflow_control->hasLinkedEntities($entity)
+          ) {
+            $show_usage_warning = TRUE;
+            // Build a link to the entity usage page (entity_usage_addons
+            // exposes a route like entity.{entity_type}.entity_usage).
+            $entity_type = $entity->getEntityTypeId();
+            $entity_id = $entity->id();
+            $route = "entity.{$entity_type}.entity_usage";
+            try {
+              // Get the usage total for display.
+              $usage_total = 0;
+              try {
+                $usage_service = \Drupal::service('entity_usage_addons.usage');
+                $usage_total = (int) $usage_service->getUsageTotal(
+                  $entity_type,
+                  $entity_id
+                );
+              }
+              catch (\Throwable $e) {
+                $usage_total = 0;
+              }
+              // Build a URL to the usage page and ensure it opens in a new tab.
+              $url = Url::fromRoute(
+                $route,
+                [$entity_type => $entity_id]
+              )->setOptions([
+                'attributes' => [
+                  'target' => '_blank',
+                  'rel' => 'noopener',
+                  'class' => ['button', 'button--primary'],
+                ],
+              ]);
+              $usage_link_html = Link::fromTextAndUrl(\Drupal::translation()->translate('View related content'), $url)->toString();
+            }
+            catch (\Throwable $e) {
+              // If route generation fails, fallback to a simple path link.
+              $path = '/' . $entity_type . '/' . $entity_id . '/usage';
+              $usage_link_html = '<a href="' . $path . '" target="_blank" rel="noopener" class="button button--primary">' . \Drupal::translation()->translate('View related content') . '</a>';
+            }
+          }
+        }
+        catch (\Throwable $e) {
+          // If the service isn't available or throws, don't block archive
+          // behavior — fall through to the normal confirm modal below.
+          $show_usage_warning = FALSE;
+        }
+      }
+
+      if ($show_usage_warning) {
+        // Build pluralized usage text and include it inline in the warning.
+        $usage_text = \Drupal::translation()->formatPlural($usage_total, '1 related item', '@count related items', ['@count' => $usage_total]);
+
+        // Build a render array for the modal content so we can attach a
+        // library that provides safe behaviors instead of inline JS handlers.
+        $modal_build = [
+          '#type' => 'container',
+          'message' => [
+            '#type' => 'markup',
+            '#markup' => '<p>' . \Drupal::translation()->translate('This content has @usage. Review and address the related content before archiving.', ['@usage' => $usage_text]) . '</p>',
+          ],
+          'actions' => [
+            '#type' => 'container',
+            '#attributes' => ['class' => ['va-gov-workflow-modal-actions']],
+            'usage_link' => [
+              '#type' => 'markup',
+              '#markup' => $usage_link_html,
+            ],
+          ],
+          '#attached' => [
+            'library' => ['va_gov_workflow/modal'],
+          ],
+        ];
+
+        $rendered = \Drupal::service('renderer')->renderRoot($modal_build);
+        $response->addCommand(new OpenModalDialogCommand($title, $rendered, ['width' => '600']));
+      }
+    }
+    else {
+      if (isset($form['moderation_state'])) {
+        // Prefer re-rendering the full form when possible so that attached
+        // libraries and drupalSettings are included and Drupal behaviors are
+        // re-applied. This prevents AJAX handlers from only working once.
+        if (!empty($form['#id'])) {
+          try {
+            $rendered_form = \Drupal::service('renderer')->renderRoot($form);
+            $response->addCommand(new ReplaceCommand('#' . $form['#id'], $rendered_form));
+          }
+          catch (\Throwable $e) {
+            // Fallback to rendering only the moderation element.
+            if (isset($form['moderation_state']['widget'][0]['state'])) {
+              $to_render = $form['moderation_state']['widget'][0]['state'];
+            }
+            else {
+              $to_render = $form['moderation_state'];
+            }
+            $rendered = \Drupal::service('renderer')->renderRoot($to_render);
+            $response->addCommand(new ReplaceCommand('#moderation-state-wrapper', $rendered));
+          }
+        }
+        else {
+          if (isset($form['moderation_state']['widget'][0]['state'])) {
+            $to_render = $form['moderation_state']['widget'][0]['state'];
+          }
+          else {
+            $to_render = $form['moderation_state'];
+          }
+          $rendered = \Drupal::service('renderer')->renderRoot($to_render);
+          $response->addCommand(new ReplaceCommand('#moderation-state-wrapper', $rendered));
+        }
+      }
+    }
+  }
+  catch (\Throwable $e) {
+    // Swallow exceptions to avoid breaking AJAX responses. Consider logging
+    // during development to help debug issues.
+    \Drupal::logger('va_gov_workflow')->error($e->getMessage());
+  }
+  return $response;
 }

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.services.yml
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.services.yml
@@ -7,6 +7,7 @@ services:
       - '@va_gov_workflow.workflow_content_control'
       - '@va_gov_workflow.flagger'
       - '@va_gov_notifications.notifications_manager'
+      - '@entity_usage_addons.usage'
     tags:
       - { name: event_subscriber }
   va_gov_workflow.flagger:
@@ -14,7 +15,7 @@ services:
     arguments: ['@flag', '@entity_type.manager']
   va_gov_workflow.workflow_content_control:
     class: Drupal\va_gov_workflow\Service\WorkflowContentControl
-    arguments: ['@va_gov_user.user_perms']
+    arguments: ['@va_gov_user.user_perms', '@entity_usage_addons.usage']
   va_gov_workflow.migrate_event_subscriber:
     class: Drupal\va_gov_workflow\EventSubscriber\MigrateEventSubscriber
     arguments: ['@va_gov_workflow.flagger']

--- a/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
+++ b/docroot/themes/custom/vagovclaro/assets/scss/components/_elements.scss
@@ -364,3 +364,8 @@ textarea:user-invalid {
   color: var(--va-red-dark);
   margin: 5px 0;
 }
+
+// For modal message to prevent url hyphenation
+p:has(+ .va-gov-workflow-modal-actions) {
+  hyphens: none;
+}

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -857,7 +857,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         ],
       ],
       [
-        'administrator_users',
+        'admnistrator_users',
         [
           'access entity usage statistics',
           'administer users',

--- a/tests/phpunit/Security/RolesPermissionsTest.php
+++ b/tests/phpunit/Security/RolesPermissionsTest.php
@@ -99,6 +99,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         'content_admin',
         [
           'access block library',
+          'access entity usage statistics',
           'accept translation jobs',
           'access administration pages',
           'access files overview',
@@ -240,6 +241,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         'content_creator_benefits_hubs',
         [
           'access block library',
+          'access entity usage statistics',
           'access files overview',
           'create landing_page content',
           'create page content',
@@ -252,6 +254,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         'content_creator_resources_and_support',
         [
           'access block library',
+          'access entity usage statistics',
           'access files overview',
           'create checklist content',
           'create faq_multiple_q_a content',
@@ -267,6 +270,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
       [
         'content_creator_vba',
         [
+          'access entity usage statistics',
           'create vba_facility_service content',
           'view node link report',
         ],
@@ -274,6 +278,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
       [
         'content_creator_vet_center',
         [
+          'access entity usage statistics',
           'create vet_center_cap content',
           'create vet_center_facility_health_servi content',
           'view node link report',
@@ -285,6 +290,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
           'access administration pages',
           'access block library',
           'access content overview',
+          'access entity usage statistics',
           'access files overview',
           'access media overview',
           'access user profiles',
@@ -454,6 +460,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
           'access administration pages',
           'access block library',
           'access content overview',
+          'access entity usage statistics',
           'access files overview',
           'access media overview',
           'access user profiles',
@@ -615,6 +622,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
           'access administration pages',
           'access block library',
           'access content overview',
+          'access entity usage statistics',
           'access files overview',
           'access media overview',
           'access user profiles',
@@ -849,8 +857,9 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         ],
       ],
       [
-        'admnistrator_users',
+        'administrator_users',
         [
+          'access entity usage statistics',
           'administer users',
           'assign content_admin role',
           'assign content_api_consumer role',
@@ -883,6 +892,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         'office_content_creator',
         [
           'access block library',
+          'access entity usage statistics',
           'access files overview',
           'create event content',
           'create outreach_asset content',
@@ -894,6 +904,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         'vamc_content_creator',
         [
           'access block library',
+          'access entity usage statistics',
           'access files overview',
           'create event content',
           'create full_width_banner_alert content',
@@ -912,6 +923,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         'homepage_manager',
         [
           'access block library',
+          'access entity usage statistics',
           'create banner content',
           'create benefit_promo block content',
           'create cta_with_link block content',
@@ -954,6 +966,7 @@ class RolesPermissionsTest extends VaGovExistingSiteBase {
         'translation_manager',
         [
           'accept translation jobs',
+          'access entity usage statistics',
           'create content translations',
           'create translation jobs',
           'delete translation jobs',


### PR DESCRIPTION
## Description

Relates to #22068

The key changes involve the following:
- creating a modal screen and dialog that is triggered when a user tries to archive content that is referenced by other content
- allowing all editors to have access to the usage tab

### Generated description
This pull request introduces support for entity usage statistics across multiple user roles and integrates the entity usage service into the workflow event subscriber. The main goal is to allow various content-related roles to access entity usage data and to prepare the backend for future enhancements that may leverage usage statistics in workflows.

**Role Configuration Updates:**

* Added the `entity_usage` module as a dependency to all major content-related user roles, including administrator, content admin, content creator, editor, publisher, reviewer, form builder, homepage manager, office content creator, rates editor, redirect administrator, translation manager, and VAMC content creator roles. [[1]](diffhunk://#diff-0df1e3d41f2168633d70305f64d21ea4225ee48ac416438f92795c5ff71738d5R11) [[2]](diffhunk://#diff-f65b1f9147f3793112d406dbb1c58461ef659c177cd7a79935b84d2b313f8d3dR31) [[3]](diffhunk://#diff-72961c4521043d75283a1614cb456b19383be464a13eee7890620598cd3b07d5R12) [[4]](diffhunk://#diff-37a786a0be9e81472f71f8eb7544ff2457aa6393a1ed7e34100d101a09e1c2baR16) [[5]](diffhunk://#diff-54a3c1d149d5ae77bf0cae88326ccf2ad5c2e9b16cdd25b722617b48cfd0acc6R8) [[6]](diffhunk://#diff-2083ed41b66bb83aae8940c60d22666210beea2384dac1c79772c338d663f834R9) [[7]](diffhunk://#diff-fbf6d89c71649ff01015f05b51fecade6f4d81df4b95b1789b3698f376599231R75) [[8]](diffhunk://#diff-35ffa13d43e28d7ed20adbc1f619b5afb7212eda134a17946e8db261de0a2bdfR78) [[9]](diffhunk://#diff-223c1ebfc02859c52107c3883167816af6f6f26fa2ce6851af7f4ae10fdf0b18R75) [[10]](diffhunk://#diff-17e772dbe6290f030b0c4e4f98c27b97d91a6a32f73cb159c2907af0554a5dfeR6) [[11]](diffhunk://#diff-6998909881f006eb5c53e900e436ef84380ff272c42331bd7012587b1011adf0R19) [[12]](diffhunk://#diff-c0d71675f4fa95ece957c8042b8b12387537fbc508c55b9e191aee26338f3faaR11) [[13]](diffhunk://#diff-9aee10010b981b752f2f5832a2ab3029e5720c88d83a608ed33524abc1489942R17) [[14]](diffhunk://#diff-278ff00ab49b88394d57305f0b6ce0e9b597b3a5e632c74494bc604a8a1c1cc2R9) [[15]](diffhunk://#diff-24b72b9b0e10de9b38e188a741465fb53f450fa2c4ee02455d83e4a7484b488eR12) [[16]](diffhunk://#diff-9ed44982996c08f8ae71ee03c4d48b7abfeb8e10a426b8f6b60eea26f8be3b44R18)
* Granted the `access entity usage statistics` permission to these roles, enabling them to view usage statistics for entities they manage. [[1]](diffhunk://#diff-0df1e3d41f2168633d70305f64d21ea4225ee48ac416438f92795c5ff71738d5R29) [[2]](diffhunk://#diff-f65b1f9147f3793112d406dbb1c58461ef659c177cd7a79935b84d2b313f8d3dR65) [[3]](diffhunk://#diff-72961c4521043d75283a1614cb456b19383be464a13eee7890620598cd3b07d5R26) [[4]](diffhunk://#diff-37a786a0be9e81472f71f8eb7544ff2457aa6393a1ed7e34100d101a09e1c2baR30) [[5]](diffhunk://#diff-54a3c1d149d5ae77bf0cae88326ccf2ad5c2e9b16cdd25b722617b48cfd0acc6R19) [[6]](diffhunk://#diff-2083ed41b66bb83aae8940c60d22666210beea2384dac1c79772c338d663f834R21) [[7]](diffhunk://#diff-fbf6d89c71649ff01015f05b51fecade6f4d81df4b95b1789b3698f376599231R101) [[8]](diffhunk://#diff-35ffa13d43e28d7ed20adbc1f619b5afb7212eda134a17946e8db261de0a2bdfR105) [[9]](diffhunk://#diff-223c1ebfc02859c52107c3883167816af6f6f26fa2ce6851af7f4ae10fdf0b18R100) [[10]](diffhunk://#diff-17e772dbe6290f030b0c4e4f98c27b97d91a6a32f73cb159c2907af0554a5dfeR17) [[11]](diffhunk://#diff-6998909881f006eb5c53e900e436ef84380ff272c42331bd7012587b1011adf0R33) [[12]](diffhunk://#diff-c0d71675f4fa95ece957c8042b8b12387537fbc508c55b9e191aee26338f3faaR25) [[13]](diffhunk://#diff-9aee10010b981b752f2f5832a2ab3029e5720c88d83a608ed33524abc1489942R39) [[14]](diffhunk://#diff-278ff00ab49b88394d57305f0b6ce0e9b597b3a5e632c74494bc604a8a1c1cc2R26) [[15]](diffhunk://#diff-24b72b9b0e10de9b38e188a741465fb53f450fa2c4ee02455d83e4a7484b488eR23) [[16]](diffhunk://#diff-9ed44982996c08f8ae71ee03c4d48b7abfeb8e10a426b8f6b60eea26f8be3b44R32)

**Backend Integration:**

* Injected the `entity_usage_addons\Service\Usage` service into the `EntityEventSubscriber` class, making usage statistics available for future workflow logic and event handling. [[1]](diffhunk://#diff-3ac50fb449172bb531c74d4919048a7f1d9009cb47726ffa7836fbd34de8c4a7R10) [[2]](diffhunk://#diff-3ac50fb449172bb531c74d4919048a7f1d9009cb47726ffa7836fbd34de8c4a7R22-R31) [[3]](diffhunk://#diff-3ac50fb449172bb531c74d4919048a7f1d9009cb47726ffa7836fbd34de8c4a7R68-R74) [[4]](diffhunk://#diff-3ac50fb449172bb531c74d4919048a7f1d9009cb47726ffa7836fbd34de8c4a7R103-R119)

**Frontend Usability Enhancement:**

* Added a new JavaScript behavior (`restore-scroll.js`) to preserve and restore the window scroll position during AJAX updates, preventing page jumps and improving user experience when interacting with moderation or other dynamic content.

## Testing done
Manually

## Screenshots
<img width="1695" height="1137" alt="Screenshot 2025-09-02 at 3 07 15 PM" src="https://github.com/user-attachments/assets/10a0f430-b973-4ed5-9d71-16a7d3733e9a" />

## QA steps
### Test usage tab as a VBA editor
- [x] [Log in](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov) as an admin
- [x] Assign the following roles to QA Content Publisher
  - [x] Content creator - VBA
  - [x] Content Publisher
- [x] Assign the following section to QA Content Publisher
  - [x] Senator Johnny Isakson VA Atlanta Regional Office

#### Test QA Content Publisher as a VBA editor
- [x] Log in as QA Content Publisher
- [x] Go to [Senator Johnny Isakson VA Atlanta Regional Office](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov/senator-johnny-isakson-va-atlanta-regional-office)
- [x] Click on the Usage tab
- [x] Confirm that the tab shows other content that has a reference to the Senator Johnny Isakson VA Atlanta Regional Office

### Test usage tab as a Vet Center editor
#### Set up QA Content Publisher as a Vet Center editor
- [x] [Log in](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov) as an admin
- [x] Assign the following roles to QA Content Publisher
  - [x] Content creator - Vet Center
  - [x] Content Publisher
- [x] Assign the following section to QA Content Publisher
  - [x] Secaucus Vet Center

#### Test QA Content Publisher as a Vet Center editor
- [x] Log in as QA Content Publisher
- [x] Go to [Secaucus Vet Center - Telehealth](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov/secaucus-vet-center/service/secaucus-vet-center-telehealth)
- [x] Click on the Usage tab
- [x] Confirm that the tab shows other content that has a reference to the Secaucus Vet Center - Telehealth

### Test usage tab as a VAMC editor
#### Set up QA Content Publisher as a VAMC editor
- [x] [Log in](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov) as an admin
- [x] Assign the following roles to QA Content Publisher
  - [x] Content creator - VAMC
  - [x] Content Publisher
- [x] Assign the following section to QA Content Publisher
  - [x] VA Boston health care

#### Test QA Content Publisher as a VAMC editor
- [x] [Log in](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov) as QA Content Publisher
- [x] Go to [Plymouth VA clinic](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov/boston-health-care/locations/plymouth-va-clinic)
- [x] Click on the Usage tab
- [x] Confirm that the tab shows other content that has a reference to the Plymouth VA Clinic

### Test archive of content with usage
- [x] As QA Content Publisher (with VAMC editor roles and section) go to [Patient advocates - Brockton VA Medical Center
](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov/boston-health-care/locations/brockton-va-medical-center/patient-advocates)
- [x] Click the Edit tab
- [x] Try to Archive
- [x] Confirm that a modal comes up with a message about related content
- [x] Click on the **View related content**
- [x] Confirm that a new tab opens to the Usage tab
- [x] Go back to the Patient advocates - Brockton VA Medical Center tab
- [x] Click the **See related knowledge base article**
- [x] Confirm that a new tab opens to the related knowledge base article
- [x] Go back to the Patient advocates - Brockton VA Medical Center tab
- [x] Close the dialog button
- [x] Add a revision log message
- [x] Save the content 
- [x] Confirm that you archived Patient advocates - Brockton VA Medical Center 

### Test archive of content without any usage (regression test)
(_Note: This should behave as before the modal was introduced without any change._)
- [x] As QA Content Publisher, go to [Greater Boston Veteran Stand Down](https://pr22105-6v5hstzu8sjtglkkt3sekqjs9cwts39f.ci.cms.va.gov/boston-health-care/events/82333)
- [x] Go to the Usage tab
- [x] Confirm that there are no recorded usages
- [x] Go to the edit tab
- [x] Try to archive the event
- [x] Confirm that no modal is triggered
- [x] Confirm that you can save the content as Archived without issue





### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
