### PR TITLE
VACMS-23809: Replace browser-based MaxDepthTest with direct config API check

### DIFF
--- a/tests/phpunit/va_gov_magichead/functional/Field/MaxDepthTest.php
+++ b/tests/phpunit/va_gov_magichead/functional/Field/MaxDepthTest.php
@@ -16,13 +16,11 @@ class MaxDepthTest extends VaGovExistingSiteBase {
    * Tests that the max depth has a correct default value.
    */
   public function testMaxDepthDefaultValue() {
-    $user = $this->createUser([], 'Admin', TRUE);
-    $this->drupalLogin($user);
-    $this->drupalGet('/admin/structure/taxonomy/manage/va_benefits_taxonomy/overview/fields/taxonomy_term.va_benefits_taxonomy.field_va_benefit_eligibility_ov');
-    $this->assertSession()->pageTextContains('The maximum depth of a magichead item.');
-    $elements = $this->cssSelect('#edit-settings-max-depth');
-    $this->assertCount(1, $elements);
-    $this->assertSame($elements[0]->getValue(), '2');
+    $field_config = \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->load('taxonomy_term.va_benefits_taxonomy.field_va_benefit_eligibility_ov');
+    $this->assertNotNull($field_config, 'Field config exists.');
+    $this->assertSame(2, $field_config->getSetting('max_depth'));
   }
 
 }


### PR DESCRIPTION
## Summary

Relates to: #23809

- `MaxDepthTest::testMaxDepthDefaultValue` was consistently failing at the end of the full PHPUnit suite (test 380/380) with a `cURL error 6: getaddrinfo() thread failed to start` DNS failure when fetching `druplicon.png`
- After 40+ minutes and 11+ GB of memory usage, the DNS resolver thread pool was exhausted by the browser-based test making a full admin page load
- Replaced the browser-based approach (user creation, login, `drupalGet`, CSS selects) with a direct Drupal config API check via `field_config` entity storage

## Screenshots
Fixes:
<img width="1671" height="832" alt="Screenshot 2026-03-30 at 10 42 33 AM" src="https://github.com/user-attachments/assets/b6f7159d-1f94-4c08-962d-60f29917f6f5" />


## Testing Done
Locally, and CI

## QA
- [ ] Verify `MaxDepthTest` passes when run individually: `bin/phpunit tests/phpunit/va_gov_magichead/functional/Field/MaxDepthTest.php`
- [ ] Verify the full functional suite passes in Tugboat CI without the DNS error at test 380/380