### PR TITLE
VACMS-22419 - update metadata config for vamc_system_policies_page

### DIFF
--- a/config/sync/metatag.metatag_defaults.node__vamc_system_policies_page.yml
+++ b/config/sync/metatag.metatag_defaults.node__vamc_system_policies_page.yml
@@ -5,6 +5,9 @@ dependencies: {  }
 id: node__vamc_system_policies_page
 label: 'Content: VAMC System Policies Page'
 tags:
-  title: '[node:title] | [node:field_office] | Veterans Affairs'
+  description: '[node:field_cc_intro_text]'
+  og_description: '[node:field_cc_intro_text]'
   og_title: '[node:title] | [node:field_office] | Veterans Affairs'
+  title: '[node:title] | [node:field_office] | Veterans Affairs'
+  twitter_cards_description: '[node:field_cc_intro_text]'
   twitter_cards_title: '[node:title] | [node:field_office] | Veterans Affairs'


### PR DESCRIPTION
## Description
Adds missing description meta data for  vamc_system_policies_page

Closes to #22419 

### Generated description
This pull request makes a small update to the metatag defaults for VAMC System Policies Pages, focusing on improving metadata for social sharing and SEO.

* Added `description`, `og_description`, and `twitter_cards_description` tags to use `[node:field_cc_intro_text]` for improved metadata and social sharing descriptions.
* Moved the `title` tag to ensure consistent ordering with other tags.

## Testing done
Manual

## QA steps

 - [ ] Visit https://next-c8sy61wmcdpkqx9k8eju3gqeyonflbyg.ci.cms.va.gov/boston-health-care/policies/
 - [ ] verify that the meta `description` is present and has the content `Find VA policies on privacy and patient rights, family rights, visitation, and more.`
 - [ ] verify that the meta `og:description` is present and has the content `Find VA policies on privacy and patient rights, family rights, visitation, and more.`
 - [ ] verify that the meta `twitter:description` is present and has the content `Find VA policies on privacy and patient rights, family rights, visitation, and more.`

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
