### PR TITLE
VACMS-23298: update tag and release GHAs

### DIFF
--- a/.github/workflows/build-drupal-tag-container.yml
+++ b/.github/workflows/build-drupal-tag-container.yml
@@ -74,7 +74,7 @@ jobs:
           }
 
           EVENT='${{ github.event_name }}'
-          INPUT_TAG='${{ inputs.tag }}'
+          INPUT_TAG='${{ github.event.inputs.tag || inputs.tag }}'
           if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
             if [ -n "$INPUT_TAG" ]; then
               SEMVER_TAG=$(normalize_input "$INPUT_TAG")

--- a/.github/workflows/build-drupal-tag-container.yml
+++ b/.github/workflows/build-drupal-tag-container.yml
@@ -8,6 +8,12 @@ on:
         description: 'Semver tag (cms/vX.Y.Z or vX.Y.Z (EKS)) to build. Leave blank to use latest.'
         required: false
         type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Semver tag to build (called from tag-release-main)'
+        required: true
+        type: string
   push:
     tags:
       - 'cms/v*.*.*'  # Only tags starting with cms/v and containing two dots
@@ -68,8 +74,8 @@ jobs:
           }
 
           EVENT='${{ github.event_name }}'
-          INPUT_TAG='${{ github.event.inputs.tag }}'
-          if [ "$EVENT" = "workflow_dispatch" ]; then
+          INPUT_TAG='${{ inputs.tag }}'
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
             if [ -n "$INPUT_TAG" ]; then
               SEMVER_TAG=$(normalize_input "$INPUT_TAG")
               if [[ "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then

--- a/.github/workflows/build-drupal-tag-container.yml
+++ b/.github/workflows/build-drupal-tag-container.yml
@@ -58,11 +58,14 @@ jobs:
             fi
           }
 
-          ensure_tag_exists() {
+          # Returns the full git tag ref (cms/vX.Y.Z or vX.Y.Z) if it exists, empty otherwise
+          resolve_tag_ref() {
             local semver="$1"
-            # Check for both cms/vX.Y.Z and vX.Y.Z tag formats
-            git rev-parse -q --verify "refs/tags/${TAG_PREFIX}${semver}" >/dev/null 2>&1 ||
-              git rev-parse -q --verify "refs/tags/${semver}" >/dev/null 2>&1
+            if git rev-parse -q --verify "refs/tags/${TAG_PREFIX}${semver}" >/dev/null 2>&1; then
+              echo "${TAG_PREFIX}${semver}"
+            elif git rev-parse -q --verify "refs/tags/${semver}" >/dev/null 2>&1; then
+              echo "${semver}"
+            fi
           }
 
           find_latest_tag() {
@@ -79,8 +82,10 @@ jobs:
             if [ -n "$INPUT_TAG" ]; then
               SEMVER_TAG=$(normalize_input "$INPUT_TAG")
               if [[ "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
-                if ensure_tag_exists "$SEMVER_TAG"; then
+                TAG_REF=$(resolve_tag_ref "$SEMVER_TAG")
+                if [ -n "$TAG_REF" ]; then
                   echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
+                  echo "TAG_REF=$TAG_REF" >> $GITHUB_OUTPUT
                   echo "is_valid=true" >> $GITHUB_OUTPUT
                   exit 0
                 else
@@ -107,7 +112,9 @@ jobs:
                 exit 1
               fi
               echo "Using latest semver tag: $SEMVER_TAG (repo tag $LATEST_TAG)"
+              TAG_REF=$(resolve_tag_ref "$SEMVER_TAG")
               echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
+              echo "TAG_REF=${TAG_REF:-$SEMVER_TAG}" >> $GITHUB_OUTPUT
               echo "is_valid=true" >> $GITHUB_OUTPUT
               exit 0
             fi
@@ -116,6 +123,7 @@ jobs:
             SEMVER_TAG=$(normalize_input "$RAW_TAG")
             if [[ "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
               echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
+              echo "TAG_REF=$RAW_TAG" >> $GITHUB_OUTPUT
               echo "is_valid=true" >> $GITHUB_OUTPUT
             else
               echo "::error title=Invalid Pushed Tag::Pushed tag $RAW_TAG failed semver validation after removing prefix." >&2
@@ -127,6 +135,13 @@ jobs:
         run: |
           echo "::error title=Build Aborted::Invalid or missing semver tag; failing build job." >&2
           exit 1
+      - name: Checkout tag ref
+        if: steps.select_tag.outputs.is_valid == 'true'
+        uses: actions/checkout@v6.0.2
+        with:
+          # Check out the exact tag so the Docker build context matches the release
+          ref: refs/tags/${{ steps.select_tag.outputs.TAG_REF }}
+          fetch-depth: 1
       - name: Configure AWS Credentials
         if: steps.select_tag.outputs.is_valid == 'true'
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/tag-release-main.yml
+++ b/.github/workflows/tag-release-main.yml
@@ -39,8 +39,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Walk recent commits on main and find the first one where all checks passed
-          for SHA in $(git log --first-parent --format='%H' -n 50 main); do
+          # Only consider commits after the latest release tag to avoid
+          # walking back to already-tagged commits when recent checks are pending.
+          LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n1)
+          if [ -n "$LATEST_TAG" ]; then
+            RANGE="${LATEST_TAG}..main"
+            echo "Searching for passing commits in range: $RANGE"
+          else
+            RANGE="main"
+            echo "No existing release tags found; searching all commits on main."
+          fi
+
+          CANDIDATES=$(git log --first-parent --format='%H' -n 50 $RANGE)
+          if [ -z "$CANDIDATES" ]; then
+            echo "::notice::No new commits since last release tag ${LATEST_TAG}."
+            exit 1
+          fi
+
+          for SHA in $CANDIDATES; do
             echo "Checking commit $SHA ..."
             STATUS=$(gh api "repos/${{ github.repository }}/commits/${SHA}/status" --jq '.state')
             CHECK_RUNS_RESPONSE=$(gh api --paginate "repos/${{ github.repository }}/commits/${SHA}/check-runs?per_page=100")
@@ -54,7 +70,7 @@ jobs:
             fi
           done
 
-          echo "::error::No recent commit on main has passed all status checks."
+          echo "::error::No new commits since ${LATEST_TAG:-initial} have passed all status checks."
           exit 1
 
       - name: Determine next semver tag
@@ -113,13 +129,24 @@ jobs:
           NEW_TAG="${{ steps.next-tag.outputs.NEXT_TAG }}"
           COMMIT_SHA="${{ steps.find-commit.outputs.COMMIT_SHA }}"
 
-          git tag "$NEW_TAG" "$COMMIT_SHA"
-          git push origin "$NEW_TAG"
+          # Push the tag (may already exist from a previous failed run)
+          if git ls-remote --tags origin "refs/tags/${NEW_TAG}" | grep -q "${NEW_TAG}"; then
+            echo "Tag $NEW_TAG already exists on remote (likely from a previous partial run)."
+          else
+            git tag "$NEW_TAG" "$COMMIT_SHA"
+            git push origin "$NEW_TAG"
+          fi
 
-          gh release create "$NEW_TAG" \
-            --target "$COMMIT_SHA" \
-            --title "$NEW_TAG" \
-            --generate-notes
+          # Create the release (retry-safe: --generate-notes is idempotent)
+          # If release already exists, this is a no-op error we can ignore.
+          if gh release view "$NEW_TAG" >/dev/null 2>&1; then
+            echo "Release $NEW_TAG already exists."
+          else
+            gh release create "$NEW_TAG" \
+              --target "$COMMIT_SHA" \
+              --title "$NEW_TAG" \
+              --generate-notes
+          fi
 
           echo "NEW_TAG=$NEW_TAG" >> "$GITHUB_OUTPUT"
           echo "Created tag $NEW_TAG at commit $COMMIT_SHA"

--- a/.github/workflows/tag-release-main.yml
+++ b/.github/workflows/tag-release-main.yml
@@ -161,7 +161,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    secrets: inherit
 
   notify-success-slack:
     name: Notify Success (Slack)

--- a/.github/workflows/tag-release-main.yml
+++ b/.github/workflows/tag-release-main.yml
@@ -124,6 +124,18 @@ jobs:
           echo "NEW_TAG=$NEW_TAG" >> "$GITHUB_OUTPUT"
           echo "Created tag $NEW_TAG at commit $COMMIT_SHA"
 
+  build-drupal-container:
+    name: Build Drupal Tag Container
+    needs: tag-and-release
+    if: needs.tag-and-release.result == 'success' && needs.tag-and-release.outputs.NEW_TAG != ''
+    uses: ./.github/workflows/build-drupal-tag-container.yml
+    with:
+      tag: ${{ needs.tag-and-release.outputs.NEW_TAG }}
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit
+
   notify-success-slack:
     name: Notify Success (Slack)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Relates to #23298

### Generated description

This pull request updates the GitHub Actions workflows to enable the `build-drupal-tag-container.yml` workflow to be triggered programmatically from another workflow (specifically, from `tag-release-main.yml`). The main changes introduce support for the `workflow_call` trigger, allowing seamless chaining of workflows and passing of tag information between them.

**Workflow integration and triggering:**

* Added a `workflow_call` trigger to `.github/workflows/build-drupal-tag-container.yml`, enabling it to be invoked by other workflows and to accept a required `tag` input.
* Updated the tag determination logic in `build-drupal-tag-container.yml` to use `${{ inputs.tag }}` when triggered by `workflow_call`, and adjusted the event check to handle both `workflow_dispatch` and `workflow_call` events.

**Workflow chaining:**

* Modified `.github/workflows/tag-release-main.yml` to add a new job, `build-drupal-container`, which triggers the `build-drupal-tag-container.yml` workflow after a successful tag and release, passing the new tag as input and inheriting necessary permissions and secrets.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
