### PR TITLE
VACMS-21855: removing https redirect from application

### DIFF
--- a/docroot/sites/default/settings/settings.dev.php
+++ b/docroot/sites/default/settings/settings.dev.php
@@ -54,3 +54,25 @@ $public_asset_s3_base_url = "https://dsva-vagov-staging-cms-files.s3.us-gov-west
 $settings['microsoft_entra_id_client_id'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_ID');
 $settings['microsoft_entra_id_client_secret'] = getenv('MICROSOFT_ENTRA_ID_CLIENT_SECRET');
 $settings['microsoft_entra_id_tenant_id'] = getenv('MICROSOFT_ENTRA_ID_TENANT_ID');
+
+# Trust the reverse proxy.
+# You may need to replace '127.0.0.1' with your Traefik pod's IP or a broader internal network range.
+$settings['reverse_proxy'] = TRUE;
+// Allow trusted proxy addresses to be set via environment variable, or use common internal ranges by default.
+$trusted_proxy_env = getenv('TRUSTED_PROXY_ADDRESSES');
+if ($trusted_proxy_env) {
+  $settings['reverse_proxy_addresses'] = array_map('trim', explode(',', $trusted_proxy_env));
+} else {
+  $settings['reverse_proxy_addresses'] = [
+    '127.0.0.1',
+    '10.0.0.0/8',
+    '172.16.0.0/12',
+    '192.168.0.0/16',
+  ];
+}
+
+# Set the HTTP protocol to use the X-Forwarded-Proto header.
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+  $_SERVER['HTTPS'] = 'on';
+  $_SERVER['SERVER_PORT'] = 443;
+}


### PR DESCRIPTION
## Description

Relates to #21855

### Generated description

This pull request adds configuration to ensure Drupal correctly handles requests when running behind a reverse proxy, such as Traefik. The changes make proxy settings more flexible and secure by allowing trusted proxy addresses to be set via an environment variable and by ensuring HTTPS detection works properly.

**Reverse proxy support:**

* Enables the `reverse_proxy` setting and configures trusted proxy addresses, allowing these to be set via the `TRUSTED_PROXY_ADDRESSES` environment variable or defaulting to common internal network ranges.

**HTTPS protocol handling:**

* Sets the HTTP protocol to HTTPS based on the `X-Forwarded-Proto` header, ensuring Drupal recognizes secure requests when behind a proxy.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
