### PR TITLE
VACMS-21723: do a dev build of vets-website

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -200,7 +200,7 @@ services:
       # Create symlink between vets-website assets and next-build
       #        - ln -snf "${DOCROOT}/vendor/va-gov/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
       - mkdir -p "${TUGBOAT_ROOT}/next/public"
-      - ln -snf "${TUGBOAT_ROOT}/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/next/public/generated"
+      - ln -snf "${TUGBOAT_ROOT}/vets-website/build/vagovdev/generated" "${TUGBOAT_ROOT}/next/public/generated"
 
       # Update the .env file for the next build preview server
       - sed -i "s|https://mirror.cms.va.gov|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/next/envs/.env.tugboat"

--- a/scripts/next-build-frontend.sh
+++ b/scripts/next-build-frontend.sh
@@ -113,7 +113,7 @@ popd
 
 # Create symlink between vets-website assets and next-build.
 mkdir -p "${ROOT}/next/public"
-ln -snf "${ROOT}/vets-website/build/localhost/generated" "${ROOT}/next/public/generated"
+ln -snf "${ROOT}/vets-website/build/vagovdev/generated" "${ROOT}/next/public/generated"
 
 # Build vets-website again.
 echo "==> Re-building Vets Website" >> ${logfile}

--- a/scripts/vets-web-setup.sh
+++ b/scripts/vets-web-setup.sh
@@ -25,4 +25,4 @@ echo "Yarn $(yarn -v)"
 
 export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 yarn install-safe
-yarn build
+yarn build:webpack --env buildtype=vagovdev


### PR DESCRIPTION
## Description

The previous version of fetching the dev bucket assets has been reverted so that we can still install different versions of vets-website. This PR changes the build command to create a dev version so that the api paths are correct but can be built based on any branch/pr

Relates to #21723 

## Testing done
 tugboat testing

## QA steps

 - [x] log in to [PR tugboat](https://pr24050-stch4lzglq2uf29tlcc65l9dcs3weq6k.ci.cms.va.gov/)
 - [x] if you view the next preview it should appear broken (this is expected)
 - [x] [deploy next content](https://pr24050-stch4lzglq2uf29tlcc65l9dcs3weq6k.ci.cms.va.gov/admin/content/deploy/next)
 - [x] wait for it to finish
 - [x] visit the next preview
 - [x] verify that it fetches feature_toggles and banners from `dev-api.va.gov`

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
