### PR TITLE
Created EFS Backup prod Workflow

### DIFF
--- a/.github/workflows/efs-cms-backup-prod.yml
+++ b/.github/workflows/efs-cms-backup-prod.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "0 */6 * * 1-5"
   workflow_dispatch:
-  push:
-    branches:
-      - efs-backup-branch
 
 permissions:
   id-token: write
@@ -88,12 +85,12 @@ jobs:
             --query 'Parameter.Value' \
             --output text)
 
-          aws s3 cp /tmp/${timestamp}-cms-prod-files-latest.tgz s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/prod_cmsapp_files_${timestamp}.tgz --region ${{ env.region }}
+          aws s3 cp /tmp/${timestamp}-cms-prod-files-latest.tgz s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/prod_cmsapp_files_${timestamp}.tgz --region ${{ env.region }} --quiet
 
-          aws s3 cp s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/prod_cmsapp_files_${timestamp}.tgz s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/cms-prod-files-latest.tgz --region ${{ env.region }}
+          aws s3 cp s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/prod_cmsapp_files_${timestamp}.tgz s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/cms-prod-files-latest.tgz --region ${{ env.region }} --quiet
                     
           echo "s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/cms-prod-files-latest.tgz" > latest_uri
 
-          aws s3 cp latest_uri s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/latest_uri --region ${{ env.region }}
+          aws s3 cp latest_uri s3://${s3_backup_bucket}/${{ env.S3EfsBackupPath }}/latest_uri --region ${{ env.region }} --quiet
 
           rm -f /tmp/${timestamp}-cms-prod-files-latest.tgz


### PR DESCRIPTION
## Summary
- Migrated CMS production EFS backup job from Jenkins to GitHub Actions
- This is a lift-and-shift migration that replicates the existing Ansible playbook logic (`ansible/cms/roles/cms-efs-backup/tasks/main.yml`) into a native GitHub Actions workflow
- The workflow mounts the production EFS volume, creates a tar.gz archive of sites/default/files/ (excluding specific file types), and uploads to S3 sanitized bucket
- All sensitive values (EFS IPs, S3 bucket) retrieved from AWS SSM Parameter Store
- Uses self-hosted runners for VA network access and existing AWS OIDC authentication

## Related issue(s)
- https://github.com/orgs/department-of-veterans-affairs/projects/1194/views/1?pane=issue&itemId=115545764&issue=department-of-veterans-affairs%7Cva.gov-cms%7C21536

## Testing done
- Old behavior: Job runs in Jenkins on weekdays via cron trigger, executes Ansible playbook to backup EFS files
- New behavior: Workflow runs in GitHub Actions on weekdays via cron schedule, executes identical backup logic using shell commands
- Plan to test manual workflow dispatch
- Plan to verify backup archive created in S3 with correct naming, compression, and public-read ACL
- Plan to verify latest_uri reference file created in S3
- Plan to run both Jenkins and GHA workflows in parallel before decommissioning Jenkins job

## What areas of the site does it impact?
- EFS backup infrastructure for prod.cms.va.gov
- S3 backup bucket: dsva-vagov-prod-cms-backup-sanitized/files/
- No impact to application functionality - backend infrastructure only

## Acceptance criteria
- [x] Workflow replicates exact Ansible backup logic
- [x] Uses existing AWS OIDC authentication and self-hosted runners
- [x] All sensitive information retrieved from SSM Parameter Store
- [x] Backup files follow identical naming and structure
- [x] S3 ACL (public-read) and metadata preserved
- [x] Excludes same file types as Ansible (htaccess, php, css, js, export folders, xmlsitemap)
- [ ] Parallel run with Jenkins validated
- [ ] Jenkins job disabled after successful validation
- [ ] Documentation updated with new workflow location