### PR TITLE
VACMS-23576: Sprint 5 module updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -15611,23 +15611,24 @@
         },
         {
             "name": "drupal/views_bulk_edit",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/views_bulk_edit.git",
-                "reference": "3.0.0"
+                "reference": "3.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/views_bulk_edit-3.0.0.zip",
-                "reference": "3.0.0",
-                "shasum": "3b16079aa95fb4834561fcfd1197cce73b7f4b88"
+                "url": "https://ftp.drupal.org/files/projects/views_bulk_edit-3.0.1.zip",
+                "reference": "3.0.1",
+                "shasum": "8105257937e3a39e3814a526fcbe996b4c90fe5d"
             },
             "require": {
                 "drupal/core": "^9.4 || ^10 || ^11",
                 "php": ">=8.1"
             },
             "require-dev": {
+                "drupal/action": "^0.2",
                 "drupal/views_bulk_operations": "~4.2.4"
             },
             "suggest": {
@@ -15636,8 +15637,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0",
-                    "datestamp": "1725358398",
+                    "version": "3.0.1",
+                    "datestamp": "1769429619",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Description

Relates to #23576

Updates the following modules:

| Module | Current version | New version |
| --- | ---- | --- |
| ai_agents                     | 1.2.1 | 1.2.3 |
| eca                           | 2.1.17 | 2.1.18 |
| entity_reference_unpublished  | 2.0.1 | 2.0.2 |
| flood_control                 | 3.0.0 | 3.0.1 |
| geofield_map                  | 11.1.0 | 11.1.7 |
| hierarchy_manager             | 3.4.1 | 3.4.2 |
| linkyreplacer                 | 2.4.1 | 2.4.2 |
| pfm                           | 2.0.0 | 2.0.1 |
| queue_ui                      | 3.2.2 | 3.2.3 |
| upgrade_status                | 4.3.8 | 4.3.9 |
| views_bulk_edit               | 3.0.0 | 3.0.1 |

## Testing done
Manually

## Screenshots


## QA steps
### ai_agents
- Nothing to test. It's not installed.
### eca 
- [x] In the Tugboat terminal, run `drush advancedqueue:queue:list`
- [x] Confirm that the `warn_inactive_users` has no items queued
- [x] In the Tugboat terminal, run `drush eca:trigger:custom_event inactive_users_warn_60_days`
- [x] Confirm that there is some list of users in the terminal output
- [x] In the Tugboat terminal, run `drush advancedqueue:queue:list`
- [x] Confirm that the `warn_inactive_users` has some items queued
- [x] In the Tugboat terminal, run `drush advancedqueue:queue:process warn_inactive_users`
- [x] Confirm that terminal output shows success
- [x] In the Tugboat terminal, run `drush advancedqueue:queue:list`
- [x] Confirm that the `warn_inactive_users` has some items succeeded
### entity_reference_unpublished
- [x] As a content admin, go to a benefits hub landing page
- [x] Click alert
- [x] Choose an item "False" under **Published**
- [x] Add the first item
### flood_control 
- [x] As admin, go to /admin/config/people/flood-control
- [x] Set IP login limit to 1
- [x] In another browser, try to log in as a user, but use the wrong credentials
- [x] Do it again
- [ ] Confirm that you get a screen about too many failed login attempts
### geofield_map
- [x] Go to a Vet Center CAP
- [x] Change the address to one you know
- [x] Choose **Save and continue editing**
- [x] Confirm that the map has changed.
### hierarchy_manager
- [x] Go to `/admin/structure/taxonomy/manage/administration/overview` and make sure it looks OOTB drupal
- [x] As admin, go to `/admin/config/user-interface/hierarchy_manager/config`
- [x] Check the Taxonomy hierarchy setup plugin checkbox
- [x] Check the **Sections** under **Enabled bundles**
- [x] Go to `/admin/structure/taxonomy/manage/administration/overview`and see that there's a jquery-based, drag-and-droppable tree UI for managing terms
- [x] Test moving around some terms
- [x] Go back to `/admin/config/user-interface/hierarchy_manager/config` and uncheck Taxonomy hierarchy setup plugin checkbox (restoring config to its code status)
- [x] Go to `admin/structure/taxonomy/manage/administration/overview` and make sure it looks OOTB drupal
### linkyreplacer
- [x] As an administrator, go to `/node/44231/edit`, and enter a link to "https://www.google.com", and save the node as published
- [x] On node view visually verify link to "https://www.google.com"
- [x] Go to `/node/44232/edit`, and enter a link to "https://www.google.com, and save the node as published
- [x] On node view visually verify link to "https://www.google.com"
- [x] Go to /admin/content/linky, find link to "https://www.google.com", and edit the link to "https://www.merriam-webster.com/dictionary/test"
- [x] Clear cache
- [x] Visit `/node/44231` & `/node/44232` and visually verify link has been updated to "https://www.merriam-webster.com/dictionary/test"
### pfm
- [x] Go to admin/people/pfm-permissions
- [x] Click on the PFM permissions tab
- [x] Spot check filtering by various modules and roles
### queue_ui
- [x] Go to a Staff Profile
- [x] Upload an image
- [x] Go to /admin/config/system/queue-ui
- [x] Note that the "Pregenerate image" should have at least 1 item
- [x] Click "Inspect"
- [x] Click "View" on the top (or inly item)
- [x] Confirm that there is data in the entry
### upgrade_status
- [x] Go to /admin/reports/upgrade-status on prod
- [x] Go to /admin/reports/upgrade-status in Tugboat. 
- [x] Confirm that they show the same status
### views_bulk_edit
- [x] Go to `/admin/content/bulk`
- [x] Filter for the "Story" content type
- [x] Select the first 2 items
- [x] Click **Action**
- [x] Choose "Modify field values"
- [x] Click **Apply to selected items**
- [x] Click the **Title** checkbox
- [x] Add a word or string of letters
- [x] Click **Append to the current value**
- [x] Add a revision message
- [x] Click **Apply**
- [x] Click **Execute action**
- [x] Confirm that the titles of the two stories now have the value added

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
