### PR TITLE
VACMS-23207: homepage permissions fix

### DIFF
--- a/config/sync/workbench_access.access_scheme.section.yml
+++ b/config/sync/workbench_access.access_scheme.section.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.block_content.alert.field_owner
     - field.field.block_content.benefit_promo.field_administration
     - field.field.block_content.connect_with_us.field_administration
+    - field.field.block_content.cta_with_link.field_administration
     - field.field.block_content.news_promo.field_administration
     - field.field.block_content.promo.field_owner
     - field.field.media.document.field_owner
@@ -90,6 +91,10 @@ scheme_settings:
     -
       entity_type: block_content
       bundle: benefit_promo
+      field: field_administration
+    -
+      entity_type: block_content
+      bundle: cta_with_link
       field: field_administration
     -
       entity_type: block_content


### PR DESCRIPTION
## Description

Relates to #23207

## Testing done

Manual in Tugboat

## Screenshots


Logged in as VAMC editor
<img width="1670" height="138" alt="Screenshot 2026-01-21 at 3 32 37 PM" src="https://github.com/user-attachments/assets/e2cc132b-7aec-45a2-9dd0-a9c46c8bc379" />

Logged in as Content Admin
<img width="1608" height="143" alt="Screenshot 2026-01-21 at 3 32 06 PM" src="https://github.com/user-attachments/assets/677fa9cd-4ad4-417c-8224-5bb42b3e4ce1" />

Successfully updated block as Content Admin and saw it on Content Release
<img width="416" height="264" alt="Screenshot 2026-01-21 at 3 31 50 PM" src="https://github.com/user-attachments/assets/cd20ee70-fbb2-42bd-9308-69de579d73f5" />

## QA steps

As a VAMC editor 
   - [x] Log in to tugboat https://pr23282-gwdexcynlpjscs8mrjeaupnfefq0sxrk.ci.cms.va.gov/
   - [x] Go to Custom block library and filter by Block type CTA with Links https://pr23282-gwdexcynlpjscs8mrjeaupnfefq0sxrk.ci.cms.va.gov/admin/content/block?info=&type=cta_with_link
   - [x] Confirm you cannot edit Home page create account block
   
As a Content Admin
   - [x] Log in to tugboat https://pr23282-gwdexcynlpjscs8mrjeaupnfefq0sxrk.ci.cms.va.gov/
   - [x] Go to Custom block library and filter by Block type CTA with Links https://pr23282-gwdexcynlpjscs8mrjeaupnfefq0sxrk.ci.cms.va.gov/admin/content/block?info=&type=cta_with_link
   - [x] Confirm you can edit Home page create account block
   - [x] Make a change to the block and saved it as published
   - [x] Run a content release https://pr23282-gwdexcynlpjscs8mrjeaupnfefq0sxrk.ci.cms.va.gov/admin/content/deploy
   - [x] Confirm that the Homepage updates with your change

### Definition of Done

- [x] Automated tests have passed.
- [x] Code Quality Tests have passed.
- [x] Acceptance Criteria in related issue are met.
- [x] Manual Code Review Approved.
