### PR TITLE
VACMS-22585: Update error message order

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.lc_categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.lc_categories.default.yml
@@ -38,7 +38,7 @@ mode: default
 content:
   field_enforce_unique_value:
     type: allow_only_one_widget
-    weight: 2
+    weight: 1
     region: content
     settings:
       size: 1
@@ -51,7 +51,7 @@ content:
     third_party_settings: {  }
   field_topic_id:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60


### PR DESCRIPTION
## Description

Relates to #22585. 

## Testing done

Manual in Tugboat 

## Screenshots

Page | Current on Prod | Updated in PR
-- | -- | --
["Resources and Support Categories" taxonomy](https://prod.cms.va.gov/admin/structure/taxonomy/manage/lc_categories/overview) duplicate topic ID error message |<img width="919" height="715" alt="Screenshot 2025-11-06 at 4 24 10 PM" src="https://github.com/user-attachments/assets/03016ce8-7c0f-4da2-a75a-47420d2e2929" />  |  <img width="886" height="722" alt="Screenshot 2025-11-06 at 4 25 11 PM" src="https://github.com/user-attachments/assets/7458d085-0546-4d7b-97cd-3733064927ce" />

## QA steps

### Once a day - create test user

Tugboat Review Instance reset every morning, so if you're the first one in this RI any given day you'll need to do the following

- [x] Log in to the [Tugboat RI](https://pr22704-muwh4hemvfoxf8wgaqrfjll1fmnbdhop.ci.cms.va.gov) as an Admin and create a new user **QA Content Admin** with Content Admin privileges and the normal password. 

### Testthe Taxonomy

1. Log in to the [Tugboat RI](https://pr22704-muwh4hemvfoxf8wgaqrfjll1fmnbdhop.ci.cms.va.gov) as **QA Content Admin**
2. Navigate to Structure > Taxonomy > [Resources and Support Categories](https://pr22704-muwh4hemvfoxf8wgaqrfjll1fmnbdhop.ci.cms.va.gov/admin/structure/taxonomy/manage/lc_categories/overview)
    - [ ] Click + Add term
    - [ ] Attempt to create a new term that uses the same Topic ID as an existing Term
    - [ ] See the Enforce Unique Value Error Message now shows before the topic ID field, not after

### Definition of Done

- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [x] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [x] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
