### PR TITLE
Conditionally remove edit button

### DIFF
--- a/docroot/themes/custom/vagovclaro/templates/layout/taxonomy-term--products.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/layout/taxonomy-term--products.html.twig
@@ -29,9 +29,6 @@
     'vocabulary-' ~ term.bundle|clean_class,
   ]
 %}
-{%
-  set hide_contextual_links = term.bundle == 'health_care_service_taxonomy' and view_mode in ['vamc_facility_service', 'vba_facility_service', 'vet_center_service']
-%}
 <div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
   {% if not hide_contextual_links %}
     {{ title_prefix }}

--- a/docroot/themes/custom/vagovclaro/templates/layout/taxonomy-term.html.twig
+++ b/docroot/themes/custom/vagovclaro/templates/layout/taxonomy-term.html.twig
@@ -29,9 +29,6 @@
     'vocabulary-' ~ term.bundle|clean_class,
   ]
 %}
-{%
-  set hide_contextual_links = term.bundle == 'health_care_service_taxonomy' and view_mode in ['vamc_facility_service', 'vba_facility_service', 'vet_center_service']
-%}
 <div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
   {% if not hide_contextual_links %}
     {{ title_prefix }}

--- a/docroot/themes/custom/vagovclaro/vagovclaro.theme
+++ b/docroot/themes/custom/vagovclaro/vagovclaro.theme
@@ -624,3 +624,28 @@ function vagovclaro_preprocess_page(&$variables) {
   // Creating a url variable to track if we are on the landing page for KB.
   $variables['url'] = $_SERVER['REQUEST_URI'];
 }
+
+/**
+ * Implements hook_preprocess_taxonomy_term().
+ */
+function vagovclaro_preprocess_taxonomy_term(&$variables) {
+  $variables['hide_contextual_links'] = FALSE;
+
+  if (empty($variables['term']) || empty($variables['view_mode'])) {
+    return;
+  }
+
+  $is_health_service_term = $variables['term']->bundle() === 'health_care_service_taxonomy';
+  $target_view_modes = ['vamc_facility_service', 'vba_facility_service', 'vet_center_service'];
+  $is_target_view_mode = in_array($variables['view_mode'], $target_view_modes, TRUE);
+
+  if (!$is_health_service_term || !$is_target_view_mode) {
+    return;
+  }
+
+  $roles = \Drupal::currentUser()->getRoles();
+  $is_content_admin = in_array('content_admin', $roles, TRUE);
+  $is_administrator = in_array('administrator', $roles, TRUE);
+
+  $variables['hide_contextual_links'] = $is_content_admin && !$is_administrator;
+}


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21619

Removes the edit button depending on taxonomy type.

This change is scoped to the taxonomy term view displays that are marked as nationally managed (they include the “Why can’t I edit this?” national-service tooltip text), to avoid affecting unrelated taxonomy contexts.

- [`core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vamc_facility_service.yml`](https://github.com/department-of-veterans-affairs/va.gov-cms/blob/main/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vamc_facility_service.yml)
- [`core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vba_facility_service.yml`](https://github.com/department-of-veterans-affairs/va.gov-cms/blob/main/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vba_facility_service.yml)
- [`core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vet_center_service.yml`](https://github.com/department-of-veterans-affairs/va.gov-cms/blob/main/config/sync/core.entity_view_display.taxonomy_term.health_care_service_taxonomy.vet_center_service.yml)

## Testing done

https://va-gov-cms.ddev.site/lakeland-vet-center
- Tested that edit button is removed on the services mentioned in the ticket

https://va-gov-cms.ddev.site/help/how-to-use-the-pdf-media-library
- Tested that edit button is still present


