### PR TITLE
Fix tests/phpunit/Ops/MetricsTest.php test

### DIFF
--- a/tests/phpunit/Ops/MetricsTest.php
+++ b/tests/phpunit/Ops/MetricsTest.php
@@ -69,6 +69,7 @@ class MetricsTest extends VaGovExistingSiteBase {
       'BRD build type, but no deploy env' => [
         [
           "va_gov_frontend_build_type" => "brd",
+          "github_actions_deploy_env" => NULL,
         ],
         "unknown",
       ],


### PR DESCRIPTION
## Description

Fixes test failure `tests/phpunit/Ops/MetricsTest.php` in staging.

Recently, global settings were added to this test in https://github.com/department-of-veterans-affairs/va.gov-cms/pull/23106

Previously, `github_actions_deploy_env` was not set in this test. After the above PR, the test no longer passes an empty value but instead the actual environment, and this test fails in staging since staging has a deployment environment. 

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

As user _uid_ with _user_role_
1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue
   - [ ] a
   - [ ] b
   - [ ] c

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
