### PR TITLE
VACMS-20975: Adds header level to alert paragraph.

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.alert.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.alert.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - entity_browser.browser.alert_blocks
     - field.field.paragraph.alert.field_alert_block_reference
     - field.field.paragraph.alert.field_alert_heading
+    - field.field.paragraph.alert.field_alert_heading_level
     - field.field.paragraph.alert.field_alert_type
     - field.field.paragraph.alert.field_va_paragraphs
     - paragraphs.paragraphs_type.alert
@@ -32,6 +33,7 @@ third_party_settings:
     group_non_reusable_alert:
       children:
         - field_alert_heading
+        - field_alert_heading_level
         - field_va_paragraphs
         - field_alert_type
       label: 'Non-reusable alert'
@@ -77,6 +79,12 @@ content:
       js_prevent_submit: true
       count_html_characters: true
       textcount_status_message: 'Maxlength: <span class="maxlength_count">@maxlength</span><br />Used: <span class="current_count">@current_length</span><br />Remaining: <span class="remaining_count">@remaining_count</span>'
+    third_party_settings: {  }
+  field_alert_heading_level:
+    type: options_select
+    weight: 4.5
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_alert_type:
     type: options_select

--- a/config/sync/core.entity_view_display.paragraph.alert.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.alert.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.alert.field_alert_block_reference
     - field.field.paragraph.alert.field_alert_heading
+    - field.field.paragraph.alert.field_alert_heading_level
     - field.field.paragraph.alert.field_alert_type
     - field.field.paragraph.alert.field_va_paragraphs
     - paragraphs.paragraphs_type.alert
@@ -48,6 +49,13 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_alert_heading_level:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
     region: content
 hidden:
   search_api_excerpt: true

--- a/config/sync/field.field.paragraph.alert.field_alert_heading_level.yml
+++ b/config/sync/field.field.paragraph.alert.field_alert_heading_level.yml
@@ -1,0 +1,22 @@
+uuid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_alert_heading_level
+    - paragraphs.paragraphs_type.alert
+  module:
+    - options
+id: paragraph.alert.field_alert_heading_level
+field_name: field_alert_heading_level
+entity_type: paragraph
+bundle: alert
+label: 'Alert Heading Level'
+description: 'Optional field for specifying the heading level (H2-H6) for the alert heading.'
+required: false
+translatable: false
+default_value: { }
+default_value_callback: ''
+settings: { }
+field_type: list_string
+

--- a/config/sync/field.storage.paragraph.field_alert_heading_level.yml
+++ b/config/sync/field.storage.paragraph.field_alert_heading_level.yml
@@ -1,0 +1,37 @@
+uuid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_alert_heading_level
+field_name: field_alert_heading_level
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '2'
+      label: H2
+    -
+      value: '3'
+      label: H3
+    -
+      value: '4'
+      label: H4
+    -
+      value: '5'
+      label: H5
+    -
+      value: '6'
+      label: H6
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: { }
+persist_with_no_fields: false
+custom_storage: false
+


### PR DESCRIPTION
## Description

Relates to #20975 

### Generated description

This pull request adds a new optional field to the alert paragraph entity for specifying the heading level (H2-H6) of the alert heading. This enhancement allows content editors to control the semantic structure of alert headings directly from the paragraph configuration. The update includes configuration for both form and view displays, as well as the necessary field and storage definitions.

**Field addition and configuration:**

* Added a new field, `field_alert_heading_level`, to the alert paragraph bundle, allowing selection of heading levels H2-H6. The field is optional and uses a string list type. [[1]](diffhunk://#diff-56fd8c014ec4bc30bb49638ff4d0a73629ea69a9754b7a35114470908ef7e6b4R1-R22) [[2]](diffhunk://#diff-e06af52f35e60a2d634a73eed716bf45ff1ea6c25256b6939eee4bfc601b8d83R1-R37)
* Updated `core.entity_form_display.paragraph.alert.default.yml` and `core.entity_view_display.paragraph.alert.default.yml` to include the new field in both the form and view displays, ensuring editors can set and users can view the heading level. [[1]](diffhunk://#diff-64038c8ec97bffd882f055c305d97327af7edde45f9e386ed4405cd216386205R9) [[2]](diffhunk://#diff-64038c8ec97bffd882f055c305d97327af7edde45f9e386ed4405cd216386205R36) [[3]](diffhunk://#diff-64038c8ec97bffd882f055c305d97327af7edde45f9e386ed4405cd216386205R83-R88) [[4]](diffhunk://#diff-c35f48dcfada07abdaedcc128649c432980ef701132ba3def5b9180c4569994dR8) [[5]](diffhunk://#diff-c35f48dcfada07abdaedcc128649c432980ef701132ba3def5b9180c4569994dR53-R59)

## Testing done
Tested in Drupal UI

## Screenshots

<img width="1021" height="1079" alt="Screenshot 2025-12-16 at 10 38 46 AM" src="https://github.com/user-attachments/assets/864242c4-3dac-44fe-814a-1906eb452b17" />

## QA steps

As a content admin
- [ ] Visit any page from the list of affected pages [here](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20975#:~:text=Pages%20impacted%20(as%20of%2011/14/2025)%3A).
- [ ] Edit the page
- [ ] Under 'main content' edit the first 'alert' you see
- [ ] Validate the 'Alert Heading Level' is set to '-None-'
- [ ] Validate heading has options for H2 to H6
- [ ] Set a heading to one of the allowed values
- [ ] Save the node
- [ ] Under 'Alert content', validate you see the H2-6 (H2, H3, H4...whatever you set it to)

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
