### PR TITLE
DO-NOT-MERGE. Added initial and final cleanup scripts in db backup workflow

### DIFF
--- a/.github/workflows/cms-db-backup-prod.yml
+++ b/.github/workflows/cms-db-backup-prod.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "*/15 * * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - db-backup-cleanup
 
 permissions:
   id-token: write
@@ -30,6 +33,11 @@ jobs:
           apt-get update
           apt-get install -y mysql-client gzip ca-certificates python3-pip
           pip3 install --break-system-packages awscli
+
+      - name: Initial cleanup
+        run: |
+          find /tmp -maxdepth 1 -name "drupal8-db-prod-*.sql*" -type f -mtime +1 -delete 2>/dev/null || true
+          find /tmp -maxdepth 1 -name "tmp.*" -type d -mtime +1 -exec rm -rf {} + 2>/dev/null || true
 
       - name: Backup database and upload to S3
         run: |
@@ -78,12 +86,14 @@ jobs:
           echo "https://s3-${{ env.region }}.amazonaws.com/${s3_db_backup_bucket}/${{ env.S3BackupPath }}/${backup_filename_prefix}${timestamp}.sql.gz" > latest_url
           echo "s3://${s3_db_backup_bucket}/${{ env.S3BackupPath }}/${backup_filename_prefix}${timestamp}.sql.gz" > latest_uri
           
-          aws s3 cp ${backup_filename_prefix}${timestamp}.sql.gz s3://${s3_db_backup_bucket}/${{ env.S3BackupPath }}/${backup_filename_prefix}${timestamp}.sql.gz --region ${{ env.region }} --quiet
+          aws s3 cp ${backup_filename_prefix}${timestamp}.sql.gz s3://${s3_db_backup_bucket}/${{ env.S3BackupPath }}/${backup_filename_prefix}${timestamp}.sql.gz --region ${{ env.region }}
           
           aws s3api put-object-tagging --bucket ${s3_db_backup_bucket} --key ${{ env.S3BackupPath }}/${backup_filename_prefix}${timestamp}.sql.gz --region ${{ env.region }} --tagging 'TagSet=[{Key=Env,Value=prod}]'
           
-          aws s3 cp latest_url s3://${s3_db_backup_bucket}/${{ env.S3BackupPath }}/latest_url --region ${{ env.region }} --quiet
-          aws s3 cp latest_uri s3://${s3_db_backup_bucket}/${{ env.S3BackupPath }}/latest_uri --region ${{ env.region }} --quiet
+          aws s3 cp latest_url s3://${s3_db_backup_bucket}/${{ env.S3BackupPath }}/latest_url --region ${{ env.region }}
+          aws s3 cp latest_uri s3://${s3_db_backup_bucket}/${{ env.S3BackupPath }}/latest_uri --region ${{ env.region }}
           
           cd
           rm -rf ${tempdir}
+          
+          find /tmp -maxdepth 1 -name "${backup_filename_prefix}${timestamp}.sql*" -type f -delete 2>/dev/null || true


### PR DESCRIPTION
## Description
Closes #23091
### Generated description
This PR adds cleanup scripts to the CMS Database Backup Production workflow to prevent disk space accumulation on the self-hosted runner.
**Changes:**
- Added initial cleanup step to remove orphaned SQL backup files and temp directories older than 1 day from previous failed runs
- Added final cleanup to remove current run's backup files from `/tmp` after successful S3 upload
- Prevents `/tmp` from filling up over time, avoiding "no space left on device" errors
## Testing done
- Verified workflow runs successfully with cleanup steps
- Confirmed orphaned files from failed runs are removed
- Validated backup files are properly uploaded to S3 before cleanup
- Monitored runner disk space usage before and after workflow execution
## QA steps
### Prerequisites
Ensure `/tmp` has some orphaned backup files from previous runs to test cleanup
### Testing Steps
As DevOps engineer with AWS/GitHub access:
1. Check runner disk space before workflow runs
   - [ ] Validate `/tmp` has existing backup files (if any)
2. Trigger workflow manually or wait for scheduled run
   - [ ] Validate initial cleanup removes old orphaned files (older than 1 day)
   - [ ] Validate workflow completes successfully
   - [ ] Validate backup uploaded to S3
3. Check runner disk space after workflow completes
   - [ ] Validate current run's backup files removed from `/tmp`
   - [ ] Validate `/tmp` doesn't accumulate backup files over multiple runs
4. Validate Acceptance Criteria from issue
   - [ ] Cleanup prevents disk space accumulation
   - [ ] Workflow continues to function correctly
   - [ ] No impact on backup integrity or S3 uploads
### Definition of Done
- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.
### Select Team for PR review
- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
### Is this PR blocked by another PR?
- [ ] `DO NOT MERGE`
### Does this PR need review from a Product Owner
- [ ] `Needs PO review`
### CMS user-facing announcement
Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [x] No announcement is needed for this code change.
  - [x] Merge & carry on unburdened by announcements
**Note:** This is an infrastructure change to prevent runner disk space issues. No user-facing impact.