### PR TITLE
VACMS-23642: Adds user status to 2 views

### DIFF
--- a/config/sync/views.view.users_in_section.yml
+++ b/config/sync/views.view.users_in_section.yml
@@ -11,10 +11,10 @@ dependencies:
     - user
     - workbench_access
 id: users_in_section
-label: 'Users in section'
+label: "Users in section"
 module: views
-description: 'Views of users associated to a section'
-tag: ''
+description: "Views of users associated to a section"
+tag: ""
 base_table: section_association
 base_field: id
 display:
@@ -24,7 +24,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Members of this section'
+      title: "Members of this section"
       fields:
         user_id_target_id:
           id: user_id_target_id
@@ -32,48 +32,48 @@ display:
           field: user_id_target_id
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: user_id
           plugin_id: field
-          label: ''
+          label: ""
           exclude: true
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -82,14 +82,14 @@ display:
           settings:
             link: true
           group_column: target_id
-          group_columns: {  }
+          group_columns: {}
           group_rows: true
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ", "
           field_api_classes: false
         name:
           id: name
@@ -97,7 +97,7 @@ display:
           field: name
           relationship: user_id_target_id
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: user
           entity_field: name
           plugin_id: field
@@ -105,40 +105,40 @@ display:
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -147,16 +147,16 @@ display:
           settings:
             link_to_entity: true
             wrap_tag: _none
-            wrap_class: ''
+            wrap_class: ""
           group_column: value
-          group_columns: {  }
+          group_columns: {}
           group_rows: true
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ", "
           field_api_classes: false
         operations:
           id: operations
@@ -164,47 +164,47 @@ display:
           field: operations
           relationship: user_id_target_id
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: user
           plugin_id: entity_operations
-          label: ''
+          label: ""
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -215,51 +215,51 @@ display:
           field: workbench_access_section__section
           relationship: user_id_target_id
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: user
           plugin_id: workbench_access_user_section
-          label: 'Section memberships'
+          label: "Section memberships"
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          separator: '<br/>'
+          separator: "<br/>"
           type: separator
           make_link: 1
         roles_target_id:
@@ -268,7 +268,7 @@ display:
           field: roles_target_id
           relationship: user_id_target_id
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: user
           entity_field: roles
           plugin_id: user_roles
@@ -276,93 +276,93 @@ display:
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: '<em>No roles</em>'
+          empty: "<em>No roles</em>"
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
           type: separator
-          separator: '<br/>'
+          separator: "<br/>"
         status:
           id: status
           table: users_field_data
           field: status
           relationship: user_id_target_id
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: user
           entity_field: status
           plugin_id: field
-          label: ''
+          label: ""
           exclude: true
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
           element_type: h2
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -370,17 +370,17 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_false: 'Blocked users'
-            format_custom_true: 'Active users'
+            format_custom_false: "Blocked users"
+            format_custom_true: "Active users"
           group_column: value
-          group_columns: {  }
+          group_columns: {}
           group_rows: true
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ", "
           field_api_classes: false
         created:
           id: created
@@ -388,7 +388,7 @@ display:
           field: created
           relationship: user_id_target_id
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: user
           entity_field: created
           plugin_id: field
@@ -396,40 +396,40 @@ display:
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -437,26 +437,26 @@ display:
           type: timestamp
           settings:
             date_format: custom
-            custom_date_format: 'M j Y'
-            timezone: ''
+            custom_date_format: "M j Y"
+            timezone: ""
             tooltip:
-              date_format: ''
-              custom_date_format: ''
+              date_format: ""
+              custom_date_format: ""
             time_diff:
               enabled: false
-              future_format: '@interval hence'
-              past_format: '@interval ago'
+              future_format: "@interval hence"
+              past_format: "@interval ago"
               granularity: 2
               refresh: 60
           group_column: value
-          group_columns: {  }
+          group_columns: {}
           group_rows: true
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ", "
           field_api_classes: false
         access:
           id: access
@@ -464,66 +464,66 @@ display:
           field: access
           relationship: user_id_target_id
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: user
           entity_field: access
           plugin_id: field
-          label: 'Last access'
+          label: "Last access"
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: timestamp_ago
           settings:
-            future_format: '@interval hence'
-            past_format: '@interval ago'
+            future_format: "@interval hence"
+            past_format: "@interval ago"
             granularity: 1
           group_column: value
-          group_columns: {  }
+          group_columns: {}
           group_rows: true
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ", "
           field_api_classes: false
         section_id:
           id: section_id
@@ -531,53 +531,120 @@ display:
           field: section_id
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: section_id
           plugin_id: workbench_access_section_id
-          label: ''
+          label: ""
           exclude: true
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
           make_link: 0
           output_format: label
