### PR TITLE
added efs-backup-prod GHA workflow

### DIFF
--- a/.github/workflows/cms-efs-backup-prod.yml
+++ b/.github/workflows/cms-efs-backup-prod.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "*/15 * * * 1-5"
   workflow_dispatch:
+  push:
+    branches:
+      - efs-backup-prod
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
- Migrated CMS production EFS backup job from Jenkins to GitHub Actions
- This is a lift-and-shift migration that replicates the existing Ansible playbook logic (`ansible/cms/roles/cms-efs-backup/tasks/main.yml`) into a native GitHub Actions workflow
- The workflow mounts the production EFS volume, creates a tar.gz archive of sites/default/files/ (excluding specific file types), and uploads to S3 sanitized bucket
- All sensitive values (EFS IPs, S3 bucket) retrieved from AWS SSM Parameter Store
- Uses self-hosted runners for VA network access and existing AWS OIDC authentication

## Related issue(s)
- https://github.com/orgs/department-of-veterans-affairs/projects/1194/views/1?pane=issue&itemId=115545764&issue=department-of-veterans-affairs%7Cva.gov-cms%7C21536

## Testing done
- Old behavior: Job runs in Jenkins on weekdays via cron trigger, executes Ansible playbook to backup EFS files
- New behavior: Workflow runs in GitHub Actions on weekdays via cron schedule, executes identical backup logic using shell commands
- Plan to test manual workflow dispatch
- Plan to verify backup archive created in S3 with correct naming, compression, and public-read ACL
- Plan to verify latest_uri reference file created in S3
- Plan to run both Jenkins and GHA workflows in parallel before decommissioning Jenkins job

## What areas of the site does it impact?
- EFS backup infrastructure for prod.cms.va.gov
- S3 backup bucket: dsva-vagov-prod-cms-backup-sanitized/files/
- No impact to application functionality - backend infrastructure only

## Acceptance criteria
- [x] Workflow replicates exact Ansible backup logic
- [x] Uses existing AWS OIDC authentication and self-hosted runners
- [x] All sensitive information retrieved from SSM Parameter Store
- [x] Backup files follow identical naming and structure
- [x] S3 ACL (public-read) and metadata preserved
- [x] Excludes same file types as Ansible (htaccess, php, css, js, export folders, xmlsitemap)
- [ ] Parallel run with Jenkins validated
- [ ] Jenkins job disabled after successful validation
- [ ] Documentation updated with new workflow location