### PR TITLE
VACMS-21723: use dev vets api for Next in tugboat

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -197,11 +197,6 @@ services:
       - bash -lc 'composer va:web:install'
       - bash -lc 'composer va:next:install'
 
-      # Create symlink between vets-website assets and next-build
-      #        - ln -snf "${DOCROOT}/vendor/va-gov/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
-      - mkdir -p "${TUGBOAT_ROOT}/next/public"
-      - ln -snf "${TUGBOAT_ROOT}/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
-
       # Update the .env file for the next build preview server
       - sed -i "s|https://mirror.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"
 

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -196,7 +196,8 @@ services:
       - bash -lc 'composer va:theme:compile'
       - bash -lc 'composer va:web:install'
       - bash -lc 'composer va:next:install'
-
+        # Get vets-website assets in the right place
+      - BUILD_TYPE=tugboat node ./scripts/next/vets-website-assets.js
       # Create symlink between vets-website assets and next-build
       #        - ln -snf "${DOCROOT}/vendor/va-gov/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
       - mkdir -p "${TUGBOAT_ROOT}/next/public"

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -197,9 +197,9 @@ services:
       - bash -lc 'composer va:web:install'
       - bash -lc 'composer va:next:install'
 
-      # Create symlink between vets-website assets and next-build
-      - mkdir -p "${TUGBOAT_ROOT}/next/public"
-      - ln -snf "${TUGBOAT_ROOT}/next-assets/public" "${TUGBOAT_ROOT}/next/public"
+      # Copy dev assets
+      - rm -rf "${TUGBOAT_ROOT}/next/public"
+      - cp -r "${TUGBOAT_ROOT}/next-assets/public" "${TUGBOAT_ROOT}/next/public"
 
       # Update the .env file for the next build preview server
       - sed -i "s|https://mirror.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -197,6 +197,10 @@ services:
       - bash -lc 'composer va:web:install'
       - bash -lc 'composer va:next:install'
 
+      # Create symlink between vets-website assets and next-build
+      - mkdir -p "${TUGBOAT_ROOT}/next/public"
+      - ln -snf "${TUGBOAT_ROOT}/next-assets/public" "${TUGBOAT_ROOT}/next/public"
+
       # Update the .env file for the next build preview server
       - sed -i "s|https://mirror.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"
 

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -197,9 +197,9 @@ services:
       - bash -lc 'composer va:web:install'
       - bash -lc 'composer va:next:install'
 
-      # Copy dev assets
+      # Link dev assets
       - rm -rf "${TUGBOAT_ROOT}/next/public"
-      - cp -r "${TUGBOAT_ROOT}/next-assets/public" "${TUGBOAT_ROOT}/next/public"
+      - ln -snf "${TUGBOAT_ROOT}/next-assets/public" "${TUGBOAT_ROOT}/next/public"
 
       # Update the .env file for the next build preview server
       - sed -i "s|https://mirror.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -196,8 +196,7 @@ services:
       - bash -lc 'composer va:theme:compile'
       - bash -lc 'composer va:web:install'
       - bash -lc 'composer va:next:install'
-        # Get vets-website assets in the right place
-      - BUILD_TYPE=tugboat node ./scripts/next/vets-website-assets.js
+
       # Create symlink between vets-website assets and next-build
       #        - ln -snf "${DOCROOT}/vendor/va-gov/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
       - mkdir -p "${TUGBOAT_ROOT}/next/public"

--- a/scripts/next-build-frontend.sh
+++ b/scripts/next-build-frontend.sh
@@ -115,9 +115,9 @@ popd
 echo "==> Re-building Vets Website" >> ${logfile}
 ${ROOT}/scripts/vets-web-setup.sh &>> ${logfile}
 
-# Copy assets.
+# Link assets.
 rm -rf "${ROOT}/next/public"
-cp -r "${ROOT}/next-assets/public" "${ROOT}/next/public"
+ln -snf "${ROOT}/next-assets/public" "${ROOT}/next/public"
 
 # Run the build.
 echo "==> Starting build" >> ${logfile}