+        status_1:
+          id: status_1
+          table: users_field_data
+          field: status
+          relationship: user_id_target_id
+          group_type: group
+          admin_label: ""
+          entity_type: user
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ""
+            make_link: false
+            path: ""
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ""
+            more_link_path: ""
+            strip_tags: false
+            trim: false
+            preserve_tags: ""
+            html: false
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
+          element_label_colon: true
+          element_wrapper_type: ""
+          element_wrapper_class: ""
+          element_default_classes: true
+          empty: ""
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Blocked
+            format_custom_true: Active
+          group_column: value
+          group_columns: {}
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ", "
+          field_api_classes: false
       pager:
         type: none
         options:
@@ -589,7 +656,7 @@ display:
           submit_button: Apply
           reset_button: false
           reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
+          exposed_sorts_label: "Sort by"
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
@@ -601,9 +668,9 @@ display:
             administrator: administrator
       cache:
         type: tag
-        options: {  }
-      empty: {  }
-      sorts: {  }
+        options: {}
+      empty: {}
+      sorts: {}
       arguments:
         section_id:
           id: section_id
@@ -611,7 +678,7 @@ display:
           field: section_id
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: section_id
           plugin_id: string
@@ -621,16 +688,16 @@ display:
             title_enable: false
             title: All
           title_enable: true
-          title: 'Members of {{ section_id }} section'
+          title: "Members of {{ section_id }} section"
           default_argument_type: taxonomy_tid
           default_argument_options:
-            term_page: '1'
+            term_page: "1"
             node: false
             limit: false
-            vids: {  }
-            anyall: ','
+            vids: {}
+            anyall: ","
           summary_options:
-            base_path: ''
+            base_path: ""
             count: true
             override: false
             items_per_page: 25
@@ -641,15 +708,15 @@ display:
           specify_validation: false
           validate:
             type: none
-            fail: 'not found'
-          validate_options: {  }
+            fail: "not found"
+          validate_options: {}
           glossary: false
           limit: 0
           case: none
           path_case: none
           transform_dash: false
           break_phrase: false
-      filters: {  }
+      filters: {}
       filter_groups:
         operator: AND
         groups:
@@ -658,11 +725,10 @@ display:
         type: table
         options:
           grouping:
-            -
-              field: status
+            - field: status
               rendered: true
               rendered_strip: false
-          row_class: ''
+          row_class: ""
           default_row_class: true
           columns:
             user_id_target_id: user_id_target_id
@@ -676,73 +742,73 @@ display:
           default: access
           info:
             user_id_target_id:
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             name:
               sortable: true
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             workbench_access_section__section:
               sortable: false
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             roles_target_id:
               sortable: false
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             status:
               sortable: false
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             created:
               sortable: true
               default_sort_order: desc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             access:
               sortable: true
               default_sort_order: desc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             operations:
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
           override: true
           sticky: false
-          summary: ''
+          summary: ""
           empty_table: false
-          caption: ''
-          description: ''
+          caption: ""
+          description: ""
       row:
         type: fields
       query:
         type: views_query
         options:
-          query_comment: ''
+          query_comment: ""
           disable_sql_rewrite: false
           distinct: false
           replica: false
-          query_tags: {  }
+          query_tags: {}
       relationships:
         user_id_target_id:
           id: user_id_target_id
@@ -755,41 +821,41 @@ display:
           entity_field: user_id
           plugin_id: standard
           required: false
-      header: {  }
-      footer: {  }
-      display_extenders: {  }
+      header: {}
+      footer: {}
+      display_extenders: {}
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
+        - "languages:language_content"
+        - "languages:language_interface"
         - url
         - url.query_args
         - user.roles
-      tags: {  }
+      tags: {}
   section_member_page:
     id: section_member_page
     display_title: Page
     display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
+      display_extenders: {}
       path: taxonomy/term/%taxonomy_term/people
       menu:
         type: tab
-        title: 'Section members'
-        description: ''
+        title: "Section members"
+        description: ""
         weight: 0
         expanded: false
         menu_name: main
-        parent: ''
-        context: '0'
+        parent: ""
+        context: "0"
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
+        - "languages:language_content"
+        - "languages:language_interface"
         - url
         - url.query_args
         - user.roles
-      tags: {  }
+      tags: {}

--- a/config/sync/views.view.users_per_section.yml
+++ b/config/sync/views.view.users_per_section.yml
@@ -14,10 +14,10 @@ dependencies:
     - views_data_export
     - workbench_access
 id: users_per_section
-label: 'Users per section'
+label: "Users per section"
 module: views
-description: ''
-tag: ''
+description: ""
+tag: ""
 base_table: section_association
 base_field: id
 display:
@@ -27,7 +27,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Users per section'
+      title: "Users per section"
       fields:
         section_id_1:
           id: section_id_1
@@ -35,48 +35,48 @@ display:
           field: section_id
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: section_id
           plugin_id: workbench_access_section_id
