### PR TITLE
Create runbook-vet-center-name-change-outstation.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-name-change-outstation.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-name-change-outstation.md
@@ -42,7 +42,7 @@ For any Vet Center sections lacking active editors, please contact Barb Kuhn or 
      
 - [ ] **Link to Jira ticket(s):** `<jira_ticket_links>`
      
-     **Embedded Support:** Please search Jira and add links to any relevant tickets. If none found, please link once created. 
+  **Embedded Support:** Please search Jira and add links to any relevant tickets. If none found, please link once created. 
 
 URL redirects are not needed for Mobile Vet Center and Vet Center Outstation tickets because they do not have outward-facing URLs. 
 


### PR DESCRIPTION
Added per https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22938

Old "New Vet Center" runbook had MVC and Outstation steps mixed in with regular Vet Center steps -- this breaks out new Outstation runbook