### PR TITLE
VACMS-21855: removing https redirect from application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,6 @@ RUN mkdir -p /opt/drupal
 COPY . /opt/drupal
 WORKDIR /opt/drupal
 
-RUN sed -i \
-  -e '/RewriteRule \^ - \[E=protossl\]/s/^/# /' \
-  -e '/RewriteCond %{HTTPS} on/s/^/# /' \
-  -e '/RewriteRule \^ - \[E=protossl:s\]/s/^/# /' \
-  /opt/drupal/docroot/.htaccess
-
 RUN set -eux; \
   export COMPOSER_HOME="$(mktemp -d)"; \
   composer install --dev; \

--- a/docroot/sites/default/settings/settings.eks.php
+++ b/docroot/sites/default/settings/settings.eks.php
@@ -35,7 +35,7 @@ $settings['trusted_host_patterns'] = [
     'test.prod.cms.va.gov',
     'cms.va.gov',
     '.*\.us-gov-west-1\.elb\.amazonaws\.com',
-    '^eks-dev\.cms\.va\.gov$',
+    'eks-dev\.cms\.va\.gov',
 ];
 
 $settings['va_gov_frontend_build_type'] = 'eks';

--- a/docroot/sites/default/settings/settings.eks.php
+++ b/docroot/sites/default/settings/settings.eks.php
@@ -49,7 +49,18 @@ $settings['microsoft_entra_id_tenant_id'] = getenv('MICROSOFT_ENTRA_ID_TENANT_ID
 # Trust the reverse proxy.
 # You may need to replace '127.0.0.1' with your Traefik pod's IP or a broader internal network range.
 $settings['reverse_proxy'] = TRUE;
-$settings['reverse_proxy_addresses'] = ['127.0.0.1'];
+// Allow trusted proxy addresses to be set via environment variable, or use common internal ranges by default.
+$trusted_proxy_env = getenv('TRUSTED_PROXY_ADDRESSES');
+if ($trusted_proxy_env) {
+  $settings['reverse_proxy_addresses'] = array_map('trim', explode(',', $trusted_proxy_env));
+} else {
+  $settings['reverse_proxy_addresses'] = [
+    '127.0.0.1',
+    '10.0.0.0/8',
+    '172.16.0.0/12',
+    '192.168.0.0/16',
+  ];
+}
 
 # Set the HTTP protocol to use the X-Forwarded-Proto header.
 if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {

--- a/docroot/sites/default/settings/settings.eks.php
+++ b/docroot/sites/default/settings/settings.eks.php
@@ -35,6 +35,7 @@ $settings['trusted_host_patterns'] = [
     'test.prod.cms.va.gov',
     'cms.va.gov',
     '.*\.us-gov-west-1\.elb\.amazonaws\.com',
+    '^eks-dev\.cms\.va\.gov$',
 ];
 
 $settings['va_gov_frontend_build_type'] = 'eks';
@@ -44,3 +45,14 @@ $settings['va_gov_frontend_url'] = 'http://localhost:8080';
 $settings['microsoft_entra_id_client_id'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
 $settings['microsoft_entra_id_client_secret'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_SECRET');
 $settings['microsoft_entra_id_tenant_id'] = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');
+
+# Trust the reverse proxy.
+# You may need to replace '127.0.0.1' with your Traefik pod's IP or a broader internal network range.
+$settings['reverse_proxy'] = TRUE;
+$settings['reverse_proxy_addresses'] = ['127.0.0.1'];
+
+# Set the HTTP protocol to use the X-Forwarded-Proto header.
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+  $_SERVER['HTTPS'] = 'on';
+  $_SERVER['SERVER_PORT'] = 443;
+}


### PR DESCRIPTION
## Description

Relates to #21855 

### Generated description

This pull request makes configuration changes to better support running Drupal behind a reverse proxy, specifically for EKS (Elastic Kubernetes Service) environments. The updates focus on improving proxy trust settings, handling HTTPS detection, and allowing a new frontend domain.

**EKS environment configuration improvements:**

* Added `^eks-dev.cms.va.gov

## Description

Relates to #21855 

### Generated description

 to the list of trusted frontend domains in `settings.eks.php`, allowing requests from this domain.
* Enabled reverse proxy support by setting `$settings['reverse_proxy'] = TRUE` and specifying `127.0.0.1` as a trusted proxy address.
* Added logic to set the HTTP protocol to HTTPS when the `X-Forwarded-Proto` header is present, ensuring correct detection of secure requests behind a proxy.

**Dockerfile simplification:**

* Removed the `sed` command that commented out specific rewrite rules in `.htaccess`, simplifying the Docker build process.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
