### PR TITLE
Created Sanitize DB Backup Workflow

### DIFF
--- a/.github/workflows/cms-db-sanitize-prod.yml
+++ b/.github/workflows/cms-db-sanitize-prod.yml
@@ -1,0 +1,186 @@
+name: CMS Database Sanitize Production
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  region: us-gov-west-1
+  S3BackupPath: database
+  MYSQL_SANITIZE_DB_NAME: sanitize_gha
+
+jobs:
+  sanitize:
+    runs-on: self-hosted
+    container:
+      image: ubuntu:24.04
+      volumes:
+        - /home/runner:/home/runner
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
+          aws-region: ${{ env.region }}
+
+      - name: Install required packages
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y mysql-client gzip ca-certificates python3-pip
+          pip3 install --break-system-packages awscli
+
+      - name: Download and sanitize database
+        run: |
+          set -e
+          
+          timestamp=$(date "+%Y-%m-%d-%H-%M")
+          tempdir="$RUNNER_TEMP/sanitize-$(date +%s)"
+          mkdir -p $tempdir
+          cd $tempdir
+
+          s3_backup_bucket_priv=$(aws ssm get-parameter \
+            --name "/cms/prod/s3-db-backup-bucket" \
+            --region ${{ env.region }} \
+            --query 'Parameter.Value' \
+            --output text)
+          
+          s3_backup_bucket_pub=$(aws ssm get-parameter \
+            --name "/cms/prod/s3-db-backup-bucket-sanitized" \
+            --region ${{ env.region }} \
+            --query 'Parameter.Value' \
+            --output text)
+          
+          sanitize_filename_prefix=$(aws ssm get-parameter \
+            --name "/cms/prod/db-sanitize-filename" \
+            --region ${{ env.region }} \
+            --query 'Parameter.Value' \
+            --output text)
+          
+          database_host=$(aws ssm get-parameter \
+            --name "/cms/staging/db_host" \
+            --with-decryption \
+            --region ${{ env.region }} \
+            --query 'Parameter.Value' \
+            --output text)
+          
+          db_password=$(aws ssm get-parameter \
+            --name "/cms/staging/mariadb/master_password" \
+            --with-decryption \
+            --region ${{ env.region }} \
+            --query 'Parameter.Value' \
+            --output text)
+
+          replacement_password=$(aws ssm get-parameter \
+            --name "/cms/prod/db-sanitize-replacement-password" \
+            --with-decryption \
+            --region ${{ env.region }} \
+            --query 'Parameter.Value' \
+            --output text)
+
+          aws s3 cp \
+            --region ${{ env.region }} \
+            --quiet \
+            s3://${s3_backup_bucket_priv}/${{ env.S3BackupPath }}/latest_uri latest_uri
+          
+          DB_FILENAME=$(awk -F'/' '{ print $NF }' latest_uri)
+          DB_FILENAME_NO_EXT=$(echo "${DB_FILENAME}" | awk -F'.' '{ print $1 }')
+
+          aws s3 cp \
+            --region ${{ env.region }} \
+            --quiet \
+            "$(cat latest_uri)" .
+
+          gunzip "${DB_FILENAME}"
+
+          echo "File stats pre-sanitize: $(ls -lh ${DB_FILENAME_NO_EXT}.sql)"
+
+          sed -i 's/\sDEFINER="[^`]*"@"[^`]*"//g' ${DB_FILENAME_NO_EXT}.sql
+
+          mysql \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --execute "CREATE DATABASE IF NOT EXISTS ${{ env.MYSQL_SANITIZE_DB_NAME }}"
+
+          mysql \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --database=${{ env.MYSQL_SANITIZE_DB_NAME }} \
+            ${{ env.MYSQL_SANITIZE_DB_NAME }} < "${DB_FILENAME_NO_EXT}.sql"
+
+          mysql \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --execute "UPDATE users_field_data SET mail=CONCAT('user', users_field_data.uid, '@example.com');" \
+            ${{ env.MYSQL_SANITIZE_DB_NAME }}
+
+          mysql \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --execute "UPDATE users_field_data SET pass='${replacement_password}' WHERE uid>0;" \
+            ${{ env.MYSQL_SANITIZE_DB_NAME }}
+
+          mysql \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --execute "UPDATE users_field_data SET status=1 WHERE uid>0 AND status=0;" \
+            ${{ env.MYSQL_SANITIZE_DB_NAME }}
+
+          mysql \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --execute "DELETE FROM sitewide_alert WHERE id IN (SELECT id FROM sitewide_alert_field_data WHERE name = 'deploy-alert');" \
+            ${{ env.MYSQL_SANITIZE_DB_NAME }}
+
+          echo "SHOW TABLES LIKE 'cache\_%'" \
+            | mysql --host=${database_host} --user=master --password="${db_password}" --database=${{ env.MYSQL_SANITIZE_DB_NAME }} \
+            | tail --lines +2 \
+            | xargs -L1 -I% echo "TRUNCATE TABLE %;" \
+            | mysql --host=${database_host} --user=master --password="${db_password}" --database=${{ env.MYSQL_SANITIZE_DB_NAME }} --verbose
+
+          echo "TRUNCATE TABLE batch; TRUNCATE TABLE flood; TRUNCATE TABLE queue; TRUNCATE TABLE sessions; TRUNCATE TABLE watchdog; TRUNCATE TABLE content_lock; TRUNCATE TABLE user_history;" \
+            | mysql --host=${database_host} --user=master --password="${db_password}" --database=${{ env.MYSQL_SANITIZE_DB_NAME }} --verbose
+
+          mysqldump \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --single-transaction \
+            --skip-lock-tables \
+            --default-character-set=utf8mb4 \
+            ${{ env.MYSQL_SANITIZE_DB_NAME }} > ${sanitize_filename_prefix}.sql
+
+          echo "File stats post-sanitize: $(ls -lh ${sanitize_filename_prefix}.sql)"
+
+          sed -i 's/\sDEFINER="[^`]*"@"[^`]*"//g' ${sanitize_filename_prefix}.sql
+
+          gzip ${sanitize_filename_prefix}.sql
+
+          aws s3 cp \
+            --region ${{ env.region }} \
+            --quiet \
+            ${sanitize_filename_prefix}.sql.gz s3://${s3_backup_bucket_pub}/${{ env.S3BackupPath }}/${sanitize_filename_prefix}${timestamp}.sql.gz
+
+          aws s3 cp \
+            --region ${{ env.region }} \
+            --quiet \
+            s3://${s3_backup_bucket_pub}/${{ env.S3BackupPath }}/${sanitize_filename_prefix}${timestamp}.sql.gz s3://${s3_backup_bucket_pub}/${{ env.S3BackupPath }}/${sanitize_filename_prefix}latest.sql.gz
+
+          mysql \
+            --host=${database_host} \
+            --user=master \
+            --password="${db_password}" \
+            --execute "DROP DATABASE ${{ env.MYSQL_SANITIZE_DB_NAME }};"
+
+          cd
+          rm -rf ${tempdir}


