### PR TITLE
update role_delegation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,7 +179,7 @@
         "drupal/redirect": "^1.3",
         "drupal/redirect_options": "^2.1",
         "drupal/restui": "^1.16",
-        "drupal/role_delegation": "^1.4",
+        "drupal/role_delegation": "^1.6",
         "drupal/s3fs": "^3.6",
         "drupal/schemata": "^1.0",
         "drupal/search_api": "^1.40",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f0decc02d12ece3b809618cc10ec563",
+    "content-hash": "d31f531c210df57fdceadf4c1e89783e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -13597,17 +13597,17 @@
         },
         {
             "name": "drupal/role_delegation",
-            "version": "1.4.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/role_delegation.git",
-                "reference": "8.x-1.4"
+                "reference": "8.x-1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/role_delegation-8.x-1.4.zip",
-                "reference": "8.x-1.4",
-                "shasum": "7637fb2506b134bc888c74d3dcfa79c8a0c207aa"
+                "url": "https://ftp.drupal.org/files/projects/role_delegation-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "792971461a3b86cb8f6937d0eecd3745899bb7bf"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11"
@@ -13615,8 +13615,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.4",
-                    "datestamp": "1751012870",
+                    "version": "8.x-1.6",
+                    "datestamp": "1769768673",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Description

Relates to #23405 

### Generated description
This pull request updates the `drupal/role_delegation` module to a newer version, ensuring compatibility and access to recent improvements.

Dependency update:

* Upgraded the `drupal/role_delegation` dependency from version `^1.4` to `^1.6` in `composer.json`.

## Testing done
Manual testing

## QA steps
 - log in as a CMS account admin. (view people with that role here: https://pr23451-jgxqvoxngs02doii5paokwb5duulejtr.ci.cms.va.gov/admin/people?user=&status=1&role=admnistrator_users&workbench_access_section__section=All)
 - verify that you can still assign other users to the following roles:
    - Content API Consumer
    - Content creator - Benefits hubs
    - Content creator - Resources and support
    - Content creator - Outreach Hub
    - Content creator - VAMC
    - Content creator - VBA
    - Content creator - Vet Center
    - Content editor
    - Content reviewer
    - Content publisher
    - Content admin
    - Redirect admin

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`



