### PR TITLE
VACMS-21012: Adds 155 day inactive warning

### DIFF
--- a/config/sync/advancedqueue.advancedqueue_queue.product_owner_no_active_users_notification.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.product_owner_no_active_users_notification.yml
@@ -10,6 +10,7 @@ backend_configuration:
 processor: cron
 processing_time: 10
 locked: false
+stop_when_empty: true
 threshold:
   type: 2
   limit: 30

--- a/config/sync/eca.eca.warn_inactive_users_155_days.yml
+++ b/config/sync/eca.eca.warn_inactive_users_155_days.yml
@@ -9,9 +9,9 @@ dependencies:
     - eca_content
     - eca_views
     - va_gov_eca
-id: warn_inactive_users_90_days
+id: warn_inactive_users_155_days
 modeller: core
-label: 'Warn Inactive Users after 90 days'
+label: 'Warn Inactive Users after 155 days'
 version: ''
 weight: 0
 events:
@@ -19,7 +19,7 @@ events:
     plugin: 'eca_base:eca_custom'
     label: 'ECA custom event'
     configuration:
-      event_id: inactive_users_warn_90_days
+      event_id: inactive_users_warn_155_days
     successors:
       -
         id: eca_views_query
@@ -28,7 +28,7 @@ events:
     plugin: 'content_entity:custom'
     label: 'ECA custom event (entity-aware)'
     configuration:
-      event_id: queue_results_90
+      event_id: queue_results_155
     successors:
       -
         id: queue_notification
@@ -42,7 +42,7 @@ actions:
     configuration:
       token_name: results
       view_id: inactive_users
-      display_id: inactive_90_days
+      display_id: inactive_155_days
       arguments: ''
     successors:
       -
@@ -59,7 +59,7 @@ actions:
     plugin: eca_trigger_content_entity_custom_event
     label: 'Trigger a custom event (entity-aware)'
     configuration:
-      event_id: queue_results_90
+      event_id: queue_results_155
       tokens: ''
       object: results
     successors: {  }
@@ -67,9 +67,9 @@ actions:
     plugin: create_advancedqueue_job
     label: 'Queue notification'
     configuration:
-      token_name: 'job'
+      token_name: job
       type: va_gov_warn_inactive_users_notification
-      payload: "template_values:\r\n  template: warn_inactive_users\r\n  uid: \"[entity:uid]\"\r\nvalues:\r\n  field_warning_days: \"90\""
+      payload: "template_values:\r\n  template: warn_inactive_users\r\n  uid: \"[entity:uid]\"\r\nvalues:\r\n  field_warning_days: \"155\""
       queue: warn_inactive_users
     successors:
       -

--- a/config/sync/language/en/message.template.warn_inactive_users.yml
+++ b/config/sync/language/en/message.template.warn_inactive_users.yml
@@ -1,7 +1,7 @@
 text:
   -
-    value: '<p>Warning: At least [message:field_warning_days] days since last VA Drupal log in</p>'
+    value: '<p>Warning: At least 5 months since last VA Drupal log in</p>'
     format: rich_text
   -
-    value: "<p>Hi,&nbsp;</p><p>It appears you have not accessed <a href='https://prod.va.cms.gov'>the VA Drupal site</a> since [message:uid:entity:login:date:custom:F j, Y, g: i a], which is at least [message:field_warning_days] days ago.&nbsp;</p><p>If you do not log in at least every 180 days, your account will be deactivated.</p>"
+    value: "<p>Hello,</p><p>You are receiving this email because you have not accessed your <a href='https://prod.va.cms.gov'>VA Drupal CMS account</a> in over 5 months. To comply with VA Platform Security standards, we require all Drupal CMS users to sign in at least once every 5 months. If you no longer work with Drupal CMS and would like to make your account inactive, please email <a href='mailto:vadrupalcms@va.gov'>vadrupalcms@va.gov</a> to contact the Drupal CMS Helpdesk.</p><br><p>Thank you,<br>VA Drupal CMS Support</p>"
     format: rich_text

