### PR TITLE
VACMS-21489: Updates Cypress test

### DIFF
--- a/tests/cypress/integration/features/platform/content_release.feature
+++ b/tests/cypress/integration/features/platform/content_release.feature
@@ -73,9 +73,9 @@ Feature: Content Release
     Then I should see "Invalid selection."
 
     # Select vets-website branch.
-    When I fill in autocomplete field with selector "#edit-vets-website-git-ref" with value "main"
-    Then I should see "BRANCH main"
-    When I fill in autocomplete field with selector "#edit-vets-website-git-ref" with value "BRANCH main (main)"
+    When I fill in autocomplete field with selector "#edit-vets-website-git-ref" with value "cms_branch_check"
+    Then I should see "BRANCH cms_branch_check"
+    When I fill in autocomplete field with selector "#edit-vets-website-git-ref" with value "BRANCH cms_branch_check (cms_branch_check)"
     And I click the "Release content" button
     And I wait for form submission
     Then I should see "Content release requested successfully"


### PR DESCRIPTION
## Description

Relates to #21489 

### Generated description
This pull request updates the branch selection test in the `Feature: Content Release` Cypress integration test. The test now uses the `cms_branch_check` branch instead of the previous `main` branch for the `vets-website` autocomplete field.

Testing updates:

* Changed the branch selection in the `#edit-vets-website-git-ref` autocomplete field from `main` to `cms_branch_check`, and updated corresponding assertions to match the new branch name.

## Testing done
- [ ] Cypress

## Screenshots
<img width="920" height="404" alt="Screenshot 2025-12-03 at 10 56 16" src="https://github.com/user-attachments/assets/a30948ec-a94f-4167-847c-0436067fb4d3" />



## QA steps
- [ ] If it passes Cypress testing, we should be good.


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

