### PR TITLE
VACMS-23017: Forces moderation state choice

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -34,7 +34,8 @@
             "3285657 - The content has either been modified by another user, or you have already submitted modifications error": "patches/3285657-node-lock-translations.patch",
             "VACMS-19177 remove username form logging in user module": "patches/VACMS-19177-patch-for-user-module-to-log-uid.patch",
             "3082011 - Fix for orphaned label tags": "patches/3082011-19-do-not-use-label-HTML-tag-in-item-form-element.patch",
-            "3397718 - 'To log in to this site, your browser must accept cookies from the domain' error message displayed when user goes back and reload the page": "patches/3397718-must-accept-cookies.patch"
+            "3397718 - 'To log in to this site, your browser must accept cookies from the domain' error message displayed when user goes back and reload the page": "patches/3397718-must-accept-cookies.patch",
+            "VACMS-23017 - Force user to choose moderation state": "patches/VACMS-23017-content-moderation-default-placeholder.patch"
         },
         "drupal/decoupled_router": {
             "3111456 - Unable to resolve path on node in other language than default": "patches/3111456-resolve-language-issues.patch"

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -11,7 +11,6 @@ use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\WidgetBase;
@@ -464,7 +463,7 @@ function va_gov_backend_form_alter(&$form, FormStateInterface $form_state, $form
       '#ief_submit_trigger_all' => TRUE,
       '#type' => 'submit',
       '#weight' => 10,
-      '#value' => 'Save draft and continue editing',
+      '#value' => 'Save and continue editing',
       '#submit' => [
         '::submitForm',
         '::save',
@@ -544,16 +543,9 @@ function va_gov_backend_form_field_config_edit_form_alter(&$form, FormStateInter
 function va_gov_backend_field_widget_single_element_moderation_state_default_form_alter(&$element, FormStateInterface $form_state, $context) {
   $base_form_id = $form_state->getBuildInfo()['base_form_id'] ?? '';
   if ($base_form_id === 'node_form') {
-
-    // Set default new state to "Draft" when node is in "Published" state
-    // to help prevent accidentally publishing un-proofed edits.
-    /** @var \Drupal\Core\Entity\EntityFormInterface $form_object */
-    $form_object = $form_state->getFormObject();
-    $entity = $form_object->getEntity();
-    if ($entity instanceof EntityPublishedInterface && $entity->isPublished()) {
-      $element['state']['#default_value'] = 'draft';
-    }
-
+    // Update the title to indicate the dropdown is for saving state.
+    // The moderation state widget now uses a placeholder that requires explicit
+    // selection per VACMS-23017, so we no longer set a default value.
     $element['state']['#title'] = t('Save as');
   }
 }
@@ -893,7 +885,9 @@ function va_gov_backend_form_alter_submit(array &$form, FormStateInterface $form
 
   // Save it and associate with user.
   $node->setRevisionUserId($uid);
-  $node->set('moderation_state', 'draft');
+  // $node->set('moderation_state', 'draft');
+  $moderation_state = $node->get('moderation_state')->getString();
+  $node->set('moderation_state', $moderation_state);
   $node->save();
 
   $nid = $node->id();
@@ -1879,7 +1873,8 @@ function _va_gov_backend_has_suspicious_nbsp_density(FieldableEntityInterface $e
 
       $nbsp_count = substr_count($value, '&nbsp;') + substr_count($value, "\xC2\xA0");
       if ($nbsp_count < 5) {
-        // Less than 5 nbsp is very few. Present assumption: This amount is more likely deliberate.
+        // Less than 5 nbsp is very few.
+        // Present assumption: This amount is more likely deliberate.
         continue;
       }
 
@@ -1892,8 +1887,9 @@ function _va_gov_backend_has_suspicious_nbsp_density(FieldableEntityInterface $e
       $nbsp_ratio = $nbsp_count / $space_like_count;
       if ($nbsp_ratio >= 0.2) {
         /*
-         * 20% is a rough guess for what threshold constitutes suspiscious nbps:space density.
-         * This value is erring on the side of "only surface warning if it's unreasonable to think this isn't suspiscious"
+         * 20% is a rough guess for the threshold.
+         * This value is erring on the side of "only surface warning if it's
+         * unreasonable to think this isn't suspiscious."
          * Tweak as needed.
          */
         return TRUE;

--- a/docroot/modules/custom/va_gov_backend/va_gov_backend.module
+++ b/docroot/modules/custom/va_gov_backend/va_gov_backend.module
@@ -1889,7 +1889,7 @@ function _va_gov_backend_has_suspicious_nbsp_density(FieldableEntityInterface $e
         /*
          * 20% is a rough guess for the threshold.
          * This value is erring on the side of "only surface warning if it's
-         * unreasonable to think this isn't suspiscious."
+         * unreasonable to think this isn't suspicious."
          * Tweak as needed.
          */
         return TRUE;

--- a/patches/VACMS-23017-content-moderation-default-placeholder.patch
+++ b/patches/VACMS-23017-content-moderation-default-placeholder.patch
@@ -1,6 +1,6 @@
-diff --git a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php b/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
---- a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
-+++ b/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+diff --git a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+--- a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
++++ b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
 @@ -153,6 +153,8 @@ class ModerationStateWidget extends OptionsSelectWidget {
        }
      }
@@ -22,13 +22,12 @@ diff --git a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/Modera
          '#access' => !empty($transition_labels),
          '#wrapper_attributes' => [
            'class' => ['container-inline'],
-@@ -184,6 +187,12 @@ class ModerationStateWidget extends OptionsSelectWidget {
+@@ -184,6 +187,11 @@ class ModerationStateWidget extends OptionsSelectWidget {
     * {@inheritdoc}
     */
    public static function validateElement(array $element, FormStateInterface $form_state) {
 +    if ($element['state']['#value'] === '') {
 +      $form_state->setError($element['state'], t('Choose a moderation state.'));
-+      $form_state->setValueForElement($element, [$element['state']['#key_column'] => $element['state']['#original_state']]);
 +      return;
 +    }
 +

--- a/patches/VACMS-23017-content-moderation-default-placeholder.patch
+++ b/patches/VACMS-23017-content-moderation-default-placeholder.patch
@@ -1,6 +1,6 @@
-diff --git a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
---- a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
-+++ b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+diff --git a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php b/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+--- a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
++++ b/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
 @@ -153,6 +153,8 @@ class ModerationStateWidget extends OptionsSelectWidget {
        }
      }

--- a/patches/VACMS-23017-content-moderation-default-placeholder.patch
+++ b/patches/VACMS-23017-content-moderation-default-placeholder.patch
@@ -1,0 +1,36 @@
+diff --git a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+--- a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
++++ b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+@@ -153,6 +153,8 @@ class ModerationStateWidget extends OptionsSelectWidget {
+       }
+     }
+ 
++    $transition_options = ['' => $this->t('- Choose a moderation state -')] + $transition_labels;
++
+     $element += [
+       '#type' => 'container',
+       'current' => [
+@@ -168,8 +170,9 @@ class ModerationStateWidget extends OptionsSelectWidget {
+         '#type' => 'select',
+         '#title' => $entity->isNew() ? $this->t('Save as') : $this->t('Change to'),
+         '#key_column' => $this->column,
+-        '#options' => $transition_labels,
+-        '#default_value' => $default_value,
++        '#options' => $transition_options,
++        '#default_value' => '',
++        '#original_state' => $default_value,
+         '#access' => !empty($transition_labels),
+         '#wrapper_attributes' => [
+           'class' => ['container-inline'],
+@@ -184,6 +187,12 @@ class ModerationStateWidget extends OptionsSelectWidget {
+    * {@inheritdoc}
+    */
+   public static function validateElement(array $element, FormStateInterface $form_state) {
++    if ($element['state']['#value'] === '') {
++      $form_state->setError($element['state'], t('Choose a moderation state.'));
++      $form_state->setValueForElement($element, [$element['state']['#key_column'] => $element['state']['#original_state']]);
++      return;
++    }
++
+     $form_state->setValueForElement($element, [$element['state']['#key_column'] => $element['state']['#value']]);
+   }

--- a/patches/VACMS-23017-content-moderation-default-placeholder.patch
+++ b/patches/VACMS-23017-content-moderation-default-placeholder.patch
@@ -1,10 +1,10 @@
-diff --git a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
---- a/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
-+++ b/docroot/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+diff --git a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php b/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+--- a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
++++ b/core/modules/content_moderation/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
 @@ -153,6 +153,8 @@ class ModerationStateWidget extends OptionsSelectWidget {
        }
      }
- 
+
 +    $transition_options = ['' => $this->t('- Choose a moderation state -')] + $transition_labels;
 +
      $element += [

--- a/patches/VACMS-23017-content-moderation-default-placeholder.patch
+++ b/patches/VACMS-23017-content-moderation-default-placeholder.patch
@@ -10,7 +10,7 @@ diff --git a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/Modera
      $element += [
        '#type' => 'container',
        'current' => [
-@@ -168,8 +170,9 @@ class ModerationStateWidget extends OptionsSelectWidget {
+@@ -168,8 +170,10 @@
          '#type' => 'select',
          '#title' => $entity->isNew() ? $this->t('Save as') : $this->t('Change to'),
          '#key_column' => $this->column,
@@ -18,11 +18,12 @@ diff --git a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/Modera
 -        '#default_value' => $default_value,
 +        '#options' => $transition_options,
 +        '#default_value' => '',
++        '#required' => TRUE,
 +        '#original_state' => $default_value,
          '#access' => !empty($transition_labels),
          '#wrapper_attributes' => [
            'class' => ['container-inline'],
-@@ -184,6 +187,11 @@ class ModerationStateWidget extends OptionsSelectWidget {
+@@ -185,6 +189,11 @@
     * {@inheritdoc}
     */
    public static function validateElement(array $element, FormStateInterface $form_state) {
@@ -33,3 +34,4 @@ diff --git a/core/modules/content_moderation/src/Plugin/Field/FieldWidget/Modera
 +
      $form_state->setValueForElement($element, [$element['state']['#key_column'] => $element['state']['#value']]);
    }
+

--- a/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
@@ -27,7 +27,7 @@ Feature: Content Type: Campaign Landing Page
     And I click to expand "Q&As"
     And I select 10 items from the "Add Reusable Q&As" Entity Browser modal
     And I wait "2" seconds
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -36,7 +36,7 @@ Feature: Content Type: Campaign Landing Page
     # Test fewer than minimum FAQs cannot be added.
     When I click the button with selector "[data-drupal-selector='edit-field-clp-reusable-q-a-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_reusable_q_a_0_remove']"
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -45,7 +45,7 @@ Feature: Content Type: Campaign Landing Page
     # Test required Q&As if FAQ segment is enabled
     When I click the button with selector "[data-drupal-selector='edit-field-clp-faq-paragraphs-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_faq_paragraphs_0_remove']"
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see "A minimum of 3 Q&As is required when the FAQ page segment is enabled. Disable the FAQs page segment if there are no Q&As to add."
@@ -53,7 +53,7 @@ Feature: Content Type: Campaign Landing Page
     # Test that no Q&A is required if the FAQ page segment is disabled
     When I click to expand "FAQs"
     And I disable the page segment
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then the element with selector ".messages__content" should contain "Campaign Landing Page"

--- a/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
@@ -27,6 +27,7 @@ Feature: Content Type: Campaign Landing Page
     And I click to expand "Q&As"
     And I select 10 items from the "Add Reusable Q&As" Entity Browser modal
     And I wait "2" seconds
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -35,6 +36,7 @@ Feature: Content Type: Campaign Landing Page
     # Test fewer than minimum FAQs cannot be added.
     When I click the button with selector "[data-drupal-selector='edit-field-clp-reusable-q-a-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_reusable_q_a_0_remove']"
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -43,6 +45,7 @@ Feature: Content Type: Campaign Landing Page
     # Test required Q&As if FAQ segment is enabled
     When I click the button with selector "[data-drupal-selector='edit-field-clp-faq-paragraphs-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_faq_paragraphs_0_remove']"
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see "A minimum of 3 Q&As is required when the FAQ page segment is enabled. Disable the FAQs page segment if there are no Q&As to add."
@@ -50,6 +53,7 @@ Feature: Content Type: Campaign Landing Page
     # Test that no Q&A is required if the FAQ page segment is disabled
     When I click to expand "FAQs"
     And I disable the page segment
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then the element with selector ".messages__content" should contain "Campaign Landing Page"

--- a/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
@@ -27,7 +27,7 @@ Feature: Content Type: Campaign Landing Page
     And I click to expand "Q&As"
     And I select 10 items from the "Add Reusable Q&As" Entity Browser modal
     And I wait "2" seconds
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -36,7 +36,7 @@ Feature: Content Type: Campaign Landing Page
     # Test fewer than minimum FAQs cannot be added.
     When I click the button with selector "[data-drupal-selector='edit-field-clp-reusable-q-a-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_reusable_q_a_0_remove']"
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -45,7 +45,7 @@ Feature: Content Type: Campaign Landing Page
     # Test required Q&As if FAQ segment is enabled
     When I click the button with selector "[data-drupal-selector='edit-field-clp-faq-paragraphs-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_faq_paragraphs_0_remove']"
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see "A minimum of 3 Q&As is required when the FAQ page segment is enabled. Disable the FAQs page segment if there are no Q&As to add."
@@ -53,7 +53,7 @@ Feature: Content Type: Campaign Landing Page
     # Test that no Q&A is required if the FAQ page segment is disabled
     When I click to expand "FAQs"
     And I disable the page segment
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then the element with selector ".messages__content" should contain "Campaign Landing Page"

--- a/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
+++ b/tests/cypress/integration/features/content_type/campaign_landing_page/clp_faq.feature
@@ -27,7 +27,7 @@ Feature: Content Type: Campaign Landing Page
     And I click to expand "Q&As"
     And I select 10 items from the "Add Reusable Q&As" Entity Browser modal
     And I wait "2" seconds
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -36,7 +36,7 @@ Feature: Content Type: Campaign Landing Page
     # Test fewer than minimum FAQs cannot be added.
     When I click the button with selector "[data-drupal-selector='edit-field-clp-reusable-q-a-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_reusable_q_a_0_remove']"
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see an element with the selector "#edit-field-clp-faq-paragraphs-0-subform-field-question-0-value.error"
@@ -45,7 +45,7 @@ Feature: Content Type: Campaign Landing Page
     # Test required Q&As if FAQ segment is enabled
     When I click the button with selector "[data-drupal-selector='edit-field-clp-faq-paragraphs-0-top'] .paragraphs-dropdown-toggle"
     And I click the button with selector "[name='field_clp_faq_paragraphs_0_remove']"
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then I should see "A minimum of 3 Q&As is required when the FAQ page segment is enabled. Disable the FAQs page segment if there are no Q&As to add."
@@ -53,7 +53,7 @@ Feature: Content Type: Campaign Landing Page
     # Test that no Q&A is required if the FAQ page segment is disabled
     When I click to expand "FAQs"
     And I disable the page segment
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I save the node
     Then the element with selector ".messages__content" should contain "Campaign Landing Page"

--- a/tests/cypress/integration/features/content_type/checklist.feature
+++ b/tests/cypress/integration/features/content_type/checklist.feature
@@ -9,6 +9,7 @@ Feature: Content Type: Checklist
   Scenario: Log in, edit, and save nodes with save and continue button and confirm revision saves changes.
     When I am logged in as a user with the "administrator" role
     And I create a "checklist" node and continue
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     # Verify data has been saved
     Then "error has been found:" should not exist
@@ -36,4 +37,5 @@ Feature: Content Type: Checklist
 
     # Make sure we are in draft state
     Then I edit the node
+    Then I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And the option "Draft" from dropdown with selector "#edit-moderation-state-0-state" should be selected

--- a/tests/cypress/integration/features/content_type/event.feature
+++ b/tests/cypress/integration/features/content_type/event.feature
@@ -151,7 +151,7 @@ Feature: Content Type: Event
   Scenario: Confirm creating "Featured" Events is possible.
     Given I am logged in as a user with the "content_admin" role
     And I create a "event" node and continue
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I feature the content
     When I save the node

--- a/tests/cypress/integration/features/content_type/event.feature
+++ b/tests/cypress/integration/features/content_type/event.feature
@@ -151,7 +151,7 @@ Feature: Content Type: Event
   Scenario: Confirm creating "Featured" Events is possible.
     Given I am logged in as a user with the "content_admin" role
     And I create a "event" node and continue
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I feature the content
     When I save the node

--- a/tests/cypress/integration/features/content_type/event.feature
+++ b/tests/cypress/integration/features/content_type/event.feature
@@ -151,7 +151,7 @@ Feature: Content Type: Event
   Scenario: Confirm creating "Featured" Events is possible.
     Given I am logged in as a user with the "content_admin" role
     And I create a "event" node and continue
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I feature the content
     When I save the node

--- a/tests/cypress/integration/features/content_type/event.feature
+++ b/tests/cypress/integration/features/content_type/event.feature
@@ -151,6 +151,7 @@ Feature: Content Type: Event
   Scenario: Confirm creating "Featured" Events is possible.
     Given I am logged in as a user with the "content_admin" role
     And I create a "event" node and continue
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with fake text
     And I feature the content
     When I save the node

--- a/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_facility.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vamc/health_care_local_facility.feature
@@ -18,6 +18,7 @@ Feature: CMS Users may effectively interact with the VAMC Facility form
     And I select option "-- VA Alaska health care" from dropdown "Parent link"
     Then an element with the selector '[data-drupal-selector="edit-group-covid-19-safety-guidelines"]' should not exist
     And I scroll to position "bottom"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I click the button to create node and continue
     Then "[Test Data] Facility Name" should exist

--- a/tests/cypress/integration/features/content_type/facilities/vamc/nonclinical_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vamc/nonclinical_service.feature
@@ -11,6 +11,7 @@ Scenario: Login and confirm that saving a VAMC Nonclinical Service works as expe
   # Billing and insurance - Buffalo VA Medical Center
 
   When I am at "node/52453/edit"
+  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I save the node
   Then I should see "Address"

--- a/tests/cypress/integration/features/content_type/facilities/vamc/nonclinical_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vamc/nonclinical_service.feature
@@ -11,7 +11,7 @@ Scenario: Login and confirm that saving a VAMC Nonclinical Service works as expe
   # Billing and insurance - Buffalo VA Medical Center
 
   When I am at "node/52453/edit"
-  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+  And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I save the node
   Then I should see "Address"

--- a/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
@@ -67,6 +67,7 @@ Feature: CMS User may effectively interact with the VBA Facility form
     And I select the "Allow site visitors to dismiss banner" radio button
     And I fill in field with selector "#edit-field-banner-title-0-value" with value "[Test Data] Test banner title."
     And I fill in ckeditor "edit-field-banner-content-0-value" with "[Test Data] Banner Body"
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I uncheck the "Display a banner alert on this facility" checkbox
     And I save the node

--- a/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
@@ -67,7 +67,7 @@ Feature: CMS User may effectively interact with the VBA Facility form
     And I select the "Allow site visitors to dismiss banner" radio button
     And I fill in field with selector "#edit-field-banner-title-0-value" with value "[Test Data] Test banner title."
     And I fill in ckeditor "edit-field-banner-content-0-value" with "[Test Data] Banner Body"
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I uncheck the "Display a banner alert on this facility" checkbox
     And I save the node

--- a/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
@@ -67,7 +67,7 @@ Feature: CMS User may effectively interact with the VBA Facility form
     And I select the "Allow site visitors to dismiss banner" radio button
     And I fill in field with selector "#edit-field-banner-title-0-value" with value "[Test Data] Test banner title."
     And I fill in ckeditor "edit-field-banner-content-0-value" with "[Test Data] Banner Body"
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I uncheck the "Display a banner alert on this facility" checkbox
     And I save the node

--- a/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vba/vba_facility.feature
@@ -67,7 +67,7 @@ Feature: CMS User may effectively interact with the VBA Facility form
     And I select the "Allow site visitors to dismiss banner" radio button
     And I fill in field with selector "#edit-field-banner-title-0-value" with value "[Test Data] Test banner title."
     And I fill in ckeditor "edit-field-banner-content-0-value" with "[Test Data] Banner Body"
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I uncheck the "Display a banner alert on this facility" checkbox
     And I save the node

--- a/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
@@ -63,7 +63,7 @@ Scenario: Administrators should be able to rename a Vet Center - Facility Servic
   Then I select option '3751' from dropdown with selector 'select[data-drupal-selector^="edit-field-office"]'
   # Women Veteran Care
   And I select option '57' from dropdown with selector 'select[data-drupal-selector^="edit-field-service-name-and-descripti"]'
-  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+  And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I save the node
   Then I should see "Duluth Vet Center - Women Veteran care"

--- a/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
+++ b/tests/cypress/integration/features/content_type/facilities/vet_center/vet_center_facility_service.feature
@@ -63,6 +63,7 @@ Scenario: Administrators should be able to rename a Vet Center - Facility Servic
   Then I select option '3751' from dropdown with selector 'select[data-drupal-selector^="edit-field-office"]'
   # Women Veteran Care
   And I select option '57' from dropdown with selector 'select[data-drupal-selector^="edit-field-service-name-and-descripti"]'
+  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I save the node
   Then I should see "Duluth Vet Center - Women Veteran care"

--- a/tests/cypress/integration/features/content_type/person_profile.feature
+++ b/tests/cypress/integration/features/content_type/person_profile.feature
@@ -29,6 +29,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   # Create the page with intention of using biography without providing both required.
   Given I click the edit tab
   And I check the "Create profile page with biography" checkbox
+  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I click the "Save" button
   Then I am prevented from saving the node by "textarea" "#edit-field-intro-text-0-value" with error "Please fill out this field."
@@ -39,6 +40,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   Then I should see "1 error has been found: Body text"
 
   # Create the page with intention of using biography providing required fields.
+  I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
   Given I fill in ckeditor "edit-field-body-0-value" with "[Test Data] Profile Body"
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been updated."
@@ -49,6 +51,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I fill in field with selector "#edit-field-intro-text-0-value" with value "[Test Data] Better words."
   And I uncheck the "Create profile page with biography" checkbox
+  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been updated."
   And I should see "Better words."
@@ -66,6 +69,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I wait "5" seconds
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-number-0-value']" with value "402-867-5309"
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-extension-0-value']" with value "x1234"
+  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been created."

--- a/tests/cypress/integration/features/content_type/person_profile.feature
+++ b/tests/cypress/integration/features/content_type/person_profile.feature
@@ -29,7 +29,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   # Create the page with intention of using biography without providing both required.
   Given I click the edit tab
   And I check the "Create profile page with biography" checkbox
-  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+  And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I click the "Save" button
   Then I am prevented from saving the node by "textarea" "#edit-field-intro-text-0-value" with error "Please fill out this field."
@@ -51,7 +51,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I fill in field with selector "#edit-field-intro-text-0-value" with value "[Test Data] Better words."
   And I uncheck the "Create profile page with biography" checkbox
-  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+  And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been updated."
   And I should see "Better words."
@@ -69,7 +69,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I wait "5" seconds
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-number-0-value']" with value "402-867-5309"
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-extension-0-value']" with value "x1234"
-  And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+  And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been created."

--- a/tests/cypress/integration/features/content_type/person_profile.feature
+++ b/tests/cypress/integration/features/content_type/person_profile.feature
@@ -15,7 +15,6 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I click the "Add Phone number" button
   And I wait "5" seconds
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-number-0-value']" with value "402-867-5309"
-  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I click the button with selector "[data-drupal-selector='edit-field-telephone-0-top-links-remove-button']"
   And I wait for an element with the selector "[data-drupal-selector='edit-field-telephone-0-top-links-confirm-remove-button']" to exist
   And I click the button with selector "[data-drupal-selector='edit-field-telephone-0-top-links-confirm-remove-button']"
@@ -23,6 +22,8 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I click the "Add Phone number" button
   And I wait "5" seconds
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-number-0-value']" with value "402-867-5309"
+  Then I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+  And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been created."
 
@@ -40,8 +41,8 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   Then I should see "1 error has been found: Body text"
 
   # Create the page with intention of using biography providing required fields.
-  I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
   Given I fill in ckeditor "edit-field-body-0-value" with "[Test Data] Profile Body"
+  Then I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been updated."
 
@@ -51,7 +52,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I fill in field with selector "#edit-field-intro-text-0-value" with value "[Test Data] Better words."
   And I uncheck the "Create profile page with biography" checkbox
-  And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+  Then I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been updated."
   And I should see "Better words."
@@ -69,7 +70,7 @@ Scenario: Log in and create a Person Profile with attention to conditional field
   And I wait "5" seconds
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-number-0-value']" with value "402-867-5309"
   And I fill in field with selector "[data-drupal-selector*='subform-field-phone-extension-0-value']" with value "x1234"
-  And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+  Then I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
   And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
   And I click the "Save" button
   Then I should see "Staff Profile James Smith has been created."

--- a/tests/cypress/integration/features/platform/media.feature
+++ b/tests/cypress/integration/features/platform/media.feature
@@ -33,7 +33,7 @@ Feature: Media entities
     When I create a "document" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Document" file
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "document" downloadable file link
@@ -44,7 +44,7 @@ Feature: Media entities
     Then I create a "image" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Image" file
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "image" downloadable file link
@@ -55,7 +55,7 @@ Feature: Media entities
     Then I create a "video" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Video" file
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "video" file link

--- a/tests/cypress/integration/features/platform/media.feature
+++ b/tests/cypress/integration/features/platform/media.feature
@@ -33,7 +33,7 @@ Feature: Media entities
     When I create a "document" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Document" file
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "document" downloadable file link
@@ -44,7 +44,7 @@ Feature: Media entities
     Then I create a "image" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Image" file
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "image" downloadable file link
@@ -55,7 +55,7 @@ Feature: Media entities
     Then I create a "video" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Video" file
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "video" file link

--- a/tests/cypress/integration/features/platform/media.feature
+++ b/tests/cypress/integration/features/platform/media.feature
@@ -33,6 +33,7 @@ Feature: Media entities
     When I create a "document" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Document" file
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "document" downloadable file link
@@ -43,6 +44,7 @@ Feature: Media entities
     Then I create a "image" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Image" file
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "image" downloadable file link
@@ -53,6 +55,7 @@ Feature: Media entities
     Then I create a "video" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Video" file
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "video" file link

--- a/tests/cypress/integration/features/platform/media.feature
+++ b/tests/cypress/integration/features/platform/media.feature
@@ -33,7 +33,7 @@ Feature: Media entities
     When I create a "document" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Document" file
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "document" downloadable file link
@@ -44,7 +44,7 @@ Feature: Media entities
     Then I create a "image" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Image" file
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "image" downloadable file link
@@ -55,7 +55,7 @@ Feature: Media entities
     Then I create a "video" media
     And I create a "documentation_page" node and continue
     And I add a main content block with a link to a "Video" file
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see a "video" file link

--- a/tests/cypress/integration/features/platform/text_validation.feature
+++ b/tests/cypress/integration/features/platform/text_validation.feature
@@ -11,6 +11,7 @@ Feature: Text fields are validated
     And I click the "Add Content block" button
     And I scroll to element "div.ck-content"
     And I fill in ckeditor "edit-field-content-block-0-subform-field-wysiwyg-0-value" with '<a href="https://staging.cms.va.gov/">test</a>'
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see "1 error has been found: Text"

--- a/tests/cypress/integration/features/platform/text_validation.feature
+++ b/tests/cypress/integration/features/platform/text_validation.feature
@@ -21,6 +21,7 @@ Feature: Text fields are validated
     And I create a "health_care_region_detail_page" node
     And I click the edit tab
     And I fill in 'Page introduction' with "https://prod.cms.va.gov/"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-0-value" with value "[Test Data] Revision log message."
     And I save the node
     Then I should see "1 error has been found: Page introduction"

--- a/tests/cypress/integration/features/platform/translation.feature
+++ b/tests/cypress/integration/features/platform/translation.feature
@@ -30,14 +30,14 @@ Feature: Translation functionality testing.
     And I click the edit tab
     Then the element with selector ".field--name-title .textfield_counter_counter" should contain "Characters remaining"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then the element with selector ".field--name-field-intro-text-limited-html .form-item--error-message" should contain "cannot be longer"
     And I click the "Translate" link
     And I click the button with selector "ul.dropbutton a[hreflang=es]"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
-    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then I should see "has been updated."

--- a/tests/cypress/integration/features/platform/translation.feature
+++ b/tests/cypress/integration/features/platform/translation.feature
@@ -30,12 +30,14 @@ Feature: Translation functionality testing.
     And I click the edit tab
     Then the element with selector ".field--name-title .textfield_counter_counter" should contain "Characters remaining"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then the element with selector ".field--name-field-intro-text-limited-html .form-item--error-message" should contain "cannot be longer"
     And I click the "Translate" link
     And I click the button with selector "ul.dropbutton a[hreflang=es]"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
+    And I select option "Draft" from dropdown with selector "edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then I should see "has been updated."

--- a/tests/cypress/integration/features/platform/translation.feature
+++ b/tests/cypress/integration/features/platform/translation.feature
@@ -30,14 +30,14 @@ Feature: Translation functionality testing.
     And I click the edit tab
     Then the element with selector ".field--name-title .textfield_counter_counter" should contain "Characters remaining"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then the element with selector ".field--name-field-intro-text-limited-html .form-item--error-message" should contain "cannot be longer"
     And I click the "Translate" link
     And I click the button with selector "ul.dropbutton a[hreflang=es]"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
-    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then I should see "has been updated."

--- a/tests/cypress/integration/features/platform/translation.feature
+++ b/tests/cypress/integration/features/platform/translation.feature
@@ -30,14 +30,14 @@ Feature: Translation functionality testing.
     And I click the edit tab
     Then the element with selector ".field--name-title .textfield_counter_counter" should contain "Characters remaining"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then the element with selector ".field--name-field-intro-text-limited-html .form-item--error-message" should contain "cannot be longer"
     And I click the "Translate" link
     And I click the button with selector "ul.dropbutton a[hreflang=es]"
     Given I fill in ckeditor field "edit-field-intro-text-limited-html-0-value" with 1010 characters
-    And I select option "Draft" from dropdown "select#edit-moderation-state-0-state"
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in "Revision log message" with "It is a message"
     And I save the node
     Then I should see "has been updated."

--- a/tests/cypress/integration/features/platform/translation.feature
+++ b/tests/cypress/integration/features/platform/translation.feature
@@ -20,6 +20,7 @@ Feature: Translation functionality testing.
     And I click the "Translate" link
     And I click the button with selector "ul.dropbutton a[hreflang=es]"
     And I fill in field with selector "#edit-field-intro-text-wrapper textarea" with value "This is not Spanish."
+    And I select option "Draft" from dropdown with selector "select#edit-moderation-state-0-state"
     And I fill in field with selector "#edit-revision-log-wrapper textarea" with value "This is a revision message."
     And I click the button with selector "form#node-landing-page-form input#edit-submit"
     Then I should see "This is not Spanish."

--- a/tests/cypress/integration/step_definitions/common/i_click_the_button_to_create_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_click_the_button_to_create_node.js
@@ -1,7 +1,7 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 
 Given(`I click the button to create node and continue`, () => {
-  cy.contains("input", "Save draft and continue editing").click({
+  cy.contains("input", "Save and continue editing").click({
     force: true,
   });
   cy.location("pathname", { timeout: 10000 }).should(

--- a/tests/cypress/integration/step_definitions/common/i_create_a_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_create_a_node.js
@@ -331,11 +331,11 @@ const creators = {
         { force: true }
       );
     });
+    cy.get("#edit-moderation-state-0-state").select("draft", { force: true });
     cy.get("#edit-revision-log-0-value").type(
       `[Test revision log 1]${faker.lorem.sentence()}`,
       { force: true }
     );
-    cy.get("#edit-moderation-state-0-state").select("draft", { force: true });
     cy.get("button").contains("Save and insert").click({ force: true });
     cy.get(
       'div.media-library-item[data-drupal-selector="edit-field-media-selection-0"]',
@@ -354,6 +354,7 @@ const creators = {
 
     cy.findAllByLabelText("City").type(faker.address.city(), { force: true });
     cy.findAllByLabelText("State").select("Alabama", { force: true });
+    cy.get("#edit-moderation-state-0-state").select("draft", { force: true });
     cy.get("#edit-revision-log-0-value").type(
       `[Test revision log]${faker.lorem.sentence()}`,
       { force: true }
@@ -372,6 +373,7 @@ const creators = {
     cy.get("#manage-instances form").find("input.form-submit").click();
     cy.get("#manage-instances form").should("not.exist");
     cy.get("button.ui-dialog-titlebar-close").click();
+    cy.get("#edit-moderation-state-0-state").select("draft", { force: true });
     return cy.wait(1000);
   },
   health_care_region_detail_page: () => {

--- a/tests/cypress/integration/step_definitions/common/i_create_a_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_create_a_node.js
@@ -556,6 +556,7 @@ Given("I create a {string} node", (contentType) => {
   cy.injectAxe();
   cy.scrollTo("top");
   cy.checkAccessibility();
+  cy.get("#edit-moderation-state-0-state").select("draft", { force: true });
   creator().then(() => {
     cy.get("#edit-revision-log-0-value").type(
       `[Test revision log]${faker.lorem.sentence()}`,
@@ -591,7 +592,7 @@ Given("I create a {string} node and continue", (contentType) => {
   cy.injectAxe();
   cy.scrollTo("top");
   cy.checkAccessibility();
-  cy.get("#edit-moderation-state-0-state").select("Draft", { force: true });
+  cy.get("#edit-moderation-state-0-state").select("draft", { force: true });
   creator().then(() => {
     cy.get("#edit-revision-log-0-value").type(
       `[Test revision log]${faker.lorem.sentence()}`,

--- a/tests/cypress/integration/step_definitions/common/i_create_a_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_create_a_node.js
@@ -326,6 +326,7 @@ const creators = {
       `[Test revision log 1]${faker.lorem.sentence()}`,
       { force: true }
     );
+    cy.get("#edit-moderation-state-0-state").select("Draft", { force: true });
     cy.get("button").contains("Save and insert").click({ force: true });
     cy.get(
       'div.media-library-item[data-drupal-selector="edit-field-media-selection-0"]',
@@ -590,6 +591,7 @@ Given("I create a {string} node and continue", (contentType) => {
   cy.injectAxe();
   cy.scrollTo("top");
   cy.checkAccessibility();
+  cy.get("#edit-moderation-state-0-state").select("Draft", { force: true });
   creator().then(() => {
     cy.get("#edit-revision-log-0-value").type(
       `[Test revision log]${faker.lorem.sentence()}`,

--- a/tests/cypress/integration/step_definitions/common/i_create_a_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_create_a_node.js
@@ -192,6 +192,15 @@ const creators = {
           '[data-drupal-selector="edit-inline-entity-form-field-owner"]'
         ).select("VACO", { force: true });
       });
+    /** Set moderation state */
+    cy.get("iframe.entity-browser-modal-iframe")
+      .iframe()
+      .within(() => {
+        cy.get("#edit-inline-entity-form-moderation-state-0-state").select(
+          "draft",
+          { force: true }
+        );
+      });
     cy.get("iframe.entity-browser-modal-iframe")
       .iframe()
       .within(() => {

--- a/tests/cypress/integration/step_definitions/common/i_create_a_node.js
+++ b/tests/cypress/integration/step_definitions/common/i_create_a_node.js
@@ -326,7 +326,7 @@ const creators = {
       `[Test revision log 1]${faker.lorem.sentence()}`,
       { force: true }
     );
-    cy.get("#edit-moderation-state-0-state").select("Draft", { force: true });
+    cy.get("#edit-moderation-state-0-state").select("draft", { force: true });
     cy.get("button").contains("Save and insert").click({ force: true });
     cy.get(
       'div.media-library-item[data-drupal-selector="edit-field-media-selection-0"]',

--- a/tests/phpunit/Content/ContentModerationTest.php
+++ b/tests/phpunit/Content/ContentModerationTest.php
@@ -20,7 +20,7 @@ class ContentModerationTest extends VaGovExistingSiteBase {
    * Prevent accidental publication of un-proofed nodes.
    *
    * When a "Published" node is being edited, the default moderation state
-   * should be set to "Draft".
+   * should be set to "null".
    *
    * @dataProvider preventPublishingUnproofedNodesDataProvider
    */
@@ -29,7 +29,7 @@ class ContentModerationTest extends VaGovExistingSiteBase {
     string $baseFormId,
     array $expectedElement,
     bool $formEntityIsPublishable = FALSE,
-    bool $formEntityIsPublished = FALSE
+    bool $formEntityIsPublished = FALSE,
   ) {
     $context = [];
     $formStateProphecy = $this->prophesize(FormStateInterface::CLASS);
@@ -125,7 +125,7 @@ class ContentModerationTest extends VaGovExistingSiteBase {
         'node_form',
         [
           'state' => [
-            '#default_value' => 'draft',
+            '#default_value' => 'null',
             '#title' => 'Save as',
           ],
         ],


### PR DESCRIPTION
## Description

Relates to #23017 

### Generated description
This pull request enforces that content editors must explicitly choose a moderation state (such as "Draft" or "Published") when saving content, rather than defaulting to "Draft." This change is implemented via a new patch to the content moderation widget, updates to backend logic, and corresponding updates to tests to reflect the new required selection. Additionally, some minor code cleanup and comment improvements are included.

**Content Moderation Improvements:**

* Added a new patch (`VACMS-23017-content-moderation-default-placeholder.patch`) to the moderation state widget so that the moderation state dropdown now shows a required placeholder ("- Choose a moderation state -") and requires the user to select a value before saving. The form will not submit unless a moderation state is chosen. [[1]](diffhunk://#diff-503d79a900d170c04b12b2d53f88e9dc18aeb1280d7a92292cde6c523e14d339R1-R37) [[2]](diffhunk://#diff-9540ac7b31547230b801b4a177eb55996f76d6abe1028635240e9b24cbee9022L37-R38)
* Updated the backend form alteration logic in `va_gov_backend.module` to remove the previous defaulting of the moderation state to "Draft" and to update the field label, aligning with the new patch behavior. [[1]](diffhunk://#diff-567d531330304beb9522b26b7f7b660b4e481f6dcb381e1280b13b21786b1f50L547-R548) [[2]](diffhunk://#diff-567d531330304beb9522b26b7f7b660b4e481f6dcb381e1280b13b21786b1f50L896-R890)
* Changed the label on the "Save draft and continue editing" button to "Save and continue editing" for clarity.

**Automated Test Updates:**

* Updated Cypress feature tests for various content types to explicitly select a moderation state ("Draft") from the dropdown before saving, ensuring tests pass with the new required moderation state selection. [[1]](diffhunk://#diff-766d32764f0656ba749cfac9c38a0d93479076647210a61e061cbdfe62de47dfR30) [[2]](diffhunk://#diff-766d32764f0656ba749cfac9c38a0d93479076647210a61e061cbdfe62de47dfR39) [[3]](diffhunk://#diff-766d32764f0656ba749cfac9c38a0d93479076647210a61e061cbdfe62de47dfR48-R56) [[4]](diffhunk://#diff-edf9dc859e319f69aaf805def996aafd2597756c91075b213294040826479dbeR12) [[5]](diffhunk://#diff-edf9dc859e319f69aaf805def996aafd2597756c91075b213294040826479dbeR40) [[6]](diffhunk://#diff-fd6c9b6507ffeb5ec840e7857253742ab4c8fae3945179d45c43b50af35712c7R154) [[7]](diffhunk://#diff-2d06bc473d1da7e00aa45942f7f5196db9b2dbf34d71b081a128006963e9f732R21) [[8]](diffhunk://#diff-89bbd2a48eeb0b26bfa03964053ad9f0e2ae3b200174cdf6ba0250a0e7f27028R14) [[9]](diffhunk://#diff-1222770ef76837a92ead3b3e697b892c33ce5545beb015eb84c100852c77db86R70) [[10]](diffhunk://#diff-00974cf581ef4bd54025c778cd920732c2fcd8ad98b959bd9fe991a14a353ccfR66) [[11]](diffhunk://#diff-8f097c9a4d246d6838b4e9acad47de504eb517753378e0fe178aa7b98714820dL18-R33) [[12]](diffhunk://#diff-8f097c9a4d246d6838b4e9acad47de504eb517753378e0fe178aa7b98714820dR45) [[13]](diffhunk://#diff-8f097c9a4d246d6838b4e9acad47de504eb517753378e0fe178aa7b98714820dR55) [[14]](diffhunk://#diff-8f097c9a4d246d6838b4e9acad47de504eb517753378e0fe178aa7b98714820dR73) [[15]](diffhunk://#diff-be38b8f36c253fadc1ac8ed82d31cec95746723664f1eb35e4584ced6a5fe3ddR36) [[16]](diffhunk://#diff-be38b8f36c253fadc1ac8ed82d31cec95746723664f1eb35e4584ced6a5fe3ddR47)

**Code Cleanup and Comments:**

* Improved comments and formatting in the `_va_gov_backend_has_suspicious_nbsp_density` function for clarity and correctness. [[1]](diffhunk://#diff-567d531330304beb9522b26b7f7b660b4e481f6dcb381e1280b13b21786b1f50L1882-R1877) [[2]](diffhunk://#diff-567d531330304beb9522b26b7f7b660b4e481f6dcb381e1280b13b21786b1f50L1895-R1892)
* Removed an unused import (`EntityPublishedInterface`) from `va_gov_backend.module`.

## Testing done
Cypress (so much cypress)

## Screenshots
![save-as-moderation-state-part1-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f152bda0-0ae5-4c63-95cf-a908b4e3e9d8)

## QA steps
### Set up user
- [x] Log in as an admin
- [x] Assign the following role to QA Content Publisher
  - [x] Content creator - VAMC
  - [x] Content publisher
- [x] Assign the following section to QA Content Publisher
  - [x] VA Boston health care
 
### Test creating node
- [x] Log in a QA Content Publisher
- [x] Create a story, filling out all required fields but **Save as**
- [x] Try to save
- [x] Confirm that front-end validation error requires you to fill it in
- [x] Choose "Draft" from **Save as**
- [x] Save
- [x] Confirm that the story saves without error

### Test editing node
- [ ] Edit a VAMC facility node
- [ ] Make an edit or two
- [ ] Choose "Save and continue editing"
- [ ] Confirm that front-end validation error requires you to fill it in
- [ ] Choose "Draft" from **Save as**
- [ ] Choose "Save and continue editing"
- [ ] Confirm that the story saves without error
- [ ] Make another edit
- [ ] Save
- [ ] Confirm that front-end validation error requires you to fill it in
- [ ] Choose "Published" from **Save as**
- [ ] Save
- [ ] Confirm that the story saves without error
- [ ] Edit the story
- [ ] Confirm that **Save as** is set to "- Select a moderation state -"


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

