### PR TITLE
VACMS-20738: Remove "closed" operating status from Drupal

### DIFF
--- a/config/sync/field.storage.node.field_operating_status_facility.yml
+++ b/config/sync/field.storage.node.field_operating_status_facility.yml
@@ -18,9 +18,6 @@ settings:
       value: limited
       label: 'Limited services and hours'
     -
-      value: closed
-      label: 'Facility closed'
-    -
       value: temporary_closure
       label: 'Temporary facility closure'
     -

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -306,7 +306,7 @@ class Commands extends DrushCommands {
    */
   protected function clearStatusData(NodeInterface &$facility) {
     if ($facility->hasField('field_operating_status_facility')) {
-      $facility->field_operating_status_facility->value = 'closed';
+      $facility->field_operating_status_facility->value = 'temporary_closure';
     }
     if ($facility->hasField('field_operating_status_more_info')) {
       $facility->field_operating_status_more_info->value = '';


### PR DESCRIPTION
## Description

Relates to #20738. (or closes?)

### Generated description
This pull request makes a small change to the `field_operating_status_facility` field storage configuration by removing the "Facility closed" option from the list of possible values.

## Testing done
- Verified field is removed from content types and view.

## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. For each facility content type (NCA Facility, VAMC Facility, VBA Facility, Vet Center, Vet Center - Community Access Point, Vet Center - Outstation)
   - [ ] Validate that the operating status field no longer contains a 'closed' option ('temporary facility closure' is okay)
2. Then
   - [ ] Validate that Facility Status view (/admin/content/facilities/facility-status) doesn't include 'Closed' as a dropdown option for 'Operating status'

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements

### Deploy Steps

- [x] Before merging, check on production for any closed operating statuses
