### PR TITLE
reverted decoupled router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
         "drupal/crop": "^2.0",
         "drupal/csv_serialization": "^4.0",
         "drupal/ctools_block": "^4.0",
-        "drupal/decoupled_router": "^2.0",
         "drupal/default_content_deploy": "^2.1",
         "drupal/devel_entity_updates": "^4.1",
         "drupal/diff": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0d18f31b63004f55539f99e9b1116d4",
+    "content-hash": "b54bb05c68cda090a31fb1d9883d57cc",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/3111456-resolve-language-issues.patch
+++ b/patches/3111456-resolve-language-issues.patch
@@ -1,21 +1,22 @@
-diff --git a/decoupled_router/decoupled_router.services.yml b/decoupled_router/decoupled_router.services.yml
-index 90e959ca..fe2f5365 100644
---- a/decoupled_router/decoupled_router.services.yml
-+++ b/decoupled_router/decoupled_router.services.yml
-@@ -4,7 +4,7 @@ services:
+diff --git a/decoupled_router.services.yml b/decoupled_router.services.yml
+index 90e959c..5753807 100644
+--- a/decoupled_router.services.yml
++++ b/decoupled_router.services.yml
+@@ -4,7 +4,8 @@ services:
      arguments: ['decoupled_router']
    decoupled_router.router_path_translator.subscriber:
      class: Drupal\decoupled_router\EventSubscriber\RouterPathTranslatorSubscriber
 -    arguments: ['@service_container', '@logger.channel.decoupled_router', '@router.no_access_checks', '@module_handler', '@config.factory', '@path_alias.manager']
-+    arguments: ['@service_container', '@logger.channel.decoupled_router', '@router.no_access_checks', '@module_handler', '@config.factory', '@path_alias.manager', '@language_manager', '@entity.repository']
++    arguments: ['@service_container', '@logger.channel.decoupled_router', '@router.no_access_checks', '@module_handler', '@config.factory', '@path_alias.manager',
++                '@language_manager', '@entity.repository']
      tags:
        - { name: event_subscriber }
    decoupled_router.redirect_path_translator.subscriber:
-diff --git a/decoupled_router/src/EventSubscriber/RedirectPathTranslatorSubscriber.php b/decoupled_router/src/EventSubscriber/RedirectPathTranslatorSubscriber.php
-index 8d5e8f90..b3a3ac6d 100644
---- a/decoupled_router/src/EventSubscriber/RedirectPathTranslatorSubscriber.php
-+++ b/decoupled_router/src/EventSubscriber/RedirectPathTranslatorSubscriber.php
-@@ -5,8 +5,10 @@
+diff --git a/src/EventSubscriber/RedirectPathTranslatorSubscriber.php b/src/EventSubscriber/RedirectPathTranslatorSubscriber.php
+index 8d5e8f9..7e6e440 100644
+--- a/src/EventSubscriber/RedirectPathTranslatorSubscriber.php
++++ b/src/EventSubscriber/RedirectPathTranslatorSubscriber.php
+@@ -5,8 +5,10 @@ namespace Drupal\decoupled_router\EventSubscriber;
  use Drupal\Component\Serialization\Json;
  use Drupal\Core\Cache\CacheableJsonResponse;
  use Drupal\Core\GeneratedUrl;
@@ -23,13 +24,14 @@ index 8d5e8f90..b3a3ac6d 100644
  use Drupal\Core\Url;
  use Drupal\decoupled_router\PathTranslatorEvent;
 +use Symfony\Component\HttpFoundation\Request;