### PR DESCRIPTION
## Description

Closes #21537

This PR migrates the CMS database sanitization job from Jenkins to GitHub Actions. The workflow downloads the latest production database backup from the private S3 bucket (`dsva-vagov-prod-cms-backup`), sanitizes it by removing email addresses and resetting passwords to 'drupal8' for testing purposes, then uploads the sanitized backup to the public S3 bucket (`dsva-vagov-prod-cms-backup-sanitized`).

Key Implementation Details:
- Migrated script from `ansible/cms/roles/cms-db-sanitize/tasks/sanitize-db.sh.j2` in devops repo to GitHub Actions workflow
- Uses Ubuntu 24.04 container with self-hosted runner
- Installs required packages (mysql-client, awscli via pip, gzip) at runtime
- Leverages staging RDS instance as utility database for sanitization operations
- Runs every 30 minutes via cron schedule
- All configuration stored in AWS Systems Manager Parameter Store for security

New SSM Parameters Created:
- `/cms/prod/s3-db-backup-bucket-sanitized`: Public S3 bucket for sanitized backups
- `/cms/prod/db-sanitize-filename`: Filename prefix for sanitized backups
- `/cms/staging/db_host`: Staging RDS endpoint used as utility database

Sanitization Operations:
- Replaces all email addresses with `user{uid}@example.com`
- Resets all passwords to 'drupal8' for testing
- Activates all user accounts
- Removes deploy-alert sitewide alerts
- Truncates cache and temporary tables (batch, flood, queue, sessions, watchdog, content_lock, user_history)
- Removes MySQL DEFINER statements for compatibility
## Testing done
- Verified workflow runs successfully on `sanitize-db-backup` branch
- Confirmed sanitized database files uploaded to public S3 bucket with correct naming convention
- Validated sanitization operations complete without errors
- Checked staging RDS security group allows runner access on port 3306
- Verified IAM role has required permissions for S3 read/write with public ACL

## QA steps
### Prerequisites
1. Ensure all 3 new SSM parameters are created in Parameter Store
2. Verify staging RDS security group allows self-hosted runner access (port 3306)
3. Confirm IAM role `cms-infra-gha-oidc-role` has:
   - Read access to `dsva-vagov-prod-cms-backup`
   - Write access with public ACL to `dsva-vagov-prod-cms-backup-sanitized`
### Testing Steps
As DevOps engineer with AWS/GitHub access:
1. Navigate to GitHub Actions tab in va.gov-cms repository
   - [ ] Validate workflow "CMS Database Sanitize Production" appears in workflow list
2. Manually trigger workflow using "Run workflow" button
   - [ ] Validate workflow completes successfully within expected timeframe (30-60 minutes)
   - [ ] Validate no authentication or permission errors in logs
3. Check AWS S3 bucket `dsva-vagov-prod-cms-backup-sanitized/database/`
   - [ ] Validate timestamped file exists: `cms-prod-db-sanitized-{timestamp}.sql.gz`
   - [ ] Validate latest file exists: `cms-prod-db-sanitized-latest.sql.gz`
   - [ ] Validate files have public-read ACL
4. Download and verify sanitized database
   - [ ] Validate database imports successfully to test environment
   - [ ] Validate email addresses are sanitized (format: `user{uid}@example.com`)
   - [ ] Validate passwords reset to 'drupal8'
   - [ ] Validate cache tables are empty
5. Verify cron schedule behavior
   - [ ] Wait for next scheduled run (every 30 minutes)
   - [ ] Validate automated execution completes successfully
6. Then validate Acceptance Criteria from issue #21537
   - [ ] Script efficiency validated (uses existing Ansible script logic)
   - [ ] Sanitize job successfully set up in GitHub Actions
   - [ ] Jenkins job can be removed from pipeline (post-merge task)
### Definition of Done
- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.
### Select Team for PR review
- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
### Is this PR blocked by another PR?
- [ ] `DO NOT MERGE`
### Does this PR need review from a Product Owner
- [ ] `Needs PO review`
### CMS user-facing announcement
Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
**Note:** This is an infrastructure change migrating backend automation from Jenkins to GitHub Actions. No user-facing changes or CMS editor impact.
## Post-Merge Tasks
1. Remove Jenkins job from http://jenkins.vfs.va.gov/job/cms/job/cms-db-sanitize/
2. Update any documentation referencing Jenkins sanitize job
3. Monitor first few automated cron runs for stability