### PR TITLE
VACMS-23701: Disable scripts

### DIFF
--- a/scripts/compile-theme.sh
+++ b/scripts/compile-theme.sh
@@ -21,7 +21,7 @@ export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
 
 pushd ./docroot/core
 nvm install 18
-yarn install
+yarn install --ignore-scripts
 yarn build:css
 popd
 
@@ -29,7 +29,7 @@ if [[ "${CMS_ENVIRONMENT_TYPE}" == "tugboat" ]]; then
 
 pushd ./docroot/themes/custom/vagovclaro
 nvm install
-npm install
+npm install --ignore-scripts
 npm run test
 popd
 
@@ -37,7 +37,7 @@ else
 
 pushd ./docroot/themes/custom/vagovclaro
 nvm install
-npm install
+npm install --ignore-scripts
 npm run prod
 popd
 

--- a/scripts/next-install.sh
+++ b/scripts/next-install.sh
@@ -23,5 +23,5 @@ echo "Node $(node -v)"
 echo "NPM $(npm -v)"
 echo "Yarn $(yarn -v)"
 
-yarn install
+yarn install-safe --immutable
 popd > /dev/null


### PR DESCRIPTION
## Description
Updates yarn install for Next in tugboat to use install-safe script. Also updates theme npm install to add `--ignore-scripts` 

Relates to #23702 

## Testing done
 - manual testing in ddev and tugboat 

## QA steps

 - [ ] visit tugboat for this PR
 - [ ] open the Terminal for the php service
 - [ ] run `composer va:next:install`
 - [ ] verify that the install completes successfully
 - [ ] run `composer va:theme:compile`
 - [ ] verify that the compile completes successfully

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`