-
+ 
  /**
   * Event subscriber that processes a path translation with the redirect info.
-@@ -46,13 +48,32 @@ public function onPathTranslation(PathTranslatorEvent $event) {
+@@ -46,13 +48,32 @@ class RedirectPathTranslatorSubscriber extends RouterPathTranslatorSubscriber {
      $redirects_trace = [];
      while (TRUE) {
        $destination = $this->cleanSubdirInPath($destination, $event->getRequest());
++      $destination_language = '';
 +      $path_without_prefix = $destination;
 +      $langcodes = [];
 +      if ($this->languageManager->isMultilingual()) {
@@ -41,7 +43,7 @@ index 8d5e8f90..b3a3ac6d 100644
 +        $language_prefixes = $this->configFactory->get('language.negotiation')->get('url.prefixes');
 +        $lang_prefix = $language_prefixes[$langcode] ?? '';
 +        if ($langcode && ($destination === "/$lang_prefix" || strpos($destination, "/$lang_prefix/") === 0)) {
-+          $langcodes[] = $langcode;
++          $langcodes[] = $destination_language = $langcode;
 +          $path_without_prefix = $language_negotiation_url->processInbound($destination, $router_request);
 +        }
 +      }
@@ -52,8 +54,8 @@ index 8d5e8f90..b3a3ac6d 100644
          ->accessCheck(TRUE)
          // Redirects are stored without the leading slash :-(.
 -        ->condition('redirect_source.path', ltrim($destination, '/'))
-+        ->condition('redirect_source__path', ltrim($path_without_prefix, '/'))
-         ->execute();
+-        ->execute();
++        ->condition('redirect_source__path', ltrim($path_without_prefix, '/'));
 +      if (!empty($langcodes)) {
 +        $query->condition('language', $langcodes, 'IN');
 +      }
@@ -61,29 +63,38 @@ index 8d5e8f90..b3a3ac6d 100644
        $rid = reset($results);
        if (!$rid) {
          break;
-diff --git a/decoupled_router/src/EventSubscriber/RouterPathTranslatorSubscriber.php b/decoupled_router/src/EventSubscriber/RouterPathTranslatorSubscriber.php
-index cc20fad8..fa2416d9 100644
---- a/decoupled_router/src/EventSubscriber/RouterPathTranslatorSubscriber.php
-+++ b/decoupled_router/src/EventSubscriber/RouterPathTranslatorSubscriber.php
-@@ -9,7 +9,10 @@
+@@ -61,7 +82,7 @@ class RedirectPathTranslatorSubscriber extends RouterPathTranslatorSubscriber {
+       $redirect = $redirect_storage->load($rid);
+       $response->addCacheableDependency($redirect);
+       $uri = $redirect->get('redirect_redirect')->uri;
+-      $url = Url::fromUri($uri)->toString(TRUE);
++      $url = Url::fromUri($uri, $destination_language ? ['language' => $this->languageManager->getLanguage($destination_language)] : [])->toString(TRUE);
+       $redirects_trace[] = [
+         'from' => $this->makeRedirectUrl($destination, $original_query_string),
+         'to' => $this->makeRedirectUrl($url->getGeneratedUrl(), $original_query_string),
+diff --git a/src/EventSubscriber/RouterPathTranslatorSubscriber.php b/src/EventSubscriber/RouterPathTranslatorSubscriber.php
+index cc20fad..fa156a0 100644
+--- a/src/EventSubscriber/RouterPathTranslatorSubscriber.php
++++ b/src/EventSubscriber/RouterPathTranslatorSubscriber.php
+@@ -9,7 +9,10 @@ use Drupal\Core\Config\ConfigFactoryInterface;
  use Drupal\Core\Entity\ContentEntityType;
  use Drupal\Core\Entity\EntityInterface;
  use Drupal\Core\Entity\EntityMalformedException;
 +use Drupal\Core\Entity\EntityRepositoryInterface;
 +use Drupal\Core\Entity\TranslatableInterface;
  use Drupal\Core\Extension\ModuleHandlerInterface;
-+use Drupal\Core\Language\LanguageManagerInterface;
++use Drupal\language\ConfigurableLanguageManagerInterface;
  use Drupal\Core\Routing\RouteObjectInterface;
  use Drupal\Core\StringTranslation\StringTranslationTrait;
  use Drupal\Core\Url;
 @@ -73,6 +76,27 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
     */
    protected $aliasManager;
-
+ 
 +  /**
 +   * The language manager.
 +   *
-+   * @var \Drupal\Core\Language\LanguageManagerInterface
++   * @var \Drupal\language\ConfigurableLanguageManagerInterface
 +   */
 +  protected $languageManager;
 +
@@ -108,42 +119,76 @@ index cc20fad8..fa2416d9 100644
     *   The config factory.
     * @param \Drupal\path_alias\AliasManagerInterface $aliasManager
     *   The alias manager.
