### PR TITLE
System banner WSOD fix: check paragraph instance type

### DIFF
--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1081,8 +1081,16 @@ function va_gov_backend_field_widget_single_element_paragraphs_form_alter(&$elem
   if (in_array($paragraph_entity_reference_field_name, $target_paragraph_ref_fields)) {
     $widget_state = WidgetBase::getWidgetState($element['#field_parents'], $paragraph_entity_reference_field_name, $form_state);
 
-    $paragraph_instance = $widget_state['paragraphs'][$element['#delta']]['entity'];
-    $paragraph_type = $paragraph_instance->bundle();
+    $paragraph_instance = $widget_state['paragraphs'][$element['#delta']]['entity'] ?? NULL;
+    if ($paragraph_instance instanceof EntityInterface) {
+      $paragraph_type = $paragraph_instance->bundle();
+    }
+    elseif (!empty($element['#paragraph_type'])) {
+      $paragraph_type = $element['#paragraph_type'];
+    }
+    else {
+      return;
+    }
 
     if ($paragraph_type === 'q_a') {
       _va_gov_backend_restrict_qa_answer_types($element);


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21391

Solves WSOD by adding a guard around setting the paragraph_type, checking that the widget paragraph element is a EntityInterface type first. This prevents ->bundle() from being called and causing a fatal error.

Otherwise, paragraph_type falls back to $element['#paragraph_type'] as is used elsewhere.

## Testing done

- Reproduced error in tugboat
- Confirmed error no longer happens on this PR's tugboat
  - Tested that the page still works correctly

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
