### PR TITLE
VACMS-20443: Adds API cypress test for VAMC System

### DIFF
--- a/tests/cypress/integration/features/api/vamc_police.feature
+++ b/tests/cypress/integration/features/api/vamc_police.feature
@@ -5,4 +5,4 @@ Feature: API
     And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care%2Fva-police"
   Scenario: JSON API consumer can access vamc_police nodes
     Given I am an anonymous user
-    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care%2Fva-police"
+    And I should receive status code 200 when I request "/jsonapi/node/vamc_system_va_police?page[limit]=1&filter[status]=1&include=field_administration%2Cfield_office%2Cfield_phone_numbers_paragraph"

--- a/tests/cypress/integration/features/api/vamc_system.feature
+++ b/tests/cypress/integration/features/api/vamc_system.feature
@@ -1,0 +1,8 @@
+Feature: API
+
+  Scenario: JSON API consumer can access route translation for a given vamc_system
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care"
+  Scenario: JSON API consumer can access vamc_system nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care"

--- a/tests/cypress/integration/features/api/vamc_system.feature
+++ b/tests/cypress/integration/features/api/vamc_system.feature
@@ -5,4 +5,4 @@ Feature: API
     And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care"
   Scenario: JSON API consumer can access vamc_system nodes
     Given I am an anonymous user
-    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care"
+    And I should receive status code 200 when I request "/jsonapi/node/health_care_region_page?page[limit]=1&filter[status]=1&include=field_media%2Cfield_media.image%2Cfield_administration%2Cfield_related_links%2Cfield_related_links.field_va_paragraphs"


### PR DESCRIPTION
## Description

Relates to #20443

### Generated description
This pull request adds new feature scenarios to the Cypress integration tests for API functionality. The main focus is on verifying that anonymous users can successfully access route translation and vamc_system nodes via the JSON API.

New API test scenarios:

* Added a scenario to ensure anonymous users receive a 200 status code when accessing route translation for a given `vamc_system` using the `/router/translate-path` endpoint.
* Added a scenario to verify anonymous users can access `vamc_system` nodes and receive a 200 status code via the same endpoint.

## Testing done
Cypress

## Screenshots
### VAMC System
<img width="803" height="767" alt="Screenshot 2025-09-02 at 2 26 08 PM" src="https://github.com/user-attachments/assets/894230b8-d2ee-4cff-a7a4-54c70e7e17f2" />

### VA Police
<img width="806" height="810" alt="Screenshot 2025-09-02 at 2 26 24 PM" src="https://github.com/user-attachments/assets/9e242df9-2c26-405b-896b-fddef7601627" />

## QA steps
- [ ] Confirm that Cypress tests (particularly the new ones) pass


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
