### PR TITLE
Modify Tugboat build of content-build to use install-safe.

### DIFF
--- a/scripts/web-install.sh
+++ b/scripts/web-install.sh
@@ -28,7 +28,7 @@ if [[ "${BUILD_ENV}" == "eks" ]]; then
   export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 fi
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
-yarn install
+yarn install-safe
 popd
 
 popd > /dev/null


### PR DESCRIPTION
## Description
This sets content-builds running on CMS Tugboat to use install-safe. It should be merged after the install-safe work has been merged to content-build.

Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/23052

## QA Steps
We will test this prior to content-build being merged by running a CMS Tugboat content release using a non-main branch of content-build.

1. Allow this CMS PR's Tugboat to spin up.
2. Wait for the default CMS Tugboat content-build to finish. It should finish with an error because `install-safe` is not available by default.
3. Run a content-build on the CMS Tugboat using a content-build branch that contains the `install-safe` setup.
4. Verify output.

We should test that what is rendered by content-build looks correct. Good things to check:

- / (homepage; absolutely critical this looks OK before the content-build work is merged)
- /resources/ and pages under it.



