### PR TITLE
VACMS-23532 - added comment around lock breaking.

### DIFF
--- a/docroot/modules/custom/va_gov_backend/src/Commands/TestCleanupCommands.php
+++ b/docroot/modules/custom/va_gov_backend/src/Commands/TestCleanupCommands.php
@@ -87,6 +87,9 @@ class TestCleanupCommands extends DrushCommands {
         $entities = $storage->loadMultiple($ids);
         foreach ($entities as $entity) {
           try {
+            // This is not a clean way to break any locks that could exist.
+            // This will still print a warning if any content is locked,
+            // But it will delete the entity still.
             if (isset($entity->_contentModerationState)) {
               $entity->_contentModerationState->delete();
             }


### PR DESCRIPTION
## Description
Adds a comment around lock breaking in the entity cleanup drush command.

Relates to #23532 


