### PR TITLE
VACMS-22163: Updates Find a VA Form path to /forms from /find-forms

### DIFF
--- a/docroot/modules/custom/va_gov_db/va_gov_db.post_update.php
+++ b/docroot/modules/custom/va_gov_db/va_gov_db.post_update.php
@@ -6,6 +6,8 @@
  */
 
 use Psr\Log\LogLevel;
+use Drupal\node\Entity\Node;
+use Drupal\pathauto\PathautoState;
 
 /**
  * Re-save all VAMC system & facility health service nodes.
@@ -91,6 +93,21 @@ function va_gov_db_post_update_strip_trailing_redirect_slashes() {
     ->condition('redirect_source__path', '%/', 'LIKE')
     ->expression('redirect_source__path', 'TRIM(TRAILING \'/\' FROM redirect_source__path)')
     ->execute();
+}
+
+/**
+ * Move /find-forms to /forms for Centralized Forms initiative.
+ */
+function va_gov_db_post_update_move_find_forms() {
+  require_once DRUPAL_ROOT . '/../scripts/content/script-library.php';
+  $node = Node::load(2352);
+  $node->setRevisionUserId(1317);
+  $node->set('path', [
+    'alias' => '/forms',
+    'pathauto' => PathautoState::SKIP,
+    'langcode' => 'en',
+  ]);
+  save_node_revision($node, 'Updated path alias from /find-forms to /forms for Centralized Forms initiative.', TRUE);
 }
 
 /**


### PR DESCRIPTION
## Description

Relates to #22163

### Generated description

This pull request introduces a post-update hook to support the Centralized Forms initiative by moving the `/find-forms` page to `/forms`. It also adds necessary imports to enable this change.

## Testing done
Tested on local, and tugboat's FE, and confirmed that the URL change is working for the landing page.

## Screenshots

<img width="1819" height="685" alt="Screenshot 2025-10-16 at 7 58 47 PM" src="https://github.com/user-attachments/assets/77bb627c-044e-44a6-b9f1-ef72d04fc615" />

## QA steps

As CMS user (any role, or anonymous):
1. Visit /forms
   - [x] Validate that the page 'Find a VA form' loads
2. Visit /find-forms
   - [x] Validate that the page 'Find a VA form' loads (CMS redirect)

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [x] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
