### PR TITLE
Fix j2cli for tugboat

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -87,9 +87,13 @@ services:
       # .tugboat/.env.j2 Jinja2 template file support
       # Remove externally managed marker causing error in bookworm when python3 tries to install packages
       - rm -f /usr/lib/python3.11/EXTERNALLY-MANAGED
-      - apt-get install python3-apt python3-pip python3-setuptools python3
+      - apt-get install python3-apt python3-pip python3
       - echo "export PATH=/var/lib/tugboat/bin:~/.local/bin:$PATH" >> ~/.bashrc
-      - pip3 install --break-system-packages j2cli
+      # jinjanator is the actively maintained successor to j2cli (which is
+      # abandoned and broken on Python 3.11+ due to pkg_resources removal).
+      - pip3 install --break-system-packages jinjanator
+      # Create a j2 symlink so existing j2 commands continue to work.
+      - ln -snf "$(which jinjanate)" /usr/local/bin/j2
 
       # Set Datadog agent config defaults
       - j2 "${TUGBOAT_ROOT}/.tugboat/datadog.yaml.j2" -o "/etc/datadog-agent/datadog.yaml"


### PR DESCRIPTION
## Description
This removes `j2cli` and replaces it with `jinjanate`. `j2cli` has been functionally abandoned. This fixes the error below:
<img width="941" height="513" alt="CleanShot2026-03-11at13 35 02" src="https://github.com/user-attachments/assets/25955afa-817b-43bc-b92f-945b92041236" />


### Generated description

This pull request updates the `.tugboat/config.yml` setup steps to improve Python Jinja2 template support and address compatibility issues with Python 3.11+. The changes switch from the abandoned `j2cli` to the actively maintained `jinjanator`, ensure compatibility with newer Python versions, and maintain backward compatibility for existing commands.

**Python/Jinja2 template toolchain improvements:**

* Replaces the deprecated and broken `j2cli` with `jinjanator`, which is actively maintained and compatible with Python 3.11+; installs `jinjanator` using pip with the `--break-system-packages` flag.
* Adds a symlink from `jinjanator`'s executable to `j2` to preserve compatibility with existing scripts that invoke `j2`.

**Python installation and compatibility fixes:**

* Removes the externally managed marker file (`/usr/lib/python3.11/EXTERNALLY-MANAGED`) using `rm -f` to avoid errors when installing Python packages on Debian Bookworm.
* Installs `python3-pip` directly instead of using the `get-pip.py` bootstrap script, simplifying the setup and avoiding issues with the externally managed environment.

## Testing done
Tested here https://tugboat.vfs.va.gov/69b190ab343c501b6fc9c003

## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

Verify testing worked. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
