### PR TITLE
Added apple silicon arch support and php-fpm config

### DIFF
--- a/.ddev/docker-compose.override.yaml.applesiliconchip
+++ b/.ddev/docker-compose.override.yaml.applesiliconchip
@@ -1,0 +1,9 @@
+# Docker Compose override file for Apple Silicon chips.
+# This file ensures that the services run on the appropriate architecture.
+
+version: '3.6'
+services:
+  web:
+    platform: linux/arm64
+  db:
+    platform: linux/arm64

--- a/.ddev/web-build/Dockerfile.php-fpm
+++ b/.ddev/web-build/Dockerfile.php-fpm
@@ -1,0 +1,5 @@
+# Update PHP-FPM pool configuration
+RUN sed -i 's/pm.max_children = .*/pm.max_children = 10/' /etc/php/*/fpm/pool.d/www.conf && \
+    sed -i 's/pm.start_servers = .*/pm.start_servers = 2/' /etc/php/*/fpm/pool.d/www.conf && \
+    sed -i 's/pm.min_spare_servers = .*/pm.min_spare_servers = 2/' /etc/php/*/fpm/pool.d/www.conf && \
+    sed -i 's/pm.max_spare_servers = .*/pm.max_spare_servers = 10/' /etc/php/*/fpm/pool.d/www.conf


### PR DESCRIPTION
## Description
This pull request introduces improvements for local development environment compatibility and performance, specifically targeting Apple Silicon chips and PHP-FPM configuration. The changes ensure services run on the correct architecture and optimize PHP-FPM resource usage.

**Apple Silicon compatibility:**
* Added `.ddev/docker-compose.override.yaml.applesiliconchip` to set the `web` and `db` services to use the `linux/arm64` platform, ensuring proper operation on Apple Silicon hardware.

**PHP-FPM configuration optimization:**
* Updated `.ddev/web-build/Dockerfile.php-fpm` to adjust PHP-FPM pool settings, reducing `pm.max_children` to 10, setting `pm.start_servers` and `pm.min_spare_servers` to 2, and increasing `pm.max_spare_servers` to 10 for better resource management.

## Testing done
Tested on my MAC with Apple M4 chip

