### PR TITLE
VACMS-17375: Adds checks for status change.

### DIFF
--- a/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
+++ b/docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityStatus.php
@@ -339,9 +339,9 @@ class PostFacilityStatus extends PostFacilityBase implements PostServiceInterfac
     $statusChanged = FALSE;
     // Check if operating status field has changed.
     if ($nodeFacility->hasField('field_operating_status_facility')) {
-      $current_status = $nodeFacility->get('field_operating_status_facility')->value;
-      $original_status = $defaultRevision->get('field_operating_status_facility')->value;
-      $statusChanged = $current_status !== $original_status;
+      $currentStatus = $nodeFacility->get('field_operating_status_facility')->value;
+      $originalStatus = $defaultRevision->get('field_operating_status_facility')->value;
+      $statusChanged = $currentStatus !== $originalStatus;
     }
 
     // Case race. First to evaluate to TRUE wins.


### PR DESCRIPTION
## Description

Relates to #17375 .

### Generated description
This pull request updates the logic for determining when a facility status node should be pushed, making the process more precise by only triggering a push when the facility's operating status field has actually changed. This helps prevent unnecessary pushes when there are no relevant changes.

**Improved push logic for facility status:**

- Added a check for changes in the `field_operating_status_facility` field to determine if the operating status has changed between the current and default revisions.
- Updated the conditions for pushing published and draft revisions to require that the operating status field has changed, reducing unnecessary pushes.
- Added a condition to explicitly avoid pushing when publishing a draft revision on a published node if the status has not changed.

## Testing done
Tested locally by re-saving a regional benefit office node with different operating status changes as well as different moderation workflows.

## Screenshots


## QA steps

As a CMS admin
1. Edit a published node with operating status (i.e. VBA Facility, VAMC Facility, Vet Center, etc.)
2. Change the operating status and set the moderation state to draft. Fill in any additional required fields
   - [ ] Validate that the Post API message ("The facility status info ... is being sent to the Facility Locator.") **_does not_** show up.
3. Edit the node and save it as Published.
   - [ ] Validate that the Post API message **_does_** show up.
4. Edit the node and re-save as Published without changing anything.
   - [ ] Validate that the Post API message **_does not_** show up.
5. Edit the node and re-save as Draft then edit again and re-save as Published without changing any other fields.
   - [ ] Validate that the Post API message **_does not_** show up during any save.


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
