### PR TITLE
Revert "VACMS-20193: Adds Germany and South Korea as states in address module."

### DIFF
--- a/docroot/modules/custom/va_gov_address/src/EventSubscriber/AddPhilippinesAsStateSubscriber.php
+++ b/docroot/modules/custom/va_gov_address/src/EventSubscriber/AddPhilippinesAsStateSubscriber.php
@@ -7,12 +7,12 @@ use Drupal\address\Event\SubdivisionsEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Adds select countries to the US States.
+ * Adds a Philippines to the US States.
  *
  * This class follows the Centarro guidelines:
  * https://docs.drupalcommerce.org/v2/developer-guide/customers/addresses/#how-do-i-add-or-modify-subdivisions-for-a-country.
  */
-class AddCountriesAsStatesSubscriber implements EventSubscriberInterface {
+class AddPhilippinesAsStateSubscriber implements EventSubscriberInterface {
 
   /**
    * {@inheritdoc}
@@ -42,25 +42,7 @@ class AddCountriesAsStatesSubscriber implements EventSubscriberInterface {
       'country_code' => 'US',
       'id' => 'PH',
     ];
-    // Add Germany as a state.
-    $definitions['subdivisions']['DE'] = [
-      'code' => 'DE',
-      'name' => 'Germany',
-      'country_code' => 'US',
-      'id' => 'DE',
-    ];
-    // Add South Korea as a state.
-    $definitions['subdivisions']['KR'] = [
-      'code' => 'KR',
-      'name' => 'South Korea',
-      'country_code' => 'US',
-      'id' => 'KR',
-    ];
-
-    // Sort subdivisions by name.
-    uasort($definitions['subdivisions'], function ($a, $b) {
-      return strcmp($a['name'], $b['name']);
-    });
+    ksort($definitions['subdivisions']);
     $event->setDefinitions($definitions);
   }
 

--- a/docroot/modules/custom/va_gov_address/va_gov_address.services.yml
+++ b/docroot/modules/custom/va_gov_address/va_gov_address.services.yml
@@ -1,6 +1,6 @@
 services:
-  va_gov_address.add_countries_as_states_subscriber:
-    class: Drupal\va_gov_address\EventSubscriber\AddCountriesAsStatesSubscriber
+  va_gov_address.add_philippines_as_state_subscriber:
+    class: Drupal\va_gov_address\EventSubscriber\AddPhilippinesAsStateSubscriber
     arguments: ['@address.subdivision_repository']
     tags:
       - { name: event_subscriber }

--- a/tests/phpunit/va_gov_address/unit/EventSubscriber/AddPhilippinesAsStateSubscriberTest.php
+++ b/tests/phpunit/va_gov_address/unit/EventSubscriber/AddPhilippinesAsStateSubscriberTest.php
@@ -5,31 +5,31 @@ namespace tests\phpunit\va_gov_address\unit\EventSubscriber;
 use Drupal\address\Event\AddressEvents;
 use Drupal\address\Event\SubdivisionsEvent;
 use Drupal\Tests\UnitTestCase;
-use Drupal\va_gov_address\EventSubscriber\AddCountriesAsStatesSubscriber;
+use Drupal\va_gov_address\EventSubscriber\AddPhilippinesAsStateSubscriber;
 use Prophecy\Argument;
 
 /**
  * Tests custom US address group.
  *
- * @coversDefaultClass \Drupal\va_gov_address\EventSubscriber\AddCountriesAsStatesSubscriber
+ * @coversDefaultClass \Drupal\va_gov_address\EventSubscriber\AddPhilippinesAsStateSubscriber
  *
  * @group va_gov_address
  */
-class AddCountriesAsStatesSubscriberTest extends UnitTestCase {
+class AddPhilippinesAsStateSubscriberTest extends UnitTestCase {
 
   /**
    * The event subscriber under test.
    *
-   * @var \Drupal\va_gov_address\EventSubscriber\AddCountriesAsStatesSubscriber
+   * @var \Drupal\va_gov_address\EventSubscriber\AddPhilippinesAsStateSubscriber
    */
-  protected AddCountriesAsStatesSubscriber $subscriber;
+  protected AddPhilippinesAsStateSubscriber $subscriber;
 
   /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->subscriber = new AddCountriesAsStatesSubscriber();
+    $this->subscriber = new AddPhilippinesAsStateSubscriber();
   }
 
   /**
@@ -38,7 +38,7 @@ class AddCountriesAsStatesSubscriberTest extends UnitTestCase {
    * @covers ::getSubscribedEvents
    */
   public function testGetSubscribedEvents() {
-    $events = AddCountriesAsStatesSubscriber::getSubscribedEvents();
+    $events = AddPhilippinesAsStateSubscriber::getSubscribedEvents();
     $this->assertArrayHasKey(AddressEvents::SUBDIVISIONS, $events);
     $this->assertIsArray($events[AddressEvents::SUBDIVISIONS]);
     $this->assertEquals(['onSubdivisions'], array_column($events[AddressEvents::SUBDIVISIONS], 0));
@@ -70,14 +70,9 @@ class AddCountriesAsStatesSubscriberTest extends UnitTestCase {
     // Set up expected calls for getParents() and setDefinitions().
     $event->getParents()->willReturn(['US']);
     $event->setDefinitions(Argument::that(function ($definitions) {
-      // Validate that Philippines (PH), Germany (DE), and South Korea (KR)
-      // are added as subdivisions.
+      // Validate that Philippines (PH) is added as a subdivision.
       return isset($definitions['subdivisions']['PH'])
-        && isset($definitions['subdivisions']['DE'])
-        && isset($definitions['subdivisions']['KR'])
-        && $definitions['subdivisions']['PH']['name'] === 'Philippines'
-        && $definitions['subdivisions']['DE']['name'] === 'Germany'
-        && $definitions['subdivisions']['KR']['name'] === 'South Korea';
+        && $definitions['subdivisions']['PH']['name'] === 'Philippines';
     }))->shouldBeCalled();
 
     // Call the onSubdivisions method.


### PR DESCRIPTION
Reverts department-of-veterans-affairs/va.gov-cms#23623

This is in response to a defect: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/23684