### PR TITLE
VACMS-23188: Adds default for section back and removes overwrite

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_facility_vet_centers.yml
+++ b/config/sync/migrate_plus.migration.va_node_facility_vet_centers.yml
@@ -32,8 +32,6 @@ source:
   ids:
     id:
       type: string
-  constants:
-    vet_centers_tid: 190
   fields:
     -
       name: facility_type
@@ -185,19 +183,8 @@ process:
     source: hours
   field_timezone: time_zone
   field_administration:
-    -
-      plugin: callback
-      callable: trim
-      source: name
-    -
-      plugin: entity_generate
-      entity_type: taxonomy_term
-      ignore_case: true
-      value_key: name
-      bundle_key: vid
-      bundle: administration
-      values:
-        parent: constants/vet_centers_tid
+    plugin: default_value
+    default_value: 190
   langcode:
     plugin: default_value
     default_value: en
@@ -255,7 +242,6 @@ destination:
     - field_address/locality
     - field_address/postal_code
     - field_geolocation
-    - field_administration
     - field_office_hours
     - field_timezone
     - field_official_name

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_facility_vet_centers.yml
@@ -35,10 +35,6 @@ source:
   ids:
     id:
       type: string
-  # Define any constants that are needed to pass in as data.
-  constants:
-    # Vet Centers section is Term ID 190.
-    vet_centers_tid: 190
   # All the fields that are used from the source.
   fields:
     -
@@ -180,19 +176,8 @@ process:
     source: hours
   field_timezone: time_zone
   field_administration:
-    -
-      plugin: callback
-      callable: trim
-      source: name
-    -
-      plugin: entity_generate
-      entity_type: taxonomy_term
-      ignore_case: true
-      value_key: name
-      bundle_key: vid
-      bundle: administration
-      values:
-        parent: 'constants/vet_centers_tid'
+    plugin: default_value
+    default_value: 190
   langcode:
     plugin: default_value
     default_value: en
@@ -254,7 +239,6 @@ destination:
     - 'field_address/locality'
     - 'field_address/postal_code'
     - 'field_geolocation'
-    - field_administration
     - field_office_hours
     - field_timezone
     - field_official_name

--- a/tests/phpunit/Migration/VaVetCentersFacilityMigrationTest.php
+++ b/tests/phpunit/Migration/VaVetCentersFacilityMigrationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Migration;
+
+use Drupal\node\Entity\Node;
+use Tests\Support\Classes\VaGovExistingSiteBase;
+use Tests\Support\Entity\Storage as EntityStorage;
+use Tests\Support\Migration\Migrator;
+use Tests\Support\Mock\HttpClient as MockHttpClient;
+
+/**
+ * A test to confirm that the VA Facility Vet Centers Migration works correctly.
+ *
+ * @group functional
+ * @group all
+ * @group facility_migration
+ */
+class VaVetCentersFacilityMigrationTest extends VaGovExistingSiteBase {
+
+  /**
+   * Test the VA Facility Vet Centers Migration.
+   */
+  public function testVaVetCentersFacilityMigration() : void {
+    $mockClient = MockHttpClient::create('200', ['Content-Type' => 'application/json;charset=UTF-8'], file_get_contents(__DIR__ . '/fixtures/vet_centers_facility.json'));
+    $this->container->set('http_client', $mockClient);
+    $source_config_overrides = ['urls' => 'https://example.com/any/url/will/do'];
+    Migrator::doImport('va_node_facility_vet_centers', $source_config_overrides);
+    $bundle = 'vet_center';
+    $conditions = [
+      'field_facility_locator_api_id' => 'vc_0000Z',
+      'field_official_name' => 'Test Vet Center Facility',
+    ];
+    $entities = EntityStorage::getMatchingEntities('node', $bundle, $conditions);
+    $this->assertCount(1, $entities);
+
+    $nid = reset($entities);
+    $node = Node::load($nid);
+    $term_ref = $node->get('field_administration')->getValue();
+    $this->assertEquals([['target_id' => 190]], $term_ref);
+
+    EntityStorage::deleteMatchingEntities('node', $bundle, $conditions);
+  }
+
+}