--- a/config/sync/message.template.warn_inactive_users.yml
+++ b/config/sync/message.template.warn_inactive_users.yml
@@ -9,10 +9,10 @@ label: 'Warn Inactive Users'
 description: 'Warning users who have not activated or logged in recently that their account may be deactivated.'
 text:
   -
-    value: '<p>Warning: At least [message:field_warning_days] days since last VA Drupal log in</p>'
+    value: '<p>Warning: At least 5 months since last VA Drupal log in</p>'
     format: rich_text
   -
-    value: "<p>Hi,&nbsp;</p><p>It appears you have not accessed <a href='https://prod.va.cms.gov'>the VA Drupal site</a> since [message:uid:entity:login:date:custom:F j, Y], which is [message:field_warning_days] or more days ago.&nbsp;</p><p>If you do not log in at least every 180 days, your account will be deactivated.</p>"
+    value: "<p>Hello,</p><p>You are receiving this email because you have not accessed your <a href='https://prod.va.cms.gov'>VA Drupal CMS account</a> in over 5 months. To comply with VA Platform Security standards, we require all Drupal CMS users to sign in at least once every 5 months. If you no longer work with Drupal CMS and would like to make your account inactive, please email <a href='mailto:vadrupalcms@va.gov'>vadrupalcms@va.gov</a> to contact the Drupal CMS Helpdesk.</p><br><p>Thank you,<br>VA Drupal CMS Support</p>"
     format: rich_text
 settings:
   'token options':

--- a/config/sync/ultimate_cron.job.va_gov_scheduled_tasks_quarterly.yml
+++ b/config/sync/ultimate_cron.job.va_gov_scheduled_tasks_quarterly.yml
@@ -1,10 +1,10 @@
+uuid: 17633dad-53c7-4706-9aff-fe0b2f1bedb9
 langcode: en
 status: true
 dependencies:
   module:
     - va_gov_scheduled_tasks
 title: 'Do scheduled tasks quarterly'
-description: 'Checking for outdated content and other quarterly tasks'
 id: va_gov_scheduled_tasks_quarterly
 weight: 0
 module: va_gov_scheduled_tasks
@@ -14,3 +14,7 @@ scheduler:
   configuration:
     rules:
       - '0 0 15 1,4,7,10 *'
+launcher:
+  id: serial
+logger:
+  id: database

--- a/config/sync/ultimate_cron.job.va_gov_scheduled_tasks_quarterly.yml
+++ b/config/sync/ultimate_cron.job.va_gov_scheduled_tasks_quarterly.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - va_gov_scheduled_tasks
+title: 'Do scheduled tasks quarterly'
+description: 'Checking for outdated content and other quarterly tasks'
+id: va_gov_scheduled_tasks_quarterly
+weight: 0
+module: va_gov_scheduled_tasks
+callback: va_gov_scheduled_tasks_quarterly
+scheduler:
+  id: crontab
+  configuration:
+    rules:
+      - '0 0 15 1,4,7,10 *'

--- a/config/sync/views.view.inactive_users.yml
+++ b/config/sync/views.view.inactive_users.yml
@@ -1090,3 +1090,204 @@ display:
         - 'languages:language_interface'
         - user.permissions
       tags: {  }
+  inactive_users_155_days:
+    id: inactive_users_155_days
+    display_title: 'Inactive users 155 days'
+    display_plugin: page
+    position: 1
+    display_options:
+      title: 'Inactive users (155 days)'
+      filters:
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        login:
+          id: login
+          table: users_field_data
+          field: login
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: login
+          plugin_id: date
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: '-155 days'
+            type: offset
+            granularity: minute
+          group: 1
+          exposed: false
+          expose:
+            operator_id: login_op
+            label: 'Last login'
+            description: ''
+            use_operator: false
+            operator: login_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: login
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_api_consumer: '0'
+              content_creator_benefits_hubs: '0'
+              content_creator_resources_and_support: '0'
+              office_content_creator: '0'
+              vamc_content_creator: '0'
+              content_creator_vba: '0'
+              content_creator_vet_center: '0'
+              content_editor: '0'
+              content_reviewer: '0'
+              content_publisher: '0'
+              content_admin: '0'
+              redirect_administrator: '0'
+              admnistrator_users: '0'
+              administrator: '0'
+              homepage_manager: '0'
+              next_js: '0'
+              translation_manager: '0'
+              rates_editor: '0'
+              form_builder_user: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        created:
+          id: created
+          table: users_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: created
+          plugin_id: date
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: '-6 months'
+            type: offset
+            granularity: minute
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        uid_raw:
+          id: uid_raw
+          table: users_field_data
+          field: uid_raw
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: '4073'
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: OR
+        groups:
+          1: AND
+          2: AND
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders:
+        jsonapi_views:
+          enabled: true
+      path: admin/users/inactive-155-days
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.inactive_users.yml
+++ b/config/sync/views.view.inactive_users.yml
@@ -1090,8 +1090,8 @@ display:
         - 'languages:language_interface'
         - user.permissions
       tags: {  }
