### PR TITLE
VACMS-22286: homepage feature

### DIFF
--- a/config/sync/feature_toggle.features.yml
+++ b/config/sync/feature_toggle.features.yml
@@ -63,3 +63,4 @@ features:
   feature_rum_family_caregiver_hub: FEATURE_RUM_FAMILY_CAREGIVER_HUB
   feature_vet_center_outstation_enhancements: FEATURE_VET_CENTER_OUTSTATION_ENHANCEMENTS
   feature_use_entraid_for_piv_login: FEATURE_USE_ENTRAID_FOR_PIV_LOGIN
+  feature_next_build_content_homepage: FEATURE_NEXT_BUILD_CONTENT_HOMEPAGE


### PR DESCRIPTION
## Notice about main branch
Until further notice, the main branch of this repo is locked. Pull requests should be made against the [integration-202510](https://github.com/department-of-veterans-affairs/va.gov-cms/tree/integration-202510) branch. 

Merges to the main branch for critical bugs or security updates are allowed. Please contact CMS Team in the [#platform-cms-team](https://dsva.slack.com/archives/CT4GZBM8F) channel if you need assistance. 

## Description
Adds a feature to conditionally let Next build the homepage. When this is false, Next will 404 on `/` as it currently does.

Relates to #22286 

### Generated description

This pull request adds a new feature flag to the feature toggle configuration. The update introduces support for the `feature_next_build_content_homepage` feature, enabling teams to selectively enable or disable this functionality as needed.

Feature toggle configuration:

* Added `feature_next_build_content_homepage` to the `features` list in `config/sync/feature_toggle.features.yml`, allowing this feature to be managed via feature flags.

## Testing done
 - local testing

## QA steps

 - [ ] got to https://pr22591-ntsqfljpdyb80hqaipeljg7rhpdjvncd.ci.cms.va.gov/admin/config/system/feature_toggle
 - [ ] verify that the `FEATURE_NEXT_BUILD_CONTENT_HOMEPAGE` feature exists and is unchecked

### Definition of Done

- [ ] feature is in place 

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
