### PR TITLE
VACMS-23135: gha for eks staging deploy

### DIFF
--- a/.github/workflows/deploy-cms-staging.yml
+++ b/.github/workflows/deploy-cms-staging.yml
@@ -3,7 +3,8 @@ on:
   workflow_dispatch:
   schedule:
     # 19:30 UTC -> 3:30 p.m. Eastern during daylight saving, 2:30 p.m. during standard time
-    - cron: '30 19 * * 1-5'
+    - cron: '30 20 * * 1-5'
+      timezone: 'America/New_York'
 
 env:
   CMS_NOTIFICATIONS_SLACK: CJT90C0UT # cms-notifications
@@ -91,7 +92,7 @@ jobs:
     needs:
       - deploy-to-staging
       - get-tag
-    if: needs.deploy-to-staging.result == 'failure'
+    if: ${{ always() && needs.deploy-to-staging.result == 'failure' }}
 
     steps:
       - name: Notify Slack

--- a/.github/workflows/deploy-cms-staging.yml
+++ b/.github/workflows/deploy-cms-staging.yml
@@ -2,8 +2,8 @@ name: Deploy to CMS Staging M - F at 3:30pm ET
 on:
   workflow_dispatch:
   schedule:
-    # 20:30 UTC -> 3:30 p.m. Eastern during standard time, 4:30 p.m. during daylight saving
-    - cron: '30 20 * * 1-5'
+    # 19:30 UTC -> 3:30 p.m. Eastern during daylight saving, 2:30 p.m. during standard time
+    - cron: '30 19 * * 1-5'
 
 env:
   CMS_NOTIFICATIONS_SLACK: CJT90C0UT # cms-notifications

--- a/.github/workflows/deploy-cms-staging.yml
+++ b/.github/workflows/deploy-cms-staging.yml
@@ -80,7 +80,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@8c496a4b0c9158d18edcd9be8722ed0f79e8c5b4 #
         continue-on-error: true
         with:
-          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Deployment to CMS Mirror for tag ${{ needs.get-tag.outputs.IMAGE_TAG }} is complete."}}]}]}'
+          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Deployment to CMS Staging for tag ${{ needs.get-tag.outputs.IMAGE_TAG }} has been initiated."}}]}]}'
           channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -108,7 +108,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": ":bangbang: <!subteam^S01JXBLLMJL|cms-devops-engineers> Deployment of CMS Mirror using ${{ needs.get-tag.outputs.IMAGE_TAG || 'an unknown version' }} has failed."
+                        "text": ":bangbang: <!subteam^S01JXBLLMJL|cms-devops-engineers> Deployment of CMS Staging using ${{ needs.get-tag.outputs.IMAGE_TAG || 'an unknown version' }} has not been initiated."
                       }
                     }
                   ]

--- a/.github/workflows/deploy-cms-staging.yml
+++ b/.github/workflows/deploy-cms-staging.yml
@@ -1,0 +1,120 @@
+name: Deploy to CMS Staging M - F at 3:30pm ET
+on:
+  workflow_dispatch:
+  schedule:
+    # 20:30 UTC -> 3:30 p.m. Eastern during standard time, 4:30 p.m. during daylight saving
+    - cron: '30 20 * * 1-5'
+
+env:
+  CMS_NOTIFICATIONS_SLACK: CJT90C0UT # cms-notifications
+
+permissions:
+  id-token: write  # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+jobs:
+  get-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE_TAG: ${{ steps.set-outputs.outputs.IMAGE_TAG }}
+      IS_VALID: ${{ steps.set-outputs.outputs.IS_VALID }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-vagov-next-build-githubaction
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Select latest Drupal semantic tag
+        id: select-tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO_NAME="dsva/cms-drupal"
+          IMAGES_JSON=$(aws ecr describe-images --repository-name "$REPO_NAME" --query 'imageDetails' --output json)
+          SEMVER_TAG=$(echo "$IMAGES_JSON" | jq -r '
+            sort_by(.imagePushedAt) | reverse |
+            map(select(.imageTags != null) | .imageTags[]) |
+            map(select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))) |
+            first // ""
+          ')
+          echo "LAST_TAG=$SEMVER_TAG" >> "$GITHUB_ENV"
+
+      - name: Set outputs
+        id: set-outputs
+        shell: bash
+        run: |
+          IMAGE_TAG="${LAST_TAG:-}"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          if [[ "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "IS_VALID=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "IS_VALID=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-to-staging:
+    needs: get-tag
+    if: needs.get-tag.outputs.IS_VALID == 'true' && needs.get-tag.outputs.IMAGE_TAG != ''
+    uses: department-of-veterans-affairs/va.gov-cms/.github/workflows/update-manifest.yml@main
+    with:
+      image_tag: ${{ needs.get-tag.outputs.IMAGE_TAG }}
+      app_name: cms
+      environment: staging
+
+  notify-success-slack:
+    name: Notify Success (Slack)
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-to-staging
+      - get-tag
+    if: needs.deploy-to-staging.result == 'success'
+
+    steps:
+      - name: Notify Slack
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@8c496a4b0c9158d18edcd9be8722ed0f79e8c5b4 #
+        continue-on-error: true
+        with:
+          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Deployment to CMS Mirror for tag ${{ needs.get-tag.outputs.IMAGE_TAG }} is complete."}}]}]}'
+          channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  notify-failure-slack:
+    name: Notify Failure (Slack)
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-to-staging
+      - get-tag
+    if: needs.deploy-to-staging.result == 'failure'
+
+    steps:
+      - name: Notify Slack
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@8c496a4b0c9158d18edcd9be8722ed0f79e8c5b4
+        continue-on-error: true
+        with:
+          payload: >
+            {
+              "attachments": [
+                {
+                  "color": "#E01E5A",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": ":bangbang: <!subteam^S01JXBLLMJL|cms-devops-engineers> Deployment of CMS Mirror using ${{ needs.get-tag.outputs.IMAGE_TAG || 'an unknown version' }} has failed."
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description
This sets up the GHA to deploy staging every weekday at 3:30PM EDT.
Closes #23135 

### Generated description

This pull request introduces a new GitHub Actions workflow, `.github/workflows/deploy-cms-staging.yml`, to automate and schedule deployments of the CMS application to the staging environment on weekdays at 3:30pm ET. The workflow includes steps for selecting the latest semantic version tag of the Drupal image, deploying to staging, and notifying a Slack channel on success or failure.

Key changes in this pull request:

**Deployment Automation:**

* Adds a scheduled workflow (`deploy-cms-staging.yml`) to automate CMS staging deployments Monday through Friday at 3:30pm ET, using the latest semantic version tag from the `dsva/cms-drupal` ECR repository.
* Implements logic to select the most recent valid semantic version tag and validates it before proceeding with deployment.

**Integration with Existing Deployment Process:**

* Integrates with the existing `update-manifest.yml` workflow for the actual deployment step, passing the selected image tag and environment details.

**Notifications:**

* Adds Slack notifications to the `cms-notifications` channel to inform stakeholders of deployment success or failure, including tagging the CMS DevOps subteam on failures.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If this passes automated testing it should be good. Can't be tested until its merged. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
