### PR TITLE
Update config_split to 2.x and remove config_filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "drupal/computed_breadcrumbs": "^1.1",
         "drupal/config_ignore": "^3.3",
         "drupal/config_override_warn": "^1.0",
-        "drupal/config_split": "^1.10",
+        "drupal/config_split": "^2.0",
         "drupal/config_view": "^9.0",
         "drupal/config_views": "^2.0",
         "drupal/consumer_image_styles": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29d914beaafa2aec9f4d5fce5a0537d7",
+    "content-hash": "5b2259be756154050faf5b051ef4d860",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4038,72 +4038,6 @@
             }
         },
         {
-            "name": "drupal/config_filter",
-            "version": "1.13.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/config_filter.git",
-                "reference": "8.x-1.13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_filter-8.x-1.13.zip",
-                "reference": "8.x-1.13",
-                "shasum": "d9f83dbeaeaa1a1788368219a6e530f6b681459b"
-            },
-            "require": {
-                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
-            },
-            "suggest": {
-                "drupal/config_split": "Split site configuration for different environments."
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.13",
-                    "datestamp": "1727472406",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Fabian Bircher",
-                    "homepage": "https://www.drupal.org/u/bircher",
-                    "email": "opensource@fabianbircher.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Nuvole Web",
-                    "homepage": "http://nuvole.org",
-                    "email": "info@nuvole.org",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "pescetti",
-                    "homepage": "https://www.drupal.org/user/436244"
-                }
-            ],
-            "description": "Config Filter allows other modules to interact with a ConfigStorage through filter plugins.",
-            "homepage": "https://www.drupal.org/project/config_filter",
-            "keywords": [
-                "Drupal",
-                "configuration",
-                "configuration management"
-            ],
-            "support": {
-                "source": "https://git.drupalcode.org/project/config_filter",
-                "issues": "https://www.drupal.org/project/issues/config_filter",
-                "slack": "https://drupal.slack.com/archives/C45342CDD"
-            }
-        },
-        {
             "name": "drupal/config_ignore",
             "version": "3.3.0",
             "source": {
@@ -4213,27 +4147,26 @@
         },
         {
             "name": "drupal/config_split",
-            "version": "1.10.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_split.git",
-                "reference": "8.x-1.10"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_split-8.x-1.10.zip",
-                "reference": "8.x-1.10",
-                "shasum": "634b04afb920100ff7022066554253635e30dd77"
+                "url": "https://ftp.drupal.org/files/projects/config_split-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "efde01f790ca6f6023982e918fe51740da931d3e"
             },
             "require": {
-                "drupal/config_filter": "^1",
-                "drupal/core": "^9.3 || ^10"
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
             },
             "conflict": {
-                "drupal/console": "<1.3.2"
+                "drush/drush": "<10"
             },
             "require-dev": {
-                "drush/drush": "*"
+                "drupal/config_filter": "^1||^2"
             },
             "suggest": {
                 "drupal/chosen": "Chosen uses the Chosen jQuery plugin to make the <select> elements more user-friendly.",
@@ -4242,8 +4175,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.10",
-                    "datestamp": "1739381813",
+                    "version": "2.0.2",
+                    "datestamp": "1739381800",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4251,7 +4184,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9 || ^10 || ^11"
+                        "drush.services.yml": "^10 || ^11"
                     }
                 }
             },

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -36,7 +36,6 @@ module:
   components: 0
   computed_breadcrumbs: 0
   config: 0
-  config_filter: 0
   config_ignore: 0
   config_override_warn: 0
   config_split: 0


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22214

- Update config_split from 1.x to 2.x
- Remove config_filter (no longer required - config_split 2.x uses Drupal core instead)

### Generated description

This pull request updates the `drupal/config_split` dependency to a new major version and removes the `config_filter` module from the configuration. These changes help keep the codebase up to date with the latest module versions and streamline the configuration setup.

Dependency updates:

* Updated the `drupal/config_split` dependency from version `^1.10` to `^2.0` in `composer.json`, ensuring compatibility with the latest features and security fixes.

Configuration cleanup:

* Removed the `config_filter` module from the enabled modules list in `core.extension.yml`, simplifying the configuration and possibly reflecting a change in configuration management approach.

## Testing done

Tests pass, local ddev and environment working after update, 

## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

1. Do this
   - [ ] Switch to this branch
   - [ ] Run `ddev composer install`
2. Then
   - [ ] Confirm that everything is working

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
