### PR TITLE
VACMS-22319: Adds people read only view

### DIFF
--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.admin
     - user.role.authenticated
     - workbench_access.access_scheme.section
   module:
@@ -1700,10 +1699,13 @@ display:
             use_serializer_encode_only: false
       defaults:
         fields: false
-      display_extenders: {  }
+      display_extenders:
+        jsonapi_views:
+          enabled: true
       path: admin/people/vacms-user-export.csv
       displays:
         page_1: page_1
+        page_2: page_2
         default: '0'
       filename: ''
       automatic_download: false


### PR DESCRIPTION
## Notice about main branch
Until further notice, the main branch of this repo is locked. Pull requests should be made against the [integration-202510](https://github.com/department-of-veterans-affairs/va.gov-cms/tree/integration-202510) branch. 

Merges to the main branch for critical bugs or security updates are allowed. Please contact CMS Team in the [#platform-cms-team](https://dsva.slack.com/archives/CT4GZBM8F) channel if you need assistance. 

## Description
Adds a view under Facilities for People (read-only), allowing a role with "View user information", such as Content admin, to see users while not being able to edit them.

Relates to #22319

## Testing done
Manually

## Screenshots
<img width="1550" height="1137" alt="Screenshot 2025-10-14 at 3 40 01 PM" src="https://github.com/user-attachments/assets/fdae3c44-4e92-4aca-bb20-24fae0a78c70" />


## QA steps
- [ ] [Log in](https://pr22517-kkn2chj9lwt3kbmsfvhrdsyenkoqcgew.ci.cms.va.gov/admin/people/read-only) as a content-admin
- [x] Go to the ["People (read-only)" report](https://pr22517-kkn2chj9lwt3kbmsfvhrdsyenkoqcgew.ci.cms.va.gov/admin/people/read-only)
- [x] Confirm that you can see the users
- [x] Confirm that there is no edit option in the view
- [x] Filter the view
- [x] Click *Download CSV*
- [x] Confirm that the downloaded file is also filtered

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
