### PR TITLE
Set content release to start at 8 am ET.

### DIFF
--- a/docroot/modules/custom/va_gov_build_trigger/src/Traits/RunsDuringBusinessHours.php
+++ b/docroot/modules/custom/va_gov_build_trigger/src/Traits/RunsDuringBusinessHours.php
@@ -79,7 +79,7 @@ trait RunsDuringBusinessHours {
     $hour_of_day = $this->getDateFormatterService()->format($currentTime, 'custom', 'G', 'America/New_York', LanguageInterface::LANGCODE_NOT_APPLICABLE);
 
     $is_business_day = (1 <= $day_of_week && $day_of_week <= 5);
-    $is_business_hour = (9 <= $hour_of_day && $hour_of_day < 20);
+    $is_business_hour = (8 <= $hour_of_day && $hour_of_day < 20);
 
     return ($is_business_day && $is_business_hour);
   }


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/23687

This sets content release to start from 8 am rather than 9 am. 9 am was an artifact of an effort to deploy at 7 am.  This did not hold, so we can return to the generally understood time.

## QA steps
This will not be verifiable until it is on Production. You could potentially do something clever with `drush php:eval`, but it's not necessary. 