-  inactive_users_155_days:
-    id: inactive_users_155_days
+  inactive_155_days:
+    id: inactive_155_days
     display_title: 'Inactive users 155 days'
     display_plugin: page
     position: 1

--- a/docroot/modules/custom/va_gov_scheduled_tasks/config/ultimate_cron.job.va_gov_scheduled_tasks_quarterly.yml
+++ b/docroot/modules/custom/va_gov_scheduled_tasks/config/ultimate_cron.job.va_gov_scheduled_tasks_quarterly.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+ module:
+   - va_gov_scheduled_tasks
+title: 'Do scheduled tasks quarterly'
+description: 'Checking for outdated content and other quarterly tasks'
+id: va_gov_scheduled_tasks_quarterly
+weight: 0
+module: va_gov_scheduled_tasks
+callback: va_gov_scheduled_tasks_quarterly
+scheduler:
+ id: crontab
+ configuration:
+   rules:
+     - '0 0 15 1,4,7,10 *'

--- a/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.install
+++ b/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.install
@@ -5,6 +5,8 @@
  * Update functions for the va_gov_scheduled_tasks module.
  */
 
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Import new config after module is already installed.
  */
@@ -18,7 +20,7 @@ function va_gov_scheduled_tasks_update_10001() {
  */
 function va_gov_scheduled_tasks_update_10002() {
   $config_name = 'ultimate_cron.job.va_gov_scheduled_tasks_quarterly';
-  $source = new \Drupal\Core\Config\FileStorage(__DIR__ . '/config');
+  $source = new FileStorage(__DIR__ . '/config');
   $active = \Drupal::service('config.storage');
 
   if ($active->exists($config_name)) {
@@ -30,4 +32,3 @@ function va_gov_scheduled_tasks_update_10002() {
     $active->write($config_name, $data);
   }
 }
-

--- a/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.install
+++ b/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.install
@@ -12,3 +12,22 @@ function va_gov_scheduled_tasks_update_10001() {
   // Import a specific config file.
   \Drupal::service('config.installer')->installDefaultConfig('module', 'va_gov_scheduled_tasks');
 }
+
+/**
+ * Import quarterly task config from module config directory.
+ */
+function va_gov_scheduled_tasks_update_10002() {
+  $config_name = 'ultimate_cron.job.va_gov_scheduled_tasks_quarterly';
+  $source = new \Drupal\Core\Config\FileStorage(__DIR__ . '/config');
+  $active = \Drupal::service('config.storage');
+
+  if ($active->exists($config_name)) {
+    return;
+  }
+
+  $data = $source->read($config_name);
+  if ($data) {
+    $active->write($config_name, $data);
+  }
+}
+

--- a/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.module
+++ b/docroot/modules/custom/va_gov_scheduled_tasks/va_gov_scheduled_tasks.module
@@ -408,3 +408,12 @@ function va_gov_scheduled_tasks_monthly() {
   va_gov_scheduled_tasks_delete_unattached_pdfs();
   \Drupal::logger('va_gov_scheduled_tasks')->notice('Monthly tasks completed');
 }
+
+/**
+ * Tasks to run each quarter.
+ */
+function va_gov_scheduled_tasks_quarterly() {
+  \Drupal::logger('va_gov_scheduled_tasks')->notice('Quarterly tasks started');
+  va_gov_scheduled_tasks_run_drush_command('eca:trigger:custom_event inactive_users_warn_155_days');
+  \Drupal::logger('va_gov_scheduled_tasks')->notice('Quarterly tasks completed');
+}


### PR DESCRIPTION
## Description

Relates to #21012 

This PR results in an email going to users of the VA Drupal CMS who have not accessed the CMS in at least 155 days, warning them that they need to access their account.

### Generated description
This pull request updates the process for warning inactive users and introduces a new quarterly scheduled task. The main changes are: the inactive user warning period is now 155 days (about 5 months) instead of 90 days, the notification message has been updated for clarity and compliance, and a new quarterly cron job is added to trigger these warnings automatically.

**Inactive User Warning Updates**
- Changed the inactive user warning workflow from 90 days to 155 days, including renaming config files, IDs, labels, event IDs, display IDs, and payload values to reflect the new 155-day threshold. [[1]](diffhunk://#diff-e5d5c281048988221a7f5a59d6120d15aba48c088a90633e57a02911aef9ebbdL12-R22) [[2]](diffhunk://#diff-e5d5c281048988221a7f5a59d6120d15aba48c088a90633e57a02911aef9ebbdL31-R31) [[3]](diffhunk://#diff-e5d5c281048988221a7f5a59d6120d15aba48c088a90633e57a02911aef9ebbdL45-R45) [[4]](diffhunk://#diff-e5d5c281048988221a7f5a59d6120d15aba48c088a90633e57a02911aef9ebbdL62-R72)
- Added a new view display `inactive_155_days` in `views.view.inactive_users.yml` to filter and display users inactive for at least 155 days.

**Notification Message Improvements**
- Updated the notification email/message templates to reference "5 months" instead of a specific day count and rewrote the content for clarity and compliance with VA Platform Security standards. [[1]](diffhunk://#diff-15099efddcc014304987799e5f743079c3ecae6921dcc458c4e46ef1abe6cfb7L3-R6) [[2]](diffhunk://#diff-1fe8cd841afcde58c50e17cdd80169738e06e5f59ae3ade1122b5a2bfdeae30aL12-R15)

**Scheduled Task Enhancements**
- Added a new quarterly cron job (`va_gov_scheduled_tasks_quarterly`) that triggers the new 155-day inactive user warning event, including all related config and installation/update logic. [[1]](diffhunk://#diff-f0a463af7f2e6b6aeff4b439cec602712c8667c88d68e6965ca1a8971e17e557R1-R20) [[2]](diffhunk://#diff-ec463d5973aebb098be2bcfcdef1cf47b06b06d3d4c29e3940f16b5f682208e0R1-R16) [[3]](diffhunk://#diff-42864519570a4b358b5544b16d65feec445fd031400866e249951c6b7f6b8045R8-R34) [[4]](diffhunk://#diff-c92b81f024a6c03c73f2af9c94726b8cb5d1c292557cf3bfe475828e61175012R411-R419)

**Queue Processing Configuration**
- Updated the advanced queue configuration to stop processing when empty for improved resource management.

## Testing done
Manually

## Screenshots

### Email example
<img width="1080" height="782" alt="Screenshot 2026-04-13 at 11 05 30" src="https://github.com/user-attachments/assets/c668debe-7499-4cbf-b766-d28d6113a421" />

## QA steps
- [ ] Go to the Terminal
- [ ] Check the queue: `drush advancedqueue:queue:list`
- [ ] Confirm that the "warn_inactive_users" has nothing queued
- [ ] Run the ECA trigger: `eca:trigger:custom_event inactive_users_warn_155_days`
- [ ] Check the queue: `drush advancedqueue:queue:list`
- [ ] Confirm that the "warn_inactive_users" has items queued
- [ ] Process the queue: `drush advancedqueue:queue:process warn_inactive_users`
- [ ] Check the captured mail in Tugboat
- [ ] Confirm that it contains emails warning inactive users


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