-          label: 'Term id'
+          label: "Term id"
           exclude: true
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -88,7 +88,7 @@ display:
           field: id
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: id
           plugin_id: field
@@ -96,57 +96,57 @@ display:
           exclude: true
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: number_integer
           settings:
-            thousand_separator: ''
+            thousand_separator: ""
             prefix_suffix: true
           group_column: value
-          group_columns: {  }
+          group_columns: {}
           group_rows: true
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ", "
           field_api_classes: false
         section_id:
           id: section_id
@@ -154,46 +154,46 @@ display:
           field: section_id
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: section_id
           plugin_id: workbench_access_section_id
-          label: 'Section name'
+          label: "Section name"
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: false
-            path: ''
+            path: ""
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
           empty: N/A
           hide_empty: true
@@ -207,48 +207,48 @@ display:
           field: user_id_target_id
           relationship: none
           group_type: count
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: user_id
           plugin_id: field
-          label: 'Users per section'
+          label: "Users in section"
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: ""
             make_link: true
-            path: 'taxonomy/term/{{ section_id_1 }}/people'
+            path: "taxonomy/term/{{ section_id_1 }}/people"
             absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
             nl2br: false
             max_length: 0
             word_boundary: true
             ellipsis: true
             more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            more_link_text: ""
+            more_link_path: ""
             strip_tags: false
             trim: false
-            preserve_tags: ''
+            preserve_tags: ""
             html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: ""
+          element_wrapper_class: ""
           element_default_classes: true
-          empty: ''
+          empty: ""
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -257,22 +257,93 @@ display:
           settings:
             link: true
           group_column: target_id
-          group_columns: {  }
+          group_columns: {}
           group_rows: true
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ", "
           field_api_classes: false
           set_precision: false
           precision: 0
           decimal: .
           format_plural: 0
           format_plural_string: !!binary MQNAY291bnQ=
-          prefix: ''
-          suffix: ''
+          prefix: ""
+          suffix: ""
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          relationship: user_id_target_id
+          group_type: sum
+          admin_label: ""
+          entity_type: user
+          entity_field: status
+          plugin_id: field
+          label: "Active users in section"
+          exclude: false
+          alter:
+            alter_text: false
+            text: ""
+            make_link: true
+            path: "taxonomy/term/{{ section_id_1 }}/people"
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ""
+            rel: ""
+            link_class: ""
+            prefix: ""
+            suffix: ""
+            target: ""
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ""
+            more_link_path: ""
+            strip_tags: false
+            trim: false
+            preserve_tags: ""
+            html: false
+          element_type: ""
+          element_class: ""
+          element_label_type: ""
+          element_label_class: ""
+          element_label_colon: true
+          element_wrapper_type: ""
+          element_wrapper_class: ""
+          element_default_classes: true
+          empty: ""
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings: {}
+          group_column: value
+          group_columns: {}
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ", "
+          field_api_classes: false
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: 0
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ""
+          suffix: ""
       pager:
         type: full
         options:
@@ -284,14 +355,14 @@ display:
           tags:
             next: ››
             previous: ‹‹
-            first: '« First'
-            last: 'Last »'
+            first: "« First"
+            last: "Last »"
           expose:
             items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_label: "Items per page"
+            items_per_page_options: "5, 10, 25, 50"
             items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
+            items_per_page_options_all_label: "- All -"
             offset: false
             offset_label: Offset
           quantity: 9
@@ -301,7 +372,7 @@ display:
           submit_button: Apply
           reset_button: false
           reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
+          exposed_sorts_label: "Sort by"
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
@@ -312,8 +383,8 @@ display:
             administrator: administrator
       cache:
         type: tag
-        options: {  }
-      empty: {  }
+        options: {}
+      empty: {}
       sorts:
         user_id_target_id:
           id: user_id_target_id
@@ -321,16 +392,16 @@ display:
           field: user_id_target_id
           relationship: none
           group_type: count_distinct
-          admin_label: ''
+          admin_label: ""
           entity_type: section_association
           entity_field: user_id
           plugin_id: standard
           order: ASC
           expose:
-            label: ''
-            field_identifier: ''
+            label: ""
+            field_identifier: ""
           exposed: false
-      arguments: {  }
+      arguments: {}
       filters:
         access_scheme:
           id: access_scheme
@@ -349,66 +420,85 @@ display:
       style:
         type: table
         options:
-          grouping: {  }
-          row_class: ''
+          grouping: {}
+          row_class: ""
           default_row_class: true
           columns:
             section_id_1: section_id_1
             id: id
             section_id: section_id
             user_id_target_id: user_id_target_id
-          default: user_id_target_id
+            status: status
+          default: status
           info:
             section_id_1:
               sortable: false
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             id:
               sortable: false
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             section_id:
               sortable: false
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
             user_id_target_id:
               sortable: true
               default_sort_order: asc
