### PR TITLE
Adding permissions to workflows

### DIFF
--- a/.github/workflows/actions-metrics.yml
+++ b/.github/workflows/actions-metrics.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,4 +1,8 @@
 name: Cypress
+
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/default-branch-datadog-metrics.yml
+++ b/.github/workflows/default-branch-datadog-metrics.yml
@@ -1,5 +1,8 @@
 name: Send data about the default branch to DataDog.
 
+permissions:
+  contents: read
+
 #When DST, Use 345AM When not DST Use 245AM
 on:
   schedule:

--- a/.github/workflows/pull-request-labels.yml
+++ b/.github/workflows/pull-request-labels.yml
@@ -1,5 +1,10 @@
 name: Apply Labels, owners and reviewers to pull requests and issues.
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 on:
   issues:
     types:

--- a/.github/workflows/repair-pr-title.yml
+++ b/.github/workflows/repair-pr-title.yml
@@ -1,5 +1,9 @@
 name: "Repair PR Title"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, edited]

--- a/.github/workflows/s3-backup-retention.yml
+++ b/.github/workflows/s3-backup-retention.yml
@@ -1,5 +1,9 @@
 
 name: VAgov CMS S3 Backup Manager
+
+permissions:
+  contents: read
+
 on:
   # UTC 5am is ET 1am, when Daylight Savings begins.
   # UTC 6am is ET 1am, when Daylight Savings ends.


### PR DESCRIPTION
# Description

Relates to #24047 

Addresses the [permissions-related code scanning alerts](https://github.com/department-of-veterans-affairs/va.gov-cms/security/code-scanning).

# Generated description
This pull request updates several GitHub Actions workflow files to explicitly specify the required permissions for each workflow. This enhances security and follows GitHub best practices by restricting token permissions to only what is necessary for each workflow to operate.

**Workflow permissions updates:**

*General permissions improvements:*
- Added explicit `permissions` blocks to all workflows to specify the minimum required access, such as `contents: read` or `contents: write`, improving security posture. [[1]](diffhunk://#diff-2d514bf6a99a046072785ba700d7153387729071a0752c696bc46c8250743545R1-R3) [[2]](diffhunk://#diff-d70e2aa6678b83ca96763cb18bc1f578ee224ed8592ebbb83c1b75a8d897989fR3-R5) [[3]](diffhunk://#diff-978fdf8844f5273039a630b852783a65df448b001654ed4161916f2316040bbdR3-R6)

*Workflow-specific permissions:*
- Updated `pull-request-labels.yml` to grant `pull-requests: write` and `issues: write` permissions, allowing the workflow to modify pull requests and issues.
- Updated `repair-pr-title.yml` to grant `pull-requests: write` permission, enabling the workflow to update pull request titles.
- Updated `cypress.yml` to grant `contents: write` permission, allowing the workflow to write to repository contents as needed for Cypress operations.