### PR TITLE
Remove wildcard from flag cache tags in Purge module to prevent exceptions

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -81,7 +81,8 @@
             "3053242 - Undefined index #description_display when adding a description to fieldset group type": "patches/3053242-field-group-undefined-index-description-display.patch"
         },
         "drupal/flag": {
-            "3317113 - Flags with VBO 8.x-4.x Patch 40": "patches/3317113-flag-vbo.patch"
+            "3317113 - Flags with VBO 8.x-4.x Patch 40": "patches/3317113-flag-vbo.patch",
+            "3557145 - Flag cache tags result in Purge module exception": "patches/3557145-flag-purge-tags-remove-wildcard.patch"
         },
         "drupal/flysystem_s3": {
             "3297257 - Automated Drupal 10 compatibility fixes": "patches/3297257-drupal-10-compatibility-fixes.patch"

--- a/patches/3557145-flag-purge-tags-remove-wildcard.patch
+++ b/patches/3557145-flag-purge-tags-remove-wildcard.patch
@@ -1,0 +1,23 @@
+diff --git a/src/Entity/Flagging.php b/src/Entity/Flagging.php
+index f7187f1920522241d406a7928c8cb48842706645..12e7c55ba683ed62ce365d1882a748238360df8e 100644
+--- a/src/Entity/Flagging.php
++++ b/src/Entity/Flagging.php
+@@ -245,7 +245,6 @@ class Flagging extends ContentEntityBase implements FlaggingInterface {
+
+     $tags[] = 'flagging:' . $this->bundle() . ':' . $this->getFlaggableType() . ':' . $this->getFlaggableId();
+     $tags[] = 'flagging:' . $this->bundle() . ':' . $this->getFlaggableType() . ':' . $this->getFlaggableId() . ':' . $this->getOwnerId();
+-    $tags[] = 'flagging:' . $this->bundle() . ':' . $this->getFlaggableType() . ':*:' . $this->getOwnerId();
+
+     return $tags;
+   }
+diff --git a/tests/src/Kernel/FlagCacheTagsTest.php b/tests/src/Kernel/FlagCacheTagsTest.php
+index 89fc60d107e282bddb9a0bd213fa8be4ba95ec37..2ef79a6806c2d51678922bf243f757771d792b36 100644
+--- a/tests/src/Kernel/FlagCacheTagsTest.php
++++ b/tests/src/Kernel/FlagCacheTagsTest.php
+@@ -82,7 +82,6 @@ class FlagCacheTagsTest extends FlagKernelTestBase {
+     $tags_to_invalidate = [
+       'flagging:test_flag:node:' . $this->node->id(),
+       'flagging:test_flag:node:' . $this->node->id() . ':1',
+-      'flagging:test_flag:node:*:1',
+     ];
+     Cache::invalidateTags($tags_to_invalidate);


### PR DESCRIPTION
## Description

There was an issue causing phpunit to error out on dev in EKS. This has been fixed in the flag module but not released yet. 
https://www.drupal.org/project/flag/issues/3557145

Relates to #23489

### Generated description

This pull request adds a patch to the `drupal/flag` module to address an issue with cache tag wildcards that caused exceptions when used with the Purge module. The patch removes the use of wildcard cache tags from both the `Flagging` entity and its associated kernel test.

**Flag module cache tag handling:**

* Added the `3557145-flag-purge-tags-remove-wildcard.patch` to the `drupal/flag` entry in `composer.patches.json` to fix cache tag wildcards causing Purge module exceptions.
* Updated the `Flagging` entity (`src/Entity/Flagging.php`) to remove the cache tag with a wildcard (`*`) in its tag generation logic.
* Updated the kernel test (`tests/src/Kernel/FlagCacheTagsTest.php`) to no longer expect or invalidate the wildcard cache tag.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If this passes automated testing we should be good. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
