### PR TITLE
VACMS-20461: Adds cypress test for locations listing

### DIFF
--- a/tests/cypress/integration/features/api/locations_listing.feature
+++ b/tests/cypress/integration/features/api/locations_listing.feature
@@ -1,0 +1,8 @@
+Feature: API
+
+  Scenario: JSON API consumer can access route translation for a given locations_listing
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/router/translate-path?path=%2Fboston-health-care%2Flocations"
+  Scenario: JSON API consumer can access locations_listing nodes
+    Given I am an anonymous user
+    And I should receive status code 200 when I request "/jsonapi/node/locations_listing?page[limit]=1&filter[status]=1&include=field_office%2Cfield_administration"


### PR DESCRIPTION
## Description

Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20461

### Generated description
This pull request adds new feature tests for the API endpoints related to `locations_listing`. The tests ensure that anonymous users can successfully access both the route translation and node listing endpoints, verifying correct API behavior.

API endpoint test coverage:

* Added a scenario to verify that an anonymous user receives a 200 status code when requesting route translation for a `locations_listing` path (`/router/translate-path`).
* Added a scenario to verify that an anonymous user receives a 200 status code when requesting a filtered and included list of `locations_listing` nodes via the JSON API (`/jsonapi/node/locations_listing`).

## Testing done
Cypress

## Screenshots
<img width="792" height="731" alt="Screenshot 2025-09-02 at 5 25 52 PM" src="https://github.com/user-attachments/assets/b8bd91c6-8907-4719-91d5-21f8eb2b87ba" />

## QA steps
- [ ] Confirm that the new Cypress tests pass


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
