### PR TITLE
VACMS-23236: Fixes health service error.

### DIFF
--- a/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/ArchiveCovid19Validator.php
+++ b/docroot/modules/custom/va_gov_vamc/src/Plugin/Validation/Constraint/ArchiveCovid19Validator.php
@@ -32,22 +32,26 @@ class ArchiveCovid19Validator extends ConstraintValidator {
     if ($moderationState !== 'archived') {
       if ($bundle === 'regional_health_care_service_des') {
         $tid = $entity->field_service_name_and_descripti->target_id;
-        $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($tid);
-        if ($term && str_contains($term->label(), $this->covid19Title) !== FALSE) {
-          /** @var \Drupal\va_gov_vamc\Plugin\Validation\Constraint\ArchiveCovid19 $constraint */
-          $this->getContext()
-            ->buildViolation($constraint->covid19Archived, [])
-            ->addViolation();
+        if (!empty($tid)) {
+          $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($tid);
+          if ($term && str_contains($term->label(), $this->covid19Title) !== FALSE) {
+            /** @var \Drupal\va_gov_vamc\Plugin\Validation\Constraint\ArchiveCovid19 $constraint */
+            $this->getContext()
+              ->buildViolation($constraint->covid19Archived, [])
+              ->addViolation();
+          }
         }
       }
       elseif ($bundle === 'health_care_local_health_service') {
         $nid = $entity->field_regional_health_service->target_id;
-        $referencedNode = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
-        if ($referencedNode && str_contains($referencedNode->label(), $this->covid19Title) !== FALSE) {
-          /** @var \Drupal\va_gov_vamc\Plugin\Validation\Constraint\ArchiveCovid19 $constraint */
-          $this->getContext()
-            ->buildViolation($constraint->covid19Archived, [])
-            ->addViolation();
+        if (!empty($nid)) {
+          $referencedNode = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+          if ($referencedNode && str_contains($referencedNode->label(), $this->covid19Title) !== FALSE) {
+            /** @var \Drupal\va_gov_vamc\Plugin\Validation\Constraint\ArchiveCovid19 $constraint */
+            $this->getContext()
+              ->buildViolation($constraint->covid19Archived, [])
+              ->addViolation();
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Relates to #23236.

### Generated description
This pull request improves the robustness of the `ArchiveCovid19Validator` by adding checks to ensure referenced entities exist before attempting to access their properties. This helps prevent potential errors when the referenced taxonomy term or node is missing.

**Validation improvements:**

* Added a check to ensure `field_service_name_and_descripti->target_id` is not empty before loading the taxonomy term in the `regional_health_care_service_des` bundle.
* Added a check to ensure `field_regional_health_service->target_id` is not empty before loading the referenced node in the `health_care_local_health_service` bundle.
* Adjusted function structure to properly close conditionals and improve readability.

## Testing done
Tested that I was able to create a Facility Health Service locally.

## Screenshots


## QA steps

As an editor.
1. Start to create a new Facility Health Service (/node/add/health_care_local_health_service)
   - Select a Section from the dropdown on the right rail.
   - Select a facility from the Facility dropdown
   - [ ] Verify that an error does not show up and that you can further select an item from the VAMC System Health Service dropdown.


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