-+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
++   * @param \Drupal\language\ConfigurableLanguageManagerInterface $language_manager
 +   *   The language manager.
 +   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
 +   *   The entity repository.
     */
    public function __construct(
      ContainerInterface $container,
-@@ -96,6 +124,8 @@ public function __construct(
+@@ -96,6 +124,8 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
      ModuleHandlerInterface $module_handler,
      ConfigFactoryInterface $config_factory,
      AliasManagerInterface $aliasManager,
-+    LanguageManagerInterface $language_manager,
-+    EntityRepositoryInterface $entity_repository
++    ConfigurableLanguageManagerInterface $language_manager,
++    EntityRepositoryInterface $entity_repository,
    ) {
      $this->container = $container;
      $this->logger = $logger;
-@@ -103,6 +133,8 @@ public function __construct(
+@@ -103,6 +133,8 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
      $this->moduleHandler = $module_handler;
      $this->configFactory = $config_factory;
      $this->aliasManager = $aliasManager;
 +    $this->languageManager = $language_manager;
 +    $this->entityRepository = $entity_repository;
    }
-
+ 
    /**
-@@ -116,6 +148,9 @@ public function onPathTranslation(PathTranslatorEvent $event) {
+@@ -116,25 +148,34 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
      }
      $path = $event->getPath();
      $path = $this->cleanSubdirInPath($path, $event->getRequest());
++
++    // If URL is external, we won't perform checks for content in Drupal,
++    // but assume that it's working.
++    if (UrlHelper::isExternal($path)) {
++      $response->setStatusCode(200);
++      $response->setData([
++        'resolved' => $path,
++      ]);
++
++      return;
++    }
++
 +    if ($this->languageManager->isMultilingual()) {
 +      $path = $this->getPathFromAlias($path);
 +    }
++
      try {
        $match_info = $this->router->match($path);
      }
-@@ -145,6 +180,14 @@ public function onPathTranslation(PathTranslatorEvent $event) {
+     catch (ResourceNotFoundException $exception) {
+-      // If URL is external, we won't perform checks for content in Drupal,
+-      // but assume that it's working.
+-      if (UrlHelper::isExternal($path)) {
+-        $response->setStatusCode(200);
+-        $response->setData([
+-          'resolved' => $path,
+-        ]);
+-      }
++      $response->setStatusCode(404);
+       return;
+     }
+     catch (MethodNotAllowedException $exception) {
+       $response->setStatusCode(403);
+       return;
+     }
+-    /** @var \Drupal\Core\Entity\EntityInterface $entity */
++    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+     /** @var bool $param_uses_uuid */
+     [
+       $entity,
+@@ -145,6 +186,14 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
        $this->logger->notice('A route has been found but it has no entity information.');
        return;
      }
@@ -158,7 +203,7 @@ index cc20fad8..fa2416d9 100644
      $response->addCacheableDependency($entity);
      if ($entity->getEntityType() instanceof ContentEntityType) {
        $can_view = $entity->access('view', NULL, TRUE);
-@@ -181,9 +224,14 @@ public function onPathTranslation(PathTranslatorEvent $event) {
+@@ -181,9 +230,14 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
        return;
      }
      $entity_param = $param_uses_uuid ? $entity->id() : $entity->uuid();
@@ -170,14 +215,14 @@ index cc20fad8..fa2416d9 100644
 +      [$route_parameter_entity_key => $entity_param],
 +      [
 +        'absolute' => TRUE,
-+        'language' => $entity->language(),
++        'language' => $entity->language()
 +      ]
 +    )->toString(TRUE);
      $response->addCacheableDependency($canonical_url);
      $response->addCacheableDependency($resolved_url);
      $is_home_path = $this->resolvedPathIsHomePath($resolved_url->getGeneratedUrl());
-@@ -193,6 +241,10 @@ public function onPathTranslation(PathTranslatorEvent $event) {
-
+@@ -193,6 +247,10 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
+ 
      $label_accessible = $entity->access('view label', NULL, TRUE);
      $response->addCacheableDependency($label_accessible);
 +    $langcode = NULL;
@@ -187,7 +232,7 @@ index cc20fad8..fa2416d9 100644
      $output = [
        'resolved' => $resolved_url->getGeneratedUrl(),
        'isHomePath' => $is_home_path,
-@@ -202,6 +254,7 @@ public function onPathTranslation(PathTranslatorEvent $event) {
+@@ -202,6 +260,7 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
          'bundle' => $entity->bundle(),
          'id' => $entity->id(),
          'uuid' => $entity->uuid(),
@@ -195,14 +240,25 @@ index cc20fad8..fa2416d9 100644
        ],
      ];
      if ($label_accessible->isAllowed()) {
-@@ -219,23 +272,23 @@ public function onPathTranslation(PathTranslatorEvent $event) {
+@@ -219,23 +278,37 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
        $rt_repo = $this->container->get('jsonapi.resource_type.repository');
        $rt = $rt_repo->get($entity_type_id, $entity->bundle());
        $type_name = $rt->getTypeName();
 -      $jsonapi_base_path = $this->container->getParameter('jsonapi.base_path');
 -      $entry_point_url = Url::fromRoute('jsonapi.resource_list', [], ['absolute' => TRUE])->toString(TRUE);
-+      $jsonapi_base_path = Url::fromRoute('jsonapi.entry_point', [], ['absolute' => TRUE, 'language' => $entity->language()]);
-+      $entry_point_url = Url::fromRoute('jsonapi.resource_list', [], ['absolute' => TRUE, 'language' => $entity->language()])->toString(TRUE);
++      $jsonapi_base_path = Url::fromRoute(
++        'jsonapi.resource_list',
++        [],
++        ['language' => $entity->language()]
++      )->toString(TRUE);
++      $entry_point_url = Url::fromRoute(
++        'jsonapi.resource_list',
++        [],
++        [
++          'absolute' => TRUE,
++          'language' => $entity->language(),
++        ]
++      )->toString(TRUE);
        $route_name = sprintf('jsonapi.%s.individual', $type_name);
        $individual = Url::fromRoute(
          $route_name,
@@ -210,7 +266,10 @@ index cc20fad8..fa2416d9 100644
            static::getEntityRouteParameterName($route_name, $entity_type_id) => $entity->uuid(),
          ],
 -        ['absolute' => TRUE]
-+        ['absolute' => TRUE, 'language' => $entity->language()]
++        [
++          'absolute' => TRUE,
++          'language' => $entity->language(),
++        ]
        )->toString(TRUE);
        $response->addCacheableDependency($entry_point_url);
        $response->addCacheableDependency($individual);
@@ -219,15 +278,27 @@ index cc20fad8..fa2416d9 100644
          'resourceName' => $type_name,
 -        'pathPrefix' => trim($jsonapi_base_path, '/'),
 -        'basePath' => $jsonapi_base_path,
-+        'pathPrefix' => $jsonapi_base_path->getGeneratedUrl(),
++        'pathPrefix' => trim($jsonapi_base_path->getGeneratedUrl(), '/'),
 +        'basePath' => $jsonapi_base_path->getGeneratedUrl(),
          'entryPoint' => $entry_point_url->getGeneratedUrl(),
        ];
        $output['meta'] = [
-@@ -385,6 +438,22 @@ protected function cleanSubdirInPath($path, Request $request) {
+@@ -385,6 +458,35 @@ class RouterPathTranslatorSubscriber implements EventSubscriberInterface {
      return preg_replace(sprintf('/^%s/', $regexp), '', $path);
    }
-
+ 
++  /**
++   * Convert an alias to its source path.
++   *
++   * This is a workaround for a bug where matcher fails on aliases prefixed by
++   * a language prefix when it doesn't match the negotiated language.
++   *
++   * @param string $path
++   *   The input path string.
++   *
++   * @return string
++   *   The output path string.
++   */
 +  protected function getPathFromAlias($path) {
 +    $config = $this->configFactory->get('language.negotiation')->get('url');
 +    $language_negotiation_url = $this->languageManager->getNegotiator()
@@ -241,9 +312,96 @@ index cc20fad8..fa2416d9 100644
 +      $path = $this->aliasManager->getPathByAlias($path_without_prefix, $langcode);
 +      $path = "/$prefix" . $path;
 +    }
++
 +    return $path;
 +  }
 +
    /**
     * Checks if the resolved path is the home path.
     *
+diff --git a/tests/src/Functional/DecoupledRouterFunctionalTest.php b/tests/src/Functional/DecoupledRouterFunctionalTest.php
+index b453ba5..38f345c 100644
+--- a/tests/src/Functional/DecoupledRouterFunctionalTest.php
++++ b/tests/src/Functional/DecoupledRouterFunctionalTest.php
+@@ -231,13 +231,14 @@ class DecoupledRouterFunctionalTest extends BrowserTestBase {
+         'bundle' => 'article',
+         'id' => $node->id(),
+         'uuid' => $node->uuid(),
++        'langcode' => 'en',
+       ],
+       'label' => $node->label(),
+       'jsonapi' => [
+         'individual' => $this->buildUrl('/jsonapi/node/article/' . $node->uuid()),
+         'resourceName' => 'node--article',
+-        'pathPrefix' => 'jsonapi',
+-        'basePath' => '/jsonapi',
++        'pathPrefix' => 'web/jsonapi',
++        'basePath' => '/web/jsonapi',
+         'entryPoint' => $this->buildUrl('/jsonapi'),
+       ],
+       'meta' => [
+@@ -310,6 +311,43 @@ class DecoupledRouterFunctionalTest extends BrowserTestBase {
+     $this->assertFalse($output['isHomePath']);
+   }
+ 
++  /**
++   * Tests path argument with prefix other than negotiated language.
++   */
++  public function testUrlLanguageNegotiation() {
++    $german = ConfigurableLanguage::createFromLangcode('de');
++    $german->save();
++    $german_node = $this->createNode([
++      'uid' => ['target_id' => $this->user->id()],
++      'type' => 'article',
++      'path' => '/hallo-welt',
++      'title' => 'Hallo Welt',
++      'langcode' => 'de',
++      'status' => NodeInterface::PUBLISHED,
++    ]);
++
++    $this->drupalGet($german_node->toUrl()->toString());
++
++    $this->assertSession()->pageTextContains('Hallo Welt');
++
++    $this->drupalGet(Url::fromRoute('decoupled_router.path_translation'), [
++        'query' => [
++          'path' => '/de/hallo-welt',
++          '_format' => 'json',
++        ],
++      ]);
++    $output = $this->getSession()->getPage()->getContent();
++    // Running tests in chromedriver returns html wrapped around the JSON.
++    if (strpos($output, '<pre') !== FALSE) {
++      $output = $this->assertSession()->elementExists('css', 'pre')->getHtml();
++    }
++    $output = Json::decode($output);
++    $this->assertStringEndsWith('/de/hallo-welt', $output['resolved']);
++    $this->assertSame($german_node->id(), $output['entity']['id']);
++    $this->assertSame('node--article', $output['jsonapi']['resourceName']);
++    $this->assertStringEndsWith('/jsonapi/node/article/' . $german_node->uuid(), $output['jsonapi']['individual']);
++  }
++
+   /**
+    * Computes the base path under which the Drupal managed URLs are available.
+    *
+diff --git a/tests/src/Functional/DecoupledRouterInfoAlterTest.php b/tests/src/Functional/DecoupledRouterInfoAlterTest.php
+index f13cbab..485ef95 100644
+--- a/tests/src/Functional/DecoupledRouterInfoAlterTest.php
++++ b/tests/src/Functional/DecoupledRouterInfoAlterTest.php
+@@ -90,13 +90,14 @@ class DecoupledRouterInfoAlterTest extends BrowserTestBase {
+         'uuid' => $node->uuid(),
+         // Result of implementing the hook_decoupled_router_info_alter.
+         'owner' => $node->getOwner()->uuid(),
++        'langcode' => 'en',
+       ],
+       'label' => $node->label(),
+       'jsonapi' => [
+         'individual' => $this->buildUrl('/jsonapi/node/article/' . $node->uuid()),
+         'resourceName' => 'node--article',
+-        'pathPrefix' => 'jsonapi',
+-        'basePath' => '/jsonapi',
++        'pathPrefix' => 'web/jsonapi',
++        'basePath' => '/web/jsonapi',
+         'entryPoint' => $this->buildUrl('/jsonapi'),
+       ],
+       'meta' => [


### PR DESCRIPTION
## Description

Reverts update and patch of decoupled_router

Relates to #22129 


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