--- a/tests/phpunit/Migration/fixtures/vet_centers_facility.json
+++ b/tests/phpunit/Migration/fixtures/vet_centers_facility.json
@@ -1,0 +1,193 @@
+{
+  "data": [
+    {
+      "id": "vc_0000Z",
+      "type": "va_facilities",
+      "attributes": {
+        "name": "Test Vet Center Facility",
+        "facilityType": "vet_center",
+        "visn": "1",
+        "lat": 38.8977,
+        "long": -77.0365,
+        "timeZone": "America/New_York",
+        "address": {
+          "physical": {
+            "address1": "1234 Freedom Rd",
+            "address2": null,
+            "address3": null,
+            "city": "Washington",
+            "state": "DC",
+            "zip": "20001"
+          }
+        },
+        "phone": {
+          "main": "2025551234"
+        },
+        "hours": {
+          "monday": "8:00am - 4:30pm",
+          "tuesday": "8:00am - 4:30pm",
+          "wednesday": "8:00am - 4:30pm",
+          "thursday": "8:00am - 4:30pm",
+          "friday": "8:00am - 4:30pm",
+          "saturday": "Closed",
+          "sunday": "Closed"
+        }
+      }
+    },
+    {
+      "_comment": "This is an item that should be skipped on the migration because it's not a vet center.",
+      "id": "vha_999999",
+      "type": "va_facilities",
+      "attributes": {
+        "name": "Test VA Clinic",
+        "facilityType": "va_health_facility",
+        "classification": "Multi-Specialty CBOC",
+        "parent": {
+          "id": "vha_550",
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550"
+        },
+        "website": "https://www.va.gov/illiana-health-care/locations/bloomington-va-clinic/",
+        "lat": 40.45095922,
+        "long": -88.9880427,
+        "timeZone": "America/Chicago",
+        "address": {
+          "physical": {
+            "zip": "61704-7527",
+            "city": "Bloomington",
+            "state": "IL",
+            "address1": "207 Hamilton Road"
+          }
+        },
+        "phone": {
+          "fax": "217-554-3089",
+          "main": "309-827-4090",
+          "pharmacy": "217-554-3208",
+          "afterHours": "217-554-3000",
+          "patientAdvocate": "217-554-4968",
+          "mentalHealthClinic": "217-554-4530",
+          "enrollmentCoordinator": "217-554-7386"
+        },
+        "hours": {
+          "monday": "730AM-630PM",
+          "tuesday": "600AM-630PM",
+          "wednesday": "600AM-630PM",
+          "thursday": "600AM-630PM",
+          "friday": "600AM-400PM",
+          "saturday": "Closed",
+          "sunday": "Closed"
+        },
+        "operationalHoursSpecialInstructions": [
+          "More hours are available for some services. To learn more, call our main phone number."
+        ],
+        "services": {
+          "health": [
+            {
+              "name": "Audiology and speech",
+              "serviceId": "audiology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/audiology"
+            },
+            {
+              "name": "Cardiology",
+              "serviceId": "cardiology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/cardiology"
+            },
+            {
+              "name": "Dermatology",
+              "serviceId": "dermatology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/dermatology"
+            },
+            {
+              "name": "Gynecology",
+              "serviceId": "gynecology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/gynecology"
+            },
+            {
+              "name": "Homeless Veteran care",
+              "serviceId": "homeless",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/homeless"
+            },
+            {
+              "name": "Laboratory and pathology",
+              "serviceId": "laboratory",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/laboratory"
+            },
+            {
+              "name": "MentalHealth",
+              "serviceId": "mentalHealth",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/mentalHealth"
+            },
+            {
+              "name": "Nutrition, food, and dietary care",
+              "serviceId": "nutrition",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/nutrition"
+            },
+            {
+              "name": "Optometry",
+              "serviceId": "optometry",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/optometry"
+            },
+            {
+              "name": "Pharmacy",
+              "serviceId": "pharmacy",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/pharmacy"
+            },
+            {
+              "name": "Physical medicine and rehabilitation",
+              "serviceId": "physicalMedicine",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/physicalMedicine"
+            },
+            {
+              "name": "Podiatry",
+              "serviceId": "podiatry",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/podiatry"
+            },
+            {
+              "name": "Primary care",
+              "serviceId": "primaryCare",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/primaryCare"
+            },
+            {
+              "name": "Psychology",
+              "serviceId": "psychology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/psychology"
+            },
+            {
+              "name": "Smoking and tobacco cessation",
+              "serviceId": "smoking",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/smoking"
+            },
+            {
+              "name": "Social work",
+              "serviceId": "socialWork",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/socialWork"
+            },
+            {
+              "name": "MOVE! weight management",
+              "serviceId": "weightManagement",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/weightManagement"
+            },
+            {
+              "name": "Women Veteran care",
+              "serviceId": "womensHealth",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services/womensHealth"
+            }
+          ],
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_550GG/services",
+          "lastUpdated": "2024-05-26"
+        },
+        "satisfaction": {
+          "health": {
+            "primaryCareUrgent": 0.0,
+            "primaryCareRoutine": 0.8899999856948853
+          },
+          "effectiveDate": "2024-02-08"
+        },
+        "mobile": false,
+        "operatingStatus": {
+          "code": "NORMAL"
+        },
+        "visn": "12"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Relates to #23188 .

This takes the same PR from #23116 and removes 'field_administration' from the overwrite_properties of the migration in order to prevent overwriting every node with the default 'Vet Center' section (tid 190).

### Generated description
This pull request refactors the migration configuration for VA Vet Centers facilities by simplifying how the `field_administration` is handled and removing unnecessary constants. It also adds a new PHPUnit test to verify the migration works as expected, using a fixture file for sample data.

**Migration configuration simplification:**

* Replaced the previous multi-step process for setting `field_administration` (which involved trimming, generating a taxonomy term, and referencing a constant) with a direct assignment of the default value `190`. This removes the need for the `vet_centers_tid` constant and streamlines the migration logic. [[1]](diffhunk://#diff-48f5a90deaa7e1b3cbc173bdfd9613daa6f664d2f751fb5439a6b1bcda8e6cb1L35-L36) [[2]](diffhunk://#diff-48f5a90deaa7e1b3cbc173bdfd9613daa6f664d2f751fb5439a6b1bcda8e6cb1L188-R187) [[3]](diffhunk://#diff-d7c31478d57779a076b4b734959101f5f524d8e7efab55375d5da9dcd9c157d2L38-L41) [[4]](diffhunk://#diff-d7c31478d57779a076b4b734959101f5f524d8e7efab55375d5da9dcd9c157d2L183-R180)
* Removed `field_administration` from the list of destination fields in both migration configuration files, reflecting that its value is now set directly and does not require mapping. [[1]](diffhunk://#diff-48f5a90deaa7e1b3cbc173bdfd9613daa6f664d2f751fb5439a6b1bcda8e6cb1L258) [[2]](diffhunk://#diff-d7c31478d57779a076b4b734959101f5f524d8e7efab55375d5da9dcd9c157d2L257)

**Testing improvements:**

* Added a new PHPUnit test `VaVetCentersFacilityMigrationTest.php` that mocks the HTTP client and verifies a Vet Center facility node is migrated correctly, including checking that the `field_administration` is set to the expected term ID (190).
* Introduced a fixture file `vet_centers_facility.json` to provide sample migration data for testing, including both a Vet Center facility and a non-matching VA Clinic to confirm filtering behavior.

## Testing done
Added phpunit test. Also ran the vet center migration locally and verified that the vet center section dashboard displayed as intended

## QA Step

As an administrator:
- Log in and go to the Vet Centers migration (https://cms-b5gssyrlkvalmr9choiq7nlk7nzpixcj.ci.cms.va.gov/admin/structure/migrate/manage/facility/migrations/va_node_facility_vet_centers/execute)
  - Hit 'Execute' to run the migration.
- Once the migration is finished, browse to the Vet Centers section dashboard (https://cms-b5gssyrlkvalmr9choiq7nlk7nzpixcj.ci.cms.va.gov/section/vet-centers)
  - [ ] Verify the dashboard displays as it should:
    - [ ] Subsection with Districts 1-5
    - [ ] Filters containing Title contains, Content Type, and Moderation State
    - [ ] List of Vet centers


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
