### PR TITLE
VACMS-23756: Revert dual publishing for Lovell program pages

### DIFF
--- a/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
+++ b/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Drupal\va_gov_batch\cbo_scripts;
+
+require_once __DIR__ . '/../../../../../../scripts/content/script-library.php';
+
+use Drupal\codit_batch_operations\BatchOperations;
+use Drupal\codit_batch_operations\BatchScriptInterface;
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\NodeInterface;
+
+/**
+ * For VACMS-23756.
+ *
+ * This script gathers all the dual-published 'Programs' pages for Lovell sites.
+ * It sets the page to be a VA page and duplicates it for Tricare. Basically
+ * we are un-dual-publishing the pages and making 2 separate pages for VA and
+ * Tricare, which is the requested setup. Menu links need to be cleaned up
+ * afterward.
+ *
+ * To run: drush codit-batch-operations:run DuplicateLovellProgramPages.
+ */
+class DuplicateLovellProgramPages extends BatchOperations implements BatchScriptInterface {
+
+  const LOVELL_FEDERAL_SYSTEM_ID = '15007';
+  const VA_SYSTEM_ID = '49451';
+  const TRICARE_SYSTEM_ID = '49011';
+  const BOTH_ID = '347';
+  const VA_ID = '1040';
+  const TRICARE_ID = '1039';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTitle(): string {
+    return "Removes dual publishing then duplicates Lovell program pages";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCompletedMessage(): string {
+    return '@total Programs pages were duplicated.';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function gatherItemsToProcess(): array {
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $items = [];
+    $parent_uuids = $this->getParentLinkUuids();
+
+    if (empty($parent_uuids)) {
+      return $items;
+    }
+
+    // Query for VAMC Detail Pages with the correct menu parent.
+    $menu_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+    $menu_query = $menu_storage->getQuery()
+      ->condition('parent', $parent_uuids, 'IN')
+      ->accessCheck(FALSE);
+    $mids = $menu_query->execute();
+
+    $nids = [];
+    $menu_links = MenuLinkContent::loadMultiple($mids);
+    foreach ($menu_links as $link) {
+      $uri = $link->link->uri;
+      if (preg_match('/entity:node\/(\d+)/', $uri, $matches)) {
+        $nids[] = $matches[1];
+      }
+    }
+
+    if (!empty($nids)) {
+      foreach ($nids as $nid) {
+        /** @var \Drupal\node\NodeInterface $node */
+        $node = $node_storage->load($nid);
+        // Check if node matches criteria.
+        $office = $node->get('field_office')->target_id;
+        $admin = $node->get('field_administration')->target_id;
+        $published = $node->isPublished();
+        if ($published
+          && $office == self::LOVELL_FEDERAL_SYSTEM_ID
+          && $admin == self::BOTH_ID
+          && !in_array($nid, $items)
+        ) {
+          $items[] = $nid;
+        }
+      }
+    }
+    return $items;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processOne(string $key, mixed $item, array &$sandbox): string {
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->load($item);
+    if (!$node) {
+      return "Node $item not found.";
+    }
+    try {
+      $this->updateNode($node, FALSE);
+      $this->batchOpLog->appendLog(
+        "Updated node {$node->getTitle()} (ID: {$node->id()}) for VA values.");
+
+      // Duplicate node for TRICARE.
+      $duplicate = $node->createDuplicate();
+      $this->updateNode($duplicate, TRUE);
+      $this->batchOpLog->appendLog(
+        "Updating node {$duplicate->getTitle()} (ID: {$duplicate->id()}) for Tricare values.");
+
+    }
+    catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
+      $message = $e->getMessage();
+      $this->batchOpLog->appendError('Could not update/duplicate node: ' . $message);
+    }
+
+    return "Node $item updated for VA and duplicated for TRICARE.";
+  }
+
+  /**
+   * Gets the UUIDs of the Lovell Programs menu links.
+   *
+   * @return array
+   *   The array of UUIDs.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getParentLinkUuids(): array {
+    $menu_link_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+
+    // Get menu parent UUIDs.
+    $target_titles = ['Programs - Tricare', 'Programs - VA'];
+    $parent_uuids = [];
+
+    $query = $menu_link_storage->getQuery()
+      ->condition('title', $target_titles, 'IN')
+      ->accessCheck(FALSE);
+    $ids = $query->execute();
+
+    if (!empty($ids)) {
+      $links = $menu_link_storage->loadMultiple($ids);
+      /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $link */
+      foreach ($links as $link) {
+        $parent_uuids[$link->get('title')->value] = 'menu_link_content:' . $link->uuid();
+      }
+    }
+    return $parent_uuids;
+  }
+
+  /**
+   * Updates a node's office and administration for VA or Tricare.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to update.
+   * @param bool $tricare
+   *   Whether this is a Tricare node or not.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function updateNode(NodeInterface $node, bool $tricare): void {
+
+    /** @var \Drupal\node\NodeStorageInterface $node_storage */
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+    // Update original node to VA values.
+    $node->set('field_office', $tricare ? self::TRICARE_SYSTEM_ID : self::VA_SYSTEM_ID);
+    $node->set('field_administration', $tricare ? self::TRICARE_ID : self::VA_ID);
+    $revision_message = "Un-dual-publishing for VA and TRICARE split Programs pages.";
+
+    $default_rev_id = $node->getRevisionId();
+    $latest_revision_id = $node_storage->getLatestRevisionId($node->id());
+
+    // Save forward revisions if they exist.
+    if ($latest_revision_id > $default_rev_id) {
+      /** @var \Drupal\node\NodeInterface $revision */
+      $revision = $node_storage->loadRevision($latest_revision_id);
+      $existing_message = $revision->getRevisionLogMessage() ?? '';
+      save_node_revision($revision, $revision_message . ' - ' . $existing_message, FALSE);
+    }
+    save_node_revision($node, $revision_message);
+  }
+
+}