--- a/scripts/next-build-frontend.sh
+++ b/scripts/next-build-frontend.sh
@@ -115,9 +115,9 @@ popd
 echo "==> Re-building Vets Website" >> ${logfile}
 ${ROOT}/scripts/vets-web-setup.sh &>> ${logfile}
 
-# Create symlink between vets-website assets and next-build.
-mkdir -p "${ROOT}/next/public"
-ln -snf "${ROOT}/next-assets/public" "${ROOT}/next/public"
+# Copy assets.
+rm -rf "${ROOT}/next/public"
+cp -r "${ROOT}/next-assets/public" "${ROOT}/next/public"
 
 # Run the build.
 echo "==> Starting build" >> ${logfile}

--- a/scripts/next-build-frontend.sh
+++ b/scripts/next-build-frontend.sh
@@ -111,13 +111,13 @@ else
 fi
 popd
 
-# Create symlink between vets-website assets and next-build.
-mkdir -p "${ROOT}/next/public"
-ln -snf "${ROOT}/vets-website/build/localhost/generated" "${ROOT}/next/public/generated"
-
 # Build vets-website again.
 echo "==> Re-building Vets Website" >> ${logfile}
 ${ROOT}/scripts/vets-web-setup.sh &>> ${logfile}
+
+# Create symlink between vets-website assets and next-build.
+mkdir -p "${ROOT}/next/public"
+ln -snf "${ROOT}/next-assets/public" "${ROOT}/next/public"
 
 # Run the build.
 echo "==> Starting build" >> ${logfile}

--- a/scripts/next-install.sh
+++ b/scripts/next-install.sh
@@ -10,7 +10,8 @@ source ~/.bashrc
 if [ ! -d next ]; then
   git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/next-build.git next
 else
-  echo "Repo next-build already cloned."
+  echo "Repo next-build already cloned. Updating..."
+  git -C next pull origin $(git -C next rev-parse --abbrev-ref HEAD)
 fi
 
 pushd next

--- a/scripts/next-install.sh
+++ b/scripts/next-install.sh
@@ -7,7 +7,7 @@ source ~/.bashrc
 
 # Installs the content-build dependencies.
 
-if [ ! -d next ]; then
+if [ ! -d next/src ]; then
   git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/next-build.git next
 else
   echo "Repo next-build already cloned. Updating..."

--- a/scripts/next-install.sh
+++ b/scripts/next-install.sh
@@ -11,6 +11,7 @@ if [ ! -d next/src ]; then
   git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/next-build.git next
 else
   echo "Repo next-build already cloned. Updating..."
+  git -C next reset --hard
   git -C next pull origin $(git -C next rev-parse --abbrev-ref HEAD)
 fi
 

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -9,7 +9,7 @@ source ~/.bashrc
 git config pull.rebase true
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
-REPO_ROOT="$(cd "$(dirname "$SCRIPT_DIR/../..")" &> /dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." &> /dev/null && pwd)"
 
 if [ ! -d vets-website ]; then
   git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/vets-website.git vets-website
@@ -87,7 +87,7 @@ BUNDLE_URL="${BUCKET}${bundleFileName}"
 BUNDLE_FILE="${bundleFileName#/}"
 BUNDLE_PATH="$REPO_ROOT/next/public/$BUNDLE_FILE"
 
-echo "Downloading: $BUNDLE_URL"
+echo "Downloading: $BUNDLE_URL to $BUNDLE_PATH"
 mkdir -p "$(dirname "$BUNDLE_PATH")"
 if ! curl -s -f -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
   echo "Warning: Failed to download $BUNDLE_URL"

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -87,20 +87,17 @@ else
     exit 1
   fi
   
-  # Parse JSON and download each asset
-  echo "$MANIFEST" | grep -o '"[^"]*"' | grep -v "generated/../" | while read -r entry; do
-    entry=$(echo "$entry" | sed 's/"//g')
-    BUNDLE_URL="$BUCKET$entry"
-    
+  # Parse JSON values
+  echo "$MANIFEST" | jq -r '.[]' | while read -r bundleFileName; do
+    BUNDLE_URL="${BUCKET}${bundleFileName}"
+
     # Remove leading slash if present
