### PR TITLE
VACMS-24184: Refactor tag resolution logic in build-drupal-tag-container.yml for improved clarity and validation

### DIFF
--- a/.github/workflows/build-drupal-tag-container.yml
+++ b/.github/workflows/build-drupal-tag-container.yml
@@ -76,50 +76,30 @@ jobs:
             } | sort -V -r | head -n1
           }
 
-          EVENT='${{ github.event_name }}'
           INPUT_TAG='${{ github.event.inputs.tag || inputs.tag }}'
-          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
-            if [ -n "$INPUT_TAG" ]; then
-              SEMVER_TAG=$(normalize_input "$INPUT_TAG")
-              if [[ "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
-                TAG_REF=$(resolve_tag_ref "$SEMVER_TAG")
-                if [ -n "$TAG_REF" ]; then
-                  echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
-                  echo "TAG_REF=$TAG_REF" >> $GITHUB_OUTPUT
-                  echo "is_valid=true" >> $GITHUB_OUTPUT
-                  exit 0
-                else
-                  echo "::error title=Invalid Tag::Provided tag ${TAG_PREFIX}$SEMVER_TAG does not exist in repository." >&2
-                  echo "is_valid=false" >> $GITHUB_OUTPUT
-                  exit 1
-                fi
+          RAW_TAG="$GITHUB_REF_NAME"
+
+          # Priority order: explicit input, pushed tag ref, then latest semver.
+          if [ -n "$INPUT_TAG" ]; then
+            SEMVER_TAG=$(normalize_input "$INPUT_TAG")
+            if [[ "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
+              TAG_REF=$(resolve_tag_ref "$SEMVER_TAG")
+              if [ -n "$TAG_REF" ]; then
+                echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
+                echo "TAG_REF=$TAG_REF" >> $GITHUB_OUTPUT
+                echo "is_valid=true" >> $GITHUB_OUTPUT
+                exit 0
               else
-                echo "::error title=Invalid Semver::Provided tag $INPUT_TAG is not strict semver vX.Y.Z (prefix ${TAG_PREFIX} optional)." >&2
+                echo "::error title=Invalid Tag::Provided tag ${TAG_PREFIX}$SEMVER_TAG does not exist in repository." >&2
                 echo "is_valid=false" >> $GITHUB_OUTPUT
                 exit 1
               fi
             else
-              LATEST_TAG=$(find_latest_tag)
-              if [ -z "$LATEST_TAG" ]; then
-                echo "::error title=No Tags Found::No semver tags (${TAG_PREFIX}vX.Y.Z or vX.Y.Z) found in repository." >&2
-                echo "is_valid=false" >> $GITHUB_OUTPUT
-                exit 1
-              fi
-              SEMVER_TAG="$LATEST_TAG"
-              if [[ ! "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
-                echo "::error title=Invalid Tag Format::Latest tag $LATEST_TAG does not match expected semver pattern." >&2
-                echo "is_valid=false" >> $GITHUB_OUTPUT
-                exit 1
-              fi
-              echo "Using latest semver tag: $SEMVER_TAG (repo tag $LATEST_TAG)"
-              TAG_REF=$(resolve_tag_ref "$SEMVER_TAG")
-              echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
-              echo "TAG_REF=${TAG_REF:-$SEMVER_TAG}" >> $GITHUB_OUTPUT
-              echo "is_valid=true" >> $GITHUB_OUTPUT
-              exit 0
+              echo "::error title=Invalid Semver::Provided tag $INPUT_TAG is not strict semver vX.Y.Z (prefix ${TAG_PREFIX} optional)." >&2
+              echo "is_valid=false" >> $GITHUB_OUTPUT
+              exit 1
             fi
-          else
-            RAW_TAG="$GITHUB_REF_NAME"
+          elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
             SEMVER_TAG=$(normalize_input "$RAW_TAG")
             if [[ "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
               echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
@@ -129,6 +109,25 @@ jobs:
               echo "::error title=Invalid Pushed Tag::Pushed tag $RAW_TAG failed semver validation after removing prefix." >&2
               echo "is_valid=false" >> $GITHUB_OUTPUT
             fi
+          else
+            LATEST_TAG=$(find_latest_tag)
+            if [ -z "$LATEST_TAG" ]; then
+              echo "::error title=No Tags Found::No semver tags (${TAG_PREFIX}vX.Y.Z or vX.Y.Z) found in repository." >&2
+              echo "is_valid=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+            SEMVER_TAG="$LATEST_TAG"
+            if [[ ! "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
+              echo "::error title=Invalid Tag Format::Latest tag $LATEST_TAG does not match expected semver pattern." >&2
+              echo "is_valid=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+            echo "Using latest semver tag: $SEMVER_TAG (repo tag $LATEST_TAG)"
+            TAG_REF=$(resolve_tag_ref "$SEMVER_TAG")
+            echo "IMAGE_TAG=$SEMVER_TAG" >> $GITHUB_OUTPUT
+            echo "TAG_REF=${TAG_REF:-$SEMVER_TAG}" >> $GITHUB_OUTPUT
+            echo "is_valid=true" >> $GITHUB_OUTPUT
+            exit 0
           fi
       - name: Abort on invalid tag
         if: steps.select_tag.outputs.is_valid != 'true'


### PR DESCRIPTION
## Description

Relates to #24184 

### Generated description

This pull request updates the tag selection logic in the `build-drupal-tag-container` GitHub Actions workflow to improve how tags are chosen and validated when building containers. The main improvement is a clearer and more robust priority order for determining which tag to use, as well as more explicit handling of tags pushed directly to the repository.

**Tag selection and validation improvements:**

* Refactored the tag selection logic to prioritize: (1) explicit workflow input, (2) a pushed tag ref, and (3) the latest semver tag, making the process more predictable and maintainable.
* Added explicit handling for cases where a tag is pushed directly (`GITHUB_REF_TYPE=tag`), ensuring the pushed tag is validated and used if it matches the semver pattern.
* Removed redundant and now-unreachable code for tag validation, simplifying the workflow logic and reducing duplication.

## Testing done


## Screenshots


## QA steps

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

If this passes automated testing it should be good.

### Select Team for PR review

- [x] `CMS Team`
- [ ] `Public websites`
- [ ] `Facilities`
- [ ] `User support`
- [ ] `Accelerated Publishing`


### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`

### Does this PR need review from a Product Owner

- [ ] `Needs PO review`

### CMS user-facing announcement

Is an announcement needed to let editors know of this change?
- [ ] Yes, and it's written in issue ____ and queued for publication.
  - [ ] Merge and ping the UX writer so they are ready to publish after deployment
- [ ] Yes, but it hasn't yet been written
  - [ ] Don't merge yet -- ping the UX writer to write and queue content
- [ ] No announcement is needed for this code change.
  - [ ] Merge & carry on unburdened by announcements
