### PR TITLE
Remove field_va_form_url from va_node_form migration

### DIFF
--- a/config/sync/migrate_plus.migration.va_node_form.yml
+++ b/config/sync/migrate_plus.migration.va_node_form.yml
@@ -323,7 +323,6 @@ destination:
     - field_va_form_revision_date
     - field_va_form_row_id
     - field_va_form_title
-    - field_va_form_url
     - new_revision
     - revision_default
     - revision_log

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_form.yml
@@ -309,7 +309,6 @@ destination:
     - field_va_form_revision_date
     - field_va_form_row_id
     - field_va_form_title
-    - field_va_form_url
     - new_revision
     - revision_default
     - revision_log


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22299

### Generated description

Removes the form url as a migrator destination which prevents the URL from being overwritten.

## Testing done