-    BUNDLE_FILE=$(echo "$entry" | sed 's/^\///')
+    BUNDLE_FILE="${bundleFileName#/}"
     BUNDLE_PATH="$REPO_ROOT/public/$BUNDLE_FILE"
-    
+
     echo "Downloading: $BUNDLE_URL"
-    if curl -s -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
-      mkdir -p "$(dirname "$BUNDLE_PATH")"
-      curl -s -o "$BUNDLE_PATH" "$BUNDLE_URL"
-    else
+    mkdir -p "$(dirname "$BUNDLE_PATH")"
+    if ! curl -s -f -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
       echo "Warning: Failed to download $BUNDLE_URL"
     fi
   done

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -58,7 +58,7 @@ esac
 
 FILE_MANIFEST_PATH="generated/file-manifest.json"
 VETS_WEBSITE_ASSET_PATH="$REPO_ROOT/vets-website/src/site/assets"
-DESTINATION_PATH="$REPO_ROOT/public/generated"
+DESTINATION_PATH="$REPO_ROOT/next/public/generated"
 
 echo "Gathering vets-website assets from $BUILD_TYPE build..."
 

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -38,7 +38,7 @@ DEV_BUCKET="http://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
 
 FILE_MANIFEST_PATH="generated/file-manifest.json"
 VETS_WEBSITE_ASSET_PATH="$REPO_ROOT/vets-website/src/site/assets"
-DESTINATION_PATH="$REPO_ROOT/next/public/generated"
+DESTINATION_PATH="$REPO_ROOT/next-assets/public/generated"
 
 echo "Gathering vets-website assets from DEV build..."
 
@@ -65,7 +65,7 @@ BUNDLE_URL="${DEV_BUCKET}${bundleFileName}"
 
 # Remove leading slash if present
 BUNDLE_FILE="${bundleFileName#/}"
-BUNDLE_PATH="$REPO_ROOT/next/public/$BUNDLE_FILE"
+BUNDLE_PATH="$REPO_ROOT/next-assets/public/$BUNDLE_FILE"
 
 echo "Downloading: $BUNDLE_URL to $BUNDLE_PATH"
 mkdir -p "$(dirname "$BUNDLE_PATH")"
@@ -77,7 +77,7 @@ done
 # Move additional assets (images and fonts) from vets-website
 echo "Copying additional assets from vets-website..."
 if [ -d "$VETS_WEBSITE_ASSET_PATH/img" ]; then
-  cp -r "$VETS_WEBSITE_ASSET_PATH/img" "$REPO_ROOT/next/public/" && echo "Copied image assets."
+  cp -r "$VETS_WEBSITE_ASSET_PATH/img" "$REPO_ROOT/next-assets/public/" && echo "Copied image assets."
 fi
 
 if [ -d "$VETS_WEBSITE_ASSET_PATH/fonts" ]; then

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -69,38 +69,28 @@ if [ -d "$DESTINATION_PATH" ]; then
 fi
 
 # Handle asset gathering based on build type
-if [ "$BUILD_TYPE" = "localhost" ]; then
-  echo "Attempting to symlink assets from local vets-website repo..."
-  if mkdir -p "$(dirname "$DESTINATION_PATH")" && ln -s "$LOCAL_BUCKET" "$DESTINATION_PATH"; then
-    echo "Symlink created successfully!"
-  else
-    echo "Error creating symlink. Ensure your local vets-website assets are built."
-    exit 1
-  fi
-else
-  echo "Downloading assets from $BUCKET..."
-  mkdir -p "$DESTINATION_PATH"
-  
-  # Fetch manifest and download all assets
-  if ! MANIFEST=$(curl -s "$BUCKET/$FILE_MANIFEST_PATH"); then
-    echo "Error: Failed to fetch file manifest from $BUCKET"
-    exit 1
-  fi
-  
-  # Parse JSON values
-  echo "$MANIFEST" | jq -r '.[]' | while read -r bundleFileName; do
-    BUNDLE_URL="${BUCKET}${bundleFileName}"
 
