### PR TITLE
Revert "VACMS-20738: Remove "closed" operating status from Drupal"

### DIFF
--- a/config/sync/field.storage.node.field_operating_status_facility.yml
+++ b/config/sync/field.storage.node.field_operating_status_facility.yml
@@ -18,6 +18,9 @@ settings:
       value: limited
       label: 'Limited services and hours'
     -
+      value: closed
+      label: 'Facility closed'
+    -
       value: temporary_closure
       label: 'Temporary facility closure'
     -

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -306,7 +306,7 @@ class Commands extends DrushCommands {
    */
   protected function clearStatusData(NodeInterface &$facility) {
     if ($facility->hasField('field_operating_status_facility')) {
-      $facility->field_operating_status_facility->value = 'temporary_closure';
+      $facility->field_operating_status_facility->value = 'closed';
     }
     if ($facility->hasField('field_operating_status_more_info')) {
       $facility->field_operating_status_more_info->value = '';


### PR DESCRIPTION
Reverts department-of-veterans-affairs/va.gov-cms#22322