### PR TITLE
VACMS-22120: Usage tab message

### DIFF
--- a/docroot/modules/custom/va_gov_workflow/src/VaGovWorkflowInterface.php
+++ b/docroot/modules/custom/va_gov_workflow/src/VaGovWorkflowInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\va_gov_workflow;
+
+/**
+ * Provides an interface for the VA.gov workflow module.
+ */
+interface VaGovWorkflowInterface {
+
+  /**
+   * The node ID of the Usage tab Knowledge Base article.
+   */
+  const KBA_ID = '82190';
+
+}

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -13,6 +13,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Ajax\OpenModalDialogCommand;
+use Drupal\va_gov_workflow\VaGovWorkflowInterface;
 
 /**
  * Implements hook_help().
@@ -136,7 +137,7 @@ function va_gov_workflow_moderation_state_ajax_callback(
         $route = "entity.{$entity_type}.entity_usage";
         // Build a link to the knowledge base article.
         // Use the node id of the relevant knowledge base article.
-        $kb_id = '82190';
+        $kb_id = VaGovWorkflowInterface::KBA_ID;
 
         try {
           // Get the usage total for display.
@@ -291,16 +292,18 @@ function va_gov_workflow_moderation_state_ajax_callback(
  */
 function va_gov_workflow_preprocess_page(array &$variables) {
   $route = \Drupal::routeMatch()->getRouteName();
-  if ($route !== 'entity_usage.usage_list' && $route !== 'entity.node.entity_usage') {
+  if ($route !== 'entity.node.entity_usage') {
     return;
   }
   // Build render array and insert into page content variable.
-  $entity_type = \Drupal::routeMatch()->getParameter('entity_type');
-  $entity_id = \Drupal::routeMatch()->getParameter('entity_id');
+  $markup = "<div><p>This tab shows a list of pages that link to this content.</p>";
+  $markup .= "<p>To archive this content, first remove its link from these pages (or unpublish these pages, if necessary). You only need to remove links from the pages that show \"Published\" in the \"Status\" column and “Default” in the “Used in” column.</p>";
+  $markup .= "<p>For step-by-step instructions on how to use this tab to archive content, check the <a href=\"/node/" . VaGovWorkflowInterface::KBA_ID . "\">Knowledge Base article</a>.</p>";
+  $markup .= "</div>";
+
   $notice = [
     '#type' => 'container',
-    '#attributes' => ['class' => ['entity-usage-top-notice', 'messages', 'messages--info']],
-    '#markup' => t('Usage information for @type @id', ['@type' => $entity_type, '@id' => $entity_id]),
+    '#markup' => $markup,
     '#cache' => [
       'contexts' => ['route', 'user.permissions'],
       'tags' => ['entity_usage:usage_list'],

--- a/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
+++ b/docroot/modules/custom/va_gov_workflow/va_gov_workflow.module
@@ -285,3 +285,39 @@ function va_gov_workflow_moderation_state_ajax_callback(
   }
   return $response;
 }
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function va_gov_workflow_preprocess_page(array &$variables) {
+  $route = \Drupal::routeMatch()->getRouteName();
+  if ($route !== 'entity_usage.usage_list' && $route !== 'entity.node.entity_usage') {
+    return;
+  }
+  // Build render array and insert into page content variable.
+  $entity_type = \Drupal::routeMatch()->getParameter('entity_type');
+  $entity_id = \Drupal::routeMatch()->getParameter('entity_id');
+  $notice = [
+    '#type' => 'container',
+    '#attributes' => ['class' => ['entity-usage-top-notice', 'messages', 'messages--info']],
+    '#markup' => t('Usage information for @type @id', ['@type' => $entity_type, '@id' => $entity_id]),
+    '#cache' => [
+      'contexts' => ['route', 'user.permissions'],
+      'tags' => ['entity_usage:usage_list'],
+    ],
+    '#weight' => 0,
+  ];
+  // Insert into theme page variable. Prepend so the notice appears above
+  // other content in the system_main area. Fall back to top-level content
+  // if system_main isn't present for a theme.
+  if (isset($variables['page']['content']['system_main']) && is_array($variables['page']['content']['system_main'])) {
+    $variables['page']['content']['system_main'] = ['entity_usage_top_notice' => $notice] + $variables['page']['content']['system_main'];
+  }
+  elseif (isset($variables['page']['content']) && is_array($variables['page']['content'])) {
+    $variables['page']['content'] = ['entity_usage_top_notice' => $notice] + $variables['page']['content'];
+  }
+  else {
+    // Last resort: directly set the key under system_main.
+    $variables['page']['content']['system_main']['entity_usage_top_notice'] = $notice;
+  }
+}


### PR DESCRIPTION
## Description

Relates to #22120

### Generated description
This pull request introduces a new interface to centralize the Knowledge Base article node ID and improves the user experience on the entity usage tab by adding a helpful notice. The most important changes are grouped below:

**Centralization of Knowledge Base Article Reference:**

* Added a new `VaGovWorkflowInterface` in `va_gov_workflow` to define a constant `KBA_ID` for the Knowledge Base article node ID, ensuring this value is maintained in a single place.
* Updated references to the Knowledge Base article node ID in `va_gov_workflow.module` to use the new `VaGovWorkflowInterface::KBA_ID` constant instead of a hardcoded string. [[1]](diffhunk://#diff-130071ae21eeb7a0792a6adec6cfc370dc4aa4c87223d63d00380431384ae7acR16) [[2]](diffhunk://#diff-130071ae21eeb7a0792a6adec6cfc370dc4aa4c87223d63d00380431384ae7acL139-R140)

**User Experience Improvements:**

* Added a `hook_preprocess_page` implementation in `va_gov_workflow.module` to inject a notice at the top of the entity usage tab. This notice explains how to use the tab and links to the Knowledge Base article for further instructions, improving guidance for content editors.

## Testing done
Manually

## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
