### PR TITLE
VACMS-17085: Implement VAMC system level mental health number

### DIFF
--- a/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.default.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_supplemental_status_more_i
     - field.field.node.health_care_local_facility.field_telephone
     - field.field.node.health_care_local_facility.field_timezone
+    - field.field.node.health_care_local_facility.field_use_default_mental_health
     - node.type.health_care_local_facility
     - workflows.workflow.editorial
   module:
@@ -218,7 +219,7 @@ third_party_settings:
         required_fields: false
     group_mental_health_phone_number:
       children:
-        - field_mental_health_phone
+        - field_use_default_mental_health
         - field_telephone
       label: 'Mental health phone number'
       region: content
@@ -382,7 +383,7 @@ content:
     third_party_settings: {  }
   field_telephone:
     type: entity_reference_paragraphs
-    weight: 22
+    weight: 32
     region: content
     settings:
       title: 'phone number'
@@ -397,6 +398,13 @@ content:
     weight: 30
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_use_default_mental_health:
+    type: boolean_checkbox
+    weight: 31
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   flag:
     weight: 12

--- a/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
+++ b/config/sync/core.entity_form_display.node.health_care_local_facility.inline_entity_form.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_supplemental_status_more_i
     - field.field.node.health_care_local_facility.field_telephone
     - field.field.node.health_care_local_facility.field_timezone
+    - field.field.node.health_care_local_facility.field_use_default_mental_health
     - node.type.health_care_local_facility
   module:
     - field_group
@@ -160,6 +161,7 @@ hidden:
   field_supplemental_status_more_i: true
   field_telephone: true
   field_timezone: true
+  field_use_default_mental_health: true
   flag: true
   langcode: true
   moderation_state: true

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.health_care_region_page.field_administration
     - field.field.node.health_care_region_page.field_appointments_online
     - field.field.node.health_care_region_page.field_clinical_health_services
+    - field.field.node.health_care_region_page.field_default_mental_health_phon
     - field.field.node.health_care_region_page.field_description
     - field.field.node.health_care_region_page.field_facebook
     - field.field.node.health_care_region_page.field_flickr
@@ -44,7 +45,7 @@ third_party_settings:
       label: 'Section settings'
       region: content
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -59,7 +60,7 @@ third_party_settings:
       label: 'Editorial Workflow'
       region: content
       parent_name: ''
-      weight: 11
+      weight: 12
       format_type: fieldset
       format_settings:
         classes: ''
@@ -189,7 +190,7 @@ third_party_settings:
       label: 'VA Health Connect and Health Records System'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: fieldset
       format_settings:
         classes: admin-editable
@@ -223,7 +224,7 @@ third_party_settings:
       label: 'System Menu'
       region: content
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -233,6 +234,22 @@ third_party_settings:
         description: ''
         required_fields: true
         weight: 0
+    group_default_mental_health_phon:
+      children:
+        - field_default_mental_health_phon
+      label: 'Default mental health phone number'
+      region: content
+      parent_name: ''
+      weight: 9
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        description: ''
+        required_fields: true
+        description_display: after
 id: node.health_care_region_page.default
 targetEntityType: node
 bundle: health_care_region_page
@@ -250,6 +267,18 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_default_mental_health_phon:
+    type: entity_reference_paragraphs
+    weight: 40
+    region: content
+    settings:
+      title: 'phone number'
+      title_plural: 'phone numbers'
+      edit_mode: open
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: phone_number
     third_party_settings: {  }
   field_description:
     type: string_textfield_with_counter
@@ -328,7 +357,7 @@ content:
     third_party_settings: {  }
   field_last_saved_by_an_editor:
     type: datetime_timestamp
-    weight: 40
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -359,7 +388,7 @@ content:
     third_party_settings: {  }
   field_related_links:
     type: paragraphs
-    weight: 22
+    weight: 21
     region: content
     settings:
       title: Link

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -249,6 +249,7 @@ third_party_settings:
         label_as_html: false
         description: ''
         required_fields: true
+        open: false
         description_display: after
 id: node.health_care_region_page.default
 targetEntityType: node
@@ -269,17 +270,31 @@ content:
       display_label: true
     third_party_settings: {  }
   field_default_mental_health_phon:
-    type: entity_reference_paragraphs
+    type: paragraphs
     weight: 40
     region: content
     settings:
       title: 'phone number'
       title_plural: 'phone numbers'
       edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
       default_paragraph_type: phone_number
-    third_party_settings: {  }
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        convert: '0'
+        duplicate: '0'
+    third_party_settings:
+      paragraphs_features:
+        add_in_between: false
+        add_in_between_link_count: 3
+        delete_confirmation: false
+        show_drag_and_drop: true
+        show_collapse_all: true
   field_description:
     type: string_textfield_with_counter
     weight: 5

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -270,31 +270,17 @@ content:
       display_label: true
     third_party_settings: {  }
   field_default_mental_health_phon:
-    type: paragraphs
+    type: entity_reference_paragraphs
     weight: 40
     region: content
     settings:
       title: 'phone number'
       title_plural: 'phone numbers'
       edit_mode: open
-      closed_mode: summary
-      autocollapse: none
-      closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
       default_paragraph_type: phone_number
-      features:
-        add_above: '0'
-        collapse_edit_all: collapse_edit_all
-        convert: '0'
-        duplicate: '0'
-    third_party_settings:
-      paragraphs_features:
-        add_in_between: false
-        add_in_between_link_count: 3
-        delete_confirmation: false
-        show_drag_and_drop: true
-        show_collapse_all: true
+    third_party_settings: {  }
   field_description:
     type: string_textfield_with_counter
     weight: 5

--- a/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_form_display.node.health_care_region_page.default.yml
@@ -247,9 +247,8 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         label_as_html: false
-        description: ''
+        description: 'This phone number will be the default mental health phone number for VAMC facilities in this system. You can override this at the facility level if there is a more specific number. For more guidance, read <a href="https://prod.cms.va.gov/help/vamc/how-to-add-or-edit-a-vamc-facility-mental-health-phone-number" target="_blank" rel="noopener noreferrer">the Knowledge Base article on mental health phone numbers (opens in a new window).</a>'
         required_fields: true
-        open: false
         description_display: after
 id: node.health_care_region_page.default
 targetEntityType: node

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.default.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_supplemental_status_more_i
     - field.field.node.health_care_local_facility.field_telephone
     - field.field.node.health_care_local_facility.field_timezone
+    - field.field.node.health_care_local_facility.field_use_default_mental_health
     - image.style.crop_3_2
     - node.type.health_care_local_facility
   module:
@@ -283,6 +284,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 22
+    region: content
+  field_use_default_mental_health:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 28
     region: content
   flag_email_node:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.external_content.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_supplemental_status_more_i
     - field.field.node.health_care_local_facility.field_telephone
     - field.field.node.health_care_local_facility.field_timezone
+    - field.field.node.health_care_local_facility.field_use_default_mental_health
     - node.type.health_care_local_facility
   module:
     - address