--- a/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
+++ b/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
@@ -8,8 +8,10 @@ use Drupal\codit_batch_operations\BatchOperations;
 use Drupal\codit_batch_operations\BatchScriptInterface;
 use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
+use Exception;
 
 /**
  * For VACMS-23756.
@@ -67,7 +69,8 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
     $nids = [];
     $menu_links = MenuLinkContent::loadMultiple($mids);
     foreach ($menu_links as $link) {
-      $uri = $link->link->uri;
+      $link_field = $link->get('link')->getValue();
+      $uri = !empty($link_field[0]['uri']) ? $link_field[0]['uri'] : '';
       if (preg_match('/entity:node\/(\d+)/', $uri, $matches)) {
         $nids[] = $matches[1];
       }
@@ -77,6 +80,9 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
       foreach ($nids as $nid) {
         /** @var \Drupal\node\NodeInterface $node */
         $node = $node_storage->load($nid);
+        if (empty($node)) {
+          continue;
+        }
         // Check if node matches criteria.
         $office = $node->get('field_office')->target_id;
         $admin = $node->get('field_administration')->target_id;
@@ -115,7 +121,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
         "Updating node {$duplicate->getTitle()} (ID: {$duplicate->id()}) for Tricare values.");
 
     }
-    catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
+    catch (InvalidPluginDefinitionException | PluginNotFoundException | EntityStorageException | Exception $e) {
       $message = $e->getMessage();
       $this->batchOpLog->appendError('Could not update/duplicate node: ' . $message);
     }
