### PR TITLE
VACMS-20671: Update deprecated commands code

### DIFF
--- a/READMES/custom-drush-commands.md
+++ b/READMES/custom-drush-commands.md
@@ -7,7 +7,7 @@ See [SiteStatusCommands.php](../docroot/modules/custom/va_gov_build_trigger/src/
 - `va-gov:disable-deploy-mode` -- Sets the Deploy Mode flag to FALSE. It is not normally necessary to perform this operation manually.
 - `va-gov:enable-deploy-mode` -- Sets the Deploy Mode flag to TRUE. It is not normally necessary to perform this operation manually.
 - `va-gov:get-deploy-mode` -- Indicates whether the CMS is currently in Deploy Mode, which is a precautionary measure used to prevent content changes while content is being deployed.
-- 
+-
 
 ### Content release commands
 
@@ -74,6 +74,5 @@ See [Commands.php](docroot/modules/custom/va_gov_live_field_migration/src/Comman
 
 ### Global commands
 
-See [Commands.php](docroot/modules/custom/va_gov_live_field_migration/src/Commands/Commands.php).
-- `va:gov-clean-revs` (vg-cr) -- Clean up bad node revisions.
+See [Commands.php](docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php).
 - `va_gov_migrate:flag-missing-facilities` -- (alias va-gov-flag-missing-facilities) -- Flag any facilities that no longer exist in Facilty API.

--- a/READMES/custom-drush-commands.md
+++ b/READMES/custom-drush-commands.md
@@ -7,7 +7,6 @@ See [SiteStatusCommands.php](../docroot/modules/custom/va_gov_build_trigger/src/
 - `va-gov:disable-deploy-mode` -- Sets the Deploy Mode flag to FALSE. It is not normally necessary to perform this operation manually.
 - `va-gov:enable-deploy-mode` -- Sets the Deploy Mode flag to TRUE. It is not normally necessary to perform this operation manually.
 - `va-gov:get-deploy-mode` -- Indicates whether the CMS is currently in Deploy Mode, which is a precautionary measure used to prevent content changes while content is being deployed.
--
 
 ### Content release commands
 

--- a/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Commands/Commands.php
@@ -31,18 +31,6 @@ class Commands extends DrushCommands {
   }
 
   /**
-   * Clean up bad node revisions.
-   *
-   * @command va:gov-clean-revs
-   * @aliases vg-cr,va-gov-clean-revs
-   */
-  public function cleanRevs() {
-    $messages = $this->vaGovMigrateService->cleanRevs();
-    $this->logger->log('success', $messages['success']);
-    $this->logger->warning($messages['warning']);
-  }
-
-  /**
    * Archive IntranetOnly forms in the CMS.
    *
    * @command va_gov_migrate:archive-intranet-only-forms

--- a/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
@@ -3,7 +3,6 @@
 namespace Drupal\va_gov_migrate\Service;
 
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\migrate_plus\DataFetcherPluginManager;
 use Drupal\migrate_plus\Entity\Migration;

--- a/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
@@ -99,45 +99,6 @@ class VaGovMigrateService {
   }
 
   /**
-   * Clean up bad node revisions.
-   */
-  public function cleanRevs() {
-    $time = 1572551719;
-
-    $query = $this->database->select('node_revision', 'nr');
-    $query->condition('revision_timestamp', $time);
-    $query->fields('nr', ['vid']);
-    $vids = $query->execute()->fetchCol();
-
-    $query = $this->database->select('node_revision', 'nr');
-    $query->condition('revision_log', 'Update of status by migration.');
-    $query->condition('nid', 1884);
-    $query->fields('nr', ['vid']);
-    $more_vids = $query->execute()->fetchCol();
-
-    $vids = array_merge($vids, $more_vids);
-    $this->migrateChannelLogger->info('Attempting to Delete ' . count($vids) . ' node revisions');
-    $missed_vids = [];
-    foreach ($vids as $vid) {
-      try {
-        $this->migrateChannelLogger->info('Deleting: ' . $vid);
-        $this->entityTypeManager->getStorage('node')->deleteRevision($vid);
-      }
-      catch (EntityStorageException $e) {
-        $this->migrateChannelLogger->warning('Vid ' . $vid . ' could not be deleted: ' . $e->getMessage());
-        $missed_vids[] = $vid;
-      }
-    }
-
-    $count = count($vids) - count($missed_vids);
-    // @phpstan-ignore-next-line
-    return [
-      'success' => "Deleted {$count} revision(s).",
-      'warning' => 'The following revisions were not deleted: ' . implode(', ', $missed_vids),
-    ];
-  }
-
-  /**
    * Archive IntranetOnly forms in the CMS.
    *
    * @throws \League\Csv\UnavailableStream

--- a/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
+++ b/docroot/modules/custom/va_gov_migrate/src/Service/VaGovMigrateService.php
@@ -112,7 +112,7 @@ class VaGovMigrateService {
    *   Thrown if the storage handler couldn't be loaded.
    */
   public function archiveIntranetOnlyForms() {
-    $csv = Reader::createFromPath(DRUPAL_ROOT . '/sites/default/files/migrate_source/va_forms_data.csv', 'r');
+    $csv = Reader::from(DRUPAL_ROOT . '/sites/default/files/migrate_source/va_forms_data.csv', 'r');
     $csv->setHeaderOffset(0);
     $csv->setEnclosure('"');
     $csv->setDelimiter(',');

--- a/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
+++ b/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
@@ -79,8 +79,10 @@ if ($updated_rowid === NULL && $target_rowid !== NULL) {
   $new_row = array_fill(0, count($header), '');
   $new_row[$rowid_index] = $target_rowid;
   $new_row[$intranet_only_index] = '1';
-  $new_row[0] = $target_rowid; // FormNum
-  $new_row[1] = "Test Form {$target_rowid}"; // FormTitle
+  // FormNum.
+  $new_row[0] = $target_rowid;
+  // FormTitle.
+  $new_row[1] = "Test Form {$target_rowid}";
   fputcsv($output, $new_row);
   $updated_rowid = $target_rowid;
 }

--- a/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
+++ b/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
@@ -10,6 +10,11 @@
  *   -- [rowid]
  */
 
+require_once __DIR__ . '/script-library.php';
+
+$env = getenv('CMS_ENVIRONMENT_TYPE') ?: 'ci';
+exit_if_not_local_or_tugboat($env);
+
 $target_rowid = $extra[0] ?? ($argv[1] ?? NULL);
 $csv_path = DRUPAL_ROOT . '/sites/default/files/migrate_source/va_forms_data.csv';
 

--- a/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
+++ b/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
@@ -5,7 +5,7 @@
  * Test harness for archiveIntranetOnlyForms().
  *
  * Usage:
- *   phpcs:ignore Generic.Files.LineLength.TooLong
+ *   phpcs:ignore Generic.Files.LineLength
  *   drush scr scripts/content/VACMS-20671-test-archive-intranet-only-forms.php -- [rowid]
  */
 

--- a/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
+++ b/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
@@ -60,9 +60,14 @@ if ($rowid_index === FALSE || $intranet_only_index === FALSE) {
 fputcsv($output, $header);
 
 $updated_rowid = NULL;
+$found_target = FALSE;
 while (($row = fgetcsv($input)) !== FALSE) {
   $current_rowid = $row[$rowid_index] ?? NULL;
   $should_update = FALSE;
+
+  if ($target_rowid !== NULL && (string) $current_rowid === (string) $target_rowid) {
+    $found_target = TRUE;
+  }
 
   if ($updated_rowid === NULL && isset($row[$intranet_only_index]) && $row[$intranet_only_index] !== '1') {
     if ($target_rowid === NULL) {
@@ -81,8 +86,8 @@ while (($row = fgetcsv($input)) !== FALSE) {
   fputcsv($output, $row);
 }
 
-// If target rowid was specified but not found, add it as a test row.
-if ($updated_rowid === NULL && $target_rowid !== NULL) {
+// If target rowid was specified but truly not found in the file, add it as a test row.
+if (!$found_target && $target_rowid !== NULL) {
   $new_row = array_fill(0, count($header), '');
   $new_row[$rowid_index] = $target_rowid;
   $new_row[$intranet_only_index] = '1';

--- a/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
+++ b/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @file
+ * Test harness for archiveIntranetOnlyForms().
+ *
+ * Usage:
+ *   drush scr scripts/content/VACMS-20671-test-archive-intranet-only-forms.php -- [rowid]
+ */
+
+$target_rowid = $extra[0] ?? ($argv[1] ?? NULL);
+$csv_path = DRUPAL_ROOT . '/sites/default/files/migrate_source/va_forms_data.csv';
+
+if (!is_file($csv_path)) {
+  throw new RuntimeException("Forms CSV not found at {$csv_path}");
+}
+
+$backup_path = sprintf('%s.bak.%s', $csv_path, date('YmdHis'));
+if (!copy($csv_path, $backup_path)) {
+  throw new RuntimeException("Unable to create backup at {$backup_path}");
+}
+
+$input = fopen($csv_path, 'r');
+if ($input === FALSE) {
+  throw new RuntimeException("Unable to open {$csv_path} for reading");
+}
+
+$temp_path = sprintf('%s.tmp.%s', $csv_path, uniqid('', TRUE));
+$output = fopen($temp_path, 'w');
+if ($output === FALSE) {
+  fclose($input);
+  throw new RuntimeException("Unable to open {$temp_path} for writing");
+}
+
+$header = fgetcsv($input);
+if ($header === FALSE) {
+  fclose($input);
+  fclose($output);
+  @unlink($temp_path);
+  throw new RuntimeException('Forms CSV is empty');
+}
+
+$rowid_index = array_search('rowid', $header, TRUE);
+$intranet_only_index = array_search('IntranetOnly', $header, TRUE);
+
+if ($rowid_index === FALSE || $intranet_only_index === FALSE) {
+  fclose($input);
+  fclose($output);
+  @unlink($temp_path);
+  throw new RuntimeException('Forms CSV is missing rowid or IntranetOnly columns');
+}
+
+fputcsv($output, $header);
+
+$updated_rowid = NULL;
+while (($row = fgetcsv($input)) !== FALSE) {
+  $current_rowid = $row[$rowid_index] ?? NULL;
+  $should_update = FALSE;
+
+  if ($updated_rowid === NULL && isset($row[$intranet_only_index]) && $row[$intranet_only_index] !== '1') {
+    if ($target_rowid === NULL) {
+      $should_update = TRUE;
+    }
+    elseif ((string) $current_rowid === (string) $target_rowid) {
+      $should_update = TRUE;
+    }
+  }
+
+  if ($should_update) {
+    $row[$intranet_only_index] = '1';
+    $updated_rowid = $current_rowid ?? '[missing rowid]';
+  }
+
+  fputcsv($output, $row);
+}
+
+// If target rowid was specified but not found, add it as a test row.
+if ($updated_rowid === NULL && $target_rowid !== NULL) {
+  $new_row = array_fill(0, count($header), '');
+  $new_row[$rowid_index] = $target_rowid;
+  $new_row[$intranet_only_index] = '1';
+  $new_row[0] = $target_rowid; // FormNum
+  $new_row[1] = "Test Form {$target_rowid}"; // FormTitle
+  fputcsv($output, $new_row);
+  $updated_rowid = $target_rowid;
+}
+
+fclose($input);
+fclose($output);
+
+if ($updated_rowid === NULL) {
+  @unlink($temp_path);
+  throw new RuntimeException('No non-IntranetOnly rows were found to update');
+}
+
+if (!rename($temp_path, $csv_path)) {
+  @unlink($temp_path);
+  throw new RuntimeException("Unable to replace {$csv_path} with updated CSV");
+}
+
+print "Updated rowid: {$updated_rowid}\n";
+print "Backup created at: {$backup_path}\n";
+
+\Drupal::service('va_gov_migrate.va_gov_migrate_service')->archiveIntranetOnlyForms();
+
+print "archiveIntranetOnlyForms() completed.\n";

--- a/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
+++ b/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
@@ -5,8 +5,9 @@
  * Test harness for archiveIntranetOnlyForms().
  *
  * Usage:
- *   phpcs:ignore Generic.Files.LineLength
- *   drush scr scripts/content/VACMS-20671-test-archive-intranet-only-forms.php -- [rowid]
+ *   drush scr \
+ *   scripts/content/VACMS-20671-test-archive-intranet-only-forms.php \
+ *   -- [rowid]
  */
 
 $target_rowid = $extra[0] ?? ($argv[1] ?? NULL);

--- a/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
+++ b/scripts/content/VACMS-20671-test-archive-intranet-only-forms.php
@@ -5,6 +5,7 @@
  * Test harness for archiveIntranetOnlyForms().
  *
  * Usage:
+ *   phpcs:ignore Generic.Files.LineLength.TooLong
  *   drush scr scripts/content/VACMS-20671-test-archive-intranet-only-forms.php -- [rowid]
  */
 


### PR DESCRIPTION
## Description

Relates to #20671 

While looking into the deprecated code, it appeared that the function `cleanRevs()` may have only been used a handful of times (or even just once) in the distant past:
- it queried revisions with a hardcoded timestamp of 1572551719 (Thu Oct 31 2019 19:55:19 GMT+0000)
- it also queried node id of 1884 
- when it was upgraded 5 years ago for D9, the developers either thought is [looked like one-time](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/4852#pullrequestreview-623265291) code or couldn't say either way
- it is not called by any process we currently run on a schedule

In the same file, there was also deprecated code from League/Csv, which I addressed.

### Generated description
This pull request removes the obsolete "clean bad node revisions" Drush command and its implementation, updates the CSV reader instantiation for compatibility, and adds a new script for testing the `archiveIntranetOnlyForms` functionality. The documentation is also updated to reflect these changes.

**Removal of obsolete functionality:**
- Removed the `va:gov-clean-revs` Drush command and its implementation from both `Commands.php` and `VaGovMigrateService.php`, as well as its documentation reference. This command was used to clean up bad node revisions and is no longer needed. [[1]](diffhunk://#diff-a76723e759483c48ee5ca4ef4790f0fe80914e6ee3d0fafbb20378a1d6c8a3baL33-L44) [[2]](diffhunk://#diff-4b371100d1c098ced540796966059d7f365e2f4118b0ac7cfe35f2c9c892d243L101-L139) [[3]](diffhunk://#diff-e8533102d7376e6a72a672972843b132542ab8b90c17648447f41ae3e8a1fdd8L77-R77)

**Code and compatibility improvements:**
- Updated the CSV reader instantiation in `archiveIntranetOnlyForms` to use `Reader::from()` instead of `Reader::createFromPath()` because `createFromPath()` was deprecated
- Removed an unused `use` statement for `EntityStorageException` in `VaGovMigrateService.php`.

**Testing enhancements:**
- Added a new script `VACMS-20671-test-archive-intranet-only-forms.php` to allow for targeted testing of the `archiveIntranetOnlyForms` method, including CSV backup, row updating, and error handling.

## Testing done
- Manually with new test script (see below)

## Screenshots
N/A

## QA steps (for testing the form archiving deprecated code change)
- [x] Log in as an admin
- [x] Go to the forms content
- [x] Choose a currently published form
- [x] Get the the "Row ID" from the **Forms DB Data**
- [x] In the Terminal, Run the following command: `drush scr scripts/content/VACMS-20671-test-archive-intranet-only-forms.php -- [Row ID]`
- [x] Confirm that the terminal shows the form as archived
- [x] In the browser, confirm that the form has been archived

### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.
- [ ] If there are field changes, front end output has been thoroughly checked.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`

