### PR TITLE
VACMS-21012: Updates message with correct URL to prod

### DIFF
--- a/config/sync/language/en/message.template.warn_inactive_users.yml
+++ b/config/sync/language/en/message.template.warn_inactive_users.yml
@@ -3,5 +3,5 @@ text:
     value: '<p>Warning: At least 5 months since last VA Drupal log in</p>'
     format: rich_text
   -
-    value: "<p>Hello,</p><p>You are receiving this email because you have not accessed your <a href='https://prod.va.cms.gov'>VA Drupal CMS account</a> in over 5 months. To comply with VA Platform Security standards, we require all Drupal CMS users to sign in at least once every 5 months. If you no longer work with Drupal CMS and would like to make your account inactive, please email <a href='mailto:vadrupalcms@va.gov'>vadrupalcms@va.gov</a> to contact the Drupal CMS Helpdesk.</p><br><p>Thank you,<br>VA Drupal CMS Support</p>"
+    value: "<p>Hello,</p><p>You are receiving this email because you have not accessed your <a href='https://prod.cms.va.gov'>VA Drupal CMS account</a> in over 5 months. To comply with VA Platform Security standards, we require all Drupal CMS users to sign in at least once every 5 months. If you no longer work with Drupal CMS and would like to make your account inactive, please email <a href='mailto:vadrupalcms@va.gov'>vadrupalcms@va.gov</a> to contact the Drupal CMS Helpdesk.</p><br><p>Thank you,<br>VA Drupal CMS Support</p>"
     format: rich_text

--- a/config/sync/message.template.warn_inactive_users.yml
+++ b/config/sync/message.template.warn_inactive_users.yml
@@ -12,7 +12,7 @@ text:
     value: '<p>Warning: At least 5 months since last VA Drupal log in</p>'
     format: rich_text
   -
-    value: "<p>Hello,</p><p>You are receiving this email because you have not accessed your <a href='https://prod.va.cms.gov'>VA Drupal CMS account</a> in over 5 months. To comply with VA Platform Security standards, we require all Drupal CMS users to sign in at least once every 5 months. If you no longer work with Drupal CMS and would like to make your account inactive, please email <a href='mailto:vadrupalcms@va.gov'>vadrupalcms@va.gov</a> to contact the Drupal CMS Helpdesk.</p><br><p>Thank you,<br>VA Drupal CMS Support</p>"
+    value: "<p>Hello,</p><p>You are receiving this email because you have not accessed your <a href='https://prod.cms.va.gov'>VA Drupal CMS account</a> in over 5 months. To comply with VA Platform Security standards, we require all Drupal CMS users to sign in at least once every 5 months. If you no longer work with Drupal CMS and would like to make your account inactive, please email <a href='mailto:vadrupalcms@va.gov'>vadrupalcms@va.gov</a> to contact the Drupal CMS Helpdesk.</p><br><p>Thank you,<br>VA Drupal CMS Support</p>"
     format: rich_text
 settings:
   'token options':


### PR DESCRIPTION
## Description

Relates to #21012 

### Generated description
This pull request updates the inactive user warning email template to use the correct VA Drupal CMS login URL. The URL in the message was changed from `https://prod.va.cms.gov` to `https://prod.cms.va.gov` to ensure users are directed to the correct site.

* Updated the inactive user warning email template in both `config/sync/language/en/message.template.warn_inactive_users.yml` and `config/sync/message.template.warn_inactive_users.yml` to use `https://prod.cms.va.gov` as the login URL instead of the incorrect `https://prod.va.cms.gov`. [[1]](diffhunk://#diff-15099efddcc014304987799e5f743079c3ecae6921dcc458c4e46ef1abe6cfb7L6-R6) [[2]](diffhunk://#diff-1fe8cd841afcde58c50e17cdd80169738e06e5f59ae3ade1122b5a2bfdeae30aL15-R15)
## Testing done


## Screenshots
N/A

## QA steps
- [ ] Review the url in the messages
- [ ] Confirm that it is correct

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