@@ -164,6 +170,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   protected function updateNode(NodeInterface $node, bool $tricare): void {
 
@@ -173,19 +180,132 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
     // Update original node to VA values.
     $node->set('field_office', $tricare ? self::TRICARE_SYSTEM_ID : self::VA_SYSTEM_ID);
     $node->set('field_administration', $tricare ? self::TRICARE_ID : self::VA_ID);
-    $revision_message = "Un-dual-publishing for VA and TRICARE split Programs pages.";
 
-    $default_rev_id = $node->getRevisionId();
-    $latest_revision_id = $node_storage->getLatestRevisionId($node->id());
+    $is_duplicate = $node->isNew();
+    if (!$is_duplicate) {
+      $revision_message = "Un-dual-publishing for VA and TRICARE split Programs pages.";
 
-    // Save forward revisions if they exist.
-    if ($latest_revision_id > $default_rev_id) {
-      /** @var \Drupal\node\NodeInterface $revision */
-      $revision = $node_storage->loadRevision($latest_revision_id);
-      $existing_message = $revision->getRevisionLogMessage() ?? '';
-      save_node_revision($revision, $revision_message . ' - ' . $existing_message, FALSE);
+      $default_rev_id = $node->getRevisionId();
+      $latest_revision_id = $node_storage->getLatestRevisionId($node->id());
+
+      // Save forward revisions if they exist.
+      if ($latest_revision_id > $default_rev_id) {
+        /** @var \Drupal\node\NodeInterface $revision */
+        $revision = $node_storage->loadRevision($latest_revision_id);
+        $revision->set('field_office', $tricare ? self::TRICARE_SYSTEM_ID : self::VA_SYSTEM_ID);
+        $revision->set('field_administration', $tricare ? self::TRICARE_ID : self::VA_ID);
+        $existing_message = $revision->getRevisionLogMessage() ?? '';
+        save_node_revision($revision, $revision_message . ' - ' . $existing_message, FALSE);
+        $this->batchOpLog->appendLog('Saving forward revision for: ' . $node->getTitle());
+      }
+      save_node_revision($node, $revision_message);
+      $this->batchOpLog->appendLog('Saving original node for: ' . $node->getTitle());
+    } else {
+      // Always save the duplicate node first.
+      $node->save();
+      $this->batchOpLog->appendLog('Saving duplicate node for: ' . $node->getTitle());
     }
-    save_node_revision($node, $revision_message);
+
+
+    $this->setMenuLinks($tricare, $node);
+    $this->setUrlAlias($tricare, $node);
+
+  }
+
+  /**
+   * Update the URL alias for the node based on whether it's VA or Tricare.
+   *
+   * @param bool $tricare
+   *   Whether its a tricare node or not.
+   * @param NodeInterface $node
+   *   The node to update
+   *
+   * @throws EntityStorageException
+   * @throws InvalidPluginDefinitionException
+   * @throws PluginNotFoundException
+   */
+  protected function setUrlAlias(bool $tricare, NodeInterface $node): void {
+    $fac_type = ($tricare ? 'tricare' : 'va');
+    $url_title = rawurlencode(strtr(strtolower($node->getTitle()), ' ', '_'));
+    $new_alias = "/lovell-federal-health-care-$fac_type/programs-$fac_type/" . $url_title;
+
+    // Remove all existing aliases for this node.
+    $path_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
+    $aliases = $path_storage->loadByProperties(['path' => '/node/' . $node->id()]);
+    foreach ($aliases as $alias) {
+      $alias->delete();
+    }
+
+    // Set the new alias and disable Pathauto.
+    if ($node->hasField('path')) {
+      $node->set('path', ['alias' => $new_alias, 'pathauto' => 0]);
+    }
+    $node->save();
+    $this->batchOpLog->appendLog('Set alias for node ' . $node->id() . ' to ' . $new_alias);
+  }
+
+  /**
+   * Updates or creates a menu link for the node.
+   *
+   * @param bool $tricare
+   *   Whether the node is Tricare or not.
+   * @param NodeInterface $node
+   *   The node being updated.
+   *
+   * @throws EntityStorageException
+   * @throws InvalidPluginDefinitionException
+   * @throws PluginNotFoundException
+   */
+  protected function setMenuLinks(bool $tricare, NodeInterface $node): void {
+    $menu_link_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+    $section_value = $tricare ? 'tricare' : 'va';
+
+    // Update menu link for this node.
+    $parent_uuids = $this->getParentLinkUuids();
+    $this->batchOpLog->appendLog('Got parent link uuids of: ' . implode(', ', $parent_uuids));
+    $parent_uuid = $tricare ? ($parent_uuids['Programs - Tricare'] ?? null) : ($parent_uuids['Programs - VA'] ?? null);
+
+    $menu_link_entities = $menu_link_storage->loadByProperties([
+      'link__uri' => 'entity:node/' . $node->id(),
+    ]);
+    $this->batchOpLog->appendLog('Found ' . count($menu_link_entities) . ' menu links for node ID ' . $node->id());
+
+    // Always ensure a menu link exists for the duplicate node (or for any node if needed).
+    // Only create a menu link if one does not already exist for this node.
+    if (empty($menu_link_entities) && $parent_uuid) {
+      // Use the entity_field.manager service to check for field_menu_section.
+      $field_manager = \Drupal::service('entity_field.manager');
+      $menu_link_fields = $field_manager->getFieldDefinitions('menu_link_content', 'menu_link_content');
+      $menu_link_data = [
+        'title' => $node->getTitle(),
+        'link' => ['uri' => 'entity:node/' . $node->id()],
+        'menu_name' => 'lovell-federal-health-care',
+        'parent' => $parent_uuid,
+        'enabled' => TRUE,
+      ];
+
+      if (isset($menu_link_fields['field_menu_section'])) {
+        $menu_link_data['field_menu_section'] = $section_value;
+      }
+      $this->batchOpLog->appendLog('Creating menu link with data: ' . implode(', ', $menu_link_data));
+      $menu_link = MenuLinkContent::create($menu_link_data);
+
+      $menu_link->save();
+      $this->batchOpLog->appendLog('Saving new menu link for: ' . $node->getTitle());
+    } else {
+      // If a menu link exists, update its parent to ensure correctness.
+      foreach ($menu_link_entities as $menu_link) {
+        if ($parent_uuid) {
+          $menu_link->set('parent', $parent_uuid);
+        }
+        // Also update field_menu_section if present.
+        if ($menu_link->hasField('field_menu_section')) {
+          $menu_link->set('field_menu_section', $section_value);
+        }
+        $menu_link->save();
+        $this->batchOpLog->appendLog('Updating existing menu link for: ' . $node->getTitle());
+      }
+    }
   }
 
 }