@@ -275,6 +276,7 @@ hidden:
   field_supplemental_status_more_i: true
   field_telephone: true
   field_timezone: true
+  field_use_default_mental_health: true
   flag_awaiting_csv: true
   flag_awaiting_editor: true
   flag_awaiting_redirect: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.ief_table.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_supplemental_status_more_i
     - field.field.node.health_care_local_facility.field_telephone
     - field.field.node.health_care_local_facility.field_timezone
+    - field.field.node.health_care_local_facility.field_use_default_mental_health
     - image.style.thumbnail
     - node.type.health_care_local_facility
   module:
@@ -128,6 +129,7 @@ hidden:
   field_supplemental_status_more_i: true
   field_telephone: true
   field_timezone: true
+  field_use_default_mental_health: true
   flag_awaiting_csv: true
   flag_awaiting_editor: true
   flag_awaiting_redirect: true

--- a/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_care_local_facility.teaser.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.node.health_care_local_facility.field_supplemental_status_more_i
     - field.field.node.health_care_local_facility.field_telephone
     - field.field.node.health_care_local_facility.field_timezone
+    - field.field.node.health_care_local_facility.field_use_default_mental_health
     - node.type.health_care_local_facility
   module:
     - user
@@ -106,5 +107,6 @@ hidden:
   field_supplemental_status_more_i: true
   field_telephone: true
   field_timezone: true
+  field_use_default_mental_health: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.health_care_region_page.field_administration
     - field.field.node.health_care_region_page.field_appointments_online
     - field.field.node.health_care_region_page.field_clinical_health_services
+    - field.field.node.health_care_region_page.field_default_mental_health_phon
     - field.field.node.health_care_region_page.field_description
     - field.field.node.health_care_region_page.field_facebook
     - field.field.node.health_care_region_page.field_flickr
@@ -28,6 +29,7 @@ dependencies:
     - image.style.large
     - node.type.health_care_region_page
   module:
+    - entity_reference_revisions
     - field_group
     - link
     - linkit
@@ -59,6 +61,7 @@ third_party_settings:
         - field_other_va_locations
         - field_appointments_online
         - field_clinical_health_services
+        - field_default_mental_health_phon
       label: Content
       parent_name: ''
       region: content
@@ -152,7 +155,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 10
+    weight: 8
     region: content
   field_clinical_health_services:
     type: entity_reference_label
@@ -160,7 +163,16 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 11
+    weight: 9
+    region: content
+  field_default_mental_health_phon:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 26
     region: content
   field_description:
     type: string
@@ -264,7 +276,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 8
+    weight: 7
     region: content
   field_related_links:
     type: paragraph_summary

--- a/config/sync/core.entity_view_display.node.health_care_region_page.external_content.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.external_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.health_care_region_page.field_administration
     - field.field.node.health_care_region_page.field_appointments_online
     - field.field.node.health_care_region_page.field_clinical_health_services
+    - field.field.node.health_care_region_page.field_default_mental_health_phon
     - field.field.node.health_care_region_page.field_description
     - field.field.node.health_care_region_page.field_facebook
     - field.field.node.health_care_region_page.field_flickr
@@ -154,6 +155,7 @@ hidden:
   field_administration: true
   field_appointments_online: true
   field_clinical_health_services: true
+  field_default_mental_health_phon: true
   field_description: true
   field_facebook: true
   field_flickr: true

--- a/config/sync/core.entity_view_display.node.health_care_region_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_care_region_page.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.health_care_region_page.field_administration
     - field.field.node.health_care_region_page.field_appointments_online
     - field.field.node.health_care_region_page.field_clinical_health_services
+    - field.field.node.health_care_region_page.field_default_mental_health_phon
     - field.field.node.health_care_region_page.field_description
     - field.field.node.health_care_region_page.field_facebook
     - field.field.node.health_care_region_page.field_flickr
@@ -58,6 +59,7 @@ hidden:
   field_administration: true
   field_appointments_online: true
   field_clinical_health_services: true
+  field_default_mental_health_phon: true
   field_description: true
   field_facebook: true
   field_flickr: true

--- a/config/sync/field.field.node.health_care_local_facility.field_use_default_mental_health.yml
+++ b/config/sync/field.field.node.health_care_local_facility.field_use_default_mental_health.yml
@@ -1,0 +1,26 @@
+uuid: e1f3bd90-2b8b-4f37-a1e1-5a420ee7a59f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_use_default_mental_health
+    - node.type.health_care_local_facility
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.health_care_local_facility.field_use_default_mental_health
+field_name: field_use_default_mental_health
+entity_type: node
+bundle: health_care_local_facility
+label: 'Use the default mental health number for this VAMC system?'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
@@ -17,7 +17,7 @@ field_name: field_default_mental_health_phon
 entity_type: node
 bundle: health_care_region_page
 label: 'Default mental health phone number'
-description: 'This phone number will be the default mental health phone number for VAMC facilities in this system. You can override this at the facility level if there is a more specific number. For more guidance, read <a href="https://prod.cms.va.gov/help/vamc/how-to-add-or-edit-a-vamc-facility-mental-health-phone-number" target="_blank" rel="noopener noreferrer">the Knowledge Base article on mental health phone numbers (opens in a new window).</a>'
+description: ''
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
@@ -18,7 +18,7 @@ entity_type: node
 bundle: health_care_region_page
 label: 'Default mental health phone number'
 description: 'This phone number will be the default mental health phone number for VAMC facilities in this system. You can override this at the facility level if there is a more specific number. For more guidance, read <a href="https://prod.cms.va.gov/help/vamc/how-to-add-or-edit-a-vamc-facility-mental-health-phone-number">the Knowledge Base article on mental health phone numbers (opens in a new window).</a>'
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
@@ -17,7 +17,7 @@ field_name: field_default_mental_health_phon
 entity_type: node
 bundle: health_care_region_page
 label: 'Default mental health phone number'
