### PR TITLE
VACMS-10129: Adds title as legend for fieldsets.

### DIFF
--- a/docroot/themes/custom/vagovclaro/vagovclaro.theme
+++ b/docroot/themes/custom/vagovclaro/vagovclaro.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\block\Entity\Block;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
@@ -193,16 +194,16 @@ function vagovclaro_preprocess_field(&$variables) {
  * Implements hook_preprocess_fieldset().
  */
 function vagovclaro_preprocess_fieldset(&$variables) {
-  // Move the title to the legend of the fieldset for A11y.
+  // Move the field_title to the legend of the fieldset for A11y.
   if (
     isset($variables['element']['#bundle']) &&
     $variables['element']['#bundle'] === 'health_care_local_facility_servi' &&
-    $variables['element']['#title'] === '' &&
+    empty($variables['element']['#title']) &&
     !empty($variables['element']['field_title'])
   ) {
     $label = $variables['element']['field_title']['#items']->value;
     $variables['element']['#title'] = $label;
-    $variables['legend']['title']['#markup'] = '<h3>' . $label . '</h3>';
+    $variables['legend']['title']['#markup'] = '<h3>' . Html::escape($label) . '</h3>';
   }
 }
 


### PR DESCRIPTION
## Description

Relates to #10129 .

### Generated description
This pull request improves accessibility and content handling for the `health_care_local_facility_servi` paragraph type in the `vagovclaro` theme. The main changes move the paragraph title into the fieldset legend for better accessibility and hide the original title field to avoid duplication.

**Accessibility improvements:**

* Added a new `vagovclaro_preprocess_fieldset` function to move the `field_title` value into the fieldset legend as an `<h3>` for the `health_care_local_facility_servi` bundle, improving accessibility for screen readers.

**Content display adjustments:**

* Updated `vagovclaro_preprocess_paragraph` to hide the `field_title` when the paragraph type is `health_care_local_facility_servi`, since the title is now displayed in the legend.

## Testing done
Tested locally that the title now displays within a legend tag.

## Screenshots


## QA steps

- Browse to a VAMC Facility page that has Location services ("Prepare for your visit") content such as the Anderson VA Clinic (https://cms-iqmr1pso1vfamb28cmhhndamyre2ssvw.ci.cms.va.gov/columbia-south-carolina-health-care/locations/anderson-va-clinic)
- Scroll down to the "Prepare for your visit" section.
- Inspect the Heading for one of the services such as "Parking"
  - [ ] Verify that the heading is within a legend tag

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
