### PR TITLE
update replace to look for mirror

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -201,7 +201,7 @@ services:
       - ln -snf "${TUGBOAT_ROOT}/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
 
       # Update the .env file for the next build preview server
-      - sed -i "s|https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"
+      - sed -i "s|https://mirror.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"
 
       # https://www.drush.org/latest/deploycommand/ (updatedb, cache:rebuild, config:import, deploy:hook)
       - bash -lc 'drush deploy'


### PR DESCRIPTION
## Description
Updates replacer to look for new mirror url to update with tugboat URL

### Generated description
This pull request updates the `.env` configuration for the Next.js build preview server to reference a new default CMS mirror URL. This change ensures that the preview environment uses the correct content source during builds.

* Updated the `sed` command in `.tugboat/config.yml` to replace the old CMS mirror URL (`https://mirror.cms.va.gov`) with the value of `${TUGBOAT_DEFAULT_SERVICE_URL}` in the `.env.tugboat` file for the Next.js build preview server.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

