### PR TITLE
update stiewide_alert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -185,7 +185,7 @@
         "drupal/search_api": "^1.40",
         "drupal/seckit": "^2.0",
         "drupal/simplesamlphp_auth": "^4.0@RC",
-        "drupal/sitewide_alert": "^2.0",
+        "drupal/sitewide_alert": "^3.0",
         "drupal/slack": "^1.3",
         "drupal/smart_date": "^4.2.0",
         "drupal/social_media_links": "^2.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5430a8dce4cdb0eb3cc0e11ed699b12",
+    "content-hash": "4fbe4c1376bcd1fde8f0719fa038fd53",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -13983,32 +13983,31 @@
         },
         {
             "name": "drupal/sitewide_alert",
-            "version": "2.2.1",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/sitewide_alert.git",
-                "reference": "2.2.1"
+                "reference": "3.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/sitewide_alert-2.2.1.zip",
-                "reference": "2.2.1",
-                "shasum": "991c7b406fd1497d5346970080c3d2d7c3ad5bf2"
+                "url": "https://ftp.drupal.org/files/projects/sitewide_alert-3.0.1.zip",
+                "reference": "3.0.1",
+                "shasum": "258e8dcbd40346e25c77af5c9e6b55ad9ef6414a"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10",
-                "php": ">=7.4"
+                "drupal/core": "^10.3 || ^11"
             },
             "require-dev": {
-                "drupal/domain": "*",
+                "drupal/domain": "^2.0@beta",
                 "drupal/domain_entity": "*",
-                "drush/drush": "^11 || ^12"
+                "drush/drush": "^12 || ^13"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.2.1",
-                    "datestamp": "1701398224",
+                    "version": "3.0.1",
+                    "datestamp": "1752106651",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -14037,7 +14036,7 @@
                 "Drupal"
             ],
             "support": {
-                "source": "http://cgit.drupalcode.org/sitewide_alert",
+                "source": "https://cgit.drupalcode.org/sitewide_alert",
                 "issues": "https://www.drupal.org/project/issues/sitewide_alert"
             }
         },


### PR DESCRIPTION
## Description
Updates sitewide_alert module

Closes #22387 

### Generated description
This pull request updates the version constraint for the `drupal/sitewide_alert` module in the `composer.json` file to allow version 3.x instead of 2.x.

* Updated the `drupal/sitewide_alert` dependency from `^2.0` to `^3.0` in `composer.json`, enabling compatibility with the latest major release of the module.

## Testing done
Local and tugboat testing

## QA steps

 - [ ] log into tugboat site https://pr23087-nqqwwyqau2ftll6ctf7rxex4fbliczcw.ci.cms.va.gov/
 - [ ] navigate to https://pr23087-nqqwwyqau2ftll6ctf7rxex4fbliczcw.ci.cms.va.gov/admin/content/sitewide_alert
 - [ ] set a few alerts to active or make a new one
 - [ ] verify that the alerts show up
 
### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