-    # Remove leading slash if present
-    BUNDLE_FILE="${bundleFileName#/}"
-    BUNDLE_PATH="$REPO_ROOT/public/$BUNDLE_FILE"
+echo "Downloading assets from $BUCKET..."
+mkdir -p "$DESTINATION_PATH"
 
-    echo "Downloading: $BUNDLE_URL"
-    mkdir -p "$(dirname "$BUNDLE_PATH")"
-    if ! curl -s -f -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
-      echo "Warning: Failed to download $BUNDLE_URL"
-    fi
-  done
+# Fetch manifest and download all assets
+if ! MANIFEST=$(curl -s "$BUCKET/$FILE_MANIFEST_PATH"); then
+  echo "Error: Failed to fetch file manifest from $BUCKET"
+  exit 1
+fi
+
+# Parse JSON values
+echo "$MANIFEST" | jq -r '.[]' | while read -r bundleFileName; do
+BUNDLE_URL="${BUCKET}${bundleFileName}"
+
+# Remove leading slash if present
+BUNDLE_FILE="${bundleFileName#/}"
+BUNDLE_PATH="$REPO_ROOT/next/public/$BUNDLE_FILE"
+
+echo "Downloading: $BUNDLE_URL"
+mkdir -p "$(dirname "$BUNDLE_PATH")"
+if ! curl -s -f -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
+  echo "Warning: Failed to download $BUNDLE_URL"
 fi
 
 # Move additional assets (images and fonts) from vets-website

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -31,7 +31,7 @@ export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 yarn install-safe
 yarn build
 
-# Gather vets-website assets based on build type
+# Gather vets-website assets
 cd "$REPO_ROOT"
 
 DEV_BUCKET="http://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
@@ -48,7 +48,7 @@ if [ -d "$DESTINATION_PATH" ]; then
   rm -rf "$DESTINATION_PATH"
 fi
 
-# Handle asset gathering based on build type
+# Handle asset gathering
 
 echo "Downloading assets from $DEV_BUCKET..."
 mkdir -p "$DESTINATION_PATH"

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -7,6 +7,10 @@ source ~/.bashrc
 
 # Installs & builds vets-website dependencies for next-build preview.
 git config pull.rebase true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+REPO_ROOT="$(cd "$(dirname "$SCRIPT_DIR/../..")" &> /dev/null && pwd)"
+
 if [ ! -d vets-website ]; then
   git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/vets-website.git vets-website
   cd vets-website
@@ -26,3 +30,93 @@ echo "Yarn $(yarn -v)"
 export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 yarn install-safe
 yarn build