--- a/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
+++ b/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
@@ -11,7 +11,6 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
-use Exception;
 
 /**
  * For VACMS-23756.
@@ -25,6 +24,12 @@ use Exception;
  * To run: drush codit-batch-operations:run DuplicateLovellProgramPages.
  */
 class DuplicateLovellProgramPages extends BatchOperations implements BatchScriptInterface {
+  /**
+   * Cache for parent link UUIDs to avoid repeated DB queries per instance.
+   *
+   * @var array|null
+   */
+  protected ?array $parentLinkUuids = NULL;
 
   const LOVELL_FEDERAL_SYSTEM_ID = '15007';
   const VA_SYSTEM_ID = '49451';
@@ -51,16 +56,17 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    * {@inheritdoc}
    */
   public function gatherItemsToProcess(): array {
-    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $node_storage = $this->entityTypeManager->getStorage('node');
     $items = [];
     $parent_uuids = $this->getParentLinkUuids();
 
     if (empty($parent_uuids)) {
+      $this->batchOpLog->appendError("Didn't find any parent link UUIDs.");
       return $items;
     }
 
     // Query for VAMC Detail Pages with the correct menu parent.
-    $menu_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+    $menu_storage = $this->entityTypeManager->getStorage('menu_link_content');
     $menu_query = $menu_storage->getQuery()
       ->condition('parent', $parent_uuids, 'IN')
       ->accessCheck(FALSE);
@@ -69,28 +75,28 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
     $nids = [];
     $menu_links = MenuLinkContent::loadMultiple($mids);
     foreach ($menu_links as $link) {
-      $link_field = $link->get('link')->getValue();
-      $uri = !empty($link_field[0]['uri']) ? $link_field[0]['uri'] : '';
-      if (preg_match('/entity:node\/(\d+)/', $uri, $matches)) {
-        $nids[] = $matches[1];
+      // Only process enabled menu links pointing to canonical node routes.
+      if (
+        $link->isEnabled() &&
+        $link->getUrlObject()->getRouteName() === 'entity.node.canonical'
+      ) {
+        $params = $link->getUrlObject()->getRouteParameters();
+        if (!empty($params['node'])) {
+          $nids[] = $params['node'];
+        }
       }
     }
 
     if (!empty($nids)) {
       foreach ($nids as $nid) {
-        $node = $node_storage->load($nid);
-        if (!$node instanceof NodeInterface) {
-          continue;
-        }
-        // Check if node matches criteria.
-        $office = $node->get('field_office')->target_id;
-        $admin = $node->get('field_administration')->target_id;
-        $published = $node->isPublished();
-        if ($published
-          && $office == self::LOVELL_FEDERAL_SYSTEM_ID
-          && $admin == self::BOTH_ID
-          && !in_array($nid, $items)
-        ) {
+        $nodes = $node_storage->loadByProperties([
+          'nid' => $nid,
+          'field_office' => self::LOVELL_FEDERAL_SYSTEM_ID,
+          'field_administration' => self::BOTH_ID,
+          'status' => 1,
+        ]);
+        $node = reset($nodes);
+        if ($node && !in_array($nid, $items)) {
           $items[] = $nid;
         }
       }
@@ -102,7 +108,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    * {@inheritdoc}
    */
   public function processOne(string $key, mixed $item, array &$sandbox): string {
-    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $node_storage = $this->entityTypeManager->getStorage('node');
     /** @var \Drupal\node\NodeInterface $node */
     $node = $node_storage->load($item);
     if (!$node) {
@@ -120,7 +126,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
         "Updating node {$duplicate->getTitle()} (ID: {$duplicate->id()}) for Tricare values.");
 
     }
-    catch (InvalidPluginDefinitionException | PluginNotFoundException | EntityStorageException | Exception $e) {
+    catch (InvalidPluginDefinitionException | PluginNotFoundException | EntityStorageException $e) {
       $message = $e->getMessage();
       $this->batchOpLog->appendError('Could not update/duplicate node: ' . $message);
     }
@@ -138,7 +144,11 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   protected function getParentLinkUuids(): array {
-    $menu_link_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+    if (isset($this->parentLinkUuids)) {
+      return $this->parentLinkUuids;
+    }
+
+    $menu_link_storage = $this->entityTypeManager->getStorage('menu_link_content');
 
     // Get menu parent UUIDs.
     $target_titles = ['Programs - Tricare', 'Programs - VA'];
@@ -153,10 +163,12 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
       $links = $menu_link_storage->loadMultiple($ids);
       /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $link */
       foreach ($links as $link) {
-        $parent_uuids[$link->get('title')->value] = 'menu_link_content:' . $link->uuid();
+        // Key by title for VA/Tricare parent lookup later.
+        $parent_uuids[$link->getTitle()] = $link->getEntityTypeId() . ':' . $link->uuid();
       }
     }
-    return $parent_uuids;
+    $this->parentLinkUuids = $parent_uuids;
+    return $this->parentLinkUuids;
   }
 
   /**
@@ -174,7 +186,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
   protected function updateNode(NodeInterface $node, bool $tricare): void {
 
     /** @var \Drupal\node\NodeStorageInterface $node_storage */
-    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $node_storage = $this->entityTypeManager->getStorage('node');
 
     // Update original node to VA values.
     $node->set('field_office', $tricare ? self::TRICARE_SYSTEM_ID : self::VA_SYSTEM_ID);
@@ -229,7 +241,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
     $new_alias = "/lovell-federal-health-care-$fac_type/programs-$fac_type/" . $url_title;
 
     // Remove all existing aliases for this node.
-    $path_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
+    $path_storage = $this->entityTypeManager->getStorage('path_alias');
     $aliases = $path_storage->loadByProperties(['path' => '/node/' . $node->id()]);
     foreach ($aliases as $alias) {
       $alias->delete();
@@ -256,7 +268,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   protected function setMenuLinks(bool $tricare, NodeInterface $node): void {
-    $menu_link_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+    $menu_link_storage = $this->entityTypeManager->getStorage('menu_link_content');
     $section_value = $tricare ? 'tricare' : 'va';
 
     // Update menu link for this node.

--- a/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
+++ b/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
@@ -78,9 +78,8 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
 
     if (!empty($nids)) {
       foreach ($nids as $nid) {
-        /** @var \Drupal\node\NodeInterface $node */
         $node = $node_storage->load($nid);
-        if (empty($node)) {
+        if (!$node instanceof NodeInterface) {
           continue;
         }
         // Check if node matches criteria.

--- a/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
+++ b/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
@@ -222,7 +222,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\Core\Entity\EntityStorageException
- */
+   */
   protected function setUrlAlias(bool $tricare, NodeInterface $node): void {
     $fac_type = ($tricare ? 'tricare' : 'va');
     $url_title = rawurlencode(strtr(strtolower($node->getTitle()), ' ', '_'));
@@ -254,7 +254,7 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\Core\Entity\EntityStorageException
- */
+   */
   protected function setMenuLinks(bool $tricare, NodeInterface $node): void {
     $menu_link_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
     $section_value = $tricare ? 'tricare' : 'va';

--- a/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
+++ b/docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php
@@ -199,12 +199,12 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
       }
       save_node_revision($node, $revision_message);
       $this->batchOpLog->appendLog('Saving original node for: ' . $node->getTitle());
-    } else {
+    }
+    else {
       // Always save the duplicate node first.
       $node->save();
       $this->batchOpLog->appendLog('Saving duplicate node for: ' . $node->getTitle());
     }
-
 
     $this->setMenuLinks($tricare, $node);
     $this->setUrlAlias($tricare, $node);
@@ -216,13 +216,13 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    *
    * @param bool $tricare
    *   Whether its a tricare node or not.
-   * @param NodeInterface $node
-   *   The node to update
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to update.
    *
-   * @throws EntityStorageException
-   * @throws InvalidPluginDefinitionException
-   * @throws PluginNotFoundException
-   */
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+ */
   protected function setUrlAlias(bool $tricare, NodeInterface $node): void {
     $fac_type = ($tricare ? 'tricare' : 'va');
     $url_title = rawurlencode(strtr(strtolower($node->getTitle()), ' ', '_'));
@@ -248,13 +248,13 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
    *
    * @param bool $tricare
    *   Whether the node is Tricare or not.
-   * @param NodeInterface $node
+   * @param \Drupal\node\NodeInterface $node
    *   The node being updated.
    *
-   * @throws EntityStorageException
-   * @throws InvalidPluginDefinitionException
-   * @throws PluginNotFoundException
-   */
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+ */
   protected function setMenuLinks(bool $tricare, NodeInterface $node): void {
     $menu_link_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
     $section_value = $tricare ? 'tricare' : 'va';
@@ -262,14 +262,14 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
     // Update menu link for this node.
     $parent_uuids = $this->getParentLinkUuids();
     $this->batchOpLog->appendLog('Got parent link uuids of: ' . implode(', ', $parent_uuids));
-    $parent_uuid = $tricare ? ($parent_uuids['Programs - Tricare'] ?? null) : ($parent_uuids['Programs - VA'] ?? null);
+    $parent_uuid = $tricare ? ($parent_uuids['Programs - Tricare'] ?? NULL) : ($parent_uuids['Programs - VA'] ?? NULL);
 
     $menu_link_entities = $menu_link_storage->loadByProperties([
       'link__uri' => 'entity:node/' . $node->id(),
     ]);
     $this->batchOpLog->appendLog('Found ' . count($menu_link_entities) . ' menu links for node ID ' . $node->id());
 
-    // Always ensure a menu link exists for the duplicate node (or for any node if needed).
+    // Always ensure a menu link exists for the duplicate node.
     // Only create a menu link if one does not already exist for this node.
     if (empty($menu_link_entities) && $parent_uuid) {
       // Use the entity_field.manager service to check for field_menu_section.
@@ -291,7 +291,8 @@ class DuplicateLovellProgramPages extends BatchOperations implements BatchScript
 
       $menu_link->save();
       $this->batchOpLog->appendLog('Saving new menu link for: ' . $node->getTitle());
-    } else {
+    }
+    else {
       // If a menu link exists, update its parent to ensure correctness.
       foreach ($menu_link_entities as $menu_link) {
         if ($parent_uuid) {

--- a/docroot/modules/custom/va_gov_lovell/src/LovellMenuLinkTreeManipulators.php
+++ b/docroot/modules/custom/va_gov_lovell/src/LovellMenuLinkTreeManipulators.php
@@ -177,7 +177,10 @@ class LovellMenuLinkTreeManipulators {
   protected function getMenuSectionField($mid) {
     $lovell_type = '';
     if (!empty($this->menuEntities[$mid])) {
-      $lovell_type = $this->menuEntities[$mid]->field_menu_section->value;
+      $entity = $this->menuEntities[$mid];
+      if ($entity->hasField('field_menu_section') && !$entity->get('field_menu_section')->isEmpty()) {
+        $lovell_type = $entity->get('field_menu_section')->value;
+      }
     }
     return $lovell_type;
   }

--- a/docroot/modules/custom/va_gov_lovell/va_gov_lovell.deploy.php
+++ b/docroot/modules/custom/va_gov_lovell/va_gov_lovell.deploy.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Post deploy file for VA Gov Lovell.
+ */
+
+/**
+ * Duplicates dual-published Lovell program pages.
+ */
+function va_gov_lovell_deploy_duplicate_lovell_program_pages(&$sandbox) {
+  $script = \Drupal::classResolver('\Drupal\va_gov_batch\cbo_scripts\DuplicateLovellProgramPages');
+  return $script->run($sandbox, 'deploy');
+}


### PR DESCRIPTION
## Description

Relates to #23756 . (or closes?)

### Generated description
This pull request introduces a new batch operation script to automate the process of un-dual-publishing Lovell "Programs" pages and duplicating them for VA and TRICARE, along with related improvements for menu and alias handling. It also adds a post-deploy hook to trigger this operation and improves error handling for menu section field access.

**Lovell Programs Dual-Publishing Split and Automation**

* Added the `DuplicateLovellProgramPages` batch script (`docroot/modules/custom/va_gov_batch/src/cbo_scripts/DuplicateLovellProgramPages.php`) to find all dual-published Lovell "Programs" pages, update the original to VA, and create a duplicate for TRICARE, including menu and URL alias updates.
* Added a post-deploy hook (`va_gov_lovell_deploy_duplicate_lovell_program_pages`) in `va_gov_lovell.deploy.php` to execute the batch script automatically after deployment.

**Menu Link Handling and Error Prevention**

* Improved `getMenuSectionField` in `LovellMenuLinkTreeManipulators.php` to safely check for the existence and non-emptiness of the `field_menu_section` field, preventing possible errors when accessing this field.


## QA steps

As an admin
1. Browse to the content list (/admin/content)
   - [ ] Validate that the 8 most recently updated items are VAMC Detail Pages. There are 4 pages that were un-dual-published. So now there should be two of each (1 in the 'Lovell - TRICARE' section and 1 in the 'Lovell - VA' section). 
   - For each of the updated nodes:
      - [ ] Validate that the url is correct. It should follow this pattern: /lovell-federal-health-care-[va or tricare]/programs-[va or tricare]/[page-title]
      - [ ] View the page and verify that the left hand menu shows up and has the correct menu is showing (va or tricare)
      - [ ] Verify that there is a menu item for the current node in the left hand menu.

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [ ] `CMS Team`
- [ ] `Public websites`
- [x] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`