-description: 'This phone number will be the default mental health phone number for VAMC facilities in this system. You can override this at the facility level if there is a more specific number. For more guidance, read <a href="https://prod.cms.va.gov/help/vamc/how-to-add-or-edit-a-vamc-facility-mental-health-phone-number">the Knowledge Base article on mental health phone numbers (opens in a new window).</a>'
+description: 'This phone number will be the default mental health phone number for VAMC facilities in this system. You can override this at the facility level if there is a more specific number. For more guidance, read <a href="https://prod.cms.va.gov/help/vamc/how-to-add-or-edit-a-vamc-facility-mental-health-phone-number" target="_blank" rel="noopener noreferrer">the Knowledge Base article on mental health phone numbers (opens in a new window).</a>'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
+++ b/config/sync/field.field.node.health_care_region_page.field_default_mental_health_phon.yml
@@ -1,0 +1,212 @@
+uuid: 70a66d07-3e56-4761-b654-e25d9ee669f0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_default_mental_health_phon
+    - node.type.health_care_region_page
+    - paragraphs.paragraphs_type.phone_number
+  module:
+    - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.health_care_region_page.field_default_mental_health_phon
+field_name: field_default_mental_health_phon
+entity_type: node
+bundle: health_care_region_page
+label: 'Default mental health phone number'
+description: 'This phone number will be the default mental health phone number for VAMC facilities in this system. You can override this at the facility level if there is a more specific number. For more guidance, read <a href="https://prod.cms.va.gov/help/vamc/how-to-add-or-edit-a-vamc-facility-mental-health-phone-number">the Knowledge Base article on mental health phone numbers (opens in a new window).</a>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      phone_number: phone_number
+    negate: 0
+    target_bundles_drag_drop:
+      address:
+        weight: 61
+        enabled: false
+      alert:
+        weight: 62
+        enabled: false
+      alert_single:
+        weight: 63
+        enabled: false
+      audience_topics:
+        weight: 64
+        enabled: false
+      basic_accordion:
+        weight: 65
+        enabled: false
+      button:
+        weight: 66
+        enabled: false
+      centralized_content_descriptor:
+        weight: 67
+        enabled: false
+      checklist:
+        weight: 68
+        enabled: false
+      checklist_item:
+        weight: 69
+        enabled: false
+      collapsible_panel:
+        weight: 70
+        enabled: false
+      collapsible_panel_item:
+        weight: 71
+        enabled: false
+      contact_information:
+        weight: 72
+        enabled: false
+      digital_form_address:
+        weight: 73
+        enabled: false
+      digital_form_checkbox:
+        weight: 74
+        enabled: false
+      digital_form_custom_step:
+        weight: 75
+        enabled: false
+      digital_form_date_component:
+        weight: 76
+        enabled: false
+      digital_form_identification_info:
+        weight: 77
+        enabled: false
+      digital_form_list_loop:
+        weight: 78
+        enabled: false
+      digital_form_name_and_date_of_bi:
+        weight: 79
+        enabled: false
+      digital_form_page:
+        weight: 80
+        enabled: false
+      digital_form_phone_and_email:
+        weight: 81
+        enabled: false
+      digital_form_radio_button:
+        weight: 82
+        enabled: false
+      digital_form_response_option:
+        weight: 83
+        enabled: false
+      digital_form_text_area:
+        weight: 84
+        enabled: false
+      digital_form_text_input:
+        weight: 85
+        enabled: false
+      digital_form_your_personal_info:
+        weight: 86
+        enabled: false
+      downloadable_file:
+        weight: 87
+        enabled: false
+      email_contact:
+        weight: 88
+        enabled: false
+      embedded_video:
+        weight: 89
+        enabled: false
+      expandable_text:
+        weight: 90
+        enabled: false
+      featured_content:
+        weight: 91
+        enabled: false
+      health_care_local_facility_servi:
+        weight: 92
+        enabled: false
+      link_teaser:
+        weight: 93
+        enabled: false
+      link_teaser_with_image:
+        weight: 94
+        enabled: false
+      list_loop_employment_history:
+        weight: 96
+        enabled: false
+      list_of_link_teasers:
+        weight: 98
+        enabled: false
+      list_of_links:
+        weight: 97
+        enabled: false
+      lists_of_links:
+        weight: 95
+        enabled: false
+      magichead_group:
+        weight: 99
+        enabled: false
+      media:
+        weight: 100
+        enabled: false
+      media_list_images:
+        weight: 101
+        enabled: false
+      media_list_videos:
+        weight: 102
+        enabled: false
+      non_reusable_alert:
+        weight: 103
+        enabled: false
+      number_callout:
+        weight: 104
+        enabled: false
+      phone_number:
+        weight: 105
+        enabled: true
+      process:
+        weight: 106
+        enabled: false
+      q_a:
+        weight: 107
+        enabled: false
+      q_a_group:
+        weight: 108
+        enabled: false
+      q_a_section:
+        weight: 109
+        enabled: false
+      react_widget:
+        weight: 110
+        enabled: false
+      rich_text_char_limit_1000:
+        weight: 111
+        enabled: false
+      service_location:
+        weight: 112
+        enabled: false
+      service_location_address:
+        weight: 113
+        enabled: false
+      situation_update:
+        weight: 114
+        enabled: false
+      spanish_translation_summary:
+        weight: 115
+        enabled: false
+      staff_profile:
+        weight: 116
+        enabled: false
+      step:
+        weight: 117
+        enabled: false
+      step_by_step:
+        weight: 118
+        enabled: false
+      table:
+        weight: 119
+        enabled: false
+      wysiwyg:
+        weight: 120
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.storage.node.field_default_mental_health_phon.yml
+++ b/config/sync/field.storage.node.field_default_mental_health_phon.yml
@@ -1,0 +1,21 @@
+uuid: 77f6a29f-39a5-4d80-870e-2bff05e97d14
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_default_mental_health_phon
+field_name: field_default_mental_health_phon
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_use_default_mental_health.yml
+++ b/config/sync/field.storage.node.field_use_default_mental_health.yml
@@ -1,0 +1,18 @@
+uuid: fcc19420-eaa5-46c0-9751-61c0eeda3fff
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_use_default_mental_health
+field_name: field_use_default_mental_health
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.va_node_health_care_local_facility.yml
+++ b/config/sync/migrate_plus.migration.va_node_health_care_local_facility.yml
@@ -267,4 +267,3 @@ destination:
     - uid
 migration_dependencies:
   required: {  }
-include: null

--- a/config/sync/migrate_plus.migration.va_node_health_care_local_facility.yml
+++ b/config/sync/migrate_plus.migration.va_node_health_care_local_facility.yml
@@ -197,6 +197,9 @@ process:
   field_mobile:
     plugin: convert_boolean
     source: mobile
+  field_use_default_mental_health:
+    plugin: default_value
+    default_value: false
   status:
     plugin: default_value
     default_value: 0
@@ -264,3 +267,4 @@ destination:
     - uid
 migration_dependencies:
   required: {  }
+include: null

