### PR TITLE
Create runbook-vet-center-closed-mvc-or-outstation.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/runbook-vet-center-closed-mvc-or-outstation.md
+++ b/.github/ISSUE_TEMPLATE/runbook-vet-center-closed-mvc-or-outstation.md
@@ -32,7 +32,7 @@ For any Vet Center sections lacking active editors, please contact Barb Kuhn or 
 
 - [ ] **Link to Jira ticket(s):** `<jira_ticket_links>`
      
-     **Embedded Support:** Please search Jira and add links to any relevant tickets. If none found, please link once created.
+ **Embedded Support:** Please search Jira and add links to any relevant tickets. If none found, please link once created.
      
 You do not need to create any redirect tickets for Mobile Vet Center nodes, because they do not have direct URLs -- these nodes are nested within the linked Vet Center's "Locations" page.
 


### PR DESCRIPTION
Added per https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22938

Old "Closed Vet Center" runbook had MVC and Outstation steps mixed in with regular Vet Center steps -- this breaks out MVC and Outstation steps