-              align: ''
-              separator: ''
+              align: ""
+              separator: ""
               empty_column: false
-              responsive: ''
+              responsive: ""
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ""
+              separator: ""
+              empty_column: false
+              responsive: ""
           override: true
           sticky: false
-          summary: ''
+          summary: ""
           empty_table: false
-          caption: ''
-          description: ''
+          caption: ""
+          description: ""
       row:
         type: fields
         options:
           default_field_elements: true
-          inline: {  }
-          separator: ''
+          inline: {}
+          separator: ""
           hide_empty: false
       query:
         type: views_query
         options:
-          query_comment: ''
+          query_comment: ""
           disable_sql_rewrite: false
           distinct: false
           replica: false
-          query_tags: {  }
-      relationships: {  }
+          query_tags: {}
+      relationships:
+        user_id_target_id:
+          id: user_id_target_id
+          table: section_association__user_id
+          field: user_id_target_id
+          relationship: none
+          group_type: group
+          admin_label: User
+          entity_type: section_association
+          entity_field: user_id
+          plugin_id: standard
+          required: false
       group_by: true
       header:
         area:
@@ -417,28 +507,28 @@ display:
           field: area
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: ""
           plugin_id: text
           empty: false
           content:
             value: 'A <b>Section name</b> of "N/A" is  a replacement for that field when there are no results. Any such sections can be ignored.'
             format: rich_text
           tokenize: false
-      footer: {  }
+      footer: {}
       display_extenders:
         jsonapi_views:
           enabled: true
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
+        - "languages:language_content"
+        - "languages:language_interface"
         - url.query_args
         - user.roles
-      tags: {  }
+      tags: {}
   data_export_1:
     id: data_export_1
-    display_title: 'Data export'
+    display_title: "Data export"
     display_plugin: data_export
     position: 1
     display_options:
@@ -448,13 +538,13 @@ display:
           formats:
             csv: csv
           csv_settings:
-            delimiter: ','
+            delimiter: ","
             enclosure: '"'
             escape_char: \
             strip_tags: true
             trim: true
             encoding: utf8
-            utf8_bom: '0'
+            utf8_bom: "0"
             use_serializer_encode_only: false
             output_header: true
           xml_settings:
@@ -462,14 +552,14 @@ display:
             root_node_name: response
             item_node_name: item
             format_output: false
-      display_description: ''
+      display_description: ""
       display_extenders:
         jsonapi_views:
           enabled: true
       path: admin/people/users_per_section_csv
       displays:
         page_1: page_1
-        default: '0'
+        default: "0"
       filename: users_per_section.csv
       automatic_download: true
       export_method: standard
@@ -481,41 +571,41 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
+        - "languages:language_content"
+        - "languages:language_interface"
         - request_format
         - user.roles
-      tags: {  }
+      tags: {}
   page_1:
     id: page_1
     display_title: Page
     display_plugin: page
     position: 1
     display_options:
-      display_description: ''
+      display_description: ""
       display_extenders:
         jsonapi_views:
           enabled: true
       path: admin/people/users_per_section
       menu:
         type: normal
-        title: 'Users per section'
-        description: ''
+        title: "Users per section"
+        description: ""
         weight: 10
         expanded: false
         menu_name: admin
         parent: entity.user.collection
-        context: '0'
+        context: "0"
         as_local_task: true
-        local_task_link_title: ''
-        local_task_parent: 'views_view:view.users_per_section.section_member_page'
+        local_task_link_title: ""
+        local_task_parent: "views_view:view.users_per_section.section_member_page"
         local_task_weight: 0
-        local_task_custom_parent_route: ''
+        local_task_custom_parent_route: ""
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
+        - "languages:language_content"
+        - "languages:language_interface"
         - url.query_args
         - user.roles
-      tags: {  }
+      tags: {}


### PR DESCRIPTION
## Description

Relates to #23642 

Adds user status to 2 views:
- users_in_section
- users_per_section

### Generated description
(Select this text, hit the Copilot button, and select "Generate".)

## Testing done
Manually

## Screenshots
### Users per section
<img width="960" height="597" alt="image" src="https://github.com/user-attachments/assets/024e4ab8-114d-4ffa-a214-07b84f97ef78" />

### Users in section
<img width="960" height="564" alt="image" src="https://github.com/user-attachments/assets/62746b9d-f01e-4b13-9d6d-14b8023f471c" />


## QA steps
- [ ] Log in as an admin
- [ ] Go to `/admin/people/users_per_section`
- [ ] Confirm that you see the column "Active users in section"
- [ ] Click on a number in that column
- [ ] Confirm that you see the Status column
- [ ] Confirm that the data in the column is either "Active" or "Blocked"


### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
