### PR TITLE
Enhance CI wrapper and test configuration for silent token logging

### DIFF
--- a/tests.yml
+++ b/tests.yml
@@ -76,6 +76,7 @@ tasks:
       - ./tests/scripts/ci-wrapper.sh content-build-gql 'va:test:content-build-gql'
 
   set-check-status:
+    silent: true
     cmds:
       - |
         if [ "$SKIP_REPORTING" -ne 1 ]; then

--- a/tests/scripts/ci-wrapper.sh
+++ b/tests/scripts/ci-wrapper.sh
@@ -25,7 +25,9 @@ echo "Status name: ${status_name}"
 time composer "${composer_name}" 2>&1
 exit_code=$?
 
+set +x
 if [ -n "${GITHUB_TOKEN}" ]; then
+  set -x
   if [ "${exit_code}" -eq 0 ]; then
     github-status-updater \
       -action=update_state \


### PR DESCRIPTION
## Description
This will silent token logging in testing. 

### Generated description

This pull request introduces minor improvements to the CI workflow, primarily focused on the handling and visibility of status updates during test execution.

Workflow and logging improvements:

* Added `silent: true` to the `set-check-status` task in `tests.yml` to reduce unnecessary output in CI logs.
* Adjusted shell tracing in `ci-wrapper.sh` to disable verbose output before checking for `GITHUB_TOKEN`, and then re-enable it only when updating the GitHub status, minimizing log noise during sensitive operations.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

Check the logs to see if the token is present. 

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
