### PR TITLE
VACMS-23278: Removes use of JS for Content entities in Content Lock 

### DIFF
--- a/config/sync/content_lock.settings.yml
+++ b/config/sync/content_lock.settings.yml
@@ -42,9 +42,9 @@ types:
   user_history: {  }
 types_translation_lock: {  }
 types_js_lock:
-  1: node
   2: media
   3: taxonomy_term
+  4: block_content
 form_op_lock:
   block_content:
     mode: 0


### PR DESCRIPTION
This is interfering with the autosave_form js, so let's see if we really need it.

## Description

Relates to #23278 

Removes the use of JS in content_lock specifically for content entities through a configuration change.

## Testing done
Manually

## Screenshots


## QA steps
### Set up Editor 1
- [x] As an [admin](https://pr23557-w1kzmddiegx93mvy1lrukvbqvegvokw8.ci.cms.va.gov/), update the QA Content Publisher user by assigning the following section to them:
  - [x] VA Boston health care
- [x] Update the QA Content Publisher user by assigning the following roles to them:
  - [x] Content editor - VAMC
  - [x] Content publisher

### Set up Editor 2
- [x] Update the QA Content Editor user by assigning the following section to them:
  - [x] VA Boston health care
- [x] Update the QA Content Editor user by assigning the following roles to them:
  - [x] Content editor - VAMC
  - [x] Content publisher

## Edit content as Editor 1
- [x] [Log in](https://pr23557-w1kzmddiegx93mvy1lrukvbqvegvokw8.ci.cms.va.gov/) as QA Content Publisher
- [x] Edit the [Framingham VA clinic](https://pr23557-w1kzmddiegx93mvy1lrukvbqvegvokw8.ci.cms.va.gov/node/1273/edit)

## Edit same content as Editor 2
- [x] Log in as QA Content Editor in a separate browser
- [x] Edit the Framingham VA clinic
- [x] Confirm that the page is locked
- [x] Click **Break lock**
- [x] Click **Confirm break lock** on the confirmation page
- [x] Confirm that you can now edit the page


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

