### PR TITLE
VACMS-22956: Updates condition for showing drush call in log

### DIFF
--- a/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.module
+++ b/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.module
@@ -304,7 +304,7 @@ function va_gov_scheduled_tasks_run_drush_command($command) {
       '@output' => implode("\n", $output),
     ]);
   }
-  else {
+  elseif (!in_array($command, $calls_without_logging)) {
     \Drupal::logger('va_gov_scheduled_tasks')->notice('Drush command succeeded: @command Output: @output', [
       '@command' => $command,
       '@output' => implode("\n", $output),


### PR DESCRIPTION
## Description

Relates to #22956 

### Generated description
This pull request makes a small update to the logging logic in the `va_gov_scheduled_tasks_run_drush_command` function. The change ensures that logging suppression is based on the actual Drush command being run, rather than the calling function.

* Logging suppression is now determined by checking if the `$command` is in the `calls_without_logging` list, instead of the calling function.
* Minor cleanup by removing the unused `$caller` variable in the success logging block.

## Testing done
Manually

## QA steps
- [x] Go to the [terminal](https://tugboat.vfs.va.gov/tush/693b269a3a39233fa7c1f9f9)
- [x] Run the every minute task: `drush php:eval "va_gov_scheduled_tasks_every_minute();"`
- [x] Check the [log](https://pr22964-bhsulnmjdsrglriivgcgrc9u0fj9fafq.ci.cms.va.gov/admin/reports/dblog)
- [x] Confirm that there is no log entry in the va_gov_scheduled_tasks channel for drush running `advancedqueue:queue:process content_release`
- [x] Run daily task: `drush php:eval "va_gov_scheduled_tasks_daily();"`
- [x] Confirm that there is a log entry for drush running `taxonomy_entity_index:rebuild`


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

