### PR TITLE
Created cms-daily-0200 workflow

### DIFF
--- a/.github/workflows/cms-daily-0200.yml
+++ b/.github/workflows/cms-daily-0200.yml
@@ -42,6 +42,11 @@ jobs:
         run: |
           set -e
 
+          cd /home/runner
+          rm -f ${{ env.CmsFilesName }}
+          rm -rf tmp.* 2>/dev/null || true
+          echo "Initial cleanup completed"
+
           # Get parameters from SSM
           s3_backup_bucket_pub=$(aws ssm get-parameter \
             --name "/cms/prod/s3-db-backup-bucket-sanitized" \
@@ -89,13 +94,13 @@ jobs:
           # Set final permissions on files directory
           chmod 2755 ${cms_files_dir}
 
-          # Cleanup
           cd /home/runner
           rm -f ${{ env.CmsFilesName }}
           rm -rf ${temp_extract_dir}
+          echo "Final cleanup completed"
 
           # Unmount EFS
           umount ${efs_mount_dir}
           rm -rf ${efs_mount_dir}
 
-          echo "Files sync completed successfully!"
+          echo "Files sync completed successfully"


### PR DESCRIPTION
## Description
Closes #21540
### Generated description
This PR migrates the CMS Daily 0200 Files Sync job from Jenkins to GitHub Actions. The workflow downloads sanitized production files from S3 and syncs them to staging EFS daily at 0200 ET (0700 UTC).
**Key Implementation Details:**
- Migrated from Ansible playbook `cms-daily-0200.yml` in devops repo to GitHub Actions workflow
- Uses Ubuntu 24.04 container with self-hosted runner
- Downloads `cms-prod-files-latest.tgz` from `dsva-vagov-prod-cms-backup-sanitized` S3 bucket
- Mounts staging EFS, extracts files using pigz for parallel decompression
- Uses parallel rsync to efficiently sync files to `/docroot/sites/default/files`
- Sets proper permissions (2755) on files directory
- Runs daily at 0200 ET via cron schedule
**New SSM Parameter Required:**
- `/cms/staging/efs_ips`: Staging EFS mount target IP (SecureString)
**Dependencies:**
- Requires EFS backup workflow (already merged) which creates the source file backup
## Testing done
- Verified workflow runs successfully on `cms-daily-0200` branch
- Confirmed files downloaded from S3 sanitized bucket
- Validated staging EFS mount and file sync operations
- Checked proper permissions set on files directory
## QA steps
### Prerequisites
1. Ensure SSM parameter `/cms/staging/efs_ips` exists with staging EFS mount target IP
2. Verify staging EFS security group allows NFS (port 2049) from runner VPC CIDRs
3. Confirm IAM role `cms-infra-gha-oidc-role` has read access to `dsva-vagov-prod-cms-backup-sanitized` bucket
### Testing Steps
As DevOps engineer with AWS/GitHub access:
1. Navigate to GitHub Actions tab in va.gov-cms repository
   - [ ] Validate workflow "CMS Daily 0200 Files Sync" appears in workflow list
2. Manually trigger workflow using "Run workflow" button
   - [ ] Validate workflow completes successfully
   - [ ] Validate no authentication or mount errors in logs
3. Check staging EFS at `/docroot/sites/default/files`
   - [ ] Validate files are synced from production backup
   - [ ] Validate directory permissions are 2755
   - [ ] Validate file count matches expected production files
4. Verify cron schedule behavior
   - [ ] Wait for next scheduled run (daily at 0200 ET / 0700 UTC)
   - [ ] Validate automated execution completes successfully
5. Then validate Acceptance Criteria from issue
   - [ ] Files sync job successfully set up in GitHub Actions
   - [ ] Workflow follows same logic as original Ansible playbook
   - [ ] Jenkins job can be removed from pipeline (post-merge task)
### Definition of Done
- [x] Documentation has been updated, if applicable.
- [x] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.
### Select Team for PR review
- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
### Is this PR blocked by another PR?
- [ ] `DO NOT MERGE`
### Does this PR need review from a Product Owner
- [ ] `Needs PO review`
### CMS user-facing announcement
Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
**Note:** This is an infrastructure change migrating backend automation from Jenkins to GitHub Actions. No user-facing changes or CMS editor impact.
## Post-Merge Tasks
1. Remove Jenkins job from automation pipeline
2. Update documentation referencing Jenkins daily sync job
3. Monitor first few scheduled runs for stability
4. Remove `push:` branch trigger after successful production validation