### PR TITLE
Add trailing slashes to node links in JSON:API response

### DIFF
--- a/config/sync/jsonapi_extras.jsonapi_field_type_config.yml
+++ b/config/sync/jsonapi_extras.jsonapi_field_type_config.yml
@@ -3,10 +3,10 @@ resourceFields:
   link:
     fieldName: link
     enhancer:
-      id: url_link
+      id: va_gov_url_link
       settings:
         absolute_url: 0
 type: config_entity
-label: 'JSON:API Field Type Config'
+label: "JSON:API Field Type Config"
 includedFieldTypes:
   - link

--- a/docroot/modules/custom/va_gov_api/src/Plugin/jsonapi/FieldEnhancer/VaGovUrlLinkEnhancer.php
+++ b/docroot/modules/custom/va_gov_api/src/Plugin/jsonapi/FieldEnhancer/VaGovUrlLinkEnhancer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\va_gov_api\Plugin\jsonapi\FieldEnhancer;
+
+use Drupal\jsonapi_extras\Plugin\jsonapi\FieldEnhancer\UrlLinkEnhancer;
+use GuzzleHttp\Psr7\Uri;
+use Shaper\Util\Context;
+
+/**
+ * Add URL aliases to links, ensuring trailing slash for node links.
+ *
+ * VA.gov canonical URLs use trailing slashes. When editors create a link using
+ * a node reference (stored as `entity:node/{nid}`), Drupal resolves it to a
+ * path alias without a trailing slash. This enhancer adds the trailing slash
+ * only for `entity:node/*` URIs.
+ *
+ * @ResourceFieldEnhancer(
+ *   id = "va_gov_url_link",
+ *   label = @Translation("VA.gov URL for link (link field only)"),
+ *   description = @Translation("Use Url for link fields, adding trailing slash for entity:node links.")
+ * )
+ */
+class VaGovUrlLinkEnhancer extends UrlLinkEnhancer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doUndoTransform($data, Context $context) {
+    $data = parent::doUndoTransform($data, $context);
+
+    if (isset($data['uri'], $data['url']) && is_string($data['uri']) && is_string($data['url'])) {
+      $data['url'] = $this->ensureTrailingSlashForNodeLinks($data['uri'], $data['url']);
+    }
+
+    return $data;
+  }
+
+  /**
+   * Ensures node entity URLs have a trailing slash.
+   *
+   * This is intentionally conservative: it only modifies resolved URLs that
+   * originate from a node entity reference (entity:node/{nid}).
+   */
+  protected function ensureTrailingSlashForNodeLinks(string $uri, string $url): string {
+    if (!str_starts_with($uri, 'entity:node/')) {
+      return $url;
+    }
+
+    try {
+      $urlObject = new Uri($url);
+    }
+    catch (\InvalidArgumentException $e) {
+      return $url;
+    }
+
+    $path = $urlObject->getPath();
+
+    // If the URL has no path or already ends in a slash, do nothing.
+    if ($path === '' || str_ends_with($path, '/')) {
+      return $url;
+    }
+
+    return (string) $urlObject->withPath($path . '/');
+  }
+
+}


### PR DESCRIPTION
## Description

**EDIT:** Implementation changed, see https://github.com/department-of-veterans-affairs/va.gov-cms/pull/23107#issuecomment-3762011016

Relates to [#23088](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/23088)

Adds trailing slashes to internal node link URLs in JSON:API responses.
When editors link to Drupal pages using node references (e.g., entity:node/123), the resolved URL was missing a trailing slash (e.g., /education/benefits instead of /education/benefits/). Since VA.gov canonical URLs use trailing slashes, this was causing links to point to non-canonical URLs.

**Approach:** Adds a patch to jsonapi_extras that appends a trailing slash to URLs originating from entity:node/ URIs only. 

**Changes:**
- New patch: patches/VACMS-trailing-slash-internal-links.patch
- Updated composer.patches.json to register the patch
- Added tests to verify the behavior

### Generated description

This pull request introduces a patch to ensure that internal node entity links in JSON:API responses always have a trailing slash, aligning with VA.gov's canonical URL requirements. The patch is applied conservatively, affecting only `entity:node/` URIs and leaving other internal links unchanged. Comprehensive tests are added to verify this behavior.

**Enhancement to URL handling for internal links:**

* Added a new patch (`VACMS-trailing-slash-internal-links.patch`) to the `composer.patches.json` configuration for `drupal/jsonapi_extras`, ensuring URLs generated from `entity:node/` references receive a trailing slash.
* Updated the `UrlLinkEnhancer` plugin to append a trailing slash to URLs for node entity references only, using a new helper method `ensureTrailingSlashForNodeLinks`. This ensures only canonical node URLs are affected, with other URLs left unchanged.

**Automated testing for URL trailing slash behavior:**

* Added PHPUnit tests to verify that:
  - Node entity links (from `entity:node/XXX` URIs) in JSON:API responses have a trailing slash.
  - Other internal links (e.g., `internal:/some-path`) do not receive a trailing slash.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

1. Do this
   - [ ] Consume JSON:API (i.e. view page in next-build, use the API explorer, etc.)
2. Then validate Acceptance Criteria from issue
   - [ ] All links that are `entity:node/*` end with slash
   - [ ] All other links are unchanged
   - [ ] Example: check downstream URLs on page http://localhost:3999/education/ (next-build) 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