--- a/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_backend/src/EventSubscriber/EntityEventSubscriber.php
@@ -265,7 +265,9 @@ class EntityEventSubscriber implements EventSubscriberInterface {
    *   The form_state.
    */
   public function removePhoneLabel(array &$form, FormStateInterface $form_state): void {
-    if (!empty($form['#field_parents']) && in_array('field_telephone', $form['#field_parents'])) {
+    if (!empty($form['#field_parents'])
+      && (in_array('field_telephone', $form['#field_parents'])
+      || in_array('field_default_mental_health_phon', $form['#field_parents']))) {
 
       if ($form['#title'] === 'Label') {
         $form_id = $form_state->getFormObject()->getFormId();
@@ -278,6 +280,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
           'node_health_care_local_facility_edit_form',
           'node_vamc_system_billing_insurance_form',
           'node_vamc_system_billing_insurance_edit_form',
+          'node_health_care_region_page_form',
+          'node_health_care_region_page_edit_form',
         ];
 
         if (in_array($form_id, $forms_without_phone_labels)) {
@@ -288,6 +292,8 @@ class EntityEventSubscriber implements EventSubscriberInterface {
           switch ($form_id) {
             case 'node_health_care_local_facility_form':
             case 'node_health_care_local_facility_edit_form':
+            case 'node_health_care_region_page_form':
+            case 'node_health_care_region_page_edit_form':
               $form['value']['#default_value'] = 'Mental health phone';
               break;
 

--- a/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility.yml
+++ b/docroot/modules/custom/va_gov_migrate/config/install/migrate_plus.migration.va_node_health_care_local_facility.yml
@@ -24,7 +24,7 @@ source:
   data_parser_plugin: json
   urls:
     # This gets overridden in settings.php.
-    - 'https://sandbox-api.va.gov/services/va_facilities/v1/facilities?per_page=1000',
+    - 'https://sandbox-api.va.gov/services/va_facilities/v1/facilities?per_page=1000'
     - 'https://sandbox-api.va.gov/services/va_facilities/v1/facilities?per_page=1000&page=2'
     - 'https://sandbox-api.va.gov/services/va_facilities/v1/facilities?per_page=1000&page=3'
   headers:
@@ -192,6 +192,9 @@ process:
   field_mobile:
     plugin: convert_boolean
     source: mobile
+  field_use_default_mental_health:
+    plugin: default_value
+    default_value: false
   # Bring these in as unpublished.
   status:
     plugin: default_value

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -299,13 +299,13 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function setMentalHealthNumberToDefault($entity) {
+  protected function setMentalHealthNumberToDefault($entity) {
     // Get system mental health paragraph.
     $region_page = $entity->get('field_region_page')->entity;
-    $system_paragraph = $region_page->get('field_default_mental_health_phon')->entity;
+    $system_paragraph = $region_page?->get('field_default_mental_health_phon')->entity;
 
-    $phone_number = $system_paragraph->get('field_phone_number')->value;
-    $phone_extension = $system_paragraph->get('field_phone_extension')->value;
+    $phone_number = $system_paragraph?->get('field_phone_number')->value;
+    $phone_extension = $system_paragraph?->get('field_phone_extension')->value;
     $phone_type = 'tel';
 
     $facility_paragraph = $entity->get('field_telephone')->entity;
@@ -393,7 +393,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state.
    */
-  public function conditionalMentalHealthNumber(array &$form, FormStateInterface $form_state): void {
+  protected function conditionalMentalHealthNumber(array &$form, FormStateInterface $form_state): void {
     /** @var \Drupal\Core\Entity\EntityFormInterface $form_object */
     $form_object = $form_state->getFormObject();
     $node = $form_object->getEntity();
@@ -401,6 +401,12 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       && $node->hasField('field_use_default_mental_health')
       && $node->hasField('field_telephone')
     ) {
+      $region_page = $node->get('field_region_page')->entity;
+      $system_paragraph = $region_page?->get('field_default_mental_health_phon')->entity;
+      if (empty($system_paragraph)) {
+        $form['field_use_default_mental_health']['#access'] = FALSE;
+        return;
+      }
       $form['field_telephone']['#states'] = [
         'visible' => [
           ':input[name="field_use_default_mental_health[value]"]' => ['checked' => FALSE],

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\core_event_dispatcher\EntityHookEvents;
@@ -116,6 +117,13 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
   protected $userPermsService;
 
   /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * Constructs the EventSubscriber object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
@@ -138,6 +146,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     UserPermsService $user_perms_service,
     ContentHardeningDeduper $content_hardening_deduper,
     NotificationsManager $notifications_manager,
+    MessengerInterface $messenger,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $currentUser;
@@ -145,6 +154,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     $this->userPermsService = $user_perms_service;
     $this->contentHardeningDeduper = $content_hardening_deduper;
     $this->notificationsManager = $notifications_manager;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -346,7 +356,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       }
     }
     catch (EntityStorageException $e) {
-      \Drupal::messenger()->addError($this->t('An error occurred while updating the mental health phone number. %error',
+      $this->messenger->addError($this->t('An error occurred while updating the mental health phone number. %error',
         ['%error' => $e->getMessage()]
       ));
     }
@@ -427,8 +437,9 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
           $region_page = $this->entityTypeManager
             ->getStorage('node')
             ->loadUnchanged($target_id);
-        } catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
-          \Drupal::messenger()->addError($this->t('An error occurred while trying to load the target region page. %error',
+        }
+        catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
+          $this->messenger->addError($this->t('An error occurred while trying to load the target region page. %error',
             ['%error' => $e->getMessage()]
           ));
         }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -16,6 +16,7 @@ use Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityViewAlterEvent;
 use Drupal\core_event_dispatcher\Event\Form\FormIdAlterEvent;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\va_gov_notifications\Service\NotificationsManager;
 use Drupal\va_gov_user\Service\UserPermsService;
@@ -226,6 +227,13 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
         $this->notificationsManager->sendMessageOnFieldChange('title', $entity, 'Facility title changed:', 'va_facility_title_change', self::USER_CMS_HELP_DESK_NOTIFICATIONS);
       }
     }
+
+    if ($entity->bundle() === 'health_care_local_facility') {
+      $use_default_checked = $entity->get('field_use_default_mental_health')[0]->value;
+      if ($use_default_checked) {
+        $this->setMentalHealthNumberToDefault($entity);
+      }
+    }
   }
 
   /**
@@ -287,6 +295,45 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
+   * Sets the facility's mental health number to the default system number.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function setMentalHealthNumberToDefault($entity) {
+    // Get system mental health paragraph.
+    $region_page = $entity->get('field_region_page')->entity;
+    $system_paragraph = $region_page->get('field_default_mental_health_phon')->entity;
+
+    $phone_number = $system_paragraph->get('field_phone_number')->value;
+    $phone_extension = $system_paragraph->get('field_phone_extension')->value;
+    $phone_type = 'tel';
+
+    $facility_paragraph = $entity->get('field_telephone')->entity;
+    if ($facility_paragraph) {
+      // Update existing mental health phone number to match system default.
+      $facility_paragraph->set('field_phone_number', $phone_number);
+      $facility_paragraph->set('field_phone_extension', $phone_extension);
+      $facility_paragraph->set('field_phone_number_type', $phone_type);
+      $facility_paragraph->save();
+    }
+    else {
+      // Create new paragraph to match system default.
+      $values = [
+        'type' => 'phone_number',
+        'field_phone_number' => $phone_number,
+        'field_phone_extension' => $phone_extension,
+        'field_phone_number_type' => $phone_type,
+      ];
+      $new_paragraph = Paragraph::create($values);
+      $new_paragraph->save();
+      $entity->set('field_telephone', [
+        'target_id' => $new_paragraph->id(),
+        'target_revision_id' => $new_paragraph->getRevisionId(),
+      ]);
+    }
+  }
+
+  /**
    * Adds COVID status information to form and js library.
    *
    * @param array $form
@@ -335,6 +382,34 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     $form = &$event->getForm();
     $form_state = $event->getFormState();
     $this->addCovidStatusData($form, $form_state);
+    $this->conditionalMentalHealthNumber($form, $form_state);
+  }
+
+  /**
+   * Hides the telephone field based on the default mental health checkbox.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function conditionalMentalHealthNumber(array &$form, FormStateInterface $form_state): void {
+    /** @var \Drupal\Core\Entity\EntityFormInterface $form_object */
+    $form_object = $form_state->getFormObject();
+    $node = $form_object->getEntity();
+    if ($node instanceof NodeInterface
+      && $node->hasField('field_use_default_mental_health')
+      && $node->hasField('field_telephone')
+    ) {
+      $form['field_telephone']['#states'] = [
+        'visible' => [
+          ':input[name="field_use_default_mental_health[value]"]' => ['checked' => FALSE],
+        ],
+        'invisible' => [
+          ':input[name="field_use_default_mental_health[0][value]"]' => ['checked' => TRUE],
+        ],
+      ];
+    }
   }
 
   /**

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -2,8 +2,11 @@
 
 namespace Drupal\va_gov_vamc\EventSubscriber;
 
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -214,7 +217,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       && $entity->bundle() === 'health_care_local_facility'
       && $entity->hasField('field_use_default_mental_health')
     ) {
-      $use_default_checked = $entity->get('field_use_default_mental_health')->first()?->getValue()['value'];
+      $use_default_checked = $entity->get('field_use_default_mental_health')->value;
       if ($use_default_checked) {
         $this->setMentalHealthNumberToDefault($entity);
       }
@@ -317,28 +320,35 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     $phone_extension = $system_paragraph?->get('field_phone_extension')->value;
     $phone_type = 'tel';
 
-    $facility_paragraph = $entity->get('field_telephone')->entity;
-    if ($facility_paragraph) {
-      // Update existing mental health phone number to match system default.
-      $facility_paragraph->set('field_phone_number', $phone_number);
-      $facility_paragraph->set('field_phone_extension', $phone_extension);
-      $facility_paragraph->set('field_phone_number_type', $phone_type);
-      $facility_paragraph->save();
+    try {
+      $facility_paragraph = $entity->get('field_telephone')->entity;
+      if ($facility_paragraph) {
+        // Update existing mental health phone number to match system default.
+        $facility_paragraph->set('field_phone_number', $phone_number);
+        $facility_paragraph->set('field_phone_extension', $phone_extension);
+        $facility_paragraph->set('field_phone_number_type', $phone_type);
+        $facility_paragraph->save();
+      }
+      else {
+        // Create new paragraph to match system default.
+        $values = [
+          'type' => 'phone_number',
+          'field_phone_number' => $phone_number,
+          'field_phone_extension' => $phone_extension,
+          'field_phone_number_type' => $phone_type,
+        ];
+        $new_paragraph = Paragraph::create($values);
+        $new_paragraph->save();
+        $entity->set('field_telephone', [
+          'target_id' => $new_paragraph->id(),
+          'target_revision_id' => $new_paragraph->getRevisionId(),
+        ]);
+      }
     }
-    else {
-      // Create new paragraph to match system default.
-      $values = [
-        'type' => 'phone_number',
-        'field_phone_number' => $phone_number,
-        'field_phone_extension' => $phone_extension,
-        'field_phone_number_type' => $phone_type,
-      ];
-      $new_paragraph = Paragraph::create($values);
-      $new_paragraph->save();
-      $entity->set('field_telephone', [
-        'target_id' => $new_paragraph->id(),
-        'target_revision_id' => $new_paragraph->getRevisionId(),
-      ]);
+    catch (EntityStorageException $e) {
+      \Drupal::messenger()->addError($this->t('An error occurred while updating the mental health phone number. %error',
+        ['%error' => $e->getMessage()]
+      ));
     }
   }
 
@@ -410,9 +420,21 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       && $node->hasField('field_use_default_mental_health')
       && $node->hasField('field_telephone')
     ) {
-      $region_page = $node->get('field_region_page')->entity;
+      $target_id = $node->get('field_region_page')->target_id;
+      $region_page = NULL;
+      if ($target_id) {
+        try {
+          $region_page = $this->entityTypeManager
+            ->getStorage('node')
+            ->loadUnchanged($target_id);
+        } catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
+          \Drupal::messenger()->addError($this->t('An error occurred while trying to load the target region page. %error',
+            ['%error' => $e->getMessage()]
+          ));
+        }
+      }
       $system_paragraph = $region_page?->get('field_default_mental_health_phon')->entity;
-      if (empty($system_paragraph)) {
+      if ($system_paragraph->get('field_phone_number')->isEmpty()) {
         $form['field_use_default_mental_health']['#access'] = FALSE;
         return;
       }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -214,7 +214,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       && $entity->bundle() === 'health_care_local_facility'
       && $entity->hasField('field_use_default_mental_health')
     ) {
-      $use_default_checked = $entity->get('field_use_default_mental_health')->first()?->getValue();
+      $use_default_checked = $entity->get('field_use_default_mental_health')->first()?->getValue()['value'];
       if ($use_default_checked) {
         $this->setMentalHealthNumberToDefault($entity);
       }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -319,15 +319,32 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   protected function setMentalHealthNumberToDefault($entity): void {
-    // Get system mental health paragraph.
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    // Get system mental health paragraph from the region page node.
     $region_page = $entity->get('field_region_page')->entity;
-    $system_paragraph = $region_page?->get('field_default_mental_health_phon')->entity;
-    if (empty($system_paragraph)) {
+    if (empty($region_page)) {
       return;
     }
 
-    $phone_number = $system_paragraph?->get('field_phone_number')->value;
-    $phone_extension = $system_paragraph?->get('field_phone_extension')->value;
+    // Check for forward revisions of the region_page node (any moderation state).
+    $revision_ids = $node_storage->revisionIds($region_page);
+    $latest_forward_revision = NULL;
+    foreach (array_reverse($revision_ids) as $revision_id) {
+      if ($revision_id > $region_page->getRevisionId()) {
+        $revision = $node_storage->loadRevision($revision_id);
+        if ($revision) {
+          $latest_forward_revision = $revision;
+          break;
+        }
+      }
+    }
+    $region_page_to_check = $latest_forward_revision ?: $region_page;
+    $system_paragraph = $region_page_to_check?->get('field_default_mental_health_phon')->entity;
+    if (empty($system_paragraph)) {
+      return;
+    }
+    $phone_number = $system_paragraph->get('field_phone_number')->value;
+    $phone_extension = $system_paragraph->get('field_phone_extension')->value;
     $phone_type = 'tel';
 
     try {

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -201,11 +201,23 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent $event
    *   The event.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function entityPresave(EntityPresaveEvent $event): void {
     $entity = $event->getEntity();
     $this->contentHardeningDeduper->removeDuplicate($entity);
     $this->removeFieldDataFromNonClinicalServices($entity);
+
+    if ($entity instanceof NodeInterface
+      && $entity->bundle() === 'health_care_local_facility'
+      && $entity->hasField('field_use_default_mental_health')
+    ) {
+      $use_default_checked = $entity->get('field_use_default_mental_health')[0]?->value;
+      if ($use_default_checked) {
+        $this->setMentalHealthNumberToDefault($entity);
+      }
+    }
   }
 
   /**
@@ -213,8 +225,6 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent $event
    *   The event.
-   *
-   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function entityUpdate(EntityUpdateEvent $event): void {
     $entity = $event->getEntity();
@@ -227,13 +237,6 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       else {
         $this->flagger->flagFieldChanged('title', 'changed_name', $entity, "The title of this facility changed from '@old' to '@new'.");
         $this->notificationsManager->sendMessageOnFieldChange('title', $entity, 'Facility title changed:', 'va_facility_title_change', self::USER_CMS_HELP_DESK_NOTIFICATIONS);
-      }
-    }
-
-    if ($entity->bundle() === 'health_care_local_facility') {
-      $use_default_checked = $entity->get('field_use_default_mental_health')[0]?->value;
-      if ($use_default_checked) {
-        $this->setMentalHealthNumberToDefault($entity);
       }
     }
   }
@@ -305,6 +308,9 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     // Get system mental health paragraph.
     $region_page = $entity->get('field_region_page')->entity;
     $system_paragraph = $region_page?->get('field_default_mental_health_phon')->entity;
+    if (empty($system_paragraph)) {
+      return;
+    }
 
     $phone_number = $system_paragraph?->get('field_phone_number')->value;
     $phone_extension = $system_paragraph?->get('field_phone_extension')->value;

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -203,6 +203,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    *   The event.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
   public function entityPresave(EntityPresaveEvent $event): void {
     $entity = $event->getEntity();
@@ -213,7 +214,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       && $entity->bundle() === 'health_care_local_facility'
       && $entity->hasField('field_use_default_mental_health')
     ) {
-      $use_default_checked = $entity->get('field_use_default_mental_health')[0]?->value;
+      $use_default_checked = $entity->get('field_use_default_mental_health')->first()?->getValue();
       if ($use_default_checked) {
         $this->setMentalHealthNumberToDefault($entity);
       }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -9,7 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\core_event_dispatcher\EntityHookEvents;
@@ -117,11 +117,11 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
   protected $userPermsService;
 
   /**
-   * The messenger service.
+   * Logger channel factory.
    *
-   * @var \Drupal\Core\Messenger\MessengerInterface
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
    */
-  protected $messenger;
+  protected $loggerFactory;
 
   /**
    * Constructs the EventSubscriber object.
@@ -138,6 +138,8 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    *   The deduper service.
    * @param \Drupal\va_gov_notifications\Service\NotificationsManager $notifications_manager
    *   VA gov NotificationsManager service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   The Drupal logger service.
    */
   public function __construct(
     EntityTypeManager $entity_type_manager,
@@ -146,7 +148,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     UserPermsService $user_perms_service,
     ContentHardeningDeduper $content_hardening_deduper,
     NotificationsManager $notifications_manager,
-    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $loggerFactory,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $currentUser;
@@ -154,7 +156,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     $this->userPermsService = $user_perms_service;
     $this->contentHardeningDeduper = $content_hardening_deduper;
     $this->notificationsManager = $notifications_manager;
-    $this->messenger = $messenger;
+    $this->loggerFactory = $loggerFactory;
   }
 
   /**
@@ -371,7 +373,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
       }
     }
     catch (EntityStorageException $e) {
-      $this->messenger->addError($this->t('An error occurred while updating the mental health phone number. %error',
+      $this->loggerFactory->get('va_gov_vamc')->error($this->t('An error occurred while updating the mental health phone number. %error',
         ['%error' => $e->getMessage()]
       ));
     }
@@ -454,7 +456,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
             ->loadUnchanged($target_id);
         }
         catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
-          $this->messenger->addError($this->t('An error occurred while trying to load the target region page. %error',
+          $this->loggerFactory->get('va_gov_vamc')->error($this->t('An error occurred while trying to load the target region page. %error',
             ['%error' => $e->getMessage()]
           ));
         }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -320,13 +320,13 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    */
   protected function setMentalHealthNumberToDefault($entity): void {
     $node_storage = $this->entityTypeManager->getStorage('node');
-    // Get system mental health paragraph from the region page node.
+
     $region_page = $entity->get('field_region_page')->entity;
     if (empty($region_page)) {
       return;
     }
 
-    // Check for forward revisions of the region_page node (any moderation state).
+    // Check for forward revisions.
     $revision_ids = $node_storage->revisionIds($region_page);
     $latest_forward_revision = NULL;
     foreach (array_reverse($revision_ids) as $revision_id) {
@@ -350,14 +350,12 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     try {
       $facility_paragraph = $entity->get('field_telephone')->entity;
       if ($facility_paragraph) {
-        // Update existing mental health phone number to match system default.
         $facility_paragraph->set('field_phone_number', $phone_number);
         $facility_paragraph->set('field_phone_extension', $phone_extension);
         $facility_paragraph->set('field_phone_number_type', $phone_type);
         $facility_paragraph->save();
       }
       else {
-        // Create new paragraph to match system default.
         $values = [
           'type' => 'phone_number',
           'field_phone_number' => $phone_number,

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -213,6 +213,8 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\core_event_dispatcher\Event\Entity\EntityUpdateEvent $event
    *   The event.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function entityUpdate(EntityUpdateEvent $event): void {
     $entity = $event->getEntity();
@@ -229,7 +231,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
     }
 
     if ($entity->bundle() === 'health_care_local_facility') {
-      $use_default_checked = $entity->get('field_use_default_mental_health')[0]->value;
+      $use_default_checked = $entity->get('field_use_default_mental_health')[0]?->value;
       if ($use_default_checked) {
         $this->setMentalHealthNumberToDefault($entity);
       }
@@ -299,7 +301,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  protected function setMentalHealthNumberToDefault($entity) {
+  protected function setMentalHealthNumberToDefault($entity): void {
     // Get system mental health paragraph.
     $region_page = $entity->get('field_region_page')->entity;
     $system_paragraph = $region_page?->get('field_default_mental_health_phon')->entity;

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -460,7 +460,7 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
         }
       }
       $system_paragraph = $region_page?->get('field_default_mental_health_phon')->entity;
-      if ($system_paragraph->get('field_phone_number')->isEmpty()) {
+      if (!$system_paragraph || $system_paragraph->get('field_phone_number')->isEmpty()) {
         $form['field_use_default_mental_health']['#access'] = FALSE;
         return;
       }

--- a/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
+++ b/docroot/modules/custom/va_gov_vamc/src/EventSubscriber/VAMCEntityEventSubscriber.php
@@ -406,7 +406,13 @@ class VAMCEntityEventSubscriber implements EventSubscriberInterface {
           ':input[name="field_use_default_mental_health[value]"]' => ['checked' => FALSE],
         ],
         'invisible' => [
-          ':input[name="field_use_default_mental_health[0][value]"]' => ['checked' => TRUE],
+          ':input[name="field_use_default_mental_health[value]"]' => ['checked' => TRUE],
+        ],
+        'enabled' => [
+          ':input[name="field_use_default_mental_health[value]"]' => ['checked' => FALSE],
+        ],
+        'disabled' => [
+          ':input[name="field_use_default_mental_health[value]"]' => ['checked' => TRUE],
         ],
       ];
     }

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
@@ -10,7 +10,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
-use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\va_gov_facilities\FacilityOps;
 use Drupal\va_gov_vamc\EventSubscriber\VAMCEntityPreventReuse;
 

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
@@ -10,6 +10,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\va_gov_facilities\FacilityOps;
 use Drupal\va_gov_vamc\EventSubscriber\VAMCEntityPreventReuse;
 
@@ -80,6 +81,26 @@ function va_gov_vamc_node_grants(AccountInterface $account, $operation) {
     $grants['node_reuse_restrict'] = [FacilityOps::getFacilityTypeSectionId('vamc')];
   }
   return $grants;
+}
+
+/**
+ * Implements hook_entity_load().
+ */
+function va_gov_vamc_entity_load(array &$entities, $entity_type) {
+  if ($entity_type === 'node') {
+    foreach ($entities as $entity) {
+      // Only target health_care_region_page nodes with the field.
+      if ($entity->bundle() === 'health_care_region_page' && $entity->hasField('field_default_mental_health_phon')) {
+        $field = $entity->get('field_default_mental_health_phon');
+        if ($field->isEmpty()) {
+          // Create a new unsaved phone_number paragraph entity.
+          $paragraph = Paragraph::create(['type' => 'phone_number']);
+          // Attach the paragraph to the field. This does not save it yet.
+          $field->appendItem($paragraph);
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
@@ -84,26 +84,6 @@ function va_gov_vamc_node_grants(AccountInterface $account, $operation) {
 }
 
 /**
- * Implements hook_entity_load().
- */
-function va_gov_vamc_entity_load(array &$entities, $entity_type) {
-  if ($entity_type === 'node') {
-    foreach ($entities as $entity) {
-      // Only target health_care_region_page nodes with the field.
-      if ($entity->bundle() === 'health_care_region_page' && $entity->hasField('field_default_mental_health_phon')) {
-        $field = $entity->get('field_default_mental_health_phon');
-        if ($field->isEmpty()) {
-          // Create a new unsaved phone_number paragraph entity.
-          $paragraph = Paragraph::create(['type' => 'phone_number']);
-          // Attach the paragraph to the field. This does not save it yet.
-          $field->appendItem($paragraph);
-        }
-      }
-    }
-  }
-}
-
-/**
  * Modifies UI of the Facility Status VBO Modify Field Values form.
  *
  * The form that allows the user to modify field values contains too many

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
@@ -10,6 +10,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\va_gov_facilities\FacilityOps;
 use Drupal\va_gov_vamc\EventSubscriber\VAMCEntityPreventReuse;
 
@@ -93,7 +94,7 @@ function va_gov_vamc_entity_load(array &$entities, $entity_type) {
         $field = $entity->get('field_default_mental_health_phon');
         if ($field->isEmpty()) {
           // Create a new unsaved phone_number paragraph entity.
-          $paragraph = \Drupal\paragraphs\Entity\Paragraph::create(['type' => 'phone_number']);
+          $paragraph = Paragraph::create(['type' => 'phone_number']);
           // Attach the paragraph to the field. This does not save it yet.
           $field->appendItem($paragraph);
         }

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.module
@@ -83,6 +83,26 @@ function va_gov_vamc_node_grants(AccountInterface $account, $operation) {
 }
 
 /**
+ * Implements hook_entity_load().
+ */
+function va_gov_vamc_entity_load(array &$entities, $entity_type) {
+  if ($entity_type === 'node') {
+    foreach ($entities as $entity) {
+      // Only target health_care_region_page nodes with the field.
+      if ($entity->bundle() === 'health_care_region_page' && $entity->hasField('field_default_mental_health_phon')) {
+        $field = $entity->get('field_default_mental_health_phon');
+        if ($field->isEmpty()) {
+          // Create a new unsaved phone_number paragraph entity.
+          $paragraph = \Drupal\paragraphs\Entity\Paragraph::create(['type' => 'phone_number']);
+          // Attach the paragraph to the field. This does not save it yet.
+          $field->appendItem($paragraph);
+        }
+      }
+    }
+  }
+}
+
+/**
  * Modifies UI of the Facility Status VBO Modify Field Values form.
  *
  * The form that allows the user to modify field values contains too many

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
@@ -8,7 +8,7 @@ services:
       - '@va_gov_user.user_perms'
       - '@va_gov_vamc.content_hardening_deduper'
       - '@va_gov_notifications.notifications_manager'
-      - '@messenger'
+      - '@logger.factory'
     tags:
       - { name: event_subscriber }
   va_gov_vamc.entity_prevent_reuse:

--- a/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
+++ b/docroot/modules/custom/va_gov_vamc/va_gov_vamc.services.yml
@@ -8,7 +8,7 @@ services:
       - '@va_gov_user.user_perms'
       - '@va_gov_vamc.content_hardening_deduper'
       - '@va_gov_notifications.notifications_manager'
-      - '@feature_toggle.feature_status'
+      - '@messenger'
     tags:
       - { name: event_subscriber }
   va_gov_vamc.entity_prevent_reuse:


### PR DESCRIPTION
## Description

Relates to #17085 

### Generated description
This pull request introduces new fields and updates display configurations for health care facility and region page content types to support a "default mental health phone number" feature. The changes add new boolean and entity reference fields, group them appropriately in the form and view displays, and adjust field ordering for better UI organization.

**Key changes:**

### Addition of "Default Mental Health Phone Number" Fields

* Added a new boolean field `field_use_default_mental_health` to the `health_care_local_facility` node type, allowing facilities to indicate whether to use the default mental health phone number.
* Added a new entity reference field `field_default_mental_health_phon` to the `health_care_region_page` node type, enabling the association of a default mental health phone number at the region level.

### Updates to Form Displays

* Updated the form display for `health_care_local_facility` to include the new `field_use_default_mental_health` field, grouped it with mental health phone number fields, and set its display properties and ordering. [[1]](diffhunk://#diff-2702e800c5e881b0938d81ca3fecb38224efdc2953667d45637a907cdad3dd20R29) [[2]](diffhunk://#diff-2702e800c5e881b0938d81ca3fecb38224efdc2953667d45637a907cdad3dd20L221-R222) [[3]](diffhunk://#diff-2702e800c5e881b0938d81ca3fecb38224efdc2953667d45637a907cdad3dd20R402-R408) [[4]](diffhunk://#diff-2702e800c5e881b0938d81ca3fecb38224efdc2953667d45637a907cdad3dd20L385-R386)
* Updated the form display for `health_care_region_page` to add and group the `field_default_mental_health_phon` field, and adjusted weights for better field ordering. [[1]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568R9) [[2]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568R237-R252) [[3]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568L47-R48) [[4]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568L62-R63) [[5]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568L192-R193) [[6]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568L226-R227) [[7]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568R271-R282) [[8]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568L331-R360) [[9]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568L362-R391)

### Updates to View Displays

* Updated the view displays for both `health_care_local_facility` and `health_care_region_page` to show or hide the new fields as appropriate, and set their display order and grouping. [[1]](diffhunk://#diff-36c79ff8e305b6a1e8d9e199a9b6c23dc411e60f374c88874780bb58d90dd415R29) [[2]](diffhunk://#diff-36c79ff8e305b6a1e8d9e199a9b6c23dc411e60f374c88874780bb58d90dd415R288-R297) [[3]](diffhunk://#diff-755430972c121c57b4f95b86afba3ae73dd7dc646232f5d7c816307e35bacf18R30) [[4]](diffhunk://#diff-755430972c121c57b4f95b86afba3ae73dd7dc646232f5d7c816307e35bacf18R279) [[5]](diffhunk://#diff-258df7c392c6de9af3c861913fab63200bf04ea26da7fe398a078b887b3fefc5R30) [[6]](diffhunk://#diff-258df7c392c6de9af3c861913fab63200bf04ea26da7fe398a078b887b3fefc5R132) [[7]](diffhunk://#diff-52cdcc9c2967b69ef4c765b8217dd864fe98f5407922bc7d6cc811939373912bR30) [[8]](diffhunk://#diff-52cdcc9c2967b69ef4c765b8217dd864fe98f5407922bc7d6cc811939373912bR110) [[9]](diffhunk://#diff-127ad9edb1aa7e024a122a4d219cb63a1bbeb4d54fb8a660915ed4975e46ac62R9) [[10]](diffhunk://#diff-127ad9edb1aa7e024a122a4d219cb63a1bbeb4d54fb8a660915ed4975e46ac62R32) [[11]](diffhunk://#diff-127ad9edb1aa7e024a122a4d219cb63a1bbeb4d54fb8a660915ed4975e46ac62R64) [[12]](diffhunk://#diff-127ad9edb1aa7e024a122a4d219cb63a1bbeb4d54fb8a660915ed4975e46ac62L155-R175) [[13]](diffhunk://#diff-127ad9edb1aa7e024a122a4d219cb63a1bbeb4d54fb8a660915ed4975e46ac62L267-R279) [[14]](diffhunk://#diff-8e41b6fb67cf9a5e7e87cf04131b31d56f0b85f4b5cf955cfe53321802b55ddbR10) [[15]](diffhunk://#diff-8e41b6fb67cf9a5e7e87cf04131b31d56f0b85f4b5cf955cfe53321802b55ddbR158) [[16]](diffhunk://#diff-c7e99f13eacbeee5fe0edffb77432468f140069f9e10406a06f598ec065f7d97R10) [[17]](diffhunk://#diff-c7e99f13eacbeee5fe0edffb77432468f140069f9e10406a06f598ec065f7d97R62)

### Dependency and Configuration Updates

* Updated dependencies in all relevant configuration files to ensure the new fields are recognized and properly managed by Drupal's configuration system. [[1]](diffhunk://#diff-2702e800c5e881b0938d81ca3fecb38224efdc2953667d45637a907cdad3dd20R29) [[2]](diffhunk://#diff-d3716c04b5c24e38c6fad122940c047828503df8240d2bbe8b77473ebd19c451R30) [[3]](diffhunk://#diff-3f7b4a94831758dadd0d7bb81eea4b72ded2351401d744b28d6aaad5b4c93568R9) [[4]](diffhunk://#diff-36c79ff8e305b6a1e8d9e199a9b6c23dc411e60f374c88874780bb58d90dd415R29) [[5]](diffhunk://#diff-755430972c121c57b4f95b86afba3ae73dd7dc646232f5d7c816307e35bacf18R30) [[6]](diffhunk://#diff-258df7c392c6de9af3c861913fab63200bf04ea26da7fe398a078b887b3fefc5R30) [[7]](diffhunk://#diff-52cdcc9c2967b69ef4c765b8217dd864fe98f5407922bc7d6cc811939373912bR30) [[8]](diffhunk://#diff-127ad9edb1aa7e024a122a4d219cb63a1bbeb4d54fb8a660915ed4975e46ac62R9) [[9]](diffhunk://#diff-127ad9edb1aa7e024a122a4d219cb63a1bbeb4d54fb8a660915ed4975e46ac62R32) [[10]](diffhunk://#diff-8e41b6fb67cf9a5e7e87cf04131b31d56f0b85f4b5cf955cfe53321802b55ddbR10) [[11]](diffhunk://#diff-c7e99f13eacbeee5fe0edffb77432468f140069f9e10406a06f598ec065f7d97R10)

### Field Visibility Adjustments

* Set the new fields to be hidden or visible in various view and inline entity form displays as appropriate for their intended use. [[1]](diffhunk://#diff-d3716c04b5c24e38c6fad122940c047828503df8240d2bbe8b77473ebd19c451R164) [[2]](diffhunk://#diff-755430972c121c57b4f95b86afba3ae73dd7dc646232f5d7c816307e35bacf18R279) [[3]](diffhunk://#diff-258df7c392c6de9af3c861913fab63200bf04ea26da7fe398a078b887b3fefc5R132) [[4]](diffhunk://#diff-52cdcc9c2967b69ef4c765b8217dd864fe98f5407922bc7d6cc811939373912bR110) [[5]](diffhunk://#diff-8e41b6fb67cf9a5e7e87cf04131b31d56f0b85f4b5cf955cfe53321802b55ddbR158) [[6]](diffhunk://#diff-c7e99f13eacbeee5fe0edffb77432468f140069f9e10406a06f598ec065f7d97R62)

These changes collectively enable facilities and regions to manage and display default mental health phone numbers more flexibly and consistently across the site.


## QA steps

As an editor:
1. Edit a VAMC Facility node (i.e. /eastern-colorado-health-care/locations/la-junta-va-clinic/)
   - [x] Verify that there is no checkbox for 'Use the default mental health number for this VAMC system?'
2. Edit a VAMC System node (i.e. /eastern-colorado-health-care/)
   - Try to save the node without adding a Default mental health phone number
   - [x] Verify that the Default mental health number is required.
   - Add a new Default mental health phone number and save the system
3. Edit a facility node within the system you just saved (i.e /eastern-colorado-health-care/locations/la-junta-va-clinic/)
   - [ ] Verify there is now a checkbox for 'Use the default mental health number for this VAMC system?'
   - Check the box and save the node.
   - [ ] Verify that the 'Mental health phone number' shows the number that you saved for the system.


### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`