### PR TITLE
VACMS-23298: refactor tag and release workflow to use dedicated scrip…

### DIFF
--- a/.github/workflows/tag-release-main.yml
+++ b/.github/workflows/tag-release-main.yml
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          COMMIT_SHA=$(bash scripts/find-latest-passing-main-commit.sh --repo "${{ github.repository }}" --max-commits 0 --verbose)
+          COMMIT_SHA=$(bash scripts/find-latest-passing-main-commit.sh --repo "${{ github.repository }}" --max-commits 250 --fallback-max-commits 750 --verbose)
           echo "Found passing commit: $COMMIT_SHA"
           echo "COMMIT_SHA=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/tag-release-main.yml
+++ b/.github/workflows/tag-release-main.yml
@@ -38,40 +38,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          # Only consider commits after the latest release tag to avoid
-          # walking back to already-tagged commits when recent checks are pending.
-          LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n1)
-          if [ -n "$LATEST_TAG" ]; then
-            RANGE="${LATEST_TAG}..main"
-            echo "Searching for passing commits in range: $RANGE"
-          else
-            RANGE="main"
-            echo "No existing release tags found; searching all commits on main."
-          fi
-
-          CANDIDATES=$(git log --first-parent --format='%H' -n 50 $RANGE)
-          if [ -z "$CANDIDATES" ]; then
-            echo "::notice::No new commits since last release tag ${LATEST_TAG}."
-            exit 1
-          fi
-
-          for SHA in $CANDIDATES; do
-            echo "Checking commit $SHA ..."
-            STATUS=$(gh api "repos/${{ github.repository }}/commits/${SHA}/status" --jq '.state')
-            CHECK_RUNS_RESPONSE=$(gh api --paginate "repos/${{ github.repository }}/commits/${SHA}/check-runs?per_page=100")
-            CHECK_RUNS=$(printf '%s\n' "$CHECK_RUNS_RESPONSE" | jq -s '[.[].check_runs[] | select(.conclusion == "success" or .conclusion == "skipped")] | length')
-            TOTAL_CHECK_RUNS=$(printf '%s\n' "$CHECK_RUNS_RESPONSE" | jq -s '[.[].check_runs[]] | length')
-
-            if [[ "$STATUS" == "success" && "$TOTAL_CHECK_RUNS" -gt 0 && "$CHECK_RUNS" -eq "$TOTAL_CHECK_RUNS" ]]; then
-              echo "Found passing commit: $SHA"
-              echo "COMMIT_SHA=$SHA" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-
-          echo "::error::No new commits since ${LATEST_TAG:-initial} have passed all status checks."
-          exit 1
+          COMMIT_SHA=$(bash scripts/find-latest-passing-main-commit.sh --repo "${{ github.repository }}" --max-commits 0 --verbose)
+          echo "Found passing commit: $COMMIT_SHA"
+          echo "COMMIT_SHA=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Determine next semver tag
         id: next-tag

--- a/scripts/find-latest-passing-main-commit.sh
+++ b/scripts/find-latest-passing-main-commit.sh
@@ -48,10 +48,20 @@ log() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
+      if [[ $# -lt 2 || "${2-}" == -* ]]; then
+        log "Missing value for --repo (expected: owner/name)"
+        usage
+        exit 2
+      fi
       REPO="$2"
       shift 2
       ;;
     --max-commits)
+      if [[ $# -lt 2 || "${2-}" == -* ]]; then
+        log "Missing value for --max-commits (expected: non-negative integer)"
+        usage
+        exit 2
+      fi
       MAX_COMMITS="$2"
       shift 2
       ;;

--- a/scripts/find-latest-passing-main-commit.sh
+++ b/scripts/find-latest-passing-main-commit.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 # No tags/releases are created.
 
 MAX_COMMITS=0
+FALLBACK_MAX_COMMITS=""
 REPO="${REPO:-}"
 VERBOSE=0
 JSON_MODE=0
@@ -16,11 +17,12 @@ REQUIRED_CHECKS_JSON='["va/tests/cypress","va/tests/phpunit","va/tests/status-er
 
 usage() {
   cat <<'EOF'
-Usage: find-latest-passing-main-commit.sh [--repo owner/name] [--max-commits N] [--verbose] [--json] [--json-pretty]
+Usage: find-latest-passing-main-commit.sh [--repo owner/name] [--max-commits N] [--fallback-max-commits N] [--verbose] [--json] [--json-pretty]
 
 Options:
   --repo owner/name   GitHub repository (defaults to current gh repo)
   --max-commits N     Number of commits to inspect (default: 0 = all since last tag)
+  --fallback-max-commits N  Cap for fallback full-main scan (default: same as --max-commits)
   --verbose           Print per-commit diagnostics to stderr
   --json              Print JSON output with selected SHA and skip summary
   --json-pretty       Same as --json, but pretty-printed
@@ -65,6 +67,15 @@ while [[ $# -gt 0 ]]; do
       MAX_COMMITS="$2"
       shift 2
       ;;
+    --fallback-max-commits)
+      if [[ $# -lt 2 || "${2-}" == -* ]]; then
+        log "Missing value for --fallback-max-commits (expected: non-negative integer)"
+        usage
+        exit 2
+      fi
+      FALLBACK_MAX_COMMITS="$2"
+      shift 2
+      ;;
     --verbose)
       VERBOSE=1
       shift
@@ -99,6 +110,11 @@ done
 
 if ! [[ "$MAX_COMMITS" =~ ^[0-9]+$ ]]; then
   log "--max-commits must be a non-negative integer"
+  exit 2
+fi
+
+if [[ -n "$FALLBACK_MAX_COMMITS" ]] && ! [[ "$FALLBACK_MAX_COMMITS" =~ ^[0-9]+$ ]]; then
+  log "--fallback-max-commits must be a non-negative integer"
   exit 2
 fi
 
@@ -145,10 +161,16 @@ SAMPLED_REASONS=()
 for RANGE in "${RANGES[@]}"; do
   SEARCHED_RANGES+=("$RANGE")
 
-  if [[ "$MAX_COMMITS" -eq 0 ]]; then
+  EFFECTIVE_MAX_COMMITS="$MAX_COMMITS"
+  # Apply a separate cap when scanning full main as a fallback path.
+  if [[ "$RANGE" == "main" && -n "$LATEST_TAG" && -n "$FALLBACK_MAX_COMMITS" ]]; then
+    EFFECTIVE_MAX_COMMITS="$FALLBACK_MAX_COMMITS"
+  fi
+
+  if [[ "$EFFECTIVE_MAX_COMMITS" -eq 0 ]]; then
     CANDIDATES=$(git log --first-parent --format='%H' "$RANGE" || true)
   else
-    CANDIDATES=$(git log --first-parent --format='%H' -n "$MAX_COMMITS" "$RANGE" || true)
+    CANDIDATES=$(git log --first-parent --format='%H' -n "$EFFECTIVE_MAX_COMMITS" "$RANGE" || true)
   fi
 
   if [[ -z "$CANDIDATES" ]]; then
@@ -158,10 +180,10 @@ for RANGE in "${RANGES[@]}"; do
 
   CANDIDATE_COUNT=$(printf '%s\n' "$CANDIDATES" | sed '/^$/d' | wc -l | tr -d ' ')
   if [[ "$VERBOSE" -eq 1 ]]; then
-    if [[ "$MAX_COMMITS" -eq 0 ]]; then
+    if [[ "$EFFECTIVE_MAX_COMMITS" -eq 0 ]]; then
       log "Evaluating range: $RANGE (candidates=$CANDIDATE_COUNT, max_commits=unlimited)"
     else
-      log "Evaluating range: $RANGE (candidates=$CANDIDATE_COUNT, max_commits=$MAX_COMMITS)"
+      log "Evaluating range: $RANGE (candidates=$CANDIDATE_COUNT, max_commits=$EFFECTIVE_MAX_COMMITS)"
     fi
   fi
 

--- a/scripts/find-latest-passing-main-commit.sh
+++ b/scripts/find-latest-passing-main-commit.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Finds the newest commit on main where
+# Finds the newest mainline commit on main where
 # required VA checks are present and passing. Outputs only the commit SHA to stdout.
-# It searches commits since the latest release tag first, then falls back to full main history.
+# It searches the first-parent chain since the latest release tag first, then falls back to full first-parent main history.
 # No tags/releases are created.
 
 MAX_COMMITS=0
@@ -34,6 +34,7 @@ Output:
   --json: prints a JSON object with selected_sha and skipped_summary.
   --json-pretty: same schema as --json, but indented.
   Search order: latest_tag..main, then full main history if needed.
+  Candidate commits are taken from main's first-parent chain only.
   Required checks: va/tests/cypress, va/tests/phpunit,
                    va/tests/status-error, va/tests/content-build-gql.
   Exits non-zero if no qualifying commit is found.
@@ -135,9 +136,9 @@ for RANGE in "${RANGES[@]}"; do
   SEARCHED_RANGES+=("$RANGE")
 
   if [[ "$MAX_COMMITS" -eq 0 ]]; then
-    CANDIDATES=$(git log --format='%H' "$RANGE" || true)
+    CANDIDATES=$(git log --first-parent --format='%H' "$RANGE" || true)
   else
-    CANDIDATES=$(git log --format='%H' -n "$MAX_COMMITS" "$RANGE" || true)
+    CANDIDATES=$(git log --first-parent --format='%H' -n "$MAX_COMMITS" "$RANGE" || true)
   fi
 
   if [[ -z "$CANDIDATES" ]]; then

--- a/scripts/find-latest-passing-main-commit.sh
+++ b/scripts/find-latest-passing-main-commit.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # No tags/releases are created.
 
 MAX_COMMITS=0
-REPO="${REPO:-department-of-veterans-affairs/va.gov-cms}"
+REPO="${REPO:-}"
 VERBOSE=0
 JSON_MODE=0
 JSON_PRETTY=0

--- a/scripts/find-latest-passing-main-commit.sh
+++ b/scripts/find-latest-passing-main-commit.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Finds the newest commit on main where
+# required VA checks are present and passing. Outputs only the commit SHA to stdout.
+# It searches commits since the latest release tag first, then falls back to full main history.
+# No tags/releases are created.
+
+MAX_COMMITS=0
+REPO="${REPO:-department-of-veterans-affairs/va.gov-cms}"
+VERBOSE=0
+JSON_MODE=0
+JSON_PRETTY=0
+MAX_REASON_SAMPLES=20
+REQUIRED_CHECKS_JSON='["va/tests/cypress","va/tests/phpunit","va/tests/status-error","va/tests/content-build-gql"]'
+
+usage() {
+  cat <<'EOF'
+Usage: find-latest-passing-main-commit.sh [--repo owner/name] [--max-commits N] [--verbose] [--json] [--json-pretty]
+
+Options:
+  --repo owner/name   GitHub repository (defaults to current gh repo)
+  --max-commits N     Number of commits to inspect (default: 0 = all since last tag)
+  --verbose           Print per-commit diagnostics to stderr
+  --json              Print JSON output with selected SHA and skip summary
+  --json-pretty       Same as --json, but pretty-printed
+  -h, --help          Show this help
+
+Environment:
+  REPO                Same as --repo
+
+Output:
+  Default: prints one commit SHA to stdout when found.
+  --json: prints a JSON object with selected_sha and skipped_summary.
+  --json-pretty: same schema as --json, but indented.
+  Search order: latest_tag..main, then full main history if needed.
+  Required checks: va/tests/cypress, va/tests/phpunit,
+                   va/tests/status-error, va/tests/content-build-gql.
+  Exits non-zero if no qualifying commit is found.
+EOF
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --max-commits)
+      MAX_COMMITS="$2"
+      shift 2
+      ;;
+    --verbose)
+      VERBOSE=1
+      shift
+      ;;
+    --json)
+      JSON_MODE=1
+      shift
+      ;;
+    --json-pretty)
+      JSON_MODE=1
+      JSON_PRETTY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "Unknown argument: $1"
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in git gh jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log "Missing required command: $cmd"
+    exit 2
+  fi
+done
+
+if ! [[ "$MAX_COMMITS" =~ ^[0-9]+$ ]]; then
+  log "--max-commits must be a non-negative integer"
+  exit 2
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "This script must run inside a git repository."
+  exit 2
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
+fi
+if [[ -z "$REPO" ]]; then
+  log "Unable to determine repository. Provide --repo owner/name or set REPO."
+  exit 2
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  log "GitHub CLI is not authenticated. Run: gh auth login"
+  exit 2
+fi
+
+JQ_JSON_FLAGS=(-n -c)
+if [[ "$JSON_PRETTY" -eq 1 ]]; then
+  JQ_JSON_FLAGS=(-n)
+fi
+
+LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n1)
+if [[ -n "$LATEST_TAG" ]]; then
+  RANGES=("${LATEST_TAG}..main" "main")
+  [[ "$VERBOSE" -eq 1 ]] && log "Searching range first: ${LATEST_TAG}..main"
+else
+  RANGES=("main")
+  [[ "$VERBOSE" -eq 1 ]] && log "No release tags found; searching all commits on main."
+fi
+
+SEARCHED_RANGES=()
+
+INSPECTED=0
+SKIPPED_TOTAL=0
+SKIPPED_MISSING_REQUIRED=0
+SKIPPED_NOT_PASSING_REQUIRED=0
+SAMPLED_REASONS=()
+
+for RANGE in "${RANGES[@]}"; do
+  SEARCHED_RANGES+=("$RANGE")
+
+  if [[ "$MAX_COMMITS" -eq 0 ]]; then
+    CANDIDATES=$(git log --format='%H' "$RANGE" || true)
+  else
+    CANDIDATES=$(git log --format='%H' -n "$MAX_COMMITS" "$RANGE" || true)
+  fi
+
+  if [[ -z "$CANDIDATES" ]]; then
+    [[ "$VERBOSE" -eq 1 ]] && log "No candidate commits found in range: $RANGE"
+    continue
+  fi
+
+  CANDIDATE_COUNT=$(printf '%s\n' "$CANDIDATES" | sed '/^$/d' | wc -l | tr -d ' ')
+  if [[ "$VERBOSE" -eq 1 ]]; then
+    if [[ "$MAX_COMMITS" -eq 0 ]]; then
+      log "Evaluating range: $RANGE (candidates=$CANDIDATE_COUNT, max_commits=unlimited)"
+    else
+      log "Evaluating range: $RANGE (candidates=$CANDIDATE_COUNT, max_commits=$MAX_COMMITS)"
+    fi
+  fi
+
+  for SHA in $CANDIDATES; do
+    INSPECTED=$((INSPECTED + 1))
+    [[ "$VERBOSE" -eq 1 ]] && log "Checking $SHA"
+
+    STATUS_RESPONSE=$(gh api "repos/${REPO}/commits/${SHA}/status")
+
+    CHECK_SUMMARY=$(printf '%s\n' "$STATUS_RESPONSE" | jq --argjson required "$REQUIRED_CHECKS_JSON" '
+    .statuses
+    | sort_by(.updated_at // .created_at // "")
+    | reduce .[] as $s ({}; .[$s.context] = $s)
+    | [to_entries[].value | select(.context as $c | $required | index($c))]
+    | {
+        missing: ($required - (map(.context))),
+        failing: [
+          .[]
+          | select(.state != "success")
+          | "\(.context)=\(.state // "none")"
+        ]
+      }
+  ')
+    MISSING_COUNT=$(printf '%s\n' "$CHECK_SUMMARY" | jq -r '.missing | length')
+    FAILING_COUNT=$(printf '%s\n' "$CHECK_SUMMARY" | jq -r '.failing | length')
+
+    if [[ "$MISSING_COUNT" -gt 0 ]]; then
+      SKIPPED_TOTAL=$((SKIPPED_TOTAL + 1))
+      SKIPPED_MISSING_REQUIRED=$((SKIPPED_MISSING_REQUIRED + 1))
+      MISSING_CHECKS=$(printf '%s\n' "$CHECK_SUMMARY" | jq -r '.missing | join(", ")')
+      if [[ "${#SAMPLED_REASONS[@]}" -lt "$MAX_REASON_SAMPLES" ]]; then
+        SAMPLED_REASONS+=("$SHA: missing_required=$MISSING_CHECKS")
+      fi
+      [[ "$VERBOSE" -eq 1 ]] && log "Missing required checks: $MISSING_CHECKS"
+      continue
+    fi
+
+    if [[ "$FAILING_COUNT" -eq 0 ]]; then
+      if [[ "$JSON_MODE" -eq 1 ]]; then
+        if [[ "${#SAMPLED_REASONS[@]}" -gt 0 ]]; then
+          REASONS_JSON=$(printf '%s\n' "${SAMPLED_REASONS[@]}" | jq -R . | jq -s .)
+        else
+          REASONS_JSON='[]'
+        fi
+
+        jq "${JQ_JSON_FLAGS[@]}" \
+          --arg selected_sha "$SHA" \
+          --arg repo "$REPO" \
+          --arg range "$RANGE" \
+          --arg latest_tag "${LATEST_TAG:-}" \
+          --argjson inspected "$INSPECTED" \
+          --argjson skipped_total "$SKIPPED_TOTAL" \
+          --argjson skipped_missing_required "$SKIPPED_MISSING_REQUIRED" \
+          --argjson skipped_not_passing_required "$SKIPPED_NOT_PASSING_REQUIRED" \
+          --argjson samples "$REASONS_JSON" \
+          --argjson searched_ranges "$(printf '%s\n' "${SEARCHED_RANGES[@]}" | jq -R . | jq -s .)" \
+          '{selected_sha: $selected_sha, repo: $repo, range: $range, searched_ranges: $searched_ranges, latest_tag: $latest_tag, inspected_commits: $inspected, skipped_summary: {total: $skipped_total, missing_required: $skipped_missing_required, not_passing_required: $skipped_not_passing_required, samples: $samples}}'
+      else
+        printf '%s\n' "$SHA"
+      fi
+      exit 0
+    fi
+
+    SKIPPED_TOTAL=$((SKIPPED_TOTAL + 1))
+    SKIPPED_NOT_PASSING_REQUIRED=$((SKIPPED_NOT_PASSING_REQUIRED + 1))
+
+    if [[ "$VERBOSE" -eq 1 ]]; then
+      FAILING_CHECKS=$(printf '%s\n' "$CHECK_SUMMARY" | jq -r '.failing | join(", ")')
+      log "Required checks not passing: $FAILING_CHECKS"
+    fi
+
+    if [[ "${#SAMPLED_REASONS[@]}" -lt "$MAX_REASON_SAMPLES" ]]; then
+      FAILING_CHECKS=$(printf '%s\n' "$CHECK_SUMMARY" | jq -r '.failing | join(", ")')
+      SAMPLED_REASONS+=("$SHA: $FAILING_CHECKS")
+    fi
+  done
+done
+
+log "No commits found with all 4 required checks passing in searched ranges: ${SEARCHED_RANGES[*]}"
+if [[ "$JSON_MODE" -eq 1 ]]; then
+  if [[ "${#SAMPLED_REASONS[@]}" -gt 0 ]]; then
+    REASONS_JSON=$(printf '%s\n' "${SAMPLED_REASONS[@]}" | jq -R . | jq -s .)
+  else
+    REASONS_JSON='[]'
+  fi
+
+  jq "${JQ_JSON_FLAGS[@]}" \
+    --arg repo "$REPO" \
+    --arg range "${SEARCHED_RANGES[0]:-main}" \
+    --arg latest_tag "${LATEST_TAG:-}" \
+    --argjson inspected "$INSPECTED" \
+    --argjson skipped_total "$SKIPPED_TOTAL" \
+    --argjson skipped_missing_required "$SKIPPED_MISSING_REQUIRED" \
+    --argjson skipped_not_passing_required "$SKIPPED_NOT_PASSING_REQUIRED" \
+    --argjson samples "$REASONS_JSON" \
+    --argjson searched_ranges "$(printf '%s\n' "${SEARCHED_RANGES[@]}" | jq -R . | jq -s .)" \
+    '{selected_sha: null, repo: $repo, range: $range, searched_ranges: $searched_ranges, latest_tag: $latest_tag, error: "no_passing_commit", inspected_commits: $inspected, skipped_summary: {total: $skipped_total, missing_required: $skipped_missing_required, not_passing_required: $skipped_not_passing_required, samples: $samples}}'
+fi
+exit 1


### PR DESCRIPTION
## Description
Relates to #23298 


### Generated description

This pull request refactors the logic for finding the latest passing commit on `main` in the release tagging workflow. The main change is to move the commit selection logic from inline shell code in the GitHub Actions workflow to a new, standalone script, making the process more maintainable, testable, and feature-rich.

Key changes:

**Workflow simplification and delegation:**
* The inline shell logic in `.github/workflows/tag-release-main.yml` that searched for the latest passing commit has been removed and replaced with a call to the new script, greatly simplifying the workflow and centralizing the logic.

**New script for commit selection:**
* Added `scripts/find-latest-passing-main-commit.sh`, a robust Bash script that:
  * Searches for the newest commit on `main` with all required checks present and passing.
  * Accepts options for repository, commit limits, verbosity, and JSON output.
  * Provides detailed diagnostics and summaries, including why commits were skipped.
  * Handles both the range since the latest release tag and the full history if needed.
  * Exits with a non-zero code and summary if no passing commit is found.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If testing passes we should be good.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