+
+# Gather vets-website assets based on build type
+cd "$REPO_ROOT"
+
+BUILD_TYPE="tugboat"
+PROD_BUCKET="http://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
+STAGING_BUCKET="http://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
+DEV_BUCKET="http://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
+LOCAL_BUCKET="$REPO_ROOT/vets-website/build/localhost/generated"
+
+# Determine bucket based on build type
+case "$BUILD_TYPE" in
+  localhost)
+    BUCKET="$LOCAL_BUCKET"
+    ;;
+  tugboat|vagovdev)
+    BUCKET="$DEV_BUCKET"
+    ;;
+  vagovstaging)
+    BUCKET="$STAGING_BUCKET"
+    ;;
+  vagovprod|*)
+    BUCKET="$PROD_BUCKET"
+    ;;
+esac
+
+FILE_MANIFEST_PATH="generated/file-manifest.json"
+VETS_WEBSITE_ASSET_PATH="$REPO_ROOT/vets-website/src/site/assets"
+DESTINATION_PATH="$REPO_ROOT/public/generated"
+
+echo "Gathering vets-website assets from $BUILD_TYPE build..."
+
+# Clean any existing assets or symlinks
+if [ -d "$DESTINATION_PATH" ]; then
+  echo "Removing existing vets-website assets..."
+  rm -rf "$DESTINATION_PATH"
+fi
+
+# Handle asset gathering based on build type
+if [ "$BUILD_TYPE" = "localhost" ]; then
+  echo "Attempting to symlink assets from local vets-website repo..."
+  if mkdir -p "$(dirname "$DESTINATION_PATH")" && ln -s "$LOCAL_BUCKET" "$DESTINATION_PATH"; then
+    echo "Symlink created successfully!"
+  else
+    echo "Error creating symlink. Ensure your local vets-website assets are built."
+    exit 1
+  fi
+else
+  echo "Downloading assets from $BUCKET..."
+  mkdir -p "$DESTINATION_PATH"
+  
+  # Fetch manifest and download all assets
+  if ! MANIFEST=$(curl -s "$BUCKET/$FILE_MANIFEST_PATH"); then
+    echo "Error: Failed to fetch file manifest from $BUCKET"
+    exit 1
+  fi
+  
+  # Parse JSON and download each asset
+  echo "$MANIFEST" | grep -o '"[^"]*"' | grep -v "generated/../" | while read -r entry; do
+    entry=$(echo "$entry" | sed 's/"//g')
+    BUNDLE_URL="$BUCKET$entry"
+    
+    # Remove leading slash if present
+    BUNDLE_FILE=$(echo "$entry" | sed 's/^\///')
+    BUNDLE_PATH="$REPO_ROOT/public/$BUNDLE_FILE"
+    
+    echo "Downloading: $BUNDLE_URL"
+    if curl -s -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
+      mkdir -p "$(dirname "$BUNDLE_PATH")"
+      curl -s -o "$BUNDLE_PATH" "$BUNDLE_URL"
+    else
+      echo "Warning: Failed to download $BUNDLE_URL"
+    fi
+  done
+fi
+
+# Move additional assets (images and fonts) from vets-website
+echo "Copying additional assets from vets-website..."
+if [ -d "$VETS_WEBSITE_ASSET_PATH/img" ]; then
+  cp -r "$VETS_WEBSITE_ASSET_PATH/img" "$REPO_ROOT/public/" && echo "Copied image assets."
+fi
+
+if [ -d "$VETS_WEBSITE_ASSET_PATH/fonts" ]; then
+  mkdir -p "$DESTINATION_PATH"
+  for font in "$VETS_WEBSITE_ASSET_PATH/fonts"/*; do
+    cp -r "$font" "$DESTINATION_PATH/" && echo "Copied font: $(basename "$font")"
+  done
+fi
+
+echo "All vets-website assets gathered successfully!"

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -89,7 +89,7 @@ BUNDLE_PATH="$REPO_ROOT/next/public/$BUNDLE_FILE"
 
 echo "Downloading: $BUNDLE_URL to $BUNDLE_PATH"
 mkdir -p "$(dirname "$BUNDLE_PATH")"
-if ! curl -s -f -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
+if ! curl -s -f --compressed -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
   echo "Warning: Failed to download $BUNDLE_URL"
 fi
 done

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -34,33 +34,13 @@ yarn build
 # Gather vets-website assets based on build type
 cd "$REPO_ROOT"
 
-BUILD_TYPE="tugboat"
-PROD_BUCKET="http://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
-STAGING_BUCKET="http://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
 DEV_BUCKET="http://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com"
-LOCAL_BUCKET="$REPO_ROOT/vets-website/build/localhost/generated"
-
-# Determine bucket based on build type
-case "$BUILD_TYPE" in
-  localhost)
-    BUCKET="$LOCAL_BUCKET"
-    ;;
-  tugboat|vagovdev)
-    BUCKET="$DEV_BUCKET"
-    ;;
-  vagovstaging)
-    BUCKET="$STAGING_BUCKET"
-    ;;
-  vagovprod|*)
-    BUCKET="$PROD_BUCKET"
-    ;;
-esac
 
 FILE_MANIFEST_PATH="generated/file-manifest.json"
 VETS_WEBSITE_ASSET_PATH="$REPO_ROOT/vets-website/src/site/assets"
 DESTINATION_PATH="$REPO_ROOT/next/public/generated"
 
-echo "Gathering vets-website assets from $BUILD_TYPE build..."
+echo "Gathering vets-website assets from DEV build..."
 
 # Clean any existing assets or symlinks
 if [ -d "$DESTINATION_PATH" ]; then
@@ -70,18 +50,18 @@ fi
 
 # Handle asset gathering based on build type
 
-echo "Downloading assets from $BUCKET..."
+echo "Downloading assets from $DEV_BUCKET..."
 mkdir -p "$DESTINATION_PATH"
 
 # Fetch manifest and download all assets
-if ! MANIFEST=$(curl -s "$BUCKET/$FILE_MANIFEST_PATH"); then
-  echo "Error: Failed to fetch file manifest from $BUCKET"
+if ! MANIFEST=$(curl -s "$DEV_BUCKET/$FILE_MANIFEST_PATH"); then
+  echo "Error: Failed to fetch file manifest from $DEV_BUCKET"
   exit 1
 fi
 
 # Parse JSON values
 echo "$MANIFEST" | jq -r '.[]' | while read -r bundleFileName; do
-BUNDLE_URL="${BUCKET}${bundleFileName}"
+BUNDLE_URL="${DEV_BUCKET}${bundleFileName}"
 
 # Remove leading slash if present
 BUNDLE_FILE="${bundleFileName#/}"

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -97,7 +97,7 @@ done
 # Move additional assets (images and fonts) from vets-website
 echo "Copying additional assets from vets-website..."
 if [ -d "$VETS_WEBSITE_ASSET_PATH/img" ]; then
-  cp -r "$VETS_WEBSITE_ASSET_PATH/img" "$REPO_ROOT/public/" && echo "Copied image assets."
+  cp -r "$VETS_WEBSITE_ASSET_PATH/img" "$REPO_ROOT/next/public/" && echo "Copied image assets."
 fi
 
 if [ -d "$VETS_WEBSITE_ASSET_PATH/fonts" ]; then

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -92,6 +92,7 @@ mkdir -p "$(dirname "$BUNDLE_PATH")"
 if ! curl -s -f -o "$BUNDLE_PATH" "$BUNDLE_URL"; then
   echo "Warning: Failed to download $BUNDLE_URL"
 fi
+done
 
 # Move additional assets (images and fonts) from vets-website
 echo "Copying additional assets from vets-website..."


### PR DESCRIPTION
## Description
Updates the `vets-web-setup.sh` script to copy the vets-website assets from the dev bucket. This brings in applications that request to `dev-api.va.gov`. This allows for banners to be fetched and displayed in the Next preview on tugboat. It also fixes little things like fonts and images not loading.

This PR also introduces changes to `next-install` that make sure next-build is refreshed on every new preview that gets built. To ensure that next-build is always up to date.

*note: [this next-build PR](https://github.com/department-of-veterans-affairs/next-build/pull/1814) changes how next deals with the image and font assets that also get added in this PR. We should do a quick follow up to this work to remove the vets-website cloning and copying of assets in `vets-web-setup` and shift our linking to focus on `public/generated`. This will all continue to work even after the Next PR is merged, but it would be good to have parity with that work.

Closes to #[21723](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21723) & #[23998](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/23998)

## Testing done
Lots of manual testing in tugboat with building from a base and building with no base.

## QA steps
 - [ ] log in to [PR tugboat](https://pr24019-cgq19zhmebzxd2agsdlujzpseqdyl8df.ci.cms.va.gov/)
 - [ ] if you view the next preview it should appear broken (this is expected)
 - [ ] [deploy next content](https://pr24019-cgq19zhmebzxd2agsdlujzpseqdyl8df.ci.cms.va.gov/admin/content/deploy/next)
 - [ ] wait for it to finish
 - [ ] visit the next preview
 - [ ] verify that it fetches feature_toggles and banners from `dev-api.va.gov`
 - [ ] verify that the fonts match prod and that the flag image loads in at the top left of the page
 - [ ] In tugboat go to the [CMS Demo Environments](https://tugboat.vfs.va.gov/5ffe2f4dfa1ca136135134f6)
 - [ ] create a new preview from the branch `VACMS-21723-test-branch` and use `VACMS-21723-use-dev-vets-api` as the base
 - [ ] after it finishes, open its terminal
 - [ ] navigate to the next dir `cd next`
 - [ ] run `git log` 
 - [ ] verify that its last commit is the latest

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

