### PR TITLE
DNM: VACMS-22681: Rolls back Centralized Forms path changes.

### DIFF
--- a/config/sync/pathauto.pattern.va_form.yml
+++ b/config/sync/pathauto.pattern.va_form.yml
@@ -7,7 +7,7 @@ dependencies:
 id: va_form
 label: 'VA Form'
 type: 'canonical_entities:node'
-pattern: 'forms/[node:field_va_form_number]'
+pattern: 'find-forms/about-form-[node:field_va_form_number]'
 selection_criteria:
   cb7993c8-f1af-4597-8e85-1bb2fc4096bb:
     id: 'entity_bundle:node'


### PR DESCRIPTION
## Description
DO NOT MERGE UNLESS WE HAVE A ROLLBACK NEED

Rolls back the changes made in VACMS-22681.
- Restores form detail page path pattern of /find-forms/about-form-[form-id]
- Restores form landing page path to /find-forms
- Batch update scripts fire automatically

Relates to #22681

## QA steps
Find a form pages have the pattern /find-forms/about-form-[form-id]
Form landing page found at /find-forms

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

### Is this PR blocked by another PR?

- [x] `DO NOT MERGE`
