### PR TITLE
VACMS-23559: Solve 'Developer log in' not always opening.

### DIFF
--- a/docroot/modules/custom/va_gov_login/js/login-toggle.es6.js
+++ b/docroot/modules/custom/va_gov_login/js/login-toggle.es6.js
@@ -3,49 +3,50 @@
  * Login form helpers.
  */
 
-((Drupal) => {
+((Drupal, once) => {
   /**
    * Handles switching between PIV card & CMS user/pass login flows.
    *
    * @type {Drupal~behavior}
    */
   Drupal.behaviors.loginFormToggle = {
-    attach() {
-      document
-        .querySelector(".js-va-login-toggle")
-        .addEventListener("click", (e) => {
-          e.preventDefault();
+    attach(context) {
+      once("login-form-toggle", ".js-va-login-toggle", context).forEach(
+        (toggle) => {
+          toggle.addEventListener("click", (e) => {
+            e.preventDefault();
 
-          // Toggle class on form to control which inputs are shown.
-          const loginForm = document.getElementById("user-login-form");
-          // loginForm.toggleClass("piv-login form-login");
-          loginForm.classList.toggle("piv-login");
-          loginForm.classList.toggle("form-login");
+            // Toggle class on form to control which inputs are shown.
+            const loginForm = document.getElementById("user-login-form");
+            loginForm.classList.toggle("piv-login");
+            loginForm.classList.toggle("form-login");
 
-          // Change text of toggle button based on which is shown.
-          const loginToggle = document.getElementById("edit-toggle");
+            // Change text of toggle button based on which is shown.
+            const loginToggle = document.getElementById("edit-toggle");
 
-          if (loginToggle.value === "Developer log in") {
-            loginToggle.value = "Log in with PIV";
-          } else {
-            loginToggle.value = "Developer log in";
-          }
-
-          // Move focus back to top of form when toggled.
-          if (loginForm.classList.contains("piv-login")) {
-            const pivLoginLink = document.querySelector("a.piv-login-link");
-            if (pivLoginLink) {
-              pivLoginLink.focus();
+            if (loginToggle.value === "Developer log in") {
+              loginToggle.value = "Log in with PIV";
+            } else {
+              loginToggle.value = "Developer log in";
             }
-          } else {
-            const usernameInput = document.querySelector(
-              ".js-login-username input"
-            );
-            if (usernameInput) {
-              usernameInput.focus();
+
+            // Move focus back to top of form when toggled.
+            if (loginForm.classList.contains("piv-login")) {
+              const pivLoginLink = document.querySelector("a.piv-login-link");
+              if (pivLoginLink) {
+                pivLoginLink.focus();
+              }
+            } else {
+              const usernameInput = document.querySelector(
+                ".js-login-username input"
+              );
+              if (usernameInput) {
+                usernameInput.focus();
+              }
             }
-          }
-        });
+          });
+        }
+      );
     },
   };
-})(Drupal);
+})(Drupal, once);

--- a/docroot/modules/custom/va_gov_login/js/login-toggle.js
+++ b/docroot/modules/custom/va_gov_login/js/login-toggle.js
@@ -4,32 +4,34 @@
 * https://www.drupal.org/node/2815083
 * @preserve
 **/
-(function (Drupal) {
+(function (Drupal, once) {
   Drupal.behaviors.loginFormToggle = {
-    attach: function attach() {
-      document.querySelector(".js-va-login-toggle").addEventListener("click", function (e) {
-        e.preventDefault();
-        var loginForm = document.getElementById("user-login-form");
-        loginForm.classList.toggle("piv-login");
-        loginForm.classList.toggle("form-login");
-        var loginToggle = document.getElementById("edit-toggle");
-        if (loginToggle.value === "Developer log in") {
-          loginToggle.value = "Log in with PIV";
-        } else {
-          loginToggle.value = "Developer log in";
-        }
-        if (loginForm.classList.contains("piv-login")) {
-          var pivLoginLink = document.querySelector("a.piv-login-link");
-          if (pivLoginLink) {
-            pivLoginLink.focus();
+    attach: function attach(context) {
+      once("login-form-toggle", ".js-va-login-toggle", context).forEach(function (toggle) {
+        toggle.addEventListener("click", function (e) {
+          e.preventDefault();
+          var loginForm = document.getElementById("user-login-form");
+          loginForm.classList.toggle("piv-login");
+          loginForm.classList.toggle("form-login");
+          var loginToggle = document.getElementById("edit-toggle");
+          if (loginToggle.value === "Developer log in") {
+            loginToggle.value = "Log in with PIV";
+          } else {
+            loginToggle.value = "Developer log in";
           }
-        } else {
-          var usernameInput = document.querySelector(".js-login-username input");
-          if (usernameInput) {
-            usernameInput.focus();
+          if (loginForm.classList.contains("piv-login")) {
+            var pivLoginLink = document.querySelector("a.piv-login-link");
+            if (pivLoginLink) {
+              pivLoginLink.focus();
+            }
+          } else {
+            var usernameInput = document.querySelector(".js-login-username input");
+            if (usernameInput) {
+              usernameInput.focus();
+            }
           }
-        }
+        });
       });
     }
   };
-})(Drupal);
+})(Drupal, once);

--- a/docroot/modules/custom/va_gov_login/va_gov_login.libraries.yml
+++ b/docroot/modules/custom/va_gov_login/va_gov_login.libraries.yml
@@ -2,3 +2,5 @@
 login-toggle:
   js:
     js/login-toggle.js: {}
+  dependencies:
+    - core/once


### PR DESCRIPTION
### Generated description

This pull request updates the login toggle functionality for the VA.gov login module to ensure proper behavior when multiple login forms are present on a page. The changes improve event handling by leveraging Drupal's `once` utility, preventing duplicate event listeners and enhancing compatibility with dynamic content.

**JavaScript behavior improvements:**

* Updated both `login-toggle.es6.js` and its compiled version `login-toggle.js` to use Drupal's `once` utility for attaching click event listeners, ensuring that listeners are only added once per element and are compatible with dynamically loaded content. [[1]](diffhunk://#diff-5b622fa37375f621eb3fb24ab65b5482a57ee07974227ba545ef570caa4155deL6-L21) [[2]](diffhunk://#diff-5b622fa37375f621eb3fb24ab65b5482a57ee07974227ba545ef570caa4155deR48-R52) [[3]](diffhunk://#diff-03a3eb6ad315ad02dcf8d03d0a2b673dc1368e7d352e7792ebafb6bfd164e33fL7-R11) [[4]](diffhunk://#diff-03a3eb6ad315ad02dcf8d03d0a2b673dc1368e7d352e7792ebafb6bfd164e33fR34-R37)

**Dependency management:**

* Added the `core/once` library as a dependency in `va_gov_login.libraries.yml` to support the new event handling approach.

Relates to #23559

## Testing done
Tested in Chrome, Safari, and the Cursor browsers

## Screenshots
<img width="1601" height="1021" alt="Screenshot 2026-02-26 at 10 02 45 AM" src="https://github.com/user-attachments/assets/3b895ed1-0d3d-4cf4-98d3-432ca5015d48" />
<img width="1550" height="918" alt="Screenshot 2026-02-26 at 10 02 24 AM" src="https://github.com/user-attachments/assets/6705efc1-d49b-4323-aae6-832f78872da4" />


## QA steps
Load Drupal anonymously
Click the 'Developer log in' link
Validate the login form opens

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